### PR TITLE
fix num_qubits when add and multiply Hamiltonian

### DIFF
--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -265,11 +265,16 @@ class Hamiltonian:
             for term, coeff in other.terms.items():
                 h.add_term(term, coeff)
             h.constant += other.constant
+
+            if h.num_qubits < self.num_qubits:
+                h._num_qubits = self.num_qubits
+
             return h
         elif isinstance(other, (int, float, complex)):
-            h = Hamiltonian()
+            h = Hamiltonian(num_qubits = self.num_qubits)
             h._terms = self._terms.copy()
             h.constant = self.constant + other
+            
             return h
         else:
             raise ValueError("Unsupported addition operation.")
@@ -291,7 +296,7 @@ class Hamiltonian:
             h.constant = self.constant * other
             return h
         elif isinstance(other, Hamiltonian):
-            h = Hamiltonian(num_qubits = self.num_qubits)
+            h = Hamiltonian()
             for term1, coeff1 in self.terms.items():
                 for term2, coeff2 in other.terms.items():
                     term, phase = simplify_pauliop_terms(term1 + term2)
@@ -309,6 +314,9 @@ class Hamiltonian:
                     h.add_term(terms, coeff2 * self.constant)
 
             h.constant += self.constant * other.constant
+
+            if h.num_qubits < self.num_qubits:
+                h._num_qubits = self.num_qubits
 
             return h
         else:

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -285,13 +285,13 @@ class Hamiltonian:
 
     def __mul__(self, other):
         if isinstance(other, (int, float, complex)):
-            h = Hamiltonian()
+            h = Hamiltonian(num_qubits = self.num_qubits)
             for term, coeff in self.terms.items():
                 h.add_term(term, coeff * other)
             h.constant = self.constant * other
             return h
         elif isinstance(other, Hamiltonian):
-            h = Hamiltonian()
+            h = Hamiltonian(num_qubits = self.num_qubits)
             for term1, coeff1 in self.terms.items():
                 for term2, coeff2 in other.terms.items():
                     term, phase = simplify_pauliop_terms(term1 + term2)

--- a/tests/core/test_operator.py
+++ b/tests/core/test_operator.py
@@ -349,3 +349,16 @@ def test_Hamiltonian_neg():
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.X, 0),), -2.0)
     expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 1),), -1.0)
     assert h1 == expected_h
+
+def test_num_qubits():
+    h = qm_o.Hamiltonian(num_qubits=3)
+    h.constant = 1.0
+    assert h.num_qubits == 3
+    h *= qm_o.X(0)
+    assert h.num_qubits == 3
+    h *= qm_o.X(1)
+    assert h.num_qubits == 3
+
+    h = qm_o.X(0) + qm_o.X(2)
+    assert h.num_qubits == 3
+    

--- a/tests/core/test_operator.py
+++ b/tests/core/test_operator.py
@@ -352,13 +352,18 @@ def test_Hamiltonian_neg():
 
 def test_num_qubits():
     h = qm_o.Hamiltonian(num_qubits=3)
-    h.constant = 1.0
+    h += 1.0
     assert h.num_qubits == 3
     h *= qm_o.X(0)
     assert h.num_qubits == 3
     h *= qm_o.X(1)
     assert h.num_qubits == 3
+    h *= qm_o.X(3)
+    assert h.num_qubits == 4
 
-    h = qm_o.X(0) + qm_o.X(2)
+    h = qm_o.Hamiltonian(num_qubits=3)
+    h += qm_o.X(0) 
     assert h.num_qubits == 3
+    h += qm_o.X(3) 
+    assert h.num_qubits == 4
     


### PR DESCRIPTION
# Change 
Fixed a bug where the num_qubits information would disappear after the calculation, even though `h = Hamiltonian(num_qubits=3)`.

# Desciption
The `__add__` and `__mul__` of `Hamiltonian` now inherit the information before the operation.
In addition, when performing an operation on two Hamiltonians, the one with the larger num_qubits is selected to be inherited.