### PR TITLE
Fix `to_latex` to work with `Pauli.I`

### DIFF
--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -224,6 +224,9 @@ class Hamiltonian:
                 else:
                     h_str += f"{coeff}{term_str}"
             else:
+                if term_str == "":
+                    # This means the term is just a constant. We can skip this.
+                    continue
                 if abs(coeff) == 1:
                     h_str += "+" + term_str if coeff > 0 else "-" + term_str
                 else:

--- a/qamomile/core/operator.py
+++ b/qamomile/core/operator.py
@@ -211,14 +211,14 @@ class Hamiltonian:
             term_str = ""
 
             for op in term:
-                if op.pauli == "I":
+                if op.pauli == Pauli.I:
                     continue
 
                 pauli_str = pauli_map.get(op.pauli, "")
                 term_str += f"{pauli_str}_{{{op.index}}}"
 
-            # At first term, we don't need to add a sign
-            if counter == 0:
+            # At first term or h_str is still empty, we don't need to add a sign
+            if counter == 0 or h_str == "":
                 if abs(coeff) == 1:
                     h_str += term_str if coeff > 0 else "-" + term_str
                 else:


### PR DESCRIPTION
# Description

Fix the bugs pointed out in #157.

# Example
The code

```python
import qamomile.core.operator as qm_o

h = qm_o.Hamiltonian()

h._terms = {
    (qm_o.PauliOperator(qm_o.Pauli.I, 0),): 1.0,
    (qm_o.PauliOperator(qm_o.Pauli.X, 0),): 1.0,
    (qm_o.PauliOperator(qm_o.Pauli.I, 0),): 1.0,
}
print(h.to_latex())
```

returns

```bash
X_{0}
```

# Other
Close #157 once this PR is merged.