### PR TITLE
Add new argument normalize_model

### DIFF
--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -72,6 +72,7 @@ class QuantumConverter(abc.ABC):
         self,
         compiled_instance,
         relax_method: jmt.pubo.RelaxationMethod = jmt.pubo.RelaxationMethod.AugmentedLagrangian,
+        normalize_model: bool = False,
     ):
         """
         Initialize the QuantumConverter.
@@ -80,9 +81,11 @@ class QuantumConverter(abc.ABC):
             compiled_instance: The compiled instance of the optimization problem.
             relax_method (jmt.pubo.RelaxationMethod): The relaxation method for PUBO conversion.
                 Defaults to AugmentedLagrangian.
+            normalize_model (bool): Normalize objective function.
+                Defaults to False
         """
         pubo_builder = jmt.pubo.transpile_to_pubo(
-            compiled_instance, relax_method=relax_method
+            compiled_instance, relax_method=relax_method, normalize = normalize_model
         )
 
         self.compiled_instance = compiled_instance

--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -81,7 +81,7 @@ class QuantumConverter(abc.ABC):
             compiled_instance: The compiled instance of the optimization problem.
             relax_method (jmt.pubo.RelaxationMethod): The relaxation method for PUBO conversion.
                 Defaults to AugmentedLagrangian.
-            normalize_model (bool): Normalize objective function.
+            normalize_model (bool): The objective function and the constraints are normalized using the maximum absolute value of the coefficients contained in each.
                 Defaults to False
         """
         pubo_builder = jmt.pubo.transpile_to_pubo(


### PR DESCRIPTION
## Change
Add `normalize_model` option to `QuantumConverter` class and pass it to `jmt.pubo.transpile_to_pubo`

## Description 
This change introduces the `normalize_model=False` argument to the` __init__` in the `QuantumConverter` class, allowing the normalization of mathematical models to be toggled on or off based on user input. 
Additionally, the argument `normalize = normalize_model` is now passed to the `jmt.pubo.transpile_to_pubo`[function](https://github.com/Jij-Inc/JijModelingTranspiler/blob/main/jijmodeling_transpiler/core/pubo/to_pubo.py)

## Example
```
import jijmodeling_transpiler.core as jmt
import qamomile.core as qm
# Assuming compiled_instance is already created and compiled
# This could be some model you've compiled using the jijmodeling_transpiler

# Toggle on the normalization by setting normalize_model to True
converter = qm.qaoa.QAOAConverter(compiled_instance, normalize_model=True)

```