### PR TITLE
Move `qubo_to_ising` to `IsingModel` as class method

### DIFF
--- a/qamomile/core/converters/converter.py
+++ b/qamomile/core/converters/converter.py
@@ -42,7 +42,7 @@ import ommx.v1
 import numpy as np
 import qamomile.core.bitssample as qm_bs
 import qamomile.core.operator as qm_o
-from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.ising_qubo import IsingModel
 from qamomile.core.transpiler import QuantumSDKTranspiler
 
 ResultType = typ.TypeVar("ResultType")
@@ -215,7 +215,7 @@ class QuantumConverter(abc.ABC):
         qubo, constant = self.instance_to_qubo(multipliers, detail_parameters)
         # TODO: When simplify-True, we met some errors.
         #       Need to be fixed.
-        ising = qubo_to_ising(qubo, simplify=False)
+        ising = IsingModel.from_qubo(qubo, simplify=False)
         ising.constant += constant
 
         if isinstance(self.normalize_ising, str):

--- a/qamomile/core/ising_qubo.py
+++ b/qamomile/core/ising_qubo.py
@@ -122,6 +122,79 @@ class IsingModel:
         for key in self.quad:
             self.quad[key] /= normalization_factor
 
+    @classmethod
+    def from_qubo(
+        cls, qubo: dict[tuple[int, int], float], constant: float = 0.0, simplify=False
+    ) -> "IsingModel":
+        r"""Converts a Quadratic Unconstrained Binary Optimization (QUBO) problem to an equivalent Ising model.
+
+        QUBO:
+            .. math::
+                \sum_{ij} Q_{ij} x_i x_j,~\text{s.t.}~x_i \in \{0, 1\}
+
+        Ising model:
+            .. math::
+                \sum_{ij} J_{ij} z_i z_j + \sum_i h_i z_i, ~\text{s.t.}~z_i \in \{-1, 1\}
+
+        Correspondence:
+            .. math::
+                x_i = \frac{1 - z_i}{2}
+            where :math:`(x_i \in \{0, 1\})` and :math:`(z_i \in \{-1, 1\})`.
+
+        This transformation is derived from the conventions used to describe the eigenstates and eigenvalues of the Pauli Z operator in quantum computing. Specifically, the eigenstates |0⟩ and |1⟩ of the Pauli Z operator correspond to the eigenvalues +1 and -1, respectively:
+
+        .. math::
+            Z|0\rangle = |0\rangle, \quad Z|1\rangle = -|1\rangle
+
+        This relationship is leveraged to map the binary variables \(x_i\) in QUBO to the spin variables \(z_i\) in the Ising model.
+
+        Examples:
+            >>> qubo = {(0, 0): 1.0, (0, 1): 2.0, (1, 1): 3.0}
+            >>> ising = IsingModel.from_qubo(qubo)
+            >>> binary = [1, 0]
+            >>> spin = [-1, 1]
+            >>> qubo_energy = calc_qubo_energy(qubo, binary)
+            >>> assert qubo_energy == ising.calc_energy(spin)
+
+            >>> qubo = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
+            >>> ising = IsingModel.from_qubo(qubo)
+            >>> assert ising.constant == -0.5
+            >>> assert ising.linear == {}
+            >>> assert ising.quad == {(0, 1): 0.5}
+
+        """
+        ising_J: dict[tuple[int, int], float] = {}
+        ising_h: dict[int, float] = {}
+        constant = 0.0
+        for (i, j), value in qubo.items():
+            if i != j:
+                ising_J[(i, j)] = value / 4.0 + ising_J.get((i, j), 0.0)
+                constant += value / 4.0
+            else:
+                constant += value / 2.0
+            ising_h[i] = -value / 4.0 + ising_h.get(i, 0.0)
+            ising_h[j] = -value / 4.0 + ising_h.get(j, 0.0)
+
+        if simplify:
+            index_map = {}
+            _J, _h = {}, {}
+            for i, hi in ising_h.items():
+                if hi != 0.0:
+                    if i not in index_map:
+                        index_map[i] = len(index_map)
+                    _h[index_map[i]] = hi
+            for (i, j), Jij in ising_J.items():
+                if Jij != 0.0:
+                    if i not in index_map:
+                        index_map[i] = len(index_map)
+                    if j not in index_map:
+                        index_map[j] = len(index_map)
+                    _J[(index_map[i], index_map[j])] = Jij
+            ising_J = _J
+            ising_h = _h
+            return cls(ising_J, ising_h, constant, index_map)
+        return cls(ising_J, ising_h, constant)
+
 
 def calc_qubo_energy(qubo: dict[tuple[int, int], float], state: list[int]) -> float:
     """Calculates the energy of the state.
@@ -134,76 +207,3 @@ def calc_qubo_energy(qubo: dict[tuple[int, int], float], state: list[int]) -> fl
     for (i, j), value in qubo.items():
         energy += value * state[i] * state[j]
     return energy
-
-
-def qubo_to_ising(
-    qubo: dict[tuple[int, int], float], constant: float = 0.0, simplify=False
-) -> IsingModel:
-    r"""Converts a Quadratic Unconstrained Binary Optimization (QUBO) problem to an equivalent Ising model.
-
-    QUBO:
-        .. math::
-            \sum_{ij} Q_{ij} x_i x_j,~\text{s.t.}~x_i \in \{0, 1\}
-
-    Ising model:
-        .. math::
-            \sum_{ij} J_{ij} z_i z_j + \sum_i h_i z_i, ~\text{s.t.}~z_i \in \{-1, 1\}
-
-    Correspondence:
-        .. math::
-            x_i = \frac{1 - z_i}{2}
-        where :math:`(x_i \in \{0, 1\})` and :math:`(z_i \in \{-1, 1\})`.
-
-    This transformation is derived from the conventions used to describe the eigenstates and eigenvalues of the Pauli Z operator in quantum computing. Specifically, the eigenstates |0⟩ and |1⟩ of the Pauli Z operator correspond to the eigenvalues +1 and -1, respectively:
-
-    .. math::
-        Z|0\rangle = |0\rangle, \quad Z|1\rangle = -|1\rangle
-
-    This relationship is leveraged to map the binary variables \(x_i\) in QUBO to the spin variables \(z_i\) in the Ising model.
-
-    Examples:
-        >>> qubo = {(0, 0): 1.0, (0, 1): 2.0, (1, 1): 3.0}
-        >>> ising = qubo_to_ising(qubo)
-        >>> binary = [1, 0]
-        >>> spin = [-1, 1]
-        >>> qubo_energy = calc_qubo_energy(qubo, binary)
-        >>> assert qubo_energy == ising.calc_energy(spin)
-
-        >>> qubo = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
-        >>> ising = qubo_to_ising(qubo)
-        >>> assert ising.constant == -0.5
-        >>> assert ising.linear == {}
-        >>> assert ising.quad == {(0, 1): 0.5}
-
-    """
-    ising_J: dict[tuple[int, int], float] = {}
-    ising_h: dict[int, float] = {}
-    constant = 0.0
-    for (i, j), value in qubo.items():
-        if i != j:
-            ising_J[(i, j)] = value / 4.0 + ising_J.get((i, j), 0.0)
-            constant += value / 4.0
-        else:
-            constant += value / 2.0
-        ising_h[i] = -value / 4.0 + ising_h.get(i, 0.0)
-        ising_h[j] = -value / 4.0 + ising_h.get(j, 0.0)
-
-    if simplify:
-        index_map = {}
-        _J, _h = {}, {}
-        for i, hi in ising_h.items():
-            if hi != 0.0:
-                if i not in index_map:
-                    index_map[i] = len(index_map)
-                _h[index_map[i]] = hi
-        for (i, j), Jij in ising_J.items():
-            if Jij != 0.0:
-                if i not in index_map:
-                    index_map[i] = len(index_map)
-                if j not in index_map:
-                    index_map[j] = len(index_map)
-                _J[(index_map[i], index_map[j])] = Jij
-        ising_J = _J
-        ising_h = _h
-        return IsingModel(ising_J, ising_h, constant, index_map)
-    return IsingModel(ising_J, ising_h, constant)

--- a/tests/core/converters/test_32qrao.py
+++ b/tests/core/converters/test_32qrao.py
@@ -1,6 +1,6 @@
 import numpy as np
 import jijmodeling as jm
-from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.ising_qubo import IsingModel
 from qamomile.core.converters.qrao.qrao32 import create_x_prime, create_y_prime, create_z_prime, qrac32_encode_ising, create_prime_operator,QRAC32Converter
 import qamomile.core.operator as qm_o
 from qamomile.core.converters.qrao.graph_coloring import (

--- a/tests/core/converters/test_qrao.py
+++ b/tests/core/converters/test_qrao.py
@@ -1,6 +1,6 @@
 import numpy as np
 import jijmodeling as jm
-from qamomile.core.ising_qubo import IsingModel, qubo_to_ising
+from qamomile.core.ising_qubo import IsingModel
 from qamomile.core.converters.qrao.graph_coloring import (
     greedy_graph_coloring,
     check_linear_term,

--- a/tests/core/test_ising_qubo.py
+++ b/tests/core/test_ising_qubo.py
@@ -1,15 +1,15 @@
-from qamomile.core.ising_qubo import qubo_to_ising, IsingModel
+from qamomile.core.ising_qubo import IsingModel
 import numpy as np
 
 
 def test_onehot_conversion():
     qubo: dict[tuple[int, int], float] = {(0, 1): 2, (0, 0): -1, (1, 1): -1}
-    ising = qubo_to_ising(qubo)
+    ising = IsingModel.from_qubo(qubo)
     assert ising.constant == -0.5
     assert ising.linear == {0: 0, 1: 0}
     assert ising.quad == {(0, 1): 0.5}
 
-    ising = qubo_to_ising(qubo, simplify=True)
+    ising = IsingModel.from_qubo(qubo, simplify=True)
     assert ising.constant == -0.5
     assert ising.linear == {}
     assert ising.quad == {(0, 1): 0.5}


### PR DESCRIPTION
# Description
- Move `qubo_to_ising` to `IsingModel` as class method in `core/ising_qubo.py` and rename it as `from_qubo`.
- Replace `qubo_to_ising` with `IsingModel.from_qubo` in files that were used `qubo_to_ising`.

# Other
Close #178 once this PR is merged.