### PR TITLE
fix name jijmodeling-transpiler-quantum to qamomile in documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install "qamomile[qiskit]"
 ```python
 import jijmodeling as jm
 import jijmodeling_transpiler as jmt
-import qamomile as jtq
+import qamomile as qamo
 
 # Create model
 problem = jm.Problem("model")
@@ -32,7 +32,7 @@ problem = jm.Problem("model")
 compiled_instance = jmt.compile_model(problem, instance_data, fixed_vars)
 
 # Transpile to QAOA of qikit
-qaoa_builder = jtq.qiskit.transpile_to_qaoa(compiled_instance)
+qaoa_builder = qamo.qiskit.transpile_to_qaoa(compiled_instance)
 ```
 
 
@@ -49,7 +49,7 @@ pip install "qamomile[quri-parts]"
 ```python
 import jijmodeling as jm
 import jijmodeling_transpiler as jmt
-import qamomile as jtq
+import qamomile as qamo
 
 # Create model
 problem = jm.Problem("model")
@@ -59,7 +59,7 @@ problem = jm.Problem("model")
 compiled_instance = jmt.compile_model(problem, instance_data, fixed_vars)
 
 # Transpile to QAOA of qikit
-qaoa_builder = jtq.quri.transpile_to_qaoa(compiled_instance)
+qaoa_builder = qamo.quri.transpile_to_qaoa(compiled_instance)
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,14 +8,14 @@ Qamomile stands for Quantum Algorithm for Mathematical OptiMization with jIjmode
 ## Installation
 The installation for qiskit is 
 ```bash
-# jijmodeling-transpiler-quantum for qiskit
-pip install "jijmodeling-transpiler-quantum[qiskit]"
+# qamomile for qiskit
+pip install "qamomile[qiskit]"
 ```
 
 The installation for QURI Parts is
 ```bash
-# jijmodeling-transpiler-quantum for quri-parts
-pip install "jijmodeling-transpiler-quantum[quri-parts]"
+# qamomile for quri-parts
+pip install "qamomile[quri-parts]"
 ```
 
 ## Quickstart
@@ -23,7 +23,7 @@ In the following example, QAOA for the graph colouring problem is implemented us
 ```python
 import jijmodeling as jm
 import jijmodeling_transpiler.core as jtc
-import jijmodeling_transpiler_quantum.qiskit as jt_qk
+import qamomile.qiskit as qamo_qk
 
 from qiskit.primitives import Estimator, Sampler
 from qiskit.algorithms.minimum_eigensolvers import QAOA
@@ -60,7 +60,7 @@ num_qubits = num_nodes * color_num
 
 # Transpile mathematical model to Qiskit Ising Hamiltonian
 compiled_instance = jtc.compile_model(problem, instance_data)
-qaoa_builder = jt_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)
+qaoa_builder = qamo_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)
 hamiltonian, _ = qaoa_builder.get_hamiltonian(multipliers={"one-color": 1})
 
 # Run QAOA by Qiskit

--- a/docs/overrides/gen_ref_pages.py
+++ b/docs/overrides/gen_ref_pages.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import mkdocs_gen_files
 
-SOURCE_DIR = "jijmodeling_transpiler_quantum"
+SOURCE_DIR = "qamomile"
 
 nav = mkdocs_gen_files.Nav()
 

--- a/docs/tutorial/alternating_ansatz_graph_coloring_qiskit.ipynb
+++ b/docs/tutorial/alternating_ansatz_graph_coloring_qiskit.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "import jijmodeling as jm\n",
     "import jijmodeling_transpiler.core as jtc\n",
-    "import qamomile.qiskit as jt_qk\n",
+    "import qamomile.qiskit as qamo_qk\n",
     "\n",
     "from qiskit.primitives import Estimator, Sampler\n",
     "from qiskit.algorithms.minimum_eigensolvers import QAOA\n",
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qaoa_builder = jt_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)\n",
+    "qaoa_builder = qamo_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)\n",
     "hamiltonian, _ = qaoa_builder.get_hamiltonian(multipliers={\"one-color\": 1})"
    ]
   },
@@ -390,7 +390,7 @@
    "outputs": [],
    "source": [
     "compiled_instance = jtc.compile_model(problem, instance_data)\n",
-    "qaoa_builder = jt_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance)\n",
+    "qaoa_builder = qamo_qk.qaoa.transpile_to_qaoa_ansatz(compiled_instance)\n",
     "ising_operator, _ = qaoa_builder.get_hamiltonian()"
    ]
   },

--- a/docs/tutorial/alternating_ansatz_graph_coloring_quri.ipynb
+++ b/docs/tutorial/alternating_ansatz_graph_coloring_quri.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "import jijmodeling as jm\n",
     "import jijmodeling_transpiler.core as jtc\n",
-    "import qamomile.quri_parts as jt_qu\n",
+    "import qamomile.quri_parts as qamo_qu\n",
     "\n",
     "import networkx as nx\n",
     "\n",
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qaoa_builder = jt_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)\n",
+    "qaoa_builder = qamo_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False,relax_method=jtc.pubo.RelaxationMethod.SquaredPenalty)\n",
     "qaoa_ansatz, hamiltonian, constant = qaoa_builder.get_qaoa_ansatz(\n",
     "    p=1, multipliers={\"one-color\": 1}\n",
     ")"
@@ -455,7 +455,7 @@
    "outputs": [],
    "source": [
     "compiled_instance = jtc.compile_model(problem, instance_data)\n",
-    "qaoa_builder = jt_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance)"
+    "qaoa_builder = qamo_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance)"
    ]
   },
   {
@@ -731,7 +731,7 @@
    ],
    "source": [
     "compiled_instance = jtc.compile_model(graph_coloring_problem(), instance_data)\n",
-    "qaoa_builder = jt_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False)\n",
+    "qaoa_builder = qamo_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False)\n",
     "qaoa_ansatz, hamiltonian, constant = qaoa_builder.get_qaoa_ansatz(\n",
     "    p=1, multipliers={\"one-color\": 1}\n",
     ")\n",
@@ -758,7 +758,7 @@
    ],
    "source": [
     "compiled_instance = jtc.compile_model(graph_coloring_problem_wo_onehot(), instance_data)\n",
-    "qaoa_builder = jt_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False)\n",
+    "qaoa_builder = qamo_qu.qaoa.transpile_to_qaoa_ansatz(compiled_instance,normalize=False)\n",
     "ising_operator, _ = qaoa_builder.get_hamiltonian()\n",
     "ansatz = create_ansatz(\n",
     "    1, ising_operator, num_qubits, num_nodes, color_num, compiled_instance\n",


### PR DESCRIPTION
# Change
- jijmodeling-transpiler-quantum is still used in `gen_ref_pages.py`, so I fixed the name
- change import name in the example