### PR TITLE
Enable jupyter-notebook-publish

### DIFF
--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -2,8 +2,7 @@ name: Deploy Jupyter Book to GitHub Pages
 
 on:
   push:
-    # !!! "test/actions_jupyter-book-publish" is temporarilily added for testing purposes. !!!
-    branches: ["main", "test/actions_jupyter-book-publish"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -105,7 +105,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v3
+  #       uses: actions/download-artifact@v4
   #     - name: Upload artifact
   #       uses: actions/upload-pages-artifact@v3
   #       with:

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -96,23 +96,23 @@ jobs:
           name: doc-jupyter-book
           path: 'docs/_build/html'
 
-  # deploy:
-  #   needs: [build-lp, build-jupyter-book, integrate-pages]
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: doc-jupyter-book
-  #         path: .
-  #     - name: Upload artifact
-  #       uses: actions/upload-pages-artifact@v3
-  #       with:
-  #         name: doc-jupyter-book
-  #         path: "."
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4
+  deploy:
+    needs: [build-lp, build-jupyter-book, integrate-pages]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: doc-jupyter-book
+          path: .
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: doc-jupyter-book
+          path: "."
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -111,7 +111,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          name: doc-jupyter-book
           path: "."
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -2,7 +2,8 @@ name: Deploy Jupyter Book to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    # !!! "test/actions_jupyter-book-publish" is temporarilily added for testing purposes. !!!
+    branches: ["main", "test/actions_jupyter-book-publish"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -106,11 +106,14 @@ jobs:
   #   steps:
   #     - name: Download all artifacts
   #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: doc-jupyter-book
+  #         path: .
   #     - name: Upload artifact
   #       uses: actions/upload-pages-artifact@v3
   #       with:
   #         name: doc-jupyter-book
-  #         path: 'docs/_build/html'
+  #         path: "."
   #     - name: Deploy to GitHub Pages
   #       id: deployment
   #       uses: actions/deploy-pages@v4

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           name: doc-landing-page
           path: 'docs/_build/html'
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           name: doc-jupyter-book-${{ matrix.lang }}
           path: 'docs/${{ matrix.lang }}/_build/html'
@@ -92,7 +92,7 @@ jobs:
           mkdir -p docs/_build/html/en && cp -r doc-jupyter-book-en/* docs/_build/html/en/
           mkdir -p docs/_build/html/ja && cp -r doc-jupyter-book-ja/* docs/_build/html/ja/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           name: doc-jupyter-book
           path: 'docs/_build/html'

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -92,7 +92,7 @@ jobs:
           mkdir -p docs/_build/html/en && cp -r doc-jupyter-book-en/* docs/_build/html/en/
           mkdir -p docs/_build/html/ja && cp -r doc-jupyter-book-ja/* docs/_build/html/ja/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           name: doc-jupyter-book
           path: 'docs/_build/html'

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           name: doc-landing-page
           path: 'docs/_build/html'
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           name: doc-jupyter-book-${{ matrix.lang }}
           path: 'docs/${{ matrix.lang }}/_build/html'
@@ -92,7 +92,7 @@ jobs:
           mkdir -p docs/_build/html/en && cp -r doc-jupyter-book-en/* docs/_build/html/en/
           mkdir -p docs/_build/html/ja && cp -r doc-jupyter-book-ja/* docs/_build/html/ja/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           name: doc-jupyter-book
           path: 'docs/_build/html'

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Create unified site structure
         run: |
           mkdir -p docs/_build/html
@@ -92,7 +92,7 @@ jobs:
           mkdir -p docs/_build/html/en && cp -r doc-jupyter-book-en/* docs/_build/html/en/
           mkdir -p docs/_build/html/ja && cp -r doc-jupyter-book-ja/* docs/_build/html/ja/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           name: doc-jupyter-book
           path: 'docs/_build/html'

--- a/docs/qamomile-lp/src/components/Explore/Explore.jsx
+++ b/docs/qamomile-lp/src/components/Explore/Explore.jsx
@@ -10,7 +10,7 @@ function Explore() {
     {
       title: 'API Reference',
       description: 'Complete documentation of Qamomile\'s API.',
-      link: 'https://jij-inc.github.io/Qamomile/autoapi/index.html'
+      link: 'https://jij-inc.github.io/Qamomile/en/autoapi/index.html'
     },
     {
       title: 'Advanced Topics',

--- a/docs/qamomile-lp/src/components/Header/Header.jsx
+++ b/docs/qamomile-lp/src/components/Header/Header.jsx
@@ -7,8 +7,8 @@ function Header() {
         <a href="/" className="logo">Qamomile</a>
         <div className="nav-links">
           <a href="https://jij-inc.github.io/Qamomile/">Docs</a>
-          <a href="https://jij-inc.github.io/Qamomile/autoapi/index.html">API</a>
-          <a href="https://jij-inc.github.io/Qamomile/quickstart.html">Guide</a>
+          <a href="https://jij-inc.github.io/Qamomile/en/autoapi/index.html">API</a>
+          <a href="https://jij-inc.github.io/Qamomile/en/quickstart.html">Guide</a>
           <a href="https://discord.gg/Km5dKF9JjG">Community</a>
           <a href="https://www.j-ij.com/">Jij Inc.</a>
         </div>


### PR DESCRIPTION
# Description
Fix some wrong URLs in documentation pages and Enable `jupyter-notebook-publish`. Thus, the new documentation pages will be published once this PR is merged.