### PR TITLE
ignore measurement gate to transpile quri-parts

### DIFF
--- a/docs/tutorial/building_quantum_circuits.ipynb
+++ b/docs/tutorial/building_quantum_circuits.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Qamomile Tutorial: Building Quantum Circuits\n",
+    "# Building Quantum Circuits\n",
     "\n",
     "## Introduction\n",
     "Welcome to this tutorial on building quantum circuits with Qamomile! While Qamomile is primarily designed for quantum optimization tasks, it also offers powerful capabilities for constructing arbitrary quantum circuits. This tutorial will guide you through the process of creating and manipulating quantum circuits using Qamomile's unique intermediate representation.\n",
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,12 +257,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulator = qk_pr.Sampler()\n",
-    "job = simulator.run(qk_circuit, shots=1000)\n",
+    "simulator = qk_pr.StatevectorSampler()\n",
+    "job = simulator.run([qk_circuit], shots=1000)\n",
     "result = job.result()"
    ]
   },
@@ -275,20 +275,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'01': 0.479, '10': 0.521}\n"
-     ]
+     "data": {
+      "text/plain": [
+       "{'01': 510, '10': 490}"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "counts = result.quasi_dists[0].binary_probabilities()\n",
-    "print(counts)"
+    "result[0].data['c'].get_counts()"
    ]
   },
   {
@@ -304,16 +306,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qamomile.quri_parts import QuriPartsTranspiler\n",
-    "\n",
-    "circuit = qm.circuit.QuantumCircuit(2)\n",
-    "circuit.h(0)\n",
-    "circuit.cx(0, 1)\n",
-    "circuit.x(1)\n",
     "\n",
     "# Transpile the circuit to QURI-Parts\n",
     "qp_transpiler = QuriPartsTranspiler()\n",
@@ -329,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,16 +340,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({2: 503, 1: 497})"
+       "Counter({1: 530, 2: 470})"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/qamomile/quri_parts/transpiler.py
+++ b/qamomile/quri_parts/transpiler.py
@@ -114,7 +114,8 @@ class QuriPartsTranspiler(
                                     param_mapping
                                 )
             elif isinstance(gate, qm_c.MeasurementGate):
-                qp_circuit.measure(gate.qubit, gate.cbit)
+                # QURI-Parts circuits don't have measurement gates
+                pass
             else:
                 raise QamomileQuriPartsTranspileError(
                     f"Unsupported gate type: {type(gate)}"

--- a/tests/quri_parts/test_quri_transpiler.py
+++ b/tests/quri_parts/test_quri_transpiler.py
@@ -178,7 +178,7 @@ def test_transpile_complex_circuit(transpiler):
     assert isinstance(quri_circuit, qp_c.LinearMappedUnboundParametricQuantumCircuit)
     assert quri_circuit.qubit_count == 3
     assert quri_circuit.cbit_count == 3
-    assert len(quri_circuit.gates) == 4
+    assert len(quri_circuit.gates) == 3  # QURI-Parts does not support measurement gate
 
 
 def test_transpile_unsupported_gate(transpiler):
@@ -353,3 +353,16 @@ def test_tsp_decode():
         (3, 3): 1,
     }
     assert sampleset[0].num_occurrences == 10
+
+
+def test_run_small_circuit():
+    circuit = qm_c.QuantumCircuit(2)
+    circuit.h(0)
+    circuit.cnot(0, 1)
+    circuit.measure_all()
+
+    transpiler = QuriPartsTranspiler()
+    quri_c = transpiler.transpile_circuit(circuit)
+    from quri_parts.qulacs.sampler import create_qulacs_vector_sampler
+    sampler = create_qulacs_vector_sampler()
+    result = sampler(quri_c, 10)


### PR DESCRIPTION
QURI-Parts does not support 'measurement gate'. So, we ignore the gate when transpile to quri-parts circuit.