### PR TITLE
Fix `add_gate` to handle `Operator` well

### DIFF
--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -234,7 +234,75 @@ class QuantumCircuit:
     def qubits_label(self) -> list[str]:
         return self._qubits_label
 
-    def add_gate(self, gate: Gate):
+    def _apply_qubit_mapping_to_operator(
+        self, operator: Operator, qubit_mapping: dict[int, int]
+    ) -> Operator:
+        """
+        Apply qubit mapping to an Operator to create a new Operator with remapped qubits.
+
+        Args:
+            operator (Operator): The original operator.
+            qubit_mapping (dict[int, int]): Mapping from original qubit indices to new indices.
+
+        Returns:
+            Operator: A new operator with remapped qubits and adjusted num_qubits.
+        """
+        # Create a new circuit with the same number of qubits as the current circuit
+        new_circuit = QuantumCircuit(self.num_qubits, 0, operator.circuit.name)
+
+        # Apply the mapping to each gate in the operator's circuit
+        for gate in operator.circuit.gates:
+            mapped_gate = self._apply_qubit_mapping_to_gate(gate, qubit_mapping)
+            new_circuit.add_gate(mapped_gate)
+
+        return Operator(new_circuit, operator.label)
+
+    def _apply_qubit_mapping_to_gate(
+        self, gate: Gate, qubit_mapping: dict[int, int]
+    ) -> Gate:
+        """
+        Apply qubit mapping to a single gate.
+
+        Args:
+            gate (Gate): The gate to remap.
+            qubit_mapping (dict[int, int]): Mapping from original qubit indices to new indices.
+
+        Returns:
+            Gate: A new gate with remapped qubits.
+        """
+        if isinstance(gate, (SingleQubitGate, ParametricSingleQubitGate)):
+            new_qubit = qubit_mapping.get(gate.qubit, gate.qubit)
+            if isinstance(gate, SingleQubitGate):
+                return SingleQubitGate(gate.gate, new_qubit)
+            else:
+                return ParametricSingleQubitGate(gate.gate, new_qubit, gate.parameter)
+        elif isinstance(gate, (TwoQubitGate, ParametricTwoQubitGate)):
+            new_control = qubit_mapping.get(gate.control, gate.control)
+            new_target = qubit_mapping.get(gate.target, gate.target)
+            if isinstance(gate, TwoQubitGate):
+                return TwoQubitGate(gate.gate, new_control, new_target)
+            else:
+                return ParametricTwoQubitGate(
+                    gate.gate, new_control, new_target, gate.parameter
+                )
+        elif isinstance(gate, ThreeQubitGate):
+            new_control1 = qubit_mapping.get(gate.control1, gate.control1)
+            new_control2 = qubit_mapping.get(gate.control2, gate.control2)
+            new_target = qubit_mapping.get(gate.target, gate.target)
+            return ThreeQubitGate(gate.gate, new_control1, new_control2, new_target)
+        elif isinstance(gate, ParametricExpGate):
+            new_indices = [qubit_mapping.get(idx, idx) for idx in gate.indices]
+            return ParametricExpGate(gate.hamiltonian, gate.parameter, new_indices)
+        elif isinstance(gate, MeasurementGate):
+            new_qubit = qubit_mapping.get(gate.qubit, gate.qubit)
+            return MeasurementGate(new_qubit, gate.cbit)
+        elif isinstance(gate, Operator):
+            return self._apply_qubit_mapping_to_operator(gate, qubit_mapping)
+        else:
+            # Return the gate as-is if no mapping is needed
+            return gate
+
+    def add_gate(self, gate: Gate, qubit_mapping: typ.Optional[dict[int, int]] = None):
         """
         Add a gate to the quantum circuit.
 
@@ -242,6 +310,8 @@ class QuantumCircuit:
 
         Args:
             gate (Gate): A gate to be added.
+            qubit_mapping (dict[int, int], optional): Mapping from original qubit indices to new indices.
+                Only applied when gate is an Operator instance. Ignored for all other gate types.
 
         Raises:
             ValueError: If the gate's qubit indices are invalid.
@@ -266,10 +336,15 @@ class QuantumCircuit:
                     f"Invalid qubit index. controled_qubit1: {gate.control1}, controled_qubit2: {gate.control2}, target_qubit: {gate.target}"
                 )
         elif isinstance(gate, Operator):
+            # First check if operator fits, regardless of qubit_mapping
             if gate.circuit.num_qubits > self.num_qubits:
                 raise ValueError(
                     f"Operator requires more qubits than available. Operator qubits: {gate.circuit.num_qubits}, Circuit qubits: {self.num_qubits}"
                 )
+            if qubit_mapping is None:
+                qubit_mapping = {i: i for i in range(gate.circuit.num_qubits)}
+            # Apply the qubit mapping to the operator.
+            gate = self._apply_qubit_mapping_to_operator(gate, qubit_mapping)
         elif isinstance(gate, ParametricExpGate):
             if gate.hamiltonian.num_qubits > self.num_qubits:
                 raise ValueError(

--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -602,17 +602,23 @@ class QuantumCircuit:
         for i in range(self.num_qubits):
             self.measure(i, i)
 
-    def append(self, gate: typ.Union[Gate, "QuantumCircuit"]):
+    def append(
+        self,
+        gate: typ.Union[Gate, "QuantumCircuit"],
+        qubit_mapping: typ.Optional[dict[int, int]] = None,
+    ):
         """
         Append another quantum circuit to this quantum circuit.
 
         Args:
