### PR TITLE
Fix jupyter-book-publish

### DIFF
--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -96,22 +96,22 @@ jobs:
           name: doc-jupyter-book
           path: 'docs/_build/html'
 
-  deploy:
-    needs: [build-lp, build-jupyter-book, integrate-pages]
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: doc-jupyter-book
-          path: .
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "."
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  # deploy:
+  #   needs: [build-lp, build-jupyter-book, integrate-pages]
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: doc-jupyter-book
+  #         path: .
+  #     - name: Upload artifact
+  #       uses: actions/upload-pages-artifact@v3
+  #       with:
+  #         path: "."
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v4

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-landing-page
           path: 'docs/_build/html'
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-jupyter-book-${{ matrix.lang }}
           path: 'docs/${{ matrix.lang }}/_build/html'
@@ -91,7 +91,7 @@ jobs:
           mkdir -p docs/_build/html/en && cp -r doc-jupyter-book-en/* docs/_build/html/en/
           mkdir -p docs/_build/html/ja && cp -r doc-jupyter-book-ja/* docs/_build/html/ja/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-jupyter-book
           path: 'docs/_build/html'

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -2,7 +2,7 @@ name: Deploy Jupyter Book to GitHub Pages
 
 on:
   push:
-    branches: ["main", "fix/jupyter-book-publish"]  # Temporary branch for testing
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -2,7 +2,7 @@ name: Deploy Jupyter Book to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix/jupyter-book-publish"]  # Temporary branch for testing
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -96,22 +96,22 @@ jobs:
           name: doc-jupyter-book
           path: 'docs/_build/html'
 
-  # deploy:
-  #   needs: [build-lp, build-jupyter-book, integrate-pages]
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: doc-jupyter-book
-  #         path: .
-  #     - name: Upload artifact
-  #       uses: actions/upload-pages-artifact@v3
-  #       with:
-  #         path: "."
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4
+  deploy:
+    needs: [build-lp, build-jupyter-book, integrate-pages]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: doc-jupyter-book
+          path: .
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Description
Fix jupyter-book-publish actions. `upload-pages-artifact@3` is used everywhere in the `yml` file but it should be used as last, right before a deployment. Change them except for the last one into `upload-artifact@v4`.