### PR TITLE
fixing annealing tutorial

### DIFF
--- a/docs/en/tutorial/usage/quantum_annealing.ipynb
+++ b/docs/en/tutorial/usage/quantum_annealing.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 30,
    "id": "be3ddbdf-1794-4c7e-96eb-5eb0a3994bf0",
    "metadata": {},
    "outputs": [
@@ -44,10 +44,10 @@
        "$$\\begin{array}{cccc}\\text{Problem:} & \\text{Maxcut} & & \\\\& & \\min \\quad \\displaystyle (-0.5) \\cdot \\sum_{e \\in E} \\left(- s_{e[0]} \\cdot s_{e[1]} + 1\\right) & \\\\\\text{{where}} & & & \\\\& x & 1\\text{-dim binary variable}\\\\\\end{array}$$"
       ],
       "text/plain": [
-       "<jijmodeling.Problem at 0x287e68e3940>"
+       "<jijmodeling.Problem at 0x22a93b7e780>"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 31,
    "id": "b3b5562e-686c-4412-b4ac-5d482795fba9",
    "metadata": {},
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
    "id": "9b27d5c1-4bc9-4365-b1ac-dbe48bda2eaa",
    "metadata": {},
    "outputs": [],
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 33,
    "id": "055212ad-8709-4850-9b99-4a24cb7ff286",
    "metadata": {},
    "outputs": [],
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 34,
    "id": "8910ed0b-1664-4211-8cbd-c3a6e9a94501",
    "metadata": {},
    "outputs": [],
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 35,
    "id": "5bb8afe1-4cc8-47bd-845a-e84212bf37b5",
    "metadata": {},
    "outputs": [],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 36,
    "id": "a61ce5bd-9064-4b2c-9890-a4251cd18f0f",
    "metadata": {},
    "outputs": [],
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 37,
    "id": "06cccc3f-42c8-432a-9aae-67ca4daa5686",
    "metadata": {},
    "outputs": [],
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 38,
    "id": "42e52cb0-99f0-4160-94b5-e96be637f59c",
    "metadata": {},
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 39,
    "id": "f2f6b220-5bdf-4ea7-87f6-d53150fa64b6",
    "metadata": {},
    "outputs": [
@@ -317,42 +317,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 40,
    "id": "45c8865b-8655-422d-97dd-50e8ccbb204d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{0: 0, 1: 1, 2: 0, 3: 0, 4: 1}, {0: 0, 1: 1, 2: 1, 3: 0, 4: 1}, {0: 1, 1: 0, 2: 0, 3: 1, 4: 0}, {0: 1, 1: 0, 2: 1, 3: 1, 4: 0}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from qamomile.core.bitssample import BitsSample\n",
+    "from qamomile.core.bitssample import BitsSample,BitsSampleSet\n",
     "samples = []\n",
     "for state,prob in final_states:\n",
     "    sample = BitsSample(bits=state, num_occurrences=1)\n",
     "    samples.append(sample)\n",
     "\n",
-    "transformed_state=[]\n",
-    "for sample in samples: \n",
-    "    # Start with all zeros\n",
-    "    cut_dict = {node: 0 for node in G.nodes()}\n",
-    "    \n",
-    "    for i, bit_num in enumerate(sample.bits):\n",
-    "        if bit_num == 1:        \n",
-    "            cut_dict[i] = 1\n",
-    "    \n",
-    "    transformed_state.append(cut_dict)\n",
-    "\n",
-    "print(transformed_state)"
+    "sample_set = BitsSampleSet(samples)\n",
+    "ommx_sample_set = qaoa_converter.decode_bits_to_sampleset(sample_set)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 41,
    "id": "73303f50-383e-4fa4-8375-a67bae5a0029",
    "metadata": {},
    "outputs": [
@@ -387,9 +369,10 @@
     "fig, axes = plt.subplots(2, 2, figsize=(10, 8)) \n",
     "axes = axes.flatten()\n",
     "\n",
-    "for i, cut_solution in enumerate(transformed_state):\n",
+    "for i, sample_id in enumerate(ommx_sample_set.sample_ids):\n",
+    "    solution = ommx_sample_set.get_sample_by_id(sample_id)\n",
     "    \n",
-    "    edge_colors, node_colors = get_edge_colors(G, cut_solution)\n",
+    "    edge_colors, node_colors = get_edge_colors(G, solution.state.entries)\n",
     "    \n",
     "    # Create the plot\n",
     "    ax = axes[i]  # Select subplot\n",
@@ -420,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 42,
    "id": "f624a3cf-8875-4754-99eb-e711f5daa92c",
    "metadata": {},
    "outputs": [],
@@ -437,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 43,
    "id": "e5102eef-e724-4161-8304-7e5b4e2bed9b",
    "metadata": {},
    "outputs": [

--- a/docs/ja/tutorial/usage/quantum_annealing.ipynb
+++ b/docs/ja/tutorial/usage/quantum_annealing.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "id": "f94226bd-5710-4655-8f73-cc105f3e8f2d",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "id": "be3ddbdf-1794-4c7e-96eb-5eb0a3994bf0",
    "metadata": {},
    "outputs": [
@@ -65,10 +65,10 @@
        "$$\\begin{array}{cccc}\\text{Problem:} & \\text{Maxcut} & & \\\\& & \\min \\quad \\displaystyle (-0.5) \\cdot \\sum_{e \\in E} \\left(- s_{e[0]} \\cdot s_{e[1]} + 1\\right) & \\\\\\text{{where}} & & & \\\\& x & 1\\text{-dim binary variable}\\\\\\end{array}$$"
       ],
       "text/plain": [
-       "<jijmodeling.Problem at 0x1e1e20ded30>"
+       "<jijmodeling.Problem at 0x25c1c9c2730>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "id": "b3b5562e-686c-4412-b4ac-5d482795fba9",
    "metadata": {},
    "outputs": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "id": "9b27d5c1-4bc9-4365-b1ac-dbe48bda2eaa",
    "metadata": {},
    "outputs": [],
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "id": "055212ad-8709-4850-9b99-4a24cb7ff286",
    "metadata": {},
    "outputs": [],
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "id": "8910ed0b-1664-4211-8cbd-c3a6e9a94501",
    "metadata": {},
    "outputs": [],
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "id": "5bb8afe1-4cc8-47bd-845a-e84212bf37b5",
    "metadata": {},
    "outputs": [],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 8,
    "id": "a61ce5bd-9064-4b2c-9890-a4251cd18f0f",
    "metadata": {},
    "outputs": [],
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "id": "06cccc3f-42c8-432a-9aae-67ca4daa5686",
    "metadata": {},
    "outputs": [],
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "id": "42e52cb0-99f0-4160-94b5-e96be637f59c",
    "metadata": {},
    "outputs": [
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 11,
    "id": "f2f6b220-5bdf-4ea7-87f6-d53150fa64b6",
    "metadata": {},
    "outputs": [
@@ -326,42 +326,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 12,
    "id": "45c8865b-8655-422d-97dd-50e8ccbb204d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{0: 0, 1: 1, 2: 0, 3: 0, 4: 1}, {0: 0, 1: 1, 2: 1, 3: 0, 4: 1}, {0: 1, 1: 0, 2: 0, 3: 1, 4: 0}, {0: 1, 1: 0, 2: 1, 3: 1, 4: 0}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from qamomile.core.bitssample import BitsSample\n",
+    "from qamomile.core.bitssample import BitsSample,BitsSampleSet\n",
     "samples = []\n",
     "for state,prob in final_states:\n",
     "    sample = BitsSample(bits=state, num_occurrences=1)\n",
     "    samples.append(sample)\n",
     "\n",
-    "transformed_state=[]\n",
-    "for sample in samples: \n",
-    "    # Start with all zeros\n",
-    "    cut_dict = {node: 0 for node in G.nodes()}\n",
-    "    \n",
-    "    for i, bit_num in enumerate(sample.bits):\n",
-    "        if bit_num == 1:        \n",
-    "            cut_dict[i] = 1\n",
-    "    \n",
-    "    transformed_state.append(cut_dict)\n",
-    "\n",
-    "print(transformed_state)"
+    "sample_set = BitsSampleSet(samples)\n",
+    "ommx_sample_set = qaoa_converter.decode_bits_to_sampleset(sample_set)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 13,
    "id": "73303f50-383e-4fa4-8375-a67bae5a0029",
    "metadata": {},
    "outputs": [
@@ -396,9 +378,10 @@
     "fig, axes = plt.subplots(2, 2, figsize=(10, 8)) \n",
     "axes = axes.flatten()\n",
     "\n",
-    "for i, cut_solution in enumerate(transformed_state):\n",
+    "for i, sample_id in enumerate(ommx_sample_set.sample_ids):\n",
+    "    solution = ommx_sample_set.get_sample_by_id(sample_id)\n",
     "    \n",
-    "    edge_colors, node_colors = get_edge_colors(G, cut_solution)\n",
+    "    edge_colors, node_colors = get_edge_colors(G, solution.state.entries)\n",
     "    \n",
     "    # Create the plot\n",
     "    ax = axes[i]  # Select subplot\n",
@@ -429,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 14,
    "id": "f624a3cf-8875-4754-99eb-e711f5daa92c",
    "metadata": {},
    "outputs": [],
@@ -446,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 15,
    "id": "e5102eef-e724-4161-8304-7e5b4e2bed9b",
    "metadata": {},
    "outputs": [

--- a/qamomile/qutip/transpiler.py
+++ b/qamomile/qutip/transpiler.py
@@ -46,7 +46,7 @@ class QuTiPTranspiler(QuantumSDKTranspiler[tuple[collections.Counter[int], int]]
             NotImplementedError: If an unsupported Pauli operator is encountered.
         """
         n = operator.num_qubits
-        H = tensor(*[qzero(2)] * n)
+        H = tensor([qzero(2)] * n)
         for term, coeff in operator.terms.items():
             op_list = [qeye(2)] * n
             for pauli in term:


### PR DESCRIPTION
Resolving issue #137 

A fix to the QuTiP transpiler fixed the issue referenced here, but further changes wer enecessary to make this tutorial run. You can no longer iterate through the 'x' values of a sample set as done previously with line 
"for transformed in qaoa_converter.decode_bits_to_sampleset(sample_set).data"

Instead, the samples are iterated over and the bit strings are manually transformed into mappings to the MaxCut nodes using:

transformed_state=[]
for sample in samples: 
    # Start with all zeros
    cut_dict = {node: 0 for node in G.nodes()}
    
    for i, bit_num in enumerate(sample.bits):
        if bit_num == 1:        
            cut_dict[i] = 1
    
    transformed_state.append(cut_dict)


The tutorial now completes and demonstrates the expected outcomes of 4 degnerate states. You can observe the solved MaxCut images and plot of the energy evolution to observe this. Slightly different solutions are found to the original sheet, but this is due to the symmetry in the problem and is okay.