-            qc (QuantumCircuit): The quantum circuit to be appended.
+            gate (Gate | QuantumCircuit): The gate or quantum circuit to be appended.
+            qubit_mapping (dict[int, int], optional): Mapping from original qubit indices to new indices.
+                Only applied when gate is an Operator instance. Ignored for all other gate types.
         """
         if isinstance(gate, QuantumCircuit):
-            self.add_gate(gate.to_gate())
+            self.add_gate(gate.to_gate(), qubit_mapping)
         else:
-            self.add_gate(gate)
+            self.add_gate(gate, qubit_mapping)
 
     def to_gate(self, label: typ.Optional[str] = None) -> Operator:
         """

--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -266,9 +266,9 @@ class QuantumCircuit:
                     f"Invalid qubit index. controled_qubit1: {gate.control1}, controled_qubit2: {gate.control2}, target_qubit: {gate.target}"
                 )
         elif isinstance(gate, Operator):
-            if gate.circuit.num_qubits < self.num_qubits:
+            if gate.circuit.num_qubits > self.num_qubits:
                 raise ValueError(
-                    f"Invalid number of qubits. Expected: {self.num_qubits}, Actual: {gate.circuit.num_qubits}"
+                    f"Operator requires more qubits than available. Operator qubits: {gate.circuit.num_qubits}, Circuit qubits: {self.num_qubits}"
                 )
         elif isinstance(gate, ParametricExpGate):
             if gate.hamiltonian.num_qubits > self.num_qubits:

--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -343,6 +343,13 @@ class QuantumCircuit:
                 )
             if qubit_mapping is None:
                 qubit_mapping = {i: i for i in range(gate.circuit.num_qubits)}
+            else:
+                # Validate that all mapping target values are within valid range
+                for target_qubit in qubit_mapping.values():
+                    if target_qubit >= self.num_qubits:
+                        raise ValueError(
+                            f"Invalid qubit mapping target: {target_qubit}. Must be < {self.num_qubits}"
+                        )
             # Apply the qubit mapping to the operator.
             gate = self._apply_qubit_mapping_to_operator(gate, qubit_mapping)
         elif isinstance(gate, ParametricExpGate):

