### PR TITLE
add (3,2)-QRAO

### DIFF
--- a/qamomile/core/converters/qrao/qrao32.py
+++ b/qamomile/core/converters/qrao/qrao32.py
@@ -8,6 +8,18 @@ from .qrao31 import color_group_to_qrac_encode
 from .graph_coloring import greedy_graph_coloring, check_linear_term
 
 def create_x_prime(idx: int) -> qm_o.PauliOperator:
+    """
+    Creates a X' operator for the given index.
+
+    .. math::
+            X' = \frac{1}{2}X_1X_2 + \frac{1}{2}X_1Z_2 + Z_1I_2
+
+    Parameters:
+    idx (int): The index of the first qubit.
+
+    Returns:
+    qm_o.PauliOperator: The X' operator for the given index.
+    """
     Xi0 = qm_o.X(idx)
     Xi1 = qm_o.X(idx + 1)
     Zi0 = qm_o.Z(idx)
@@ -15,6 +27,18 @@ def create_x_prime(idx: int) -> qm_o.PauliOperator:
     return 1 / 2 * (Xi0 * Xi1) + 1 / 2 * (Xi0 * Zi1) + Zi0
 
 def create_y_prime(idx: int) -> qm_o.Hamiltonian:
+    """
+    Creates a Y' operator for the given index.
+
+    .. math::
+            Y' = \frac{1}{2}I_1X_2 + I_1Z_2 + \frac{1}{2}Y_1Y_2
+
+    Parameters:
+    idx (int): The index of the first qubit.
+
+    Returns:
+    qm_o.PauliOperator: The Y' operator for the given index.
+    """
     Xi1 = qm_o.X(idx + 1)
     Zi1 = qm_o.Z(idx + 1)
     Yi0 = qm_o.Y(idx)
@@ -23,6 +47,18 @@ def create_y_prime(idx: int) -> qm_o.Hamiltonian:
 
 
 def create_z_prime(idx: int) -> qm_o.Hamiltonian:
+    """
+    Creates a Z' operator for the given index.
+
+    .. math::
+            Z' = Z_1Z_2 - \frac{1}{2}X_1I_2 - \frac{1}{2}Z_1X_2
+
+    Parameters:
+    idx (int): The index of the first qubit.
+
+    Returns:
+    qm_o.PauliOperator: The Z' operator for the given index.
+    """
     Xi0 = qm_o.X(idx)
     Xi1 = qm_o.X(idx + 1)
     Zi0 = qm_o.Z(idx)

