### PR TITLE
Introduction of addition and multiplication to the Hamiltonian

### DIFF
--- a/qamomile/core/converters/qaoa.py
+++ b/qamomile/core/converters/qaoa.py
@@ -124,11 +124,11 @@ class QAOAConverter(QuantumConverter):
 
         # Add linear terms
         for i, hi in ising.linear.items():
-            hamiltonian.add_term((qm_o.Z(i),), hi)
+            hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z ,i),), hi)
 
         # Add quadratic terms
         for (i, j), Jij in ising.quad.items():
-            hamiltonian.add_term((qm_o.Z(i), qm_o.Z(j)), Jij)
+            hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z ,i), qm_o.PauliOperator(qm_o.Pauli.Z ,j)), Jij)
 
         hamiltonian.constant = ising.constant
         return hamiltonian

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -82,6 +82,50 @@ class PauliOperator:
         """
         return f"{self.pauli.name}{self.index}"
 
+    # def __mul__(self, other) -> "Hamiltonian":
+    #     if isinstance(other, (int, float, complex)):
+    #         h = Hamiltonian()
+    #         h.add_term((self,), other)
+    #         return h
+    #     elif isinstance(other, PauliOperator):
+    #         h = pauli_multiplication(self, other)
+    #         return h
+    #     else:
+    #         raise ValueError("Unsupported multiplication operation.")
+
+    # def __rmul__(self, other):
+    #     return self.__mul__(other)
+
+
+def pauli_multiplication(pauli1:PauliOperator, pauli2:PauliOperator) -> "Hamiltonian":
+    h = Hamiltonian()
+    if pauli1.index == pauli2.index:
+        if pauli1.pauli == pauli2.pauli:
+            return h
+        elif pauli1.pauli == Pauli.X:
+            if pauli2.pauli == Pauli.Y:
+                h.add_term((Z(pauli1.index),), 1.0j)
+                return h
+            elif pauli2.pauli == Pauli.Z:
+                h.add_term((Y(pauli1.index),), -1.0j)
+                return h
+        elif pauli1.pauli == Pauli.Y:
+            if pauli2.pauli == Pauli.X:
+                h.add_term((Z(pauli1.index),), -1.0j)
+                return h
+            elif pauli2.pauli == Pauli.Z:
+                h.add_term((X(pauli1.index),), 1.0j)
+                return h
+        elif pauli1.pauli == Pauli.Z:
+            if pauli2.pauli == Pauli.X:
+                h.add_term((Y(pauli1.index),), 1.0j)
+                return h
+            elif pauli2.pauli == Pauli.Y:
+                h.add_term((X(pauli1.index),), -1.0j)
+                return h
+    else:
+        h.add_term((pauli1,pauli2), 1.0)
+        return h
 
 def X(index: int) -> PauliOperator:
     """
@@ -242,3 +286,28 @@ class Hamiltonian:
             f"{operators}: {coeff}" for operators, coeff in self._terms.items()
         )
         return f"Hamiltonian({terms_str})"
+    
+    def __eq__(self, other):
+        if not isinstance(other, Hamiltonian):
+            return False
+        return self.terms == other.terms and self.constant == other.constant
+
+    def __add__(self, other):
+        if isinstance(other, Hamiltonian):
+            h = Hamiltonian()
+            h._terms = self._terms.copy()
+            h.constant = self.constant
+            for term, coeff in other.terms.items():
+                h.add_term(term, coeff)
+            h.constant += other.constant
+            return h
+        elif isinstance(other, (int, float, complex)):
+            h = Hamiltonian()
+            h._terms = self._terms.copy()
+            h.constant = self.constant + other
+            return h
+        else:
+            raise ValueError("Unsupported addition operation.")
+        
+    def __radd__(self, other):
+        return self.__add__(other)

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -151,15 +151,14 @@ class Hamiltonian:
         if operators:
             # Sort the operators to ensure consistent representation
             operators = tuple(
-                    sorted(operators, key=lambda x: x.index * 10 + x.pauli.value)
-                )
+                sorted(operators, key=lambda x: x.index * 10 + x.pauli.value)
+            )
             if operators in self._terms:
                 self._terms[operators] += phase * coeff
             else:
                 self._terms[operators] = phase * coeff
         else:
             self.constant += phase * coeff
-        
 
     @property
     def num_qubits(self) -> int:
@@ -241,15 +240,15 @@ class Hamiltonian:
                         h.add_term(term, phase * coeff1 * coeff2)
                     else:
                         h.constant += phase * coeff1 * coeff2
-            
-            if not math.isclose(other.constant,0.0, abs_tol=1e-15):
+
+            if not math.isclose(other.constant, 0.0, abs_tol=1e-15):
                 for terms, coeff1 in self.terms.items():
                     h.add_term(terms, coeff1 * other.constant)
 
-            if not math.isclose(self.constant,0.0, abs_tol=1e-15):
+            if not math.isclose(self.constant, 0.0, abs_tol=1e-15):
                 for terms, coeff2 in other.terms.items():
                     h.add_term(terms, coeff2 * self.constant)
-            
+
             h.constant += self.constant * other.constant
 
             return h

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -5,7 +5,7 @@ It defines classes and functions to create and manipulate Pauli operators and Ha
 which are fundamental in quantum mechanics and quantum computing.
 
 Key Components:
-- Pauli: An enumeration of Pauli operators (X, Y, Z).
+- Pauli: An enumeration of Pauli operators (X, Y, Z, I).
 - PauliOperator: A class representing a single Pauli operator acting on a specific qubit.
 - Hamiltonian: A class representing a quantum Hamiltonian as a sum of Pauli operator products.
 
@@ -39,11 +39,13 @@ class Pauli(enum.Enum):
         X (int): Pauli X operator, represented by 0.
         Y (int): Pauli Y operator, represented by 1.
         Z (int): Pauli Z operator, represented by 2.
+        I (int): Identity operator, represented by 3.
     """
 
     X = 0
     Y = 1
     Z = 2
+    I = 3
 
 
 @dataclasses.dataclass
@@ -95,90 +97,6 @@ class PauliOperator:
 
     # def __rmul__(self, other):
     #     return self.__mul__(other)
-
-
-def pauli_multiplication(pauli1:PauliOperator, pauli2:PauliOperator) -> "Hamiltonian":
-    h = Hamiltonian()
-    if pauli1.index == pauli2.index:
-        if pauli1.pauli == pauli2.pauli:
-            return h
-        elif pauli1.pauli == Pauli.X:
-            if pauli2.pauli == Pauli.Y:
-                h.add_term((Z(pauli1.index),), 1.0j)
-                return h
-            elif pauli2.pauli == Pauli.Z:
-                h.add_term((Y(pauli1.index),), -1.0j)
-                return h
-        elif pauli1.pauli == Pauli.Y:
-            if pauli2.pauli == Pauli.X:
-                h.add_term((Z(pauli1.index),), -1.0j)
-                return h
-            elif pauli2.pauli == Pauli.Z:
-                h.add_term((X(pauli1.index),), 1.0j)
-                return h
-        elif pauli1.pauli == Pauli.Z:
-            if pauli2.pauli == Pauli.X:
-                h.add_term((Y(pauli1.index),), 1.0j)
-                return h
-            elif pauli2.pauli == Pauli.Y:
-                h.add_term((X(pauli1.index),), -1.0j)
-                return h
-    else:
-        h.add_term((pauli1,pauli2), 1.0)
-        return h
-
-def X(index: int) -> PauliOperator:
-    """
-    Creates a Pauli X operator for a specified qubit.
-
-    Args:
-        index (int): The index of the qubit.
-
-    Returns:
-        PauliOperator: A Pauli X operator acting on the specified qubit.
-
-    Example:
-        >>> X0 = X(0)
-        >>> print(X0)
-        X0
-    """
-    return PauliOperator(Pauli.X, index)
-
-
-def Y(index: int) -> PauliOperator:
-    """
-    Creates a Pauli Y operator for a specified qubit.
-
-    Args:
-        index (int): The index of the qubit.
-
-    Returns:
-        PauliOperator: A Pauli Y operator acting on the specified qubit.
-
-    Example:
-        >>> Y1 = Y(1)
-        >>> print(Y1)
-        Y1
-    """
-    return PauliOperator(Pauli.Y, index)
-
-
-def Z(index: int) -> PauliOperator:
-    """
-    Creates a Pauli Z operator for a specified qubit.
-
-    Args:
-        index (int): The index of the qubit.
-
-    Returns:
-        PauliOperator: A Pauli Z operator acting on the specified qubit.
-
-    Example:
-        >>> Z2 = Z(2)
-        >>> print(Z2)
-        Z2
-    """
-    return PauliOperator(Pauli.Z, index)
 
 
 class Hamiltonian:
@@ -311,3 +229,156 @@ class Hamiltonian:
         
     def __radd__(self, other):
         return self.__add__(other)
+
+    def __mul__(self, other):
+        if isinstance(other, (int, float, complex)):
+            h = Hamiltonian()
+            for term, coeff in self.terms.items():
+                h.add_term(term, coeff * other)
+            h.constant = self.constant * other
+            return h
+        elif isinstance(other, Hamiltonian):
+            h = Hamiltonian()
+            for term1, coeff1 in self.terms.items():
+                for term2, coeff2 in other.terms.items():
+                    term, phase = simplify_pauliop_terms(term1 + term2)
+                    h.add_term(term, phase * coeff1 * coeff2)
+            return h
+        else:
+            raise ValueError("Unsupported multiplication operation.")
+        
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+    
+
+def X(index: int) -> Hamiltonian:
+    """
+    Creates a Pauli X operator for a specified qubit.
+
+    Args:
+        index (int): The index of the qubit.
+
+    Returns:
+        Hamiltonian: A Pauli X Hamiltonian operator acting on the specified qubit.
+
+    Example:
+        >>> X0 = X(0)
+        >>> print(X0)
+        X0
+    """
+    h = Hamiltonian()
+    h.add_term((PauliOperator(Pauli.X, index),), 1.0)
+    return h
+
+
+def Y(index: int) -> Hamiltonian:
+    """
+    Creates a Pauli Y operator for a specified qubit.
+
+    Args:
+        index (int): The index of the qubit.
+
+    Returns:
+        Hamiltonian: A Pauli Y Hamiltonian operator acting on the specified qubit.
+
+    Example:
+        >>> Y1 = Y(1)
+        >>> print(Y1)
+        Y1
+    """
+    h = Hamiltonian()
+    h.add_term((PauliOperator(Pauli.Y, index),), 1.0)
+    return h
+
+
+def Z(index: int) -> Hamiltonian:
+    """
+    Creates a Pauli Z operator for a specified qubit.
+
+    Args:
+        index (int): The index of the qubit.
+
+    Returns:
+        Hamiltonian: A Pauli Z Hamiltonian operator acting on the specified qubit.
+
+    Example:
+        >>> Z2 = Z(2)
+        >>> print(Z2)
+        Z2
+    """
+    h = Hamiltonian()
+    h.add_term((PauliOperator(Pauli.Z, index),), 1.0)
+    return h
+
+def multiply_pauli_same_qubit(pauli1:PauliOperator, pauli2:PauliOperator) -> tuple[PauliOperator, complex]:
+    
+    if pauli1.index == pauli2.index:
+        if pauli1.pauli == pauli2.pauli:
+            return PauliOperator(Pauli.I, pauli1.index), 1.0
+        
+        elif pauli1.pauli == Pauli.X:
+            if pauli2.pauli == Pauli.Y:
+                return PauliOperator(Pauli.Z, pauli1.index) , 1.0j
+                
+            elif pauli2.pauli == Pauli.Z:
+                return PauliOperator(Pauli.Y, pauli1.index) , -1.0j
+            
+            elif pauli2.pauli == Pauli.I:
+                return PauliOperator(Pauli.X, pauli1.index), 1.0
+
+        elif pauli1.pauli == Pauli.Y:
+            if pauli2.pauli == Pauli.X:
+                return PauliOperator(Pauli.Z, pauli1.index) , -1.0j
+                
+            elif pauli2.pauli == Pauli.Z:
+                return PauliOperator(Pauli.X, pauli1.index) , 1.0j
+
+            elif pauli2.pauli == Pauli.I:
+                return PauliOperator(Pauli.Y, pauli1.index), 1.0
+                
+
+        elif pauli1.pauli == Pauli.Z:
+            if pauli2.pauli == Pauli.X:
+                return PauliOperator(Pauli.Y, pauli1.index) , 1.0j
+                
+            elif pauli2.pauli == Pauli.Y:
+                return PauliOperator(Pauli.X, pauli1.index) , -1.0j
+            
+            elif pauli2.pauli == Pauli.I:
+                return PauliOperator(Pauli.Z, pauli1.index), 1.0
+
+        elif pauli1.pauli == Pauli.I:
+            return pauli2, 1.0
+        
+    else:
+        raise ValueError("Pauli operators act on different qubits.")
+    
+def simplify_pauliop_terms(term:tuple[PauliOperator]) -> tuple[PauliOperator]:
+    phase = 1.0
+    paulis = {}
+
+    for op in term:
+        if op.index in paulis:
+            paulis[op.index].append(op)
+        else:
+            paulis[op.index] = [op]
+    
+    for qubit_index,_pauli_list in paulis.items():
+        if len(_pauli_list) == 1:
+            continue
+        else:
+            op = _pauli_list[0]
+            for i in range(1, len(_pauli_list)):
+                op, _phase = multiply_pauli_same_qubit(op, _pauli_list[i])
+                phase *= _phase
+                
+            paulis[qubit_index] = [op]
+
+    pauli_list = []
+    
+    for _pauli_list in paulis.values():
+        if _pauli_list[0].pauli != Pauli.I:
+            pauli_list.append(_pauli_list[0])
+
+    return set(pauli_list), phase

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -154,9 +154,9 @@ class QiskitTranspiler(QuantumSDKTranspiler[qk_primitives.BitArray]):
             qk_pauli_x = np.zeros(num_qubits, dtype=bool)
             for pauli in term:
                 if pauli.pauli == qm_o.Pauli.X:
-                    qk_pauli_x[pauli.index] = not qk_pauli_z[pauli.index]
+                    qk_pauli_x[pauli.index] = not qk_pauli_x[pauli.index]
                 elif pauli.pauli == qm_o.Pauli.Y:
-                    qk_pauli_x[pauli.index] = not qk_pauli_z[pauli.index]
+                    qk_pauli_x[pauli.index] = not qk_pauli_x[pauli.index]
                     qk_pauli_z[pauli.index] = not qk_pauli_z[pauli.index]
                 elif pauli.pauli == qm_o.Pauli.Z:
                     qk_pauli_z[pauli.index] = not qk_pauli_z[pauli.index]

--- a/tests/qiskit/test_transpiler.py
+++ b/tests/qiskit/test_transpiler.py
@@ -98,3 +98,20 @@ def test_transpile_hamiltonian(transpiler):
     assert isinstance(qiskit_hamiltonian, qk_ope.SparsePauliOp)
     assert len(qiskit_hamiltonian) == 2
     assert np.allclose(qiskit_hamiltonian.coeffs, [1.0, 2.0])
+
+    hamiltonian = Hamiltonian()
+    hamiltonian.add_term((PauliOperator(Pauli.X, 0), ), 1.0)
+    hamiltonian.add_term((PauliOperator(Pauli.X, 0), ), 1.0)
+
+    qiskit_hamiltonian = transpiler.transpile_hamiltonian(hamiltonian)
+
+    assert isinstance(qiskit_hamiltonian, qk_ope.SparsePauliOp)
+    assert len(qiskit_hamiltonian) == 1
+    assert np.allclose(qiskit_hamiltonian.coeffs, [2.0])
+    assert np.all(qiskit_hamiltonian.paulis == ['X'])
+
+
+
+
+
+    

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,5 +1,6 @@
 import qamomile.core.operator as qm_o
 
+
 def test_pauli_operator_creation():
     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
     assert X0.pauli == qm_o.Pauli.X
@@ -13,54 +14,49 @@ def test_pauli_operator_creation():
     assert Z2.pauli == qm_o.Pauli.Z
     assert Z2.index == 2
 
+
+def test_add_term():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
+
+    h = qm_o.Hamiltonian()
+    h.add_term((X0,), 1.0)
+    assert h.terms == {(X0,): 1.0}
+
+    h.add_term((Y1, Y2), 3.0)
+    assert h.terms == {(X0,): 1.0, (Y1, Y2): 3.0}
+
+    h.add_term((X0,), 1.0)
+    assert h.terms == {(X0,): 2.0, (Y1, Y2): 3.0}
+
+    h.add_term((X0, X0), -1.0)
+    assert h.terms == {(X0,): 2.0, (Y1, Y2): 3.0}
+    assert h.constant == -1.0
+
+    h.add_term((X0, Y0), -4.0)
+    assert h.terms == {(X0,): 2.0, (Y1, Y2): 3.0, (Z0,): -4.0j}
+    assert h.constant == -1.0
+
+
 def test_pauli_hamiltonian_creation():
     x0 = qm_o.X(0)
     _x0 = qm_o.Hamiltonian()
-    _x0.add_term((qm_o.PauliOperator(qm_o.Pauli.X,0),), 1.0)
+    _x0.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
     assert x0 == _x0
 
     y1 = qm_o.Y(1)
     _y1 = qm_o.Hamiltonian()
-    _y1.add_term((qm_o.PauliOperator(qm_o.Pauli.Y,1),), 1.0)
+    _y1.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 1.0)
     assert y1 == _y1
 
     z2 = qm_o.Z(2)
     _z2 = qm_o.Hamiltonian()
-    _z2.add_term((qm_o.PauliOperator(qm_o.Pauli.Z,2),), 1.0)
+    _z2.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 2),), 1.0)
     assert z2 == _z2
 
-# def test_multiplication_by_scalar():
-#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
-#     h = qm_o.Hamiltonian()
-#     h.add_term((X0,), 2.0)
-#     op = X0 * 2.0
-#     assert h == op
-
-#     Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
-#     h = qm_o.Hamiltonian()
-#     h.add_term((Y1,), 3.0)
-#     op = 3.0 * Y1
-#     assert h == op
-
-# def test_muliiplication_by_operator():
-#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
-#     Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
-#     h = qm_o.Hamiltonian()
-#     h.add_term((X0, Y1), 1.0)
-#     op = X0 * Y1
-#     assert h == op
-
-#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
-#     Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
-#     op = X0 * Y0
-#     h = qm_o.Hamiltonian()
-#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
-#     assert h == op
-
-#     op = Y0 * X0
-#     h = qm_o.Hamiltonian()
-#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), -1.0j)
-#     assert h == op
 
 def test_multiply_pauli_same_qubit():
     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
@@ -95,7 +91,7 @@ def test_multiply_pauli_same_qubit():
     ops, phase = qm_o.multiply_pauli_same_qubit(I0, Z0)
     assert ops == Z0
     assert phase == 1.0
-    
+
 
 def test_Hamiltonian_add():
     h1 = qm_o.Hamiltonian()
@@ -107,6 +103,7 @@ def test_Hamiltonian_add():
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), 1.0)
     assert h == expected_h
+
 
 def test_Hamiltonian_add_scalar():
     h = qm_o.Hamiltonian()
@@ -121,6 +118,7 @@ def test_Hamiltonian_add_scalar():
     expected_h.constant += 2.0
     assert h == expected_h
 
+
 def test_Hamiltonian_scalar_multiplication():
     h = qm_o.Hamiltonian()
     h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
@@ -134,71 +132,6 @@ def test_Hamiltonian_scalar_multiplication():
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 4.0)
     assert h == expected_h
 
-# def test_Hamiltonian_multiplication():
-#     h1 = qm_o.Hamiltonian()
-#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
-#     h2 = qm_o.Hamiltonian()
-#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
-#     h = h1 * h2
-#     expected_h = qm_o.Hamiltonian()
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
-#     assert h == expected_h
-
-#     h1 = qm_o.Hamiltonian()
-#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
-#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
-#     h2 = qm_o.Hamiltonian()
-#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
-#     h = h1 * h2
-#     expected_h = qm_o.Hamiltonian()
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 6.0)
-#     assert h == expected_h
-
-#     h1 = qm_o.Hamiltonian()
-#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
-#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
-#     h2 = qm_o.Hamiltonian()
-#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 3.0)
-#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 2),), 4.0)
-#     h = h1 * h2
-#     expected_h = qm_o.Hamiltonian()
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 3.0)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 4.0)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 6.0)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 8.0)
-#     assert h == expected_h
-
-#     x0 = qm_o.X(0)
-#     y0 = qm_o.Y(0)
-#     h = qm_o.Hamiltonian()
-#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
-#     op = x0 * y0
-#     assert h == op
-
-#     x1 = qm_o.X(1)
-#     y1 = qm_o.Y(1)
-
-#     h1 = x0 + y1
-#     h2 = x1 + y0
-#     h = h1 * h2
-#     expected_h = qm_o.Hamiltonian()
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.X, 1)), 1.0)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0j)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 1),), -1.0j)
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0)
-#     assert h == expected_h
-
-#     # h1 = x0 + y1
-#     # h2 = x0 + y0
-#     # h = h1 * h2
-#     # print(h)
-#     # expected_h = qm_o.Hamiltonian()
-#     # expected_h.add_term((,), 1.0)
-#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 0)), 1.0)
-#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0)
-#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.X, 1)), 1.0)
-#     # assert h == expected_h
 
 def test_simplify_pauliop_terms():
     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
@@ -215,12 +148,12 @@ def test_simplify_pauliop_terms():
     assert set(paulis) == set((X1, Z0))
     assert phase == -1.0j
 
-    paulis, coeffs = qm_o.simplify_pauliop_terms((Z0, ) +  (X0,))
+    paulis, coeffs = qm_o.simplify_pauliop_terms((Z0,) + (X0,))
     assert set(paulis) == set((Y0,))
     assert coeffs == 1.0j
 
     paulis, coeffs = qm_o.simplify_pauliop_terms((X0, X0))
-    
+
     assert set(paulis) == set(())
     assert coeffs == 1.0
 
@@ -229,9 +162,133 @@ def test_simplify_pauliop_terms():
     assert coeffs == 1.0
 
     paulis, coeffs = qm_o.simplify_pauliop_terms((Y0, Y0, X0, X1, Z1))
-    assert set(paulis) == set((X0,Y1))
+    assert set(paulis) == set((X0, Y1))
     assert coeffs == -1.0j
-    
+
     paulis, coeffs = qm_o.simplify_pauliop_terms(())
     assert set(paulis) == set(())
     assert coeffs == 1.0
+
+
+def test_Hamiltonian_multiplication():
+    h1 = qm_o.Hamiltonian()
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h2 = qm_o.Hamiltonian()
+    h2.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 1), qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0
+    )
+    h = h1 * h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term(
+        (
+            qm_o.PauliOperator(qm_o.Pauli.X, 0),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 1),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 2),
+        ),
+        3.0,
+    )
+    assert h == expected_h
+
+    h1 = qm_o.Hamiltonian()
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
+    h2 = qm_o.Hamiltonian()
+    h2.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 1), qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0
+    )
+    h = h1 * h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term(
+        (
+            qm_o.PauliOperator(qm_o.Pauli.X, 0),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 1),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 2),
+        ),
+        3.0,
+    )
+    expected_h.add_term(
+        (
+            qm_o.PauliOperator(qm_o.Pauli.Z, 0),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 1),
+            qm_o.PauliOperator(qm_o.Pauli.Y, 2),
+        ),
+        6.0,
+    )
+    assert h == expected_h
+
+    h1 = qm_o.Hamiltonian()
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
+    h2 = qm_o.Hamiltonian()
+    h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 3.0)
+    h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 2),), 4.0)
+    h = h1 * h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 3.0
+    )
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 4.0
+    )
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Z, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 6.0
+    )
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Z, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 8.0
+    )
+    assert h == expected_h
+
+    x0 = qm_o.X(0)
+    y0 = qm_o.Y(0)
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0j)
+    op = x0 * y0
+    assert h == op
+
+    x1 = qm_o.X(1)
+    y1 = qm_o.Y(1)
+
+    h1 = x0 + y1
+    h2 = x1 + y0
+    h = h1 * h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.X, 1)), 1.0
+    )
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0j)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 1),), -1.0j)
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0
+    )
+    assert h == expected_h
+
+    h1 = 2.0 * x0 + y1
+    h2 = x0 + y0
+    h = h1 * h2
+
+    expected_h = qm_o.Hamiltonian()
+    expected_h.constant += 2.0
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0
+    )
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0j)
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0
+    )
+    assert h == expected_h
+
+
+def test_Hamiltonian_neg():
+    x0 = qm_o.X(0)
+    y1 = qm_o.Y(1)
+
+    h = -x0
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), -1.0)
+    assert h == expected_h
+
+    h1 = -(2.0 * x0 + y1)
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), -2.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), -1.0)
+    assert h1 == expected_h

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,110 @@
+import qamomile.core.operator as qm_o
+
+def test_pauli_operator_creation():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    assert X0.pauli == qm_o.Pauli.X
+    assert X0.index == 0
+
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    assert Y1.pauli == qm_o.Pauli.Y
+    assert Y1.index == 1
+
+    Z2 = qm_o.PauliOperator(qm_o.Pauli.Z, 2)
+    assert Z2.pauli == qm_o.Pauli.Z
+    assert Z2.index == 2
+
+# def test_multiplication_by_scalar():
+#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+#     h = qm_o.Hamiltonian()
+#     h.add_term((X0,), 2.0)
+#     op = X0 * 2.0
+#     assert h == op
+
+#     Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+#     h = qm_o.Hamiltonian()
+#     h.add_term((Y1,), 3.0)
+#     op = 3.0 * Y1
+#     assert h == op
+
+# def test_muliiplication_by_operator():
+#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+#     Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+#     h = qm_o.Hamiltonian()
+#     h.add_term((X0, Y1), 1.0)
+#     op = X0 * Y1
+#     assert h == op
+
+#     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+#     Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+#     op = X0 * Y0
+#     h = qm_o.Hamiltonian()
+#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
+#     assert h == op
+
+#     op = Y0 * X0
+#     h = qm_o.Hamiltonian()
+#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), -1.0j)
+#     assert h == op
+
+def test_pauli_multiplication():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
+    assert h == qm_o.pauli_multiplication(X0, Y0)
+
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0), ), -1.0j)
+    assert h == qm_o.pauli_multiplication(X0, Z0)
+
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0), ), 1.0j)
+    assert h == qm_o.pauli_multiplication(Y0, Z0)
+
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    h = qm_o.Hamiltonian()
+    assert h == qm_o.pauli_multiplication(X0, X0)
+
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    h = qm_o.Hamiltonian()
+    assert h == qm_o.pauli_multiplication(Y0, Y0)
+
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    h = qm_o.Hamiltonian()
+    assert h == qm_o.pauli_multiplication(Z0, Z0)
+
+def test_Hamiltonian_add():
+    h1 = qm_o.Hamiltonian()
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h2 = qm_o.Hamiltonian()
+    h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), 1.0)
+    h = h1 + h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), 1.0)
+    assert h == expected_h
+
+def test_Hamiltonian_add_scalar():
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h = h + 2.0
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    expected_h.constant = 2.0
+    assert h == expected_h
+
+    h = 2.0 + h
+    expected_h.constant += 2.0
+    assert h == expected_h
+
+# def test_Hamiltonian_multiplication():
+#     h = qm_o.Hamiltonian()
+#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+#     h = h * 2.0
+#     expected_h = qm_o.Hamiltonian()
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 2.0)
+#     assert h == expected_h

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -13,6 +13,22 @@ def test_pauli_operator_creation():
     assert Z2.pauli == qm_o.Pauli.Z
     assert Z2.index == 2
 
+def test_pauli_hamiltonian_creation():
+    x0 = qm_o.X(0)
+    _x0 = qm_o.Hamiltonian()
+    _x0.add_term((qm_o.PauliOperator(qm_o.Pauli.X,0),), 1.0)
+    assert x0 == _x0
+
+    y1 = qm_o.Y(1)
+    _y1 = qm_o.Hamiltonian()
+    _y1.add_term((qm_o.PauliOperator(qm_o.Pauli.Y,1),), 1.0)
+    assert y1 == _y1
+
+    z2 = qm_o.Z(2)
+    _z2 = qm_o.Hamiltonian()
+    _z2.add_term((qm_o.PauliOperator(qm_o.Pauli.Z,2),), 1.0)
+    assert z2 == _z2
+
 # def test_multiplication_by_scalar():
 #     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
 #     h = qm_o.Hamiltonian()
@@ -46,36 +62,40 @@ def test_pauli_operator_creation():
 #     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), -1.0j)
 #     assert h == op
 
-def test_pauli_multiplication():
+def test_multiply_pauli_same_qubit():
     X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
     Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
-    h = qm_o.Hamiltonian()
-    h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
-    assert h == qm_o.pauli_multiplication(X0, Y0)
-
-    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
     Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
-    h = qm_o.Hamiltonian()
-    h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0), ), -1.0j)
-    assert h == qm_o.pauli_multiplication(X0, Z0)
+    I0 = qm_o.PauliOperator(qm_o.Pauli.I, 0)
 
-    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
-    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
-    h = qm_o.Hamiltonian()
-    h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0), ), 1.0j)
-    assert h == qm_o.pauli_multiplication(Y0, Z0)
+    ops, phase = qm_o.multiply_pauli_same_qubit(X0, Y0)
+    assert ops == Z0
+    assert phase == 1.0j
 
-    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
-    h = qm_o.Hamiltonian()
-    assert h == qm_o.pauli_multiplication(X0, X0)
+    ops, phase = qm_o.multiply_pauli_same_qubit(X0, Z0)
+    assert ops == Y0
+    assert phase == -1.0j
 
-    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
-    h = qm_o.Hamiltonian()
-    assert h == qm_o.pauli_multiplication(Y0, Y0)
+    ops, phase = qm_o.multiply_pauli_same_qubit(Y0, Z0)
+    assert ops == X0
+    assert phase == 1.0j
 
-    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
-    h = qm_o.Hamiltonian()
-    assert h == qm_o.pauli_multiplication(Z0, Z0)
+    ops, phase = qm_o.multiply_pauli_same_qubit(X0, X0)
+    assert ops == I0
+    assert phase == 1.0
+
+    ops, phase = qm_o.multiply_pauli_same_qubit(Y0, Y0)
+    assert ops == I0
+    assert phase == 1.0
+
+    ops, phase = qm_o.multiply_pauli_same_qubit(Z0, I0)
+    assert ops == Z0
+    assert phase == 1.0
+
+    ops, phase = qm_o.multiply_pauli_same_qubit(I0, Z0)
+    assert ops == Z0
+    assert phase == 1.0
+    
 
 def test_Hamiltonian_add():
     h1 = qm_o.Hamiltonian()
@@ -101,10 +121,117 @@ def test_Hamiltonian_add_scalar():
     expected_h.constant += 2.0
     assert h == expected_h
 
+def test_Hamiltonian_scalar_multiplication():
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h = h * 2.0
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 2.0)
+    assert h == expected_h
+
+    h = 2.0 * h
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 4.0)
+    assert h == expected_h
+
 # def test_Hamiltonian_multiplication():
-#     h = qm_o.Hamiltonian()
-#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
-#     h = h * 2.0
+#     h1 = qm_o.Hamiltonian()
+#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+#     h2 = qm_o.Hamiltonian()
+#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
+#     h = h1 * h2
 #     expected_h = qm_o.Hamiltonian()
-#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 2.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
 #     assert h == expected_h
+
+#     h1 = qm_o.Hamiltonian()
+#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
+#     h2 = qm_o.Hamiltonian()
+#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
+#     h = h1 * h2
+#     expected_h = qm_o.Hamiltonian()
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 3.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 6.0)
+#     assert h == expected_h
+
+#     h1 = qm_o.Hamiltonian()
+#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+#     h1.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 2.0)
+#     h2 = qm_o.Hamiltonian()
+#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 3.0)
+#     h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 2),), 4.0)
+#     h = h1 * h2
+#     expected_h = qm_o.Hamiltonian()
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 3.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 4.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 6.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 2)), 8.0)
+#     assert h == expected_h
+
+#     x0 = qm_o.X(0)
+#     y0 = qm_o.Y(0)
+#     h = qm_o.Hamiltonian()
+#     h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0), ), 1.0j)
+#     op = x0 * y0
+#     assert h == op
+
+#     x1 = qm_o.X(1)
+#     y1 = qm_o.Y(1)
+
+#     h1 = x0 + y1
+#     h2 = x1 + y0
+#     h = h1 * h2
+#     expected_h = qm_o.Hamiltonian()
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.X, 1)), 1.0)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0j)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 1),), -1.0j)
+#     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0)
+#     assert h == expected_h
+
+#     # h1 = x0 + y1
+#     # h2 = x0 + y0
+#     # h = h1 * h2
+#     # print(h)
+#     # expected_h = qm_o.Hamiltonian()
+#     # expected_h.add_term((,), 1.0)
+#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 0)), 1.0)
+#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 1.0)
+#     # expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),qm_o.PauliOperator(qm_o.Pauli.X, 1)), 1.0)
+#     # assert h == expected_h
+
+def test_simplify_pauliop_terms():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    paulis, phase = qm_o.simplify_pauliop_terms((X0, Y1))
+    assert set(paulis) == set((X0, Y1))
+    assert phase == 1.0
+
+    paulis, phase = qm_o.simplify_pauliop_terms((X1, Y0) + (X0,))
+    assert set(paulis) == set((X1, Z0))
+    assert phase == -1.0j
+
+    paulis, coeffs = qm_o.simplify_pauliop_terms((Z0, ) +  (X0,))
+    assert set(paulis) == set((Y0,))
+    assert coeffs == 1.0j
+
+    paulis, coeffs = qm_o.simplify_pauliop_terms((X0, X0))
+    
+    assert set(paulis) == set(())
+    assert coeffs == 1.0
+
+    paulis, coeffs = qm_o.simplify_pauliop_terms((Y0, Y0, X0))
+    assert set(paulis) == set((X0,))
+    assert coeffs == 1.0
+
+    paulis, coeffs = qm_o.simplify_pauliop_terms((Y0, Y0, X0, X1, Z1))
+    assert set(paulis) == set((X0,Y1))
+    assert coeffs == -1.0j
+    
+    paulis, coeffs = qm_o.simplify_pauliop_terms(())
+    assert set(paulis) == set(())
+    assert coeffs == 1.0

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -277,6 +277,35 @@ def test_Hamiltonian_multiplication():
     )
     assert h == expected_h
 
+    h1 = 2.0 * x0 + 1.0
+    h = y1 * h1
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 1.0)
+    assert h == expected_h
+
+    h = h1 * y1
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 1.0)
+    assert h == expected_h
+
+    h = h1 * h1
+    expected_h = qm_o.Hamiltonian()
+    expected_h.constant += 5.0
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 4.0)
+    print(h.constant)
+    assert h == expected_h
+
+    h2 = 4 * y1 + 3
+    h = h1 * h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.constant += 3.0
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 8.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 6.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 4.0)
+    assert h == expected_h
+
 
 def test_Hamiltonian_neg():
     x0 = qm_o.X(0)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -280,13 +280,17 @@ def test_Hamiltonian_multiplication():
     h1 = 2.0 * x0 + 1.0
     h = y1 * h1
     expected_h = qm_o.Hamiltonian()
-    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0)
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 1), qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0
+    )
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 1.0)
     assert h == expected_h
 
     h = h1 * y1
     expected_h = qm_o.Hamiltonian()
-    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0)
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.Y, 1), qm_o.PauliOperator(qm_o.Pauli.X, 0)), 2.0
+    )
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 1.0)
     assert h == expected_h
 
@@ -294,14 +298,16 @@ def test_Hamiltonian_multiplication():
     expected_h = qm_o.Hamiltonian()
     expected_h.constant += 5.0
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 4.0)
-    print(h.constant)
+
     assert h == expected_h
 
     h2 = 4 * y1 + 3
     h = h1 * h2
     expected_h = qm_o.Hamiltonian()
     expected_h.constant += 3.0
-    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 8.0)
+    expected_h.add_term(
+        (qm_o.PauliOperator(qm_o.Pauli.X, 0), qm_o.PauliOperator(qm_o.Pauli.Y, 1)), 8.0
+    )
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 6.0)
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), 4.0)
     assert h == expected_h

--- a/tests/test_qrao.py
+++ b/tests/test_qrao.py
@@ -10,6 +10,14 @@ import qamomile.core.operator as qm_o
 
 
 def test_check_linear_term_qrao31():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    X2 = qm_o.PauliOperator(qm_o.Pauli.X, 2)
+    X3 = qm_o.PauliOperator(qm_o.Pauli.X, 3)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
+    Z2 = qm_o.PauliOperator(qm_o.Pauli.Z, 2)
+
     ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
 
     max_color_group_size = 3
@@ -24,10 +32,10 @@ def test_check_linear_term_qrao31():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
-        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
-        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
-        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
+        (X0, X1): max_color_group_size * 2.0,
+        (X0, Y1): max_color_group_size * 1.0,
+        (Y1,): np.sqrt(max_color_group_size) * 5.0,
+        (X2,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -52,13 +60,13 @@ def test_check_linear_term_qrao31():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
-        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
-        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
-        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
-        (qm_o.Y(2),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.Z(2),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.X(3),): np.sqrt(max_color_group_size) * 1.0,
+        (X0, X1): max_color_group_size * 2.0,
+        (X0, Y1): max_color_group_size * 1.0,
+        (Y1,): np.sqrt(max_color_group_size) * 5.0,
+        (X2,): np.sqrt(max_color_group_size) * 2.0,
+        (Y2,): np.sqrt(max_color_group_size) * 1.0,
+        (Z2,): np.sqrt(max_color_group_size) * 1.0,
+        (X3,): np.sqrt(max_color_group_size) * 1.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -67,6 +75,14 @@ def test_check_linear_term_qrao31():
 
 
 def test_check_linear_term_qrao21():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    X2 = qm_o.PauliOperator(qm_o.Pauli.X, 2)
+    X3 = qm_o.PauliOperator(qm_o.Pauli.X, 3)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
+    Y3 = qm_o.PauliOperator(qm_o.Pauli.Y, 3)
+
     ising = IsingModel(
         {(0, 1): 2.0, (0, 2): 1.0},
         {2: 5.0, 3: 2.0, 4: 1.0, 5: 1.0, 6: 1.0},
@@ -85,13 +101,13 @@ def test_check_linear_term_qrao21():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (qm_o.X(0), qm_o.X(1)): max_color_group_size * 2.0,
-        (qm_o.X(0), qm_o.Y(1)): max_color_group_size * 1.0,
-        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 5.0,
-        (qm_o.X(2),): np.sqrt(max_color_group_size) * 2.0,
-        (qm_o.Y(2),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.X(3),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.Y(3),): np.sqrt(max_color_group_size) * 1.0,
+        (X0, X1): max_color_group_size * 2.0,
+        (X0, Y1): max_color_group_size * 1.0,
+        (Y1,): np.sqrt(max_color_group_size) * 5.0,
+        (X2,): np.sqrt(max_color_group_size) * 2.0,
+        (Y2,): np.sqrt(max_color_group_size) * 1.0,
+        (X3,): np.sqrt(max_color_group_size) * 1.0,
+        (Y3,): np.sqrt(max_color_group_size) * 1.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -100,6 +116,13 @@ def test_check_linear_term_qrao21():
 
 
 def test_check_no_quad_term_quri():
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+
+
     ising = IsingModel({}, {0: 1.0, 1: 1.0, 2: 5.0, 3: 2.0}, 6.0)
     max_color_group_size = 3
     _, color_group = greedy_graph_coloring(
@@ -114,10 +137,10 @@ def test_check_no_quad_term_quri():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (qm_o.X(0),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.Y(0),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.Z(0),): np.sqrt(max_color_group_size) * 5.0,
-        (qm_o.X(1),): np.sqrt(max_color_group_size) * 2.0,
+        (X0,): np.sqrt(max_color_group_size) * 1.0,
+        (Y0,): np.sqrt(max_color_group_size) * 1.0,
+        (Z0,): np.sqrt(max_color_group_size) * 5.0,
+        (X1,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -138,10 +161,10 @@ def test_check_no_quad_term_quri():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (qm_o.X(0),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.Y(0),): np.sqrt(max_color_group_size) * 1.0,
-        (qm_o.X(1),): np.sqrt(max_color_group_size) * 5.0,
-        (qm_o.Y(1),): np.sqrt(max_color_group_size) * 2.0,
+        (X0,): np.sqrt(max_color_group_size) * 1.0,
+        (Y0,): np.sqrt(max_color_group_size) * 1.0,
+        (X1,): np.sqrt(max_color_group_size) * 5.0,
+        (Y1,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()


### PR DESCRIPTION
# Change
- I have introduced addition and multiplication to the `Hamiltonian`.
- The return values of `X(idx)`, `Y(idx)`, and `Z(idx)` have been changed to the `Hamiltonian` class.
- Fixed a bug in the conversion to qiskit Hamiltonian.
- I have introduced `Pauli.I`.

# Example
```python
import qamomile.core.operator as qm_o

x0 = qm_o.X(0)
h1 = 2.0 * x0 + 1.0
h = h1 * h1 # 4x0 + 5.0
expected_h = qm_o.Hamiltonian()
expected_h.constant += 5.0
expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 4.0)

assert h == expected_h
```