--- a/qamomile/core/circuit/circuit.py
+++ b/qamomile/core/circuit/circuit.py
@@ -271,14 +271,14 @@ class QuantumCircuit:
             Gate: A new gate with remapped qubits.
         """
         if isinstance(gate, (SingleQubitGate, ParametricSingleQubitGate)):
-            new_qubit = qubit_mapping.get(gate.qubit, gate.qubit)
+            new_qubit = qubit_mapping[gate.qubit]
             if isinstance(gate, SingleQubitGate):
                 return SingleQubitGate(gate.gate, new_qubit)
             else:
                 return ParametricSingleQubitGate(gate.gate, new_qubit, gate.parameter)
         elif isinstance(gate, (TwoQubitGate, ParametricTwoQubitGate)):
-            new_control = qubit_mapping.get(gate.control, gate.control)
-            new_target = qubit_mapping.get(gate.target, gate.target)
+            new_control = qubit_mapping[gate.control]
+            new_target = qubit_mapping[gate.target]
             if isinstance(gate, TwoQubitGate):
                 return TwoQubitGate(gate.gate, new_control, new_target)
             else:
@@ -286,15 +286,15 @@ class QuantumCircuit:
                     gate.gate, new_control, new_target, gate.parameter
                 )
         elif isinstance(gate, ThreeQubitGate):
-            new_control1 = qubit_mapping.get(gate.control1, gate.control1)
-            new_control2 = qubit_mapping.get(gate.control2, gate.control2)
-            new_target = qubit_mapping.get(gate.target, gate.target)
+            new_control1 = qubit_mapping[gate.control1]
+            new_control2 = qubit_mapping[gate.control2]
+            new_target = qubit_mapping[gate.target]
             return ThreeQubitGate(gate.gate, new_control1, new_control2, new_target)
         elif isinstance(gate, ParametricExpGate):
-            new_indices = [qubit_mapping.get(idx, idx) for idx in gate.indices]
+            new_indices = [qubit_mapping[idx] for idx in gate.indices]
             return ParametricExpGate(gate.hamiltonian, gate.parameter, new_indices)
         elif isinstance(gate, MeasurementGate):
-            new_qubit = qubit_mapping.get(gate.qubit, gate.qubit)
+            new_qubit = qubit_mapping[gate.qubit]
             return MeasurementGate(new_qubit, gate.cbit)
         elif isinstance(gate, Operator):
             return self._apply_qubit_mapping_to_operator(gate, qubit_mapping)


### PR DESCRIPTION
# Description
Fix `add_gate` and `append` of `QuantumCircuit` as follows.

* `add_gate`
   1. When `Operator` comes as `gate`, raise ValueError if `Operator.circuit.num_qubits` is greater than `self.num_qubits`.
   2. Add `qubit_mapping: dict[int (qubit index on Operator), int (qubit index on self)]` as an argument.
   3. `qubit_mapping` is ignored if the given `gate` is not `Operator`.
   4. `Operator` is reconstructed to have the same number of qubits as `self` and the new `Operator`'s gate's qubit follows the given `qubit_mapping`. If no `qubit_mapping` is given, then the mapping is identity.
   5. If any value of `qubit_mapping` is greater than or equal to `self.num_qubits`, raise `ValueError`
* `append`
   1. Add `qubit_mapping` as same as `add_gate`.

# Example

```python
from qamomile.core.circuit import QuantumCircuit, Operator
```


<details>
<summary>
Operator.circuit.num_qubits < self.num_qubits with no qubit_mapping
</summary>

```python
qm_operator = QuantumCircuit(1)
qm_operator.h(0)

print(qm_operator)

qm_base = QuantumCircuit(2)
qm_base.add_gate(Operator(qm_operator))

print(qm_base.gates[0].circuit)
```

    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]
    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]

</details>

<details>
<summary>
Operator.circuit.num_qubits < self.num_qubits with qubit_mapping
</summary>

```python
qm_operator = QuantumCircuit(1)
qm_operator.h(0)

print(qm_operator)

qm_base = QuantumCircuit(2)
qubit_mapping = {0: 1, 1: 0}
qm_base.add_gate(Operator(qm_operator), qubit_mapping)

print(qm_base.gates[0].circuit)
```

    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]
    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=1)]
</details>

<details>
<summary>
Operator.circuit.num_qubits = self.num_qubits with qubit_mapping
</summary>

```python
qm_operator = QuantumCircuit(2)
qm_operator.h(0)

print(qm_operator)

qm_base = QuantumCircuit(2)
qubit_mapping = {0: 1, 1: 0}
qm_base.add_gate(Operator(qm_operator), qubit_mapping)

print(qm_base.gates[0].circuit)
```

    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]
    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=1)]

</details>

<details>
<summary>
Operator.circuit.num_qubits < self.num_qubits
</summary>

```python
qm_operator = QuantumCircuit(3)
qm_operator.h(0)

print(qm_operator)

qm_base = QuantumCircuit(2)
qubit_mapping = {0: 1, 1: 0}
qm_base.add_gate(Operator(qm_operator), qubit_mapping)
```

    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]



    ---------------------------------------------------------------------------

    ValueError                                Traceback (most recent call last)

    Cell In[26], line 8
          6 qm_base = QuantumCircuit(2)
          7 qubit_mapping = {0: 1, 1: 0}
    ----> 8 qm_base.add_gate(Operator(qm_operator), qubit_mapping)


    File ~/dev/Qamomile/qamomile/core/circuit/circuit.py:341, in QuantumCircuit.add_gate(self, gate, qubit_mapping)
        338 elif isinstance(gate, Operator):
        339     # First check if operator fits, regardless of qubit_mapping
        340     if gate.circuit.num_qubits > self.num_qubits:
    --> 341         raise ValueError(
        342             f"Operator requires more qubits than available. Operator qubits: {gate.circuit.num_qubits}, Circuit qubits: {self.num_qubits}"
        343         )
        344     if qubit_mapping is None:
        345         qubit_mapping = {i: i for i in range(gate.circuit.num_qubits)}


    ValueError: Operator requires more qubits than available. Operator qubits: 3, Circuit qubits: 2

</details>

<details>
<summary>
Operator.circuit.num_qubits = self.num_qubits with invalid qubit_mapping
</summary>

```python
qm_operator = QuantumCircuit(2)
qm_operator.h(0)

print(qm_operator)

qm_base = QuantumCircuit(2)
qubit_mapping = {0: 1, 1: 2}
qm_base.add_gate(Operator(qm_operator), qubit_mapping)
```

    [SingleQubitGate(gate=<SingleQubitGateType.H: 0>, qubit=0)]



    ---------------------------------------------------------------------------

    ValueError                                Traceback (most recent call last)

    Cell In[28], line 8
          6 qm_base = QuantumCircuit(2)
          7 qubit_mapping = {0: 1, 1: 2}
    ----> 8 qm_base.add_gate(Operator(qm_operator), qubit_mapping)


    File ~/dev/Qamomile/qamomile/core/circuit/circuit.py:350, in QuantumCircuit.add_gate(self, gate, qubit_mapping)
        348     for target_qubit in qubit_mapping.values():
        349         if target_qubit >= self.num_qubits:
    --> 350             raise ValueError(
        351                 f"Invalid qubit mapping target: {target_qubit}. Must be < {self.num_qubits}"
        352             )
        353 # Apply the qubit mapping to the operator.
        354 gate = self._apply_qubit_mapping_to_operator(gate, qubit_mapping)


    ValueError: Invalid qubit mapping target: 2. Must be < 2

</details>

# Other
Close #187 once this PR is merged.