### PR TITLE
Feature/param map

### DIFF
--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -489,4 +489,5 @@ class QuantumCircuit:
                 parameters.extend(gate.parameter.get_parameters())
             elif isinstance(gate, Operator):
                 parameters.extend(gate.circuit.get_parameters())
-        return set(parameters)
+        
+        return list(dict.fromkeys(parameters))

--- a/qamomile/core/converters/qaoa.py
+++ b/qamomile/core/converters/qaoa.py
@@ -30,12 +30,17 @@ and decoding functionalities.
 """
 
 import typing as typ
+import math
 import jijmodeling_transpiler.core as jmt
 import qamomile.core.bitssample as qm_bs
 import qamomile.core.circuit as qm_c
 import qamomile.core.operator as qm_o
 from qamomile.core.converters.converter import QuantumConverter
 
+
+EPSILON = 1e-15
+def is_close_zero(value: float) -> bool:
+    return math.isclose(value, 0.0, abs_tol=EPSILON)
 
 class QAOAConverter(QuantumConverter):
     """
@@ -65,12 +70,12 @@ class QAOAConverter(QuantumConverter):
 
         # Apply RZ gates for linear terms
         for i, hi in ising.linear.items():
-            if hi != 0.0:
+            if not is_close_zero(hi):
                 cost.rz(2 * hi * gamma, i)
 
         # Apply CNOT and RZ gates for quadratic terms
         for (i, j), Jij in ising.quad.items():
-            if Jij != 0.0:
+            if not is_close_zero(Jij):
                 cost.rzz(2 * Jij * gamma, i, j)
 
         cost.update_qubits_label(self.int2varlabel)
@@ -128,12 +133,12 @@ class QAOAConverter(QuantumConverter):
 
         # Add linear terms
         for i, hi in ising.linear.items():
-            if hi != 0.0:
+            if not is_close_zero(hi):
                 hamiltonian.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, i),), hi)
 
         # Add quadratic terms
         for (i, j), Jij in ising.quad.items():
-            if Jij != 0.0:
+            if not is_close_zero(Jij):
                 hamiltonian.add_term(
                     (
                         qm_o.PauliOperator(qm_o.Pauli.Z, i),

--- a/qamomile/core/converters/qrao/qrao21.py
+++ b/qamomile/core/converters/qrao/qrao21.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import typing as typ
 import numpy as np
 from qamomile.core.converters.converter import QuantumConverter
+from qamomile.core.converters.qaoa import is_close_zero
 from qamomile.core.ising_qubo import IsingModel
 import qamomile.core.operator as qm_o
 from .graph_coloring import greedy_graph_coloring, check_linear_term
@@ -20,7 +21,7 @@ def qrac21_encode_ising(
 
     # convert linear parts of the objective function into Hamiltonian.
     for idx, coeff in ising.linear.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         pauli = encoded_ope[idx]
@@ -28,7 +29,7 @@ def qrac21_encode_ising(
 
     # create Pauli terms
     for (i, j), coeff in ising.quad.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         if i == j:

--- a/qamomile/core/converters/qrao/qrao31.py
+++ b/qamomile/core/converters/qrao/qrao31.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import typing as typ
 import numpy as np
 from qamomile.core.converters.converter import QuantumConverter
+from qamomile.core.converters.qaoa import is_close_zero
 from qamomile.core.ising_qubo import IsingModel
 import qamomile.core.operator as qm_o
 from .graph_coloring import greedy_graph_coloring, check_linear_term
@@ -44,7 +45,7 @@ def qrac31_encode_ising(
 
     # convert linear parts of the objective function into Hamiltonian.
     for idx, coeff in ising.linear.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         pauli = encoded_ope[idx]
@@ -52,7 +53,7 @@ def qrac31_encode_ising(
 
     # create Pauli terms
     for (i, j), coeff in ising.quad.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         if i == j:

--- a/qamomile/core/converters/qrao/qrao32.py
+++ b/qamomile/core/converters/qrao/qrao32.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import typing as typ
 import numpy as np
 from qamomile.core.converters.converter import QuantumConverter
+from qamomile.core.converters.qaoa import is_close_zero
 from qamomile.core.ising_qubo import IsingModel
 import qamomile.core.operator as qm_o
 from .qrao31 import color_group_to_qrac_encode
@@ -87,7 +88,7 @@ def qrac32_encode_ising(
 
     # convert linear parts of the objective function into Hamiltonian.
     for idx, coeff in ising.linear.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         pauli = encoded_ope[idx]
@@ -96,7 +97,7 @@ def qrac32_encode_ising(
 
     # create quad terms
     for (i, j), coeff in ising.quad.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         if i == j:

--- a/qamomile/core/converters/qrao/qrao_space_efficient.py
+++ b/qamomile/core/converters/qrao/qrao_space_efficient.py
@@ -5,7 +5,7 @@ from qamomile.core.converters.converter import QuantumConverter
 from qamomile.core.ising_qubo import IsingModel
 import qamomile.core.operator as qm_o
 from .graph_coloring import greedy_graph_coloring, check_linear_term
-
+from qamomile.core.converters.qaoa import is_close_zero
 
 def numbering_space_efficient_encode(
     ising: IsingModel,
@@ -43,7 +43,7 @@ def qrac_space_efficient_encode_ising(
 
     # convert linear parts of the objective function into Hamiltonian.
     for idx, coeff in ising.linear.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         pauli = encoded_ope[idx]
@@ -51,7 +51,7 @@ def qrac_space_efficient_encode_ising(
 
     # create Pauli terms
     for (i, j), coeff in ising.quad.items():
-        if coeff == 0.0:
+        if is_close_zero(coeff):
             continue
 
         if i == j:

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -63,10 +63,10 @@ class QiskitTranspiler(QuantumSDKTranspiler[qk_primitives.BitArray]):
         """
         try:
             parameters = qamomile_circuit.get_parameters()
-            param_mapping = {
+            self.param_mapping = {
                 param: qiskit.circuit.Parameter(param.name) for param in parameters
             }
-            return self._circuit_convert(qamomile_circuit, param_mapping)
+            return self._circuit_convert(qamomile_circuit, self.param_mapping)
         except Exception as e:
             raise QamomileQiskitTranspileError(f"Error converting circuit: {str(e)}")
 

--- a/qamomile/quri_parts/transpiler.py
+++ b/qamomile/quri_parts/transpiler.py
@@ -63,11 +63,11 @@ class QuriPartsTranspiler(
             qp_circuit = qp_c.LinearMappedUnboundParametricQuantumCircuit(
                 qamomile_circuit.num_qubits, qamomile_circuit.num_clbits
             )
-            param_mapping = {
+            self.param_mapping = {
                 param: qp_circuit.add_parameter(param.name)
                 for param in parameters
             }
-            return self._circuit_convert(qamomile_circuit, qp_circuit, param_mapping)
+            return self._circuit_convert(qamomile_circuit, qp_circuit, self.param_mapping)
         except Exception as e:
             raise QamomileQuriPartsTranspileError(f"Error converting circuit: {str(e)}")
 


### PR DESCRIPTION
# change
- Add `param_map` attribute for Qiskit and QuriParts transpiler.
- change the `get_parameters` in `circuit` from `set` to `dict` and `list` to maintain the order in which they were added.
- The check of whether the coefficient is 0 was converted to a distance from 1e-15.
