### PR TITLE
Update usage documentation to include CUDA-Q and FQAOA

### DIFF
--- a/docs/en/tutorial/usage/index_usage.md
+++ b/docs/en/tutorial/usage/index_usage.md
@@ -7,6 +7,7 @@ Qamomile specializes in the conversion of mathematical models into quantum circu
 
 - **QAOA**: Quantum Approximate Optimization Algorithm
 - **QRAO**: Quantum Random Approximation Optimization
+- **FQAOA**: Fermionic Quantum Approximate Optimization Algorithm
 
 
 ## Supported Quantum Circuit SDKs
@@ -15,6 +16,7 @@ Qamomile specializes in the conversion of mathematical models into quantum circu
 - **Quri-parts**
 - **PennyLane**
 - **Qutip**
+- **CUDA-Q**
 
 ## Supported Neutral Atom Quantum computer SDKs
 

--- a/docs/ja/tutorial/usage/index_usage.md
+++ b/docs/ja/tutorial/usage/index_usage.md
@@ -6,6 +6,7 @@ Qamomileチュートリアルへようこそ！このガイドでは、量子最
 
 - **QAOA**：量子近似最適化アルゴリズム（Quantum Approximate Optimization Algorithm）
 - **QRAO**：量子ランダム近似最適化（Quantum Random Approximation Optimization）
+- **FQAOA**：フェルミオン量子近似最適化アルゴリズム（Fermionic Quantum Approximate Optimization Algorithm）
 
 ## 対応している量子回路 SDK
 
@@ -13,6 +14,7 @@ Qamomileチュートリアルへようこそ！このガイドでは、量子最
 - **Quri-parts**
 - **PennyLane**
 - **Qutip**
+- **CUDA-Q**
 
 ## 対応している中性原子量子コンピュータ SDK
 


### PR DESCRIPTION
## Summary
- Add CUDA-Q to Supported Quantum Circuit SDKs section in both English and Japanese documentation
- Add FQAOA (Fermionic Quantum Approximate Optimization Algorithm) to Supported Quantum Optimization Encodings and Algorithms section in both English and Japanese documentation

## Changes Made
- Updated `docs/en/tutorial/usage/index_usage.md` to include CUDA-Q in the Supported Quantum Circuit SDKs list
- Updated `docs/en/tutorial/usage/index_usage.md` to include FQAOA in the Supported Quantum Optimization Encodings and Algorithms list
- Updated `docs/ja/tutorial/usage/index_usage.md` to include CUDA-Q in the 対応している量子回路 SDK list
- Updated `docs/ja/tutorial/usage/index_usage.md` to include FQAOA in the 対応している量子最適化エンコーディングとアルゴリズム list

## Test plan
- [x] Verify English documentation lists CUDA-Q under Supported Quantum Circuit SDKs
- [x] Verify English documentation lists FQAOA under Supported Quantum Optimization Encodings and Algorithms
- [x] Verify Japanese documentation lists CUDA-Q under 対応している量子回路 SDK
- [x] Verify Japanese documentation lists FQAOA under 対応している量子最適化エンコーディングとアルゴリズム

🤖 Generated with [Claude Code](https://claude.com/claude-code)