--- a/qamomile/core/converters/qrao/qrao32.py
+++ b/qamomile/core/converters/qrao/qrao32.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+import typing as typ
+import numpy as np
+from qamomile.core.converters.converter import QuantumConverter
+from qamomile.core.ising_qubo import IsingModel
+import qamomile.core.operator as qm_o
+from .qrao31 import color_group_to_qrac_encode
+from .graph_coloring import greedy_graph_coloring, check_linear_term
+
+def create_x_prime(idx: int) -> qm_o.PauliOperator:
+    Xi0 = qm_o.X(idx)
+    Xi1 = qm_o.X(idx + 1)
+    Zi0 = qm_o.Z(idx)
+    Zi1 = qm_o.Z(idx + 1)
+    return 1 / 2 * (Xi0 * Xi1) + 1 / 2 * (Xi0 * Zi1) + Zi0
+
+def create_y_prime(idx: int) -> qm_o.Hamiltonian:
+    Xi1 = qm_o.X(idx + 1)
+    Zi1 = qm_o.Z(idx + 1)
+    Yi0 = qm_o.Y(idx)
+    Yi1 = qm_o.Y(idx + 1)
+    return 1 / 2 * Xi1 + Zi1 + 1 / 2 * (Yi0 * Yi1)
+
+
+def create_z_prime(idx: int) -> qm_o.Hamiltonian:
+    Xi0 = qm_o.X(idx)
+    Xi1 = qm_o.X(idx + 1)
+    Zi0 = qm_o.Z(idx)
+    Zi1 = qm_o.Z(idx + 1)
+    return Zi0 * Zi1 - 1 / 2 * Xi0 - 1 / 2 * (Zi0 * Xi1)
+
+def create_prime_operator(pauli_op: qm_o.PauliOperator) -> qm_o.Hamiltonian:
+    if pauli_op.pauli == qm_o.Pauli.X:
+        return create_x_prime(2 * pauli_op.index)
+    elif pauli_op.pauli == qm_o.Pauli.Y:
+        return create_y_prime(2 * pauli_op.index)
+    elif pauli_op.pauli == qm_o.Pauli.Z:
+        return create_z_prime(2 * pauli_op.index)
+    else:
+        raise ValueError("Invalid Pauli operator")
+
+def qrac32_encode_ising(
+    ising: IsingModel, color_group: dict[int, list[int]]
+) -> tuple[qm_o.Hamiltonian, dict[int, qm_o.PauliOperator]]:
+    encoded_ope = color_group_to_qrac_encode(color_group)
+
+    offset = ising.constant
+
+    hamiltonian = qm_o.Hamiltonian()
+    hamiltonian.constant = offset
+
+    # convert linear parts of the objective function into Hamiltonian.
+    for idx, coeff in ising.linear.items():
+        if coeff == 0.0:
+            continue
+
+        pauli = encoded_ope[idx]
+        prime_i = create_prime_operator(pauli)
+        hamiltonian += coeff * prime_i
+
+    # create quad terms
+    for (i, j), coeff in ising.quad.items():
+        if coeff == 0.0:
+            continue
+
+        if i == j:
+            hamiltonian.constant += coeff
+            continue
+
+        pauli_i = encoded_ope[i]
+        prime_i = create_prime_operator(pauli_i)
+
+        pauli_j = encoded_ope[j]
+        prime_j = create_prime_operator(pauli_j)
+
+        hamiltonian += coeff * prime_i * prime_j
+
+    return hamiltonian, encoded_ope
+
+class QRAC32Converter(QuantumConverter):
+
+    max_color_group_size = 3
+
+    def ising_encode(
+        self,
+        multipliers: typ.Optional[dict[str, float]] = None,
+        detail_parameters: typ.Optional[dict[str, dict[tuple[int, ...], tuple[float, float]]]] = None
+    ) -> IsingModel:
+        ising = super().ising_encode(multipliers, detail_parameters)
+
+        _, color_group = greedy_graph_coloring(
+            ising.quad.keys(),
+            self.max_color_group_size
+        )
+        color_group = check_linear_term(
+            color_group, list(ising.linear.keys()), self.max_color_group_size
+        )
+
+        self.color_group = color_group
+        return ising
+
+    def get_cost_hamiltonian(self) -> qm_o.Hamiltonian:
+        """
+        Construct the cost Hamiltonian for QRAC32.
+
+        Returns:
+            qm_o.Hamiltonian: The cost Hamiltonian.
+        """
+        ising = self.get_ising()
+
+        hamiltonian, pauli_encoding = qrac32_encode_ising(ising, self.color_group)
+        self.pauli_encoding = pauli_encoding
+        return hamiltonian
+
+    def get_encoded_pauli_list(self) -> list[qm_o.Hamiltonian]:
+        # return the encoded Pauli operators as list
+        ising = self.get_ising()
+        num_qubits = len(self.color_group)
+        zero_pauli = qm_o.Hamiltonian(num_qubits=num_qubits * 2)
+        pauli_operators = [zero_pauli] * ising.num_bits()
+        for idx, pauli in self.pauli_encoding.items():
+            observable = create_prime_operator(pauli)
+            pauli_operators[idx] = observable
+        return pauli_operators

--- a/qamomile/core/converters/qrao/qrao32.py
+++ b/qamomile/core/converters/qrao/qrao32.py
@@ -12,7 +12,7 @@ def create_x_prime(idx: int) -> qm_o.PauliOperator:
     Creates a X' operator for the given index.
 
     .. math::
