### PR TITLE
Fix the github actions

### DIFF
--- a/.github/workflows/jupyter-book-publish.yml
+++ b/.github/workflows/jupyter-book-publish.yml
@@ -98,22 +98,22 @@ jobs:
           name: doc-jupyter-book
           path: 'docs/_build/html'
 
-  # deploy:
-  #   needs: [build-lp, build-jupyter-book, integrate-pages]
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: doc-jupyter-book
-  #         path: .
-  #     - name: Upload artifact
-  #       uses: actions/upload-pages-artifact@v3
-  #       with:
-  #         path: "."
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4
+  deploy:
+    needs: [build-lp, build-jupyter-book, integrate-pages]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: doc-jupyter-book
+          path: .
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Description
This PR fixes the error raised during the process of github actions for deploying the documentation.

The error first appeared in https://github.com/Jij-Inc/Qamomile/actions/runs/19099227262 even though we didn't change anything about docs. By comparing the logs of the action above and https://github.com/Jij-Inc/Qamomile/actions/runs/18964030023, which was the action the last time successfully run, I found that a version difference with jupyter-book: [jupyter-book 2](https://jupyterbook.org/stable/) is available now, whilst our documentation is compatible with jupyter-book 1. We need to change the settings to accommodate the update. However, apparently, jupyter-book 2.0.2 does not support [custom Sphinx extensions](https://www.sphinx-doc.org/en/master/development/index.html) (see https://jupyterbook.org/stable/resources/upgrade/#should-you-upgrade). Thus, at least for now I have pinned the version of jupyter-book in the action.

# Others
Closes #227.