### PR TITLE
Add (2,1)-QRAO and fix the coefficient of (3,1)-QRAO

### DIFF
--- a/qamomile/core/converters/qrao/qrao21.py
+++ b/qamomile/core/converters/qrao/qrao21.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+import typing as typ
+import numpy as np
+from qamomile.core.converters.converter import QuantumConverter
+from qamomile.core.ising_qubo import IsingModel
+import qamomile.core.operator as qm_o
+from .graph_coloring import greedy_graph_coloring, check_linear_term
+from .qrao31 import color_group_to_qrac_encode
+
+
+def qrac21_encode_ising(
+    ising: IsingModel, color_group: dict[int, list[int]]
+) -> tuple[qm_o.Hamiltonian, dict[int, qm_o.PauliOperator]]:
+    encoded_ope = color_group_to_qrac_encode(color_group)
+
+    offset = ising.constant
+
+    hamiltonian = qm_o.Hamiltonian()
+    hamiltonian.constant = offset
+
+    # convert linear parts of the objective function into Hamiltonian.
+    for idx, coeff in ising.linear.items():
+        if coeff == 0.0:
+            continue
+
+        pauli = encoded_ope[idx]
+        hamiltonian.add_term((pauli,), np.sqrt(2) * coeff)
+
+    # create Pauli terms
+    for (i, j), coeff in ising.quad.items():
+        if coeff == 0.0:
+            continue
+
+        if i == j:
+            offset += coeff
+            continue
+
+        pauli_i = encoded_ope[i]
+
+        pauli_j = encoded_ope[j]
+
+        hamiltonian.add_term((pauli_i, pauli_j), 2 * coeff)
+
+    return hamiltonian, encoded_ope
+
+
+class QRAC21Converter(QuantumConverter):
+
+    max_color_group_size = 2
+
+    def ising_encode(
+        self,
+        multipliers: typ.Optional[dict[str, float]] = None,
+        detail_parameters: typ.Optional[dict[str, dict[tuple[int, ...], tuple[float, float]]]] = None
+    ) -> IsingModel:
+        ising = super().ising_encode(multipliers, detail_parameters)
+
+        _, color_group = greedy_graph_coloring(
+            ising.quad.keys(),
+            self.max_color_group_size
+        )
+        color_group = check_linear_term(
+            color_group, list(ising.linear.keys()), self.max_color_group_size
+        )
+
+        self.color_group = color_group
+        return ising
+
+    def get_cost_hamiltonian(self) -> qm_o.Hamiltonian:
+        """
+        Construct the cost Hamiltonian for QRAC21.
+
+        Returns:
+            qm_o.Hamiltonian: The cost Hamiltonian.
+        """
+        ising = self.get_ising()
+
+        hamiltonian, pauli_encoding = qrac21_encode_ising(ising, self.color_group)
+        self.pauli_encoding = pauli_encoding
+        return hamiltonian
+
+    def get_encoded_pauli_list(self) -> list[qm_o.Hamiltonian]:
+        # return the encoded Pauli operators as list
+        ising = self.get_ising()
+        num_qubits = len(self.color_group)
+        zero_pauli = qm_o.Hamiltonian(num_qubits=num_qubits)
+        pauli_operators = [zero_pauli] * ising.num_bits()
+        for idx, pauli in self.pauli_encoding.items():
+            observable = qm_o.Hamiltonian(num_qubits=num_qubits)
+            observable.add_term((pauli,), 1.0)
+            pauli_operators[idx] = observable
+        return pauli_operators

--- a/qamomile/core/converters/qrao/qrao31.py
+++ b/qamomile/core/converters/qrao/qrao31.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import typing as typ
+import numpy as np
 from qamomile.core.converters.converter import QuantumConverter
 from qamomile.core.ising_qubo import IsingModel
 import qamomile.core.operator as qm_o
