### PR TITLE
Introduce to Ising Hamiltonian normalization

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -31,3 +31,17 @@
       primaryClass={quant-ph},
       url={https://arxiv.org/abs/2302.09481}, 
 }
+
+@ARTICLE{Sureshbabu2023-cn,
+  title         = "Parameter setting in quantum approximate optimization of
+                   weighted problems",
+  author        = "Sureshbabu, Shree Hari and Dylan, Herman and Ruslan,
+                   Shaydulin and Joao, Basso and Shouvanik, Chakrabarti and Yue,
+                   Sun and Marco, Pistoia",
+  journal       = "arXiv [quant-ph]",
+  pages         =  1231,
+  month         =  may,
+  year          =  2023,
+  archivePrefix = "arXiv",
+  primaryClass  = "quant-ph"
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -32,16 +32,16 @@
       url={https://arxiv.org/abs/2302.09481}, 
 }
 
-@ARTICLE{Sureshbabu2023-cn,
-  title         = "Parameter setting in quantum approximate optimization of
-                   weighted problems",
-  author        = "Sureshbabu, Shree Hari and Dylan, Herman and Ruslan,
-                   Shaydulin and Joao, Basso and Shouvanik, Chakrabarti and Yue,
-                   Sun and Marco, Pistoia",
-  journal       = "arXiv [quant-ph]",
-  pages         =  1231,
-  month         =  may,
-  year          =  2023,
-  archivePrefix = "arXiv",
-  primaryClass  = "quant-ph"
+@article{Sureshbabu2024parametersettingin,
+  doi = {10.22331/q-2024-01-18-1231},
+  url = {https://doi.org/10.22331/q-2024-01-18-1231},
+  title = {Parameter {S}etting in {Q}uantum {A}pproximate {O}ptimization of {W}eighted {P}roblems},
+  author = {Sureshbabu, Shree Hari and Herman, Dylan and Shaydulin, Ruslan and Basso, Joao and Chakrabarti, Shouvanik and Sun, Yue and Pistoia, Marco},
+  journal = {{Quantum}},
+  issn = {2521-327X},
+  publisher = {{Verein zur F{\"{o}}rderung des Open Access Publizierens in den Quantenwissenschaften}},
+  volume = {8},
+  pages = {1231},
+  month = jan,
+  year = {2024}
 }

--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -75,6 +75,7 @@ class QuantumConverter(abc.ABC):
         compiled_instance,
         relax_method: jmt.pubo.RelaxationMethod = jmt.pubo.RelaxationMethod.AugmentedLagrangian,
         normalize_model: bool = False,
+        normalize_ising: typ.Optional[str] = None,
     ):
         """
         Initialize the QuantumConverter.
@@ -93,6 +94,7 @@ class QuantumConverter(abc.ABC):
         self.compiled_instance = compiled_instance
         self.pubo_builder = pubo_builder
         self.int2varlabel: dict[int, str] = {}
+        self.normalize_ising = normalize_ising
 
         self._ising: typ.Optional[IsingModel] = None
 
@@ -133,6 +135,14 @@ class QuantumConverter(abc.ABC):
         )
         ising = qubo_to_ising(qubo, simplify=False)
         ising.constant += constant
+
+        if isinstance(self.normalize_ising, str):
+            if self.normalize_ising == "abs_max":
+                ising.normalize_by_abs_max()
+            elif self.normalize_ising == "rms":
+                ising.normalize_by_rms()
+            else:
+                raise ValueError(f"Invalid value for normalize_ising: {self.normalize_ising}")
 
         var_map = self.compiled_instance.var_map.var_map
         inv_varmap = {}

--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -9,11 +9,15 @@ problems into quantum representations (e.g., Ising models) and decoding quantum
 computation results back into classical problem solutions.
 
 Key Features:
+
 - Conversion between classical optimization problems and Ising models.
+
 - Abstract methods for generating cost Hamiltonians and decoding results.
+
 - Integration with QuantumSDKTranspiler for SDK-specific result handling.
 
 Usage:
+
 Developers implementing specific quantum conversion strategies should subclass
 QuantumConverter and implement the abstract methods. The class is designed to work
 with jijmodeling for problem representation and various quantum SDKs through
@@ -32,19 +36,17 @@ Example:
 import abc
 import typing as typ
 
-import numpy as np
 import jijmodeling as jm
 import jijmodeling_transpiler.core as jmt
+import numpy as np
 import qamomile.core.bitssample as qm_bs
 import qamomile.core.operator as qm_o
-from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
-from qamomile.core.transpiler import QuantumSDKTranspiler
-
 # Import necessary functions from jijmodeling_transpiler
 from jijmodeling_transpiler.core.decode import dict_to_record
-from jijmodeling_transpiler.core.pubo.binary_decode import binary_decode
 from jijmodeling_transpiler.core.decode.evaluate import calc_expr, subs_expr
-
+from jijmodeling_transpiler.core.pubo.binary_decode import binary_decode
+from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.transpiler import QuantumSDKTranspiler
 
 ResultType = typ.TypeVar("ResultType")
 
@@ -75,10 +77,12 @@ class QuantumConverter(abc.ABC):
         compiled_instance,
         relax_method: jmt.pubo.RelaxationMethod = jmt.pubo.RelaxationMethod.AugmentedLagrangian,
         normalize_model: bool = False,
-        normalize_ising: typ.Optional[str] = None,
+        normalize_ising: typ.Optional[typ.Literal["abs_max", "rms"]] = None,
     ):
         """
         Initialize the QuantumConverter.
+
+        This method initializes the converter with the compiled instance of the optimization problem
 
         Args:
             compiled_instance: The compiled instance of the optimization problem.
@@ -86,7 +90,12 @@ class QuantumConverter(abc.ABC):
                 Defaults to AugmentedLagrangian.
             normalize_model (bool): The objective function and the constraints are normalized using the maximum absolute value of the coefficients contained in each.
                 Defaults to False
-            normalize_ising (Optional[str]): The normalization method for the Ising Hamiltonian.
+            normalize_ising (Literal["abs_max", "rms"] | None): The normalization method for the Ising Hamiltonian. 
+                Available options:
+                - "abs_max": Normalize by absolute maximum value
+                - "rms": Normalize by root mean square
+                Defaults to None.
+
         """
         pubo_builder = jmt.pubo.transpile_to_pubo(
             compiled_instance, relax_method=relax_method, normalize=normalize_model
@@ -99,12 +108,14 @@ class QuantumConverter(abc.ABC):
 
         self._ising: typ.Optional[IsingModel] = None
 
+
     def get_ising(self) -> IsingModel:
         """
         Get the Ising model representation of the problem.
 
         Returns:
             IsingModel: The Ising model representation.
+
         """
         if self._ising is None:
             self._ising = self.ising_encode()
@@ -130,6 +141,7 @@ class QuantumConverter(abc.ABC):
 
         Returns:
             IsingModel: The encoded Ising model.
+
         """
         qubo, constant = self.pubo_builder.get_qubo_dict(
             multipliers=multipliers, detail_parameters=detail_parameters

--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -86,9 +86,10 @@ class QuantumConverter(abc.ABC):
                 Defaults to AugmentedLagrangian.
             normalize_model (bool): The objective function and the constraints are normalized using the maximum absolute value of the coefficients contained in each.
                 Defaults to False
+            normalize_ising (Optional[str]): The normalization method for the Ising Hamiltonian.
         """
         pubo_builder = jmt.pubo.transpile_to_pubo(
-            compiled_instance, relax_method=relax_method, normalize = normalize_model
+            compiled_instance, relax_method=relax_method, normalize=normalize_model
         )
 
         self.compiled_instance = compiled_instance
@@ -142,7 +143,9 @@ class QuantumConverter(abc.ABC):
             elif self.normalize_ising == "rms":
                 ising.normalize_by_rms()
             else:
-                raise ValueError(f"Invalid value for normalize_ising: {self.normalize_ising}")
+                raise ValueError(
+                    f"Invalid value for normalize_ising: {self.normalize_ising}"
+                )
 
         var_map = self.compiled_instance.var_map.var_map
         inv_varmap = {}

--- a/qamomile/core/ising_qubo.py
+++ b/qamomile/core/ising_qubo.py
@@ -39,6 +39,18 @@ class IsingModel:
         return self.index_map[index]
 
     def normalize_by_abs_max(self):
+        r"""Normalize coefficients by the absolute maximum value.
+
+        The coefficients for normalized is defined as:
+        .. math::
+            W = max(|J_{ij}|, |h_i|)
+
+        We normalize the Ising Hamiltonian as
+        .. math::
+            \tilde{H} = \frac{1}{W}\sum_{ij}J_{ij}Z_iZ_j + \frac{1}{W}\sum_ih_iZ_i + \frac{1}{W}C
+
+        """
+
         if not self.linear and not self.quad:
             return  # 係数が存在しない場合は正規化しない
 
@@ -59,12 +71,15 @@ class IsingModel:
     def normalize_by_rms(self):
         r"""Normalize coefficients by the root mean square.
 
-        The coefficients are normalized by
+        The coefficients for normalized is defined as:
         .. math::
-            sqrt(sum(w_ij^2)/E_2 + sum(w_i^2)/E_1)
+            W = sqrt(sum(w_ij^2)/E_2 + sum(w_i^2)/E_1)
 
         where w_ij are quadratic coefficients and w_i are linear coefficients.
         E_2 and E_1 are the number of quadratic and linear terms respectively.
+        We normalize the Ising Hamiltonian as
+        .. math::
+            \tilde{H} = \frac{1}{W}\sum_{ij}J_{ij}Z_iZ_j + \frac{1}{W}\sum_ih_iZ_i + \frac{1}{W}C
         This method is proposed in :cite:`Sureshbabu2023-cn`
         """
         if not self.linear and not self.quad:

--- a/qamomile/core/ising_qubo.py
+++ b/qamomile/core/ising_qubo.py
@@ -1,6 +1,7 @@
 import dataclasses
-import numpy as np
 import typing as typ
+
+import numpy as np
 
 
 @dataclasses.dataclass
@@ -42,10 +43,12 @@ class IsingModel:
         r"""Normalize coefficients by the absolute maximum value.
 
         The coefficients for normalized is defined as:
+
         .. math::
-            W = max(|J_{ij}|, |h_i|)
+            W = \max(|J_{ij}|, |h_i|)
 
         We normalize the Ising Hamiltonian as
+        
         .. math::
             \tilde{H} = \frac{1}{W}\sum_{ij}J_{ij}Z_iZ_j + \frac{1}{W}\sum_ih_iZ_i + \frac{1}{W}C
 
@@ -72,15 +75,21 @@ class IsingModel:
         r"""Normalize coefficients by the root mean square.
 
         The coefficients for normalized is defined as:
+
         .. math::
-            W = sqrt(sum(w_ij^2)/E_2 + sum(w_i^2)/E_1)
+            W = \sqrt{ \frac{1}{E_2}\sum(w_ij^2) + \frac{1}{E_1}\sum(w_i^2) }
 
         where w_ij are quadratic coefficients and w_i are linear coefficients.
         E_2 and E_1 are the number of quadratic and linear terms respectively.
         We normalize the Ising Hamiltonian as
+
         .. math::
             \tilde{H} = \frac{1}{W}\sum_{ij}J_{ij}Z_iZ_j + \frac{1}{W}\sum_ih_iZ_i + \frac{1}{W}C
-        This method is proposed in :cite:`Sureshbabu2023-cn`
+        This method is proposed in :cite:`Sureshbabu2024parametersettingin`
+
+        .. bibliography::
+            :filter: docname in docnames
+
         """
         if not self.linear and not self.quad:
             return  # 係数が存在しない場合は正規化しない

--- a/tests/core/test_ising_qubo.py
+++ b/tests/core/test_ising_qubo.py
@@ -1,18 +1,18 @@
 from qamomile.core.ising_qubo import qubo_to_ising, IsingModel
+import numpy as np
 
 
 def test_onehot_conversion():
     qubo: dict[tuple[int, int], float] = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
     ising = qubo_to_ising(qubo)
     assert ising.constant == -0.5
-    assert ising.linear == {0:0,1:0}
+    assert ising.linear == {0: 0, 1: 0}
     assert ising.quad == {(0, 1): 0.5}
 
     ising = qubo_to_ising(qubo, simplify=True)
     assert ising.constant == -0.5
     assert ising.linear == {}
     assert ising.quad == {(0, 1): 0.5}
-
 
 
 def test_num_bits():
@@ -46,3 +46,89 @@ def test_num_bits():
         6.0,
     )
     assert ising.num_bits() == 1
+
+
+def test_normalize_by_abs_max():
+    # Setup: Create an Ising model with known coefficients
+    ising = IsingModel(
+        quad={(0, 1): 2.0, (1, 2): -4.0},  # max quad coeff is 4.0
+        linear={0: 1.0, 1: 3.0},  # max linear coeff is 3.0
+        constant=6.0,
+    )
+
+    # Execute normalization
+    ising.normalize_by_abs_max()
+
+    # Max coefficient was 4.0, so everything should be divided by 4.0
+    assert ising.quad[(0, 1)] == 0.5  # 2.0 / 4.0
+    assert ising.quad[(1, 2)] == -1.0  # -4.0 / 4.0
+    assert ising.linear[0] == 0.25  # 1.0 / 4.0
+    assert ising.linear[1] == 0.75  # 3.0 / 4.0
+    assert ising.constant == 1.5  # 6.0 / 4.0
+
+
+def test_normalize_by_abs_max_linear_dominant():
+    # Setup: Create an Ising model where linear term has the max coefficient
+    ising = IsingModel(
+        quad={(0, 1): 2.0},  # max quad coeff is 2.0
+        linear={0: 4.0, 1: -5.0},  # max linear coeff is 5.0
+        constant=10.0,
+    )
+
+    # Execute normalization
+    ising.normalize_by_abs_max()
+
+    # Max coefficient was 5.0, so everything should be divided by 5.0
+    assert ising.quad[(0, 1)] == 0.4  # 2.0 / 5.0
+    assert ising.linear[0] == 0.8  # 4.0 / 5.0
+    assert ising.linear[1] == -1.0  # -5.0 / 5.0
+    assert ising.constant == 2.0  # 10.0 / 5.0
+
+
+def test_normalize_by_abs_max_empty():
+    # Setup: Create an Ising model with no coefficients
+    ising = IsingModel(quad={}, linear={}, constant=0.0)
+
+    # Empty model should not be normalized
+    ising.normalize_by_abs_max()
+
+    # Values should remain unchanged
+    assert ising.constant == 0.0
+    assert len(ising.quad) == 0
+    assert len(ising.linear) == 0
+
+
+def test_normalize_by_abs_max_only_constant():
+    # Setup: Create an Ising model with only constant term
+    ising = IsingModel(quad={}, linear={}, constant=5.0)
+
+    # Model with only constant should not be normalized
+    ising.normalize_by_abs_max()
+
+    # Constant should remain unchanged
+    assert ising.constant == 5.0
+    assert len(ising.quad) == 0
+    assert len(ising.linear) == 0
+
+
+def test_normalize_by_rms():
+    # Setup: Create an Ising model with known coefficients
+    ising = IsingModel(
+        quad={(0, 1): 2.0, (1, 2): -2.0},  # sum(w_ij^2) = 8, E2 = 2
+        linear={0: 1.0, 1: -1.0},  # sum(w_i^2) = 2, E1 = 2
+        constant=6.0,
+    )
+
+    # Calculate expected normalization factor
+    # sqrt(8/2 + 2/2) = sqrt(4 + 1) = sqrt(5)
+    expected_factor = np.sqrt(5)
+
+    # Execute normalization
+    ising.normalize_by_rms()
+
+    # Check normalized values with numpy's tolerance
+    np.testing.assert_allclose(ising.quad[(0, 1)], 2.0 / expected_factor)
+    np.testing.assert_allclose(ising.quad[(1, 2)], -2.0 / expected_factor)
+    np.testing.assert_allclose(ising.linear[0], 1.0 / expected_factor)
+    np.testing.assert_allclose(ising.linear[1], -1.0 / expected_factor)
+    np.testing.assert_allclose(ising.constant, 6.0 / expected_factor)


### PR DESCRIPTION
# Change
I introduce the Ising Hamiltonian normalization to `IsingModel`.
I have implemented two types of the normalization called, `rms` and `abs_max`.
The detail explanation is in the docstring of `normalize_by_abs_max` and `normalize_by_rms` in `ising_qubo,py`.
However, I have chosen that we did not normalize Ising Hamiltonian as default because changing the default value breaks the behavior of the old version.

# Usage
You can access this option through `QuantumConverter`.
This is the example code
```python
normalize_ising = "rms"
# normalize_ising = "abs_max"
qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance, normalize_ising=normalize_ising)
```

# Benchmark
I have done two benchmarks.
So far, I feel that `abs_max` works better than the other method.

### coefficient from normal distribution
I define the problem as follows:
```python
N = 16
J = np.random.randn(N,N)
J = (J + J.T) / 2
```
![normal_dist](https://github.com/user-attachments/assets/44b19977-9183-4a6f-b391-f5dec124b6a5)

### Biased some coefficient
```python
N = 16
J = np.random.uniform(0, 10, (N, N))
J = (J + J.T) / 2
J[0,1] = 100
J[1,0] = 100
```
![biased_dist](https://github.com/user-attachments/assets/3a482482-b681-449a-b85e-955b32bf1c35)

