### PR TITLE
docs: Fix typos and suggest changes to example commands in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more detailed information, please refer to our [documentation](https://qamom
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for more details.
+We welcome contributions! Please see our [Contributing Guide](docs/contribute.md) for more details.
 
 ## License
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -15,7 +15,7 @@ Before you begin, ensure you have the following installed:
 1. Fork the qamomile repository on GitHub.
 2. Clone your fork locally:
    ```
-   gh repo clone Jij-Inc/Qamomile
+   gh repo clone username/Qamomile
    cd Qamomile
    ```
 3. Create a virtual environment and activate it:

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -16,7 +16,7 @@ Before you begin, ensure you have the following installed:
 2. Clone your fork locally:
    ```
    gh repo clone Jij-Inc/Qamomile
-   cd qamomile
+   cd Qamomile
    ```
 3. Create a virtual environment and activate it:
    ```
@@ -70,7 +70,7 @@ Our documentation is organized as follows:
 - `quickstart.md`: Guide for new users
 - `api/`: API reference documentation for qamomile.
 - `tutorial/`: Usage examples and tutorials
-- `contributing.md`: This guide
+- `contribute.md`: This guide
 
 Feel free to suggest improvements to this structure if you think it can be made more intuitive.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Explore our documentation to dive deeper into Qamomile's capabilities:
 
 ## Contributing
 
-We welcome contributions from the community! If you're interested in improving Qamomile, please check out our [Contribution Guidelines](contributing.md).
+We welcome contributions from the community! If you're interested in improving Qamomile, please check out our [Contribution Guidelines](contribute.md).
 
 ## Support
 


### PR DESCRIPTION
## 1. Typo
The link to contribution guide was broken.
Please look at first commit. cee1936bd596209a1f94c3131711eea5bc606659

## 2. Suggestion
In `contribute.md`, sample command to clone forked repository locally is `gh repo clone Jij-Inc/Qamomile`.

It clones the original repository, so I sugesste to change `Jij-Inc` to something else.
In my commit, it is changed to `username` for now. 6b42d3986bd7f9dee456785a8358c81ef4a2958b

I'm not very familiar with GitHub, so I'm sorry if there are any mistakes.
Thank you:)