@@ -46,7 +47,7 @@ def qrac31_encode_ising(
             continue
 
         pauli = encoded_ope[idx]
-        hamiltonian.add_term((pauli,), coeff)
+        hamiltonian.add_term((pauli,), np.sqrt(3) * coeff)
 
     # create Pauli terms
     for (i, j), coeff in ising.quad.items():
@@ -61,7 +62,7 @@ def qrac31_encode_ising(
 
         pauli_j = encoded_ope[j]
 
-        hamiltonian.add_term((pauli_i, pauli_j), coeff)
+        hamiltonian.add_term((pauli_i, pauli_j), 3 * coeff)
 
     return hamiltonian, encoded_ope
 

--- a/qamomile/core/ising_qubo.py
+++ b/qamomile/core/ising_qubo.py
@@ -10,8 +10,10 @@ class IsingModel:
     index_map: typ.Optional[dict[int, int]] = None
 
     def num_bits(self) -> int:
-        num_bits = max(self.linear.keys())
-        num_bits = max(num_bits, max(max(pair) for pair in self.quad.keys()))
+        num_bits = max(self.linear.keys(), default=-1)
+        num_bits = max(
+            num_bits, max((max(pair) for pair in self.quad.keys()), default=num_bits)
+        )
         return num_bits + 1
 
     def calc_energy(self, state: list[int]) -> float:

--- a/tests/test_ising_qubo.py
+++ b/tests/test_ising_qubo.py
@@ -1,0 +1,42 @@
+from qamomile.core.ising_qubo import qubo_to_ising, IsingModel
+
+
+def test_onehot_conversion():
+    qubo: dict[tuple[int, int], float] = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
+    ising = qubo_to_ising(qubo)
+    assert ising.constant == -0.5
+    assert ising.linear == {}
+    assert ising.quad == {(0, 1): 0.5}
+
+
+def test_num_bits():
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    assert ising.num_bits() == 7
+
+    ising = IsingModel({}, {0: 1.0, 1: 1.0, 2: 5.0, 3: 2.0}, 6.0)
+    assert ising.num_bits() == 4
+
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {},
+        6.0,
+    )
+    assert ising.num_bits() == 3
+
+    ising = IsingModel(
+        {},
+        {},
+        6.0,
+    )
+    assert ising.num_bits() == 0
+
+    ising = IsingModel(
+        {},
+        {0: 1.0},
+        6.0,
+    )
+    assert ising.num_bits() == 1

--- a/tests/test_qrao.py
+++ b/tests/test_qrao.py
@@ -1,0 +1,149 @@
+import numpy as np
+from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.converters.qrao.graph_coloring import (
+    greedy_graph_coloring,
+    check_linear_term,
+)
+from qamomile.core.converters.qrao.qrao31 import qrac31_encode_ising
+from qamomile.core.converters.qrao.qrao21 import qrac21_encode_ising
+import qamomile.core.operator as qm_o
+
+
+def test_check_linear_term_qrao31():
+    ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
+
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac31_encode_ising(ising, color_group)
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = {
+        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
+        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
+        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
+        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
+    }
+    assert len(qrac_hamiltonian.terms) == num_terms
+    assert qrac_hamiltonian.num_qubits < ising.num_bits()
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian.terms == expected_hamiltonian
+
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac31_encode_ising(ising, color_group)
+
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = {
+        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
+        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
+        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
+        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
+        (qm_o.Y(2),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.Z(2),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.X(3),): np.sqrt(max_color_group_size) * 1.0,
+    }
+    assert len(qrac_hamiltonian.terms) == num_terms
+    assert qrac_hamiltonian.num_qubits < ising.num_bits()
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian.terms == expected_hamiltonian
+
+
+def test_check_linear_term_qrao21():
+    ising = IsingModel(
+        {(0, 1): 2.0, (0, 2): 1.0},
+        {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
+        6.0,
+    )
+    max_color_group_size = 2
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac21_encode_ising(ising, color_group)
+
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = {
+        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
+        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
+        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
+        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
+        (qm_o.Y(2),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.X(3),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.Y(3),): np.sqrt(max_color_group_size) * 1.0,
+    }
+    assert len(qrac_hamiltonian.terms) == num_terms
+    assert qrac_hamiltonian.num_qubits < ising.num_bits()
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian.terms == expected_hamiltonian
+
+
+def test_check_no_quad_term_quri():
+    ising = IsingModel({}, {0: 1.0, 1: 1.0, 2: 5.0, 3: 2.0}, 6.0)
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac31_encode_ising(ising, color_group)
+
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = {
+        (qm_o.X(0),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.Y(0),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.Z(0),): np.sqrt(max_color_group_size) * 5.0,
+        (qm_o.X(1),): np.sqrt(max_color_group_size) * 2.0,
+    }
+    assert len(qrac_hamiltonian.terms) == num_terms
+    assert qrac_hamiltonian.num_qubits < ising.num_bits()
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian.terms == expected_hamiltonian
+
+    ising = IsingModel({}, {0: 1.0, 1: 1.0, 2: 5.0, 3: 2.0}, 6.0)
+    max_color_group_size = 2
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac21_encode_ising(ising, color_group)
+
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = {
+        (qm_o.X(0),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.Y(0),): np.sqrt(max_color_group_size) * 1.0,
+        (qm_o.X(1),): np.sqrt(max_color_group_size) * 5.0,
+        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 2.0,
+    }
+    assert len(qrac_hamiltonian.terms) == num_terms
+    assert qrac_hamiltonian.num_qubits < ising.num_bits()
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian.terms == expected_hamiltonian


### PR DESCRIPTION
# Change
This PR mainly makes two corrections and one addition.
The items to be corrected are as follows.
1. Correction of the coefficients of (3,1)-QRAO. Since 3 and $\sqrt{3}$ were missing, they were added.
2. When linear or quad of `IsingModel` is empty, an error occurred in `max` when calling `num_bits`.

The additions are
1. (2,1)-QRAO functionality has been added.