### PR TITLE
fix the repository link in the docs

### DIFF
--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pip install -U jupyter-book
           pip install sphinx-autoapi
-          pip install -U qamomile
+          pip install -U qamomile[qiskit, quri-parts]
       - name: Build the book
         run: |
           cd docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,7 +27,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
+  url: https://github.com/Jij-Inc/Qamomile  # Online location of your book
   path_to_book: docs  # Optional path to your book, relative to the repository root
   branch: master  # Which branch of the repository should be used when creating links (optional)
 


### PR DESCRIPTION
# Change
The github link on the Document site was still pointing to the jupyter book, so I changed it to point to Qamomile.
And also, fix the installation of qamomile.