-            X' = \frac{1}{2}X_1X_2 + \frac{1}{2}X_1Z_2 + Z_1I_2
+            X' = \\frac{1}{2}X_1X_2 + \\frac{1}{2}X_1Z_2 + Z_1I_2
 
     Parameters:
     idx (int): The index of the first qubit.
@@ -31,7 +31,7 @@ def create_y_prime(idx: int) -> qm_o.Hamiltonian:
     Creates a Y' operator for the given index.
 
     .. math::
-            Y' = \frac{1}{2}I_1X_2 + I_1Z_2 + \frac{1}{2}Y_1Y_2
+            Y' = \\frac{1}{2}I_1X_2 + I_1Z_2 + \\frac{1}{2}Y_1Y_2
 
     Parameters:
     idx (int): The index of the first qubit.
@@ -51,7 +51,7 @@ def create_z_prime(idx: int) -> qm_o.Hamiltonian:
     Creates a Z' operator for the given index.
 
     .. math::
-            Z' = Z_1Z_2 - \frac{1}{2}X_1I_2 - \frac{1}{2}Z_1X_2
+            Z' = Z_1Z_2 - \\frac{1}{2}X_1I_2 - \\frac{1}{2}Z_1X_2
 
     Parameters:
     idx (int): The index of the first qubit.

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -223,6 +223,12 @@ class Hamiltonian:
 
     def __radd__(self, other):
         return self.__add__(other)
+    
+    def __sub__(self, other):
+        return self + (-1.0 * other)
+    
+    def __rsub__(self, other):
+        return -1.0 * self + other
 
     def __mul__(self, other):
         if isinstance(other, (int, float, complex)):

