### PR TITLE
Fixing the order of operators when creating a QRAO Hamiltonian

### DIFF
--- a/qamomile/core/converters/qrao/qrao31.py
+++ b/qamomile/core/converters/qrao/qrao31.py
@@ -20,14 +20,15 @@ def color_group_to_qrac_encode(
 
     Examples:
         >>> color_group = {0: [0, 1, 2], 1: [3, 4], 2: [6,]}
-        >>> color_group_for_qrac_encode(color_group)
-        {0: (0, <Pauli.Z: 3>), 1: (0, <Pauli.X: 1>), 2: (0, <Pauli.Y: 2>), 3: (1, <Pauli.Z: 3>), 4: (1, <Pauli.X: 1>), 6: (2, <Pauli.Z: 3>)}
+        >>> color_group_to_qrac_encode(color_group)
+        {0: Z0, 1: X0, 2: Y0, 3: Z1, 4: X1, 6: Z2}
 
     """
     qrac31 = {}
+    paulis = [qm_o.Pauli.Z, qm_o.Pauli.X, qm_o.Pauli.Y]
     for color, group in color_group.items():
         for ope_idx, bit_index in enumerate(group):
-            qrac31[bit_index] = qm_o.PauliOperator(qm_o.Pauli(ope_idx), color)
+            qrac31[bit_index] = qm_o.PauliOperator(paulis[ope_idx], color)
     return qrac31
 
 

--- a/tests/test_qrao.py
+++ b/tests/test_qrao.py
@@ -10,13 +10,13 @@ import qamomile.core.operator as qm_o
 
 
 def test_check_linear_term_qrao31():
-    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
     X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
     X2 = qm_o.PauliOperator(qm_o.Pauli.X, 2)
-    X3 = qm_o.PauliOperator(qm_o.Pauli.X, 3)
-    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
     Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
     Z2 = qm_o.PauliOperator(qm_o.Pauli.Z, 2)
+    Z3 = qm_o.PauliOperator(qm_o.Pauli.Z, 3)
 
     ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
 
@@ -32,10 +32,10 @@ def test_check_linear_term_qrao31():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (X0, X1): max_color_group_size * 2.0,
-        (X0, Y1): max_color_group_size * 1.0,
-        (Y1,): np.sqrt(max_color_group_size) * 5.0,
-        (X2,): np.sqrt(max_color_group_size) * 2.0,
+        (Z0, Z1): max_color_group_size * 2.0,
+        (Z0, X1): max_color_group_size * 1.0,
+        (X1,): np.sqrt(max_color_group_size) * 5.0,
+        (Z2,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -60,13 +60,13 @@ def test_check_linear_term_qrao31():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (X0, X1): max_color_group_size * 2.0,
-        (X0, Y1): max_color_group_size * 1.0,
-        (Y1,): np.sqrt(max_color_group_size) * 5.0,
-        (X2,): np.sqrt(max_color_group_size) * 2.0,
+        (Z0, Z1): max_color_group_size * 2.0,
+        (Z0, X1): max_color_group_size * 1.0,
+        (X1,): np.sqrt(max_color_group_size) * 5.0,
+        (Z2,): np.sqrt(max_color_group_size) * 2.0,
+        (X2,): np.sqrt(max_color_group_size) * 1.0,
         (Y2,): np.sqrt(max_color_group_size) * 1.0,
-        (Z2,): np.sqrt(max_color_group_size) * 1.0,
-        (X3,): np.sqrt(max_color_group_size) * 1.0,
+        (Z3,): np.sqrt(max_color_group_size) * 1.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -75,13 +75,13 @@ def test_check_linear_term_qrao31():
 
 
 def test_check_linear_term_qrao21():
-    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
     X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
     X2 = qm_o.PauliOperator(qm_o.Pauli.X, 2)
     X3 = qm_o.PauliOperator(qm_o.Pauli.X, 3)
-    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
-    Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
-    Y3 = qm_o.PauliOperator(qm_o.Pauli.Y, 3)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    Z2 = qm_o.PauliOperator(qm_o.Pauli.Z, 2)
+    Z3 = qm_o.PauliOperator(qm_o.Pauli.Z, 3)
 
     ising = IsingModel(
         {(0, 1): 2.0, (0, 2): 1.0},
@@ -101,13 +101,13 @@ def test_check_linear_term_qrao21():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
-        (X0, X1): max_color_group_size * 2.0,
-        (X0, Y1): max_color_group_size * 1.0,
-        (Y1,): np.sqrt(max_color_group_size) * 5.0,
-        (X2,): np.sqrt(max_color_group_size) * 2.0,
-        (Y2,): np.sqrt(max_color_group_size) * 1.0,
+        (Z0, Z1): max_color_group_size * 2.0,
+        (Z0, X1): max_color_group_size * 1.0,
+        (X1,): np.sqrt(max_color_group_size) * 5.0,
+        (Z2,): np.sqrt(max_color_group_size) * 2.0,
+        (X2,): np.sqrt(max_color_group_size) * 1.0,
+        (Z3,): np.sqrt(max_color_group_size) * 1.0,
         (X3,): np.sqrt(max_color_group_size) * 1.0,
-        (Y3,): np.sqrt(max_color_group_size) * 1.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -121,6 +121,7 @@ def test_check_no_quad_term_quri():
     Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
     Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
     Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
 
 
     ising = IsingModel({}, {0: 1.0, 1: 1.0, 2: 5.0, 3: 2.0}, 6.0)
@@ -137,10 +138,10 @@ def test_check_no_quad_term_quri():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
+        (Z0,): np.sqrt(max_color_group_size) * 1.0,
         (X0,): np.sqrt(max_color_group_size) * 1.0,
-        (Y0,): np.sqrt(max_color_group_size) * 1.0,
-        (Z0,): np.sqrt(max_color_group_size) * 5.0,
-        (X1,): np.sqrt(max_color_group_size) * 2.0,
+        (Y0,): np.sqrt(max_color_group_size) * 5.0,
+        (Z1,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()
@@ -161,10 +162,10 @@ def test_check_no_quad_term_quri():
     num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
 
     expected_hamiltonian = {
+        (Z0,): np.sqrt(max_color_group_size) * 1.0,
         (X0,): np.sqrt(max_color_group_size) * 1.0,
-        (Y0,): np.sqrt(max_color_group_size) * 1.0,
-        (X1,): np.sqrt(max_color_group_size) * 5.0,
-        (Y1,): np.sqrt(max_color_group_size) * 2.0,
+        (Z1,): np.sqrt(max_color_group_size) * 5.0,
+        (X1,): np.sqrt(max_color_group_size) * 2.0,
     }
     assert len(qrac_hamiltonian.terms) == num_terms
     assert qrac_hamiltonian.num_qubits < ising.num_bits()


### PR DESCRIPTION
# Change
When creating the Hamiltonian for QRAO, the order used was X, Y, Z, so the operators used in (2,1)-QRAO were X and Y, which was different from the paper.
To fix this, the order of the operators used was changed to Z, X, Y, and it was made consistent with the paper.
In addition, the documentation was also incorrect, so it was corrected.