### PR TITLE
Add Google Colab buttons to tutorial

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,6 +37,10 @@ html:
   use_issues_button: true
   use_repository_button: true
 
+launch_buttons:
+  notebook_interface: "classic"
+  binderhub_url: "https://mybinder.org"
+  colab_url: "https://colab.research.google.com"
 
 sphinx:
     extra_extensions:
@@ -66,10 +70,3 @@ sphinx:
       # コードハイライトの設定
       pygments_style: 'sphinx'
       highlight_language: 'python'
-      html_theme_options:
-        code_font_family: 'monospace'
-        code_font_size: '0.9em'
-
-languages:
-  en: English
-  ja: 日本語


### PR DESCRIPTION
# Change
- Add Google Colab buttons to tutorial
- I have erased `html_theme_options:` because it conflicts buttons.