### PR TITLE
Fix github actions jupyter-book-publish

### DIFF
--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           name: doc-landing-page
-          path: 'docs/qamomile-lp/_build/html'
+          path: 'docs/_build/html'
   
   build-jupyter-book:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
The github actions to publish jupyter book contained an error, which was that the path was wrong. I fixed the path.