### PR TITLE
fix `is_close` calculation in operator

### DIFF
--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -305,11 +305,11 @@ class Hamiltonian:
                     else:
                         h.constant += phase * coeff1 * coeff2
 
-            if not math.isclose(other.constant, 0.0, abs_tol=1e-15):
+            if not math.isclose(abs(other.constant), 0.0, abs_tol=1e-15):
                 for terms, coeff1 in self.terms.items():
                     h.add_term(terms, coeff1 * other.constant)
 
-            if not math.isclose(self.constant, 0.0, abs_tol=1e-15):
+            if not math.isclose(abs(self.constant), 0.0, abs_tol=1e-15):
                 for terms, coeff2 in other.terms.items():
                     h.add_term(terms, coeff2 * self.constant)
 

--- a/tests/core/test_operator.py
+++ b/tests/core/test_operator.py
@@ -367,3 +367,14 @@ def test_num_qubits():
     h += qm_o.X(3) 
     assert h.num_qubits == 4
     
+def test_coeff_complex():
+    h = qm_o.Hamiltonian()
+    h.add_term((qm_o.PauliOperator(qm_o.Pauli.I, 0),), 1.0j)
+    h *= (1 + 1j * qm_o.Y(0))
+
+    expected_h = qm_o.Hamiltonian()
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.I, 0),), 1.0j)
+    expected_h.add_term((qm_o.PauliOperator(qm_o.Pauli.Y, 0),), -1.0)
+    assert h == expected_h
+
+    


### PR DESCRIPTION
# Change
The original code 
```python
math.isclose(other.constant, 0.0, abs_tol=1e-15)
```
is only acceptable for real value.
However, we should accept complex value as coefficient of Hamiltonian.

So, I modified this part as
```python
math.isclose(abs(other.constant), 0.0, abs_tol=1e-15)
```