--- a/tests/test_32qrao.py
+++ b/tests/test_32qrao.py
@@ -1,0 +1,107 @@
+import numpy as np
+import jijmodeling as jm
+import jijmodeling_transpiler.core as jmt
+from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.converters.qrao.qrao32 import create_x_prime, create_y_prime, create_z_prime, qrac32_encode_ising, create_prime_operator,QRAC32Converter
+import qamomile.core.operator as qm_o
+from qamomile.core.converters.qrao.graph_coloring import (
+    greedy_graph_coloring,
+    check_linear_term,
+)
+
+def test_create_x_prime():
+    X_prime = create_x_prime(0)
+
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    expected = qm_o.Hamiltonian()
+    expected.add_term((X0,X1), 1 / 2)
+    expected.add_term((X0,Z1), 1 / 2)
+    expected.add_term((Z0,), 1)
+    assert X_prime == expected
+
+def test_create_y_prime():
+    Y_prime = create_y_prime(0)
+
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    Y0 = qm_o.PauliOperator(qm_o.Pauli.Y, 0)
+    Y1 = qm_o.PauliOperator(qm_o.Pauli.Y, 1)
+    expected = qm_o.Hamiltonian()
+    expected.add_term((X1,), 1 / 2)
+    expected.add_term((Z1,), 1)
+    expected.add_term((Y0,Y1), 1 / 2)
+    assert Y_prime == expected
+
+def test_create_z_prime():
+    Z_prime = create_z_prime(0)
+
+    X0 = qm_o.PauliOperator(qm_o.Pauli.X, 0)
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    expected = qm_o.Hamiltonian()
+    expected.add_term((Z0,Z1), 1)
+    expected.add_term((X0,), -1 / 2)
+    expected.add_term((Z0,X1), -1 / 2)
+    assert Z_prime == expected
+
+def test_qrac32_encode_ising():
+    X1 = qm_o.PauliOperator(qm_o.Pauli.X, 1)
+    X2 = qm_o.PauliOperator(qm_o.Pauli.X, 2)
+    Y2 = qm_o.PauliOperator(qm_o.Pauli.Y, 2)
+    Z0 = qm_o.PauliOperator(qm_o.Pauli.Z, 0)
+    Z1 = qm_o.PauliOperator(qm_o.Pauli.Z, 1)
+    Z2 = qm_o.PauliOperator(qm_o.Pauli.Z, 2)
+    Z3 = qm_o.PauliOperator(qm_o.Pauli.Z, 3)
+
+    ising = IsingModel({(0, 1): 2.0, (0, 2): 1.0}, {2: 5.0, 3: 2.0}, 6.0)
+
+    max_color_group_size = 3
+    _, color_group = greedy_graph_coloring(
+        ising.quad.keys(), max_color_group_size=max_color_group_size
+    )
+    color_group = check_linear_term(
+        color_group, ising.linear.keys(), max_color_group_size
+    )
+
+    qrac_hamiltonian, encoding = qrac32_encode_ising(ising, color_group)
+    num_terms = len(ising.linear.keys()) + len(ising.quad.keys())
+
+    expected_hamiltonian = qm_o.Hamiltonian()
+    expected_hamiltonian.constant = 6.0
+    Z0_prime = create_prime_operator(Z0)
+    Z1_prime = create_prime_operator(Z1)
+    Z2_prime = create_prime_operator(Z2)
+    X1_prime = create_prime_operator(X1)
+
+    expected_hamiltonian += 2.0 * Z0_prime * Z1_prime
+    expected_hamiltonian += 1.0 * Z0_prime * X1_prime
+    expected_hamiltonian += 5.0 * X1_prime
+    expected_hamiltonian += 2.0 * Z2_prime
+    # expected_hamiltonian = {
+    #     (Z0, Z1): max_color_group_size * 2.0,
+    #     (Z0, X1): max_color_group_size * 1.0,
+    #     (X1,): np.sqrt(max_color_group_size) * 5.0,
+    #     (Z2,): np.sqrt(max_color_group_size) * 2.0,
+    # }
+
+    assert len(encoding) == ising.num_bits()
+    assert qrac_hamiltonian == expected_hamiltonian
+
+def test_QRAC32Converter():
+    problem = jm.Problem("sample")
+    x = jm.BinaryVar("x", shape = (3,))
+    problem += x[1] * x[2] + x[0]
+    compiled_instance = jmt.compile_model(problem, {})
+
+    converter = QRAC32Converter(compiled_instance)
+
+    # Test get_cost_hamiltonian method
+    cost_hamiltonian = converter.get_cost_hamiltonian()
+
+    pauli_list = converter.get_encoded_pauli_list()
+    print(pauli_list)
+    assert len(pauli_list) == 3

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -39,7 +39,7 @@ def test_add_term():
     h.add_term((X0, Y0), -4.0)
     assert h.terms == {(X0,): 2.0, (Y1, Y2): 3.0, (Z0,): -4.0j}
     assert h.constant == -1.0
-
+    
 
 def test_pauli_hamiltonian_creation():
     x0 = qm_o.X(0)
@@ -118,6 +118,28 @@ def test_Hamiltonian_add_scalar():
     expected_h.constant += 2.0
     assert h == expected_h
 
+def test_Hamiltonian_sub():
+    h1 = qm_o.Hamiltonian()
+    h1.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    h2 = qm_o.Hamiltonian()
+    h2.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), 1.0)
+    h = h1 - h2
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), -1.0)
+    assert h == expected_h
+
+    h = h1 - 2.0
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), 1.0)
+    expected_h.constant = -2.0
+    assert h == expected_h
+
+    h = 2.0 - h1
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), -1.0)
+    expected_h.constant = 2.0
+    assert h == expected_h
 
 def test_Hamiltonian_scalar_multiplication():
     h = qm_o.Hamiltonian()


### PR DESCRIPTION
# Change
I have implemented Space Efficient QRAO.
And, add `__sub__` for `Hamiltonian`

# Example
```python
import jijmodeling as jm
import jijmodeling_transpiler.core as jmt
from qamomile.core.converters.qrao.qrao32 import QRAC32Converter

problem = jm.Problem("sample")
x = jm.BinaryVar("x", shape = (3,))
problem += x[1] * x[2] + x[0]
compiled_instance = jmt.compile_model(problem, {})

converter = QRAC32Converter(compiled_instance)
cost_hamiltonian = converter.get_cost_hamiltonian()
pauli_list = converter.get_encoded_pauli_list()

```