### PR TITLE
allowed float type in all the parametric gates

### DIFF
--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -299,9 +299,12 @@ class QuantumCircuit:
             \end{bmatrix}
 
         Args:
-            angle (ParameterExpression): The angle parameter for the gate.
+            angle (ParameterExpression/float): The angle parameter for the gate.
             index (int): The index of the qubit to apply the gate. 
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RX, index, angle)
         )
@@ -317,9 +320,12 @@ class QuantumCircuit:
             \end{bmatrix}
 
         Args:
-            angle (ParameterExpression): The angle parameter for the gate.
+            angle (ParameterExpression/float): The angle parameter for the gate.
             index (int): The index of the qubit to apply the gate.
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RY, index, angle)
         )
@@ -335,9 +341,12 @@ class QuantumCircuit:
             \end{bmatrix}
 
         Args:
-            angle (ParameterExpression): The angle parameter for the gate.
+            angle (ParameterExpression/float): The angle parameter for the gate.
             index (int): The index of the qubit to apply the gate. 
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RZ, index, angle)
         )
@@ -360,6 +369,9 @@ class QuantumCircuit:
 
     def crx(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRX gate to the quantum circuit."""
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.CRX, controled_qubit, target_qubit, angle
@@ -368,6 +380,9 @@ class QuantumCircuit:
     
     def cry(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRY gate to the quantum circuit."""
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.CRY, controled_qubit, target_qubit, angle
@@ -376,6 +391,9 @@ class QuantumCircuit:
     
     def crz(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRZ gate to the quantum circuit."""
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.CRZ, controled_qubit, target_qubit, angle
@@ -388,6 +406,9 @@ class QuantumCircuit:
         .. math::
             R_{XX}(\theta) = \exp\left(-i\theta X\otimes X/2\right)
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.RXX, qubit1, qubit2, angle
@@ -400,6 +421,9 @@ class QuantumCircuit:
         .. math::
             R_{YY}(\theta) = \exp\left(-i\theta Y\otimes Y/2\right)
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.RYY, qubit1, qubit2, angle
@@ -412,6 +436,9 @@ class QuantumCircuit:
         .. math::
             R_{ZZ}(\theta) = \exp\left(-i\theta Z\otimes Z/2\right)
         """
+        if isinstance(angle, float):
+            angle = Parameter(angle)
+        
         self.add_gate(
             ParametricTwoQubitGate(
                 ParametricTwoQubitGateType.RZZ, qubit1, qubit2, angle

--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -37,7 +37,7 @@ import typing as typ
 import dataclasses
 import abc
 import enum
-from .parameter import ParameterExpression, Parameter
+from .parameter import ParameterExpression, Parameter, Value
 
 
 class Gate(abc.ABC):
@@ -303,7 +303,7 @@ class QuantumCircuit:
             index (int): The index of the qubit to apply the gate. 
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RX, index, angle)
@@ -324,7 +324,7 @@ class QuantumCircuit:
             index (int): The index of the qubit to apply the gate.
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RY, index, angle)
@@ -345,7 +345,7 @@ class QuantumCircuit:
             index (int): The index of the qubit to apply the gate. 
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
 
         self.add_gate(
             ParametricSingleQubitGate(ParametricSingleQubitGateType.RZ, index, angle)
@@ -370,7 +370,7 @@ class QuantumCircuit:
     def crx(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRX gate to the quantum circuit."""
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricTwoQubitGate(
@@ -381,7 +381,7 @@ class QuantumCircuit:
     def cry(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRY gate to the quantum circuit."""
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricTwoQubitGate(
@@ -392,7 +392,7 @@ class QuantumCircuit:
     def crz(self, angle: ParameterExpression, controled_qubit: int, target_qubit: int):
         """Add a CRZ gate to the quantum circuit."""
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricTwoQubitGate(
@@ -407,7 +407,7 @@ class QuantumCircuit:
             R_{XX}(\theta) = \exp\left(-i\theta X\otimes X/2\right)
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
 
         self.add_gate(
             ParametricTwoQubitGate(
@@ -422,7 +422,7 @@ class QuantumCircuit:
             R_{YY}(\theta) = \exp\left(-i\theta Y\otimes Y/2\right)
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricTwoQubitGate(
@@ -437,7 +437,7 @@ class QuantumCircuit:
             R_{ZZ}(\theta) = \exp\left(-i\theta Z\otimes Z/2\right)
         """
         if isinstance(angle, float):
-            angle = Parameter(angle)
+            angle = Value(angle)
         
         self.add_gate(
             ParametricTwoQubitGate(

--- a/tests/core/circuit/test_circuit.py
+++ b/tests/core/circuit/test_circuit.py
@@ -1,6 +1,8 @@
 # File: tests/circuit/test_circuit.py
 
 import pytest
+import random
+import math
 from qamomile.core.circuit import (
     QuantumCircuit,
     Parameter,
@@ -38,10 +40,15 @@ def test_parametric_single_qubit_gates():
     qc.rx(theta, 0)
     qc.ry(theta, 0)
     qc.rz(theta, 0)
+    qc2 = QuantumCircuit(1)
+    random_float = random.uniform(0, 4* math.pi)
+    qc2.rx(random_float, 0)
+    qc2.ry(random_float, 0)
+    qc2.rz(random_float, 0)
     assert len(qc.gates) == 3
     assert all(gate.gate in ParametricSingleQubitGateType for gate in qc.gates)
     assert all(gate.parameter == theta for gate in qc.gates)
-
+    assert all(gate.parameter == Parameter(random_float) for gate in qc2.gates)
 
 def test_two_qubit_gates():
     qc = QuantumCircuit(2)

--- a/tests/core/circuit/test_circuit.py
+++ b/tests/core/circuit/test_circuit.py
@@ -6,6 +6,7 @@ import math
 from qamomile.core.circuit import (
     QuantumCircuit,
     Parameter,
+    Value,
     SingleQubitGateType,
     ParametricSingleQubitGateType,
     TwoQubitGateType,
@@ -45,10 +46,11 @@ def test_parametric_single_qubit_gates():
     qc2.rx(random_float, 0)
     qc2.ry(random_float, 0)
     qc2.rz(random_float, 0)
+    
     assert len(qc.gates) == 3
     assert all(gate.gate in ParametricSingleQubitGateType for gate in qc.gates)
     assert all(gate.parameter == theta for gate in qc.gates)
-    assert all(gate.parameter == Parameter(random_float) for gate in qc2.gates)
+    assert all(gate.parameter.value == random_float for gate in qc2.gates)
 
 def test_two_qubit_gates():
     qc = QuantumCircuit(2)


### PR DESCRIPTION
# Change
allowed float type as angle argument in all the parametric gates

# Description 
1. added the following code in all the types inside `ParametricSingleQubitGate` and `ParametricTwoQubitGate` in `circuit.py`
 ```
   if isinstance(angle, float):
      angle = Parameter(angle)
```
2. added a corresponding test in `test_circuit.py` 

# Related issue 
#92 