### PR TITLE
Set Default `simplify` to False in `qubo_to_ising`

### DIFF
--- a/qamomile/core/bitssample.py
+++ b/qamomile/core/bitssample.py
@@ -84,6 +84,7 @@ class BitsSampleSet:
             # Convert the integer to a bit array of the specified length
             bitarray = list(map(int, bin(int_value)[2:].zfill(bit_length)[::-1]))
             bitarrays.append(BitsSample(count, bitarray))
+
         return cls(bitarrays)
 
     def get_most_common(self, n: int = 1) -> list[BitsSample]:

--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -126,7 +126,7 @@ class QuantumConverter(abc.ABC):
         qubo, constant = self.pubo_builder.get_qubo_dict(
             multipliers=multipliers, detail_parameters=detail_parameters
         )
-        ising = qubo_to_ising(qubo, simplify=True)
+        ising = qubo_to_ising(qubo, simplify=False)
         ising.constant += constant
 
         var_map = self.compiled_instance.var_map.var_map
@@ -237,6 +237,7 @@ def decode_from_dict_binary_result(
             inverse_varmap[index] = (label, forall)
 
     decoded_samples = binary_decode(samples, binary_encoder, inverse_varmap)
+
     record = dict_to_record(decoded_samples, compiled_model)
 
     evaluation = _evaluate(decoded_samples, compiled_model)

--- a/qamomile/core/converters/qaoa.py
+++ b/qamomile/core/converters/qaoa.py
@@ -65,12 +65,12 @@ class QAOAConverter(QuantumConverter):
 
         # Apply RZ gates for linear terms
         for i, hi in ising.linear.items():
-            if hi != 0:
+            if hi != 0.0:
                 cost.rz(2 * hi * beta, i)
 
         # Apply CNOT and RZ gates for quadratic terms
         for (i, j), Jij in ising.quad.items():
-            if Jij != 0:
+            if Jij != 0.0:
                 cost.rzz(2 * Jij * beta, i, j)
 
         cost.update_qubits_label(self.int2varlabel)
@@ -128,11 +128,19 @@ class QAOAConverter(QuantumConverter):
 
         # Add linear terms
         for i, hi in ising.linear.items():
-            hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z ,i),), hi)
+            if hi != 0.0:
+                hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, i),), hi)
 
         # Add quadratic terms
         for (i, j), Jij in ising.quad.items():
-            hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z ,i), qm_o.PauliOperator(qm_o.Pauli.Z ,j)), Jij)
+            if Jij != 0.0:
+                hamiltonian.add_term(
+                    (
+                        qm_o.PauliOperator(qm_o.Pauli.Z, i),
+                        qm_o.PauliOperator(qm_o.Pauli.Z, j),
+                    ),
+                    Jij,
+                )
 
         hamiltonian.constant = ising.constant
         return hamiltonian

--- a/qamomile/core/ising_qubo.py
+++ b/qamomile/core/ising_qubo.py
@@ -52,7 +52,7 @@ def calc_qubo_energy(qubo: dict[tuple[int, int], float], state: list[int]) -> fl
 
 
 def qubo_to_ising(
-    qubo: dict[tuple[int, int], float], constant: float = 0.0, simplify=True
+    qubo: dict[tuple[int, int], float], constant: float = 0.0, simplify=False
 ) -> IsingModel:
     r"""Converts a Quadratic Unconstrained Binary Optimization (QUBO) problem to an equivalent Ising model.
 

--- a/tests/qiskit/test_transpiler.py
+++ b/tests/qiskit/test_transpiler.py
@@ -47,13 +47,63 @@ def graph_coloring_instance():
     return instance_data
 
 def create_graph_coloring_operator_ansatz_initial_state(
-    compiled_instance: jmt.CompiledInstance, num_nodes: int, num_color: int
+    compiled_instance: jmt.CompiledInstance,
+    num_nodes: int,
+    num_color: int,
+    apply_vars: tuple[int, int],
 ):
     n = num_color * num_nodes
     qc = QamomileCircuit(n)
     var_map = compiled_instance.var_map.var_map["x"]
+    for pos in apply_vars:
+        qc.x(var_map[pos])  # set all nodes to color 0
+    return qc
+
+
+def tsp_problem() -> jm.Problem:
+    N = jm.Placeholder("N")
+    D = jm.Placeholder("d", ndim=2)
+    start = jm.Placeholder("start", latex="N-1")
+    x = jm.BinaryVar("x", shape=(N - 1, N - 1))
+    t = jm.Element("t", belong_to=N - 2)
+    j = jm.Element("j", belong_to=N - 1)
+    u = jm.Element("u", belong_to=(0, N - 1))
+    v = jm.Element("v", belong_to=(0, N - 1))
+
+    problem = jm.Problem("TSP")
+    problem += jm.sum(u, D[start][u] * (x[0][u] + x[N - 2][u])) + jm.sum(
+        t, jm.sum(u, jm.sum(v, D[u][v] * x[t][u] * x[t + 1][v]))
+    )
+
+    return problem
+
+
+def tsp_instance():
+    N = 5
+    np.random.seed(3)
+
+    x_pos = np.random.rand(N)
+    y_pos = np.random.rand(N)
+
+    d = [[0] * N for _ in range(N)]
+    for i in range(N):
+        for j in range(N):
+            d[i][j] = np.sqrt((x_pos[i] - x_pos[j]) ** 2 + (y_pos[i] - y_pos[j]) ** 2)
+
+    instance_data = {"N": N, "d": d, "start": N - 1}
+    return instance_data
+
+
+def create_tsp_initial_state(
+    compiled_instance: jmt.CompiledInstance, num_nodes: int = 4
+):
+    n = num_nodes * num_nodes
+    qc = qm.circuit.QuantumCircuit(n)
+    var_map = compiled_instance.var_map.var_map["x"]
+
     for i in range(num_nodes):
-        qc.x(var_map[(i, 0)])  # set all nodes to color 0
+        qc.x(var_map[(i, i)])
+
     return qc
 
 @pytest.fixture
@@ -159,7 +209,8 @@ def test_coloring_sample_decode():
     problem = graph_coloring_problem()
     instance_data = graph_coloring_instance()
     compiled_instance = jmt.compile_model(problem, instance_data)
-    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(compiled_instance, instance_data['V'], instance_data['N'])
+    apply_vars = [(0, 0), (1, 0), (2, 0), (3, 0)]
+    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(compiled_instance, instance_data['V'], instance_data['N'], apply_vars)
     qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
     qaoa_converter.ising_encode(multipliers={"one-color": 1})
     
@@ -176,3 +227,29 @@ def test_coloring_sample_decode():
     assert sampleset[0].num_occurrences == 1024
 
     
+def test_tsp_decode():
+    problem = tsp_problem()
+    instance_data = tsp_instance()
+    compiled_instance = jmt.compile_model(problem, instance_data)
+
+    qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
+    qaoa_converter.ising_encode(multipliers={"one-color": 1})
+    initial_circuit = create_tsp_initial_state(compiled_instance)
+
+    qk_transpiler = QiskitTranspiler()
+    sampler = qk_pr.StatevectorSampler()
+    qk_circ = qk_transpiler.transpile_circuit(initial_circuit)
+    qk_circ.measure_all()
+    job = sampler.run([qk_circ])
+    
+    job_result = job.result()
+    
+    sampleset = qaoa_converter.decode(qk_transpiler, job_result[0].data['meas'])
+
+    assert sampleset[0].var_values["x"].values == {
+        (0, 0): 1,
+        (1, 1): 1,
+        (2, 2): 1,
+        (3, 3): 1,
+    }
+    assert sampleset[0].num_occurrences == 1024

--- a/tests/quri_parts/test_quri_parameter_converter.py
+++ b/tests/quri_parts/test_quri_parameter_converter.py
@@ -70,7 +70,7 @@ def test_convert_binary_operator_div():
 
     assert isinstance(result, dict)
     assert len(result) == 1
-    print(result)
+  
     assert result[quri_param] == 0.5
 
 

--- a/tests/quri_parts/test_quri_transpiler.py
+++ b/tests/quri_parts/test_quri_transpiler.py
@@ -14,6 +14,7 @@ import qamomile.core as qm
 from qamomile.core.converters.qaoa import QAOAConverter
 from qamomile.quri_parts.transpiler import QuriPartsTranspiler
 
+
 def graph_coloring_problem() -> jm.Problem:
     # define variables
     V = jm.Placeholder("V")
@@ -27,11 +28,12 @@ def graph_coloring_problem() -> jm.Problem:
     problem = jm.Problem("Graph Coloring")
     # set one-hot constraint that each vertex has only one color
 
-    #problem += jm.Constraint("one-color", x[v, :].sum() == 1, forall=v)
+    # problem += jm.Constraint("one-color", x[v, :].sum() == 1, forall=v)
     problem += jm.Constraint("one-color", jm.sum(n, x[v, n]) == 1, forall=v)
     # set objective function: minimize edges whose vertices connected by edges are the same color
     problem += jm.sum([n, e], x[e[0], n] * x[e[1], n])
     return problem
+
 
 def graph_coloring_instance():
     G = nx.Graph()
@@ -43,15 +45,67 @@ def graph_coloring_instance():
     instance_data = {"V": num_nodes, "N": num_color, "E": E}
     return instance_data
 
+
 def create_graph_coloring_operator_ansatz_initial_state(
-    compiled_instance: jmt.CompiledInstance, num_nodes: int, num_color: int
+    compiled_instance: jmt.CompiledInstance,
+    num_nodes: int,
+    num_color: int,
+    apply_vars: tuple[int, int],
 ):
     n = num_color * num_nodes
     qc = qm_c.QuantumCircuit(n)
     var_map = compiled_instance.var_map.var_map["x"]
-    for i in range(num_nodes):
-        qc.x(var_map[(i, 0)])  # set all nodes to color 0
+    for pos in apply_vars:
+        qc.x(var_map[pos])  # set all nodes to color 0
     return qc
+
+
+def tsp_problem() -> jm.Problem:
+    N = jm.Placeholder("N")
+    D = jm.Placeholder("d", ndim=2)
+    start = jm.Placeholder("start", latex="N-1")
+    x = jm.BinaryVar("x", shape=(N - 1, N - 1))
+    t = jm.Element("t", belong_to=N - 2)
+    j = jm.Element("j", belong_to=N - 1)
+    u = jm.Element("u", belong_to=(0, N - 1))
+    v = jm.Element("v", belong_to=(0, N - 1))
+
+    problem = jm.Problem("TSP")
+    problem += jm.sum(u, D[start][u] * (x[0][u] + x[N - 2][u])) + jm.sum(
+        t, jm.sum(u, jm.sum(v, D[u][v] * x[t][u] * x[t + 1][v]))
+    )
+
+    return problem
+
+
+def tsp_instance():
+    N = 5
+    np.random.seed(3)
+
+    x_pos = np.random.rand(N)
+    y_pos = np.random.rand(N)
+
+    d = [[0] * N for _ in range(N)]
+    for i in range(N):
+        for j in range(N):
+            d[i][j] = np.sqrt((x_pos[i] - x_pos[j]) ** 2 + (y_pos[i] - y_pos[j]) ** 2)
+
+    instance_data = {"N": N, "d": d, "start": N - 1}
+    return instance_data
+
+
+def create_tsp_initial_state(
+    compiled_instance: jmt.CompiledInstance, num_nodes: int = 4
+):
+    n = num_nodes * num_nodes
+    qc = qm.circuit.QuantumCircuit(n)
+    var_map = compiled_instance.var_map.var_map["x"]
+
+    for i in range(num_nodes):
+        qc.x(var_map[(i, i)])
+
+    return qc
+
 
 @pytest.fixture
 def transpiler():
@@ -161,9 +215,9 @@ def test_qaoa_circuit():
     import jijmodeling as jm
     import jijmodeling_transpiler.core as jmt
 
-    x = jm.BinaryVar("x", shape=(3, ))
+    x = jm.BinaryVar("x", shape=(3,))
     problem = jm.Problem("qubo")
-    problem += -x[0]*x[1] + x[1]*x[2] + x[2]*x[0]
+    problem += -x[0] * x[1] + x[1] * x[2] + x[2] * x[0]
 
     compiled_instance = jmt.compile_model(problem, {})
     qaoa_converter = QAOAConverter(compiled_instance)
@@ -176,19 +230,98 @@ def test_qaoa_circuit():
     assert qp_circuit.qubit_count == 3
     assert qp_circuit.parameter_count == 4
 
+
 def test_coloring_sample_decode():
     problem = graph_coloring_problem()
     instance_data = graph_coloring_instance()
     compiled_instance = jmt.compile_model(problem, instance_data)
-    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(compiled_instance, instance_data['V'], instance_data['N'])
+    apply_vars = [(0, 0), (1, 0), (2, 0), (3, 0)]
+    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(
+        compiled_instance, instance_data["V"], instance_data["N"], apply_vars
+    )
     qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
     qaoa_converter.ising_encode(multipliers={"one-color": 1})
-    
+
     qp_transpiler = QuriPartsTranspiler()
     sampler = create_qulacs_vector_sampler()
     qp_circ = qp_transpiler.transpile_circuit(initial_circuit)
     qp_result = sampler(qp_circ, 10)
-    
-    sampleset = qaoa_converter.decode(qp_transpiler, (qp_result, initial_circuit.num_qubits))
-    assert sampleset[0].var_values["x"].values == {(0, 0): 1, (1, 0): 1, (2, 0): 1, (3, 0): 1}
+
+    sampleset = qaoa_converter.decode(
+        qp_transpiler, (qp_result, initial_circuit.num_qubits)
+    )
+    assert sampleset[0].var_values["x"].values == {
+        (0, 0): 1,
+        (1, 0): 1,
+        (2, 0): 1,
+        (3, 0): 1,
+    }
+    assert sampleset[0].num_occurrences == 10
+
+    apply_vars = [(0, 0), (1, 1), (2, 2)]
+    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(
+        compiled_instance, instance_data["V"], instance_data["N"], apply_vars
+    )
+    qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
+    qaoa_converter.ising_encode(multipliers={"one-color": 1})
+
+    qp_transpiler = QuriPartsTranspiler()
+    sampler = create_qulacs_vector_sampler()
+    qp_circ = qp_transpiler.transpile_circuit(initial_circuit)
+    qp_result = sampler(qp_circ, 10)
+
+    sampleset = qaoa_converter.decode(
+        qp_transpiler, (qp_result, initial_circuit.num_qubits)
+    )
+    assert sampleset[0].var_values["x"].values == {(0, 0): 1, (1, 1): 1, (2, 2): 1}
+    assert sampleset[0].num_occurrences == 10
+
+    apply_vars = [(0, 0), (0, 1), (0, 2), (2, 2)]
+    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(
+        compiled_instance, instance_data["V"], instance_data["N"], apply_vars
+    )
+    qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
+    qaoa_converter.ising_encode(multipliers={"one-color": 1})
+
+    qp_transpiler = QuriPartsTranspiler()
+    sampler = create_qulacs_vector_sampler()
+    qp_circ = qp_transpiler.transpile_circuit(initial_circuit)
+    qp_result = sampler(qp_circ, 10)
+
+    sampleset = qaoa_converter.decode(
+        qp_transpiler, (qp_result, initial_circuit.num_qubits)
+    )
+    assert sampleset[0].var_values["x"].values == {
+        (0, 0): 1,
+        (0, 1): 1,
+        (0, 2): 1,
+        (2, 2): 1,
+    }
+    assert sampleset[0].num_occurrences == 10
+
+
+def test_tsp_decode():
+    problem = tsp_problem()
+    instance_data = tsp_instance()
+    compiled_instance = jmt.compile_model(problem, instance_data)
+
+    qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
+    qaoa_converter.ising_encode(multipliers={"one-color": 1})
+    initial_circuit = create_tsp_initial_state(compiled_instance)
+
+    qp_transpiler = QuriPartsTranspiler()
+    sampler = create_qulacs_vector_sampler()
+    qp_circ = qp_transpiler.transpile_circuit(initial_circuit)
+    qp_result = sampler(qp_circ, 10)
+
+    sampleset = qaoa_converter.decode(
+        qp_transpiler, (qp_result, initial_circuit.num_qubits)
+    )
+
+    assert sampleset[0].var_values["x"].values == {
+        (0, 0): 1,
+        (1, 1): 1,
+        (2, 2): 1,
+        (3, 3): 1,
+    }
     assert sampleset[0].num_occurrences == 10

--- a/tests/test_32qrao.py
+++ b/tests/test_32qrao.py
@@ -103,5 +103,4 @@ def test_QRAC32Converter():
     cost_hamiltonian = converter.get_cost_hamiltonian()
 
     pauli_list = converter.get_encoded_pauli_list()
-    print(pauli_list)
     assert len(pauli_list) == 3

--- a/tests/test_ising_qubo.py
+++ b/tests/test_ising_qubo.py
@@ -5,8 +5,14 @@ def test_onehot_conversion():
     qubo: dict[tuple[int, int], float] = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
     ising = qubo_to_ising(qubo)
     assert ising.constant == -0.5
+    assert ising.linear == {0:0,1:0}
+    assert ising.quad == {(0, 1): 0.5}
+
+    ising = qubo_to_ising(qubo, simplify=True)
+    assert ising.constant == -0.5
     assert ising.linear == {}
     assert ising.quad == {(0, 1): 0.5}
+
 
 
 def test_num_bits():


### PR DESCRIPTION
This PR changes the default value of `simplify` to `False` in the `qubo_to_ising` to prevent index mismatches between QUBO and Ising models caused by simplification.

# Changes
Modified the default value of `simplify` parameter in `qubo_to_ising` from `True` to `False`.

This change helps avoid index mismatches that occur when simplifying the Ising model, which can lead to incorrect results when using var_map.

# Note
This is a quick fix. 
A more comprehensive solution is needed to ensure correct indexing even when `simplify=True`. This will be addressed in a future update.

# Related Issue
#66 