### PR TITLE
Fix Colab/Binder launch buttons not displaying in documentation

### DIFF
--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -74,3 +74,10 @@ sphinx:
         logo:
           image_light: "../assets/png/qamomile_logo_white_back.png"
           image_dark: "../assets/png/qamomile_with_title_white.png"
+        repository_url: "https://github.com/Jij-Inc/Qamomile"
+        repository_branch: "main"
+        path_to_docs: "docs/en"
+        launch_buttons:
+          notebook_interface: "classic"
+          binderhub_url: "https://mybinder.org"
+          colab_url: "https://colab.research.google.com"

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -74,3 +74,10 @@ sphinx:
         logo:
           image_light: "../assets/png/qamomile_logo_white_back.png"
           image_dark: "../assets/png/qamomile_with_title_white.png"
+        repository_url: "https://github.com/Jij-Inc/Qamomile"
+        repository_branch: "main"
+        path_to_docs: "docs/ja"
+        launch_buttons:
+          notebook_interface: "classic"
+          binderhub_url: "https://mybinder.org"
+          colab_url: "https://colab.research.google.com"


### PR DESCRIPTION
## Summary
- Add `repository_url`, `repository_branch`, `path_to_docs`, and `launch_buttons` settings to `html_theme_options` in the sphinx config section
- This enables Colab and Binder buttons to display correctly on notebook pages in the documentation

## Problem
The `launch_buttons` configuration was set at the top-level of `_config.yml`, but the Sphinx Book Theme expects these settings to be nested under `sphinx.config.html_theme_options.launch_buttons`. This caused the Colab and Binder buttons to not appear on the documentation pages despite being configured.

## Solution
Moved the launch button configuration to the correct location within `html_theme_options` for both English and Japanese documentation.

Fixes #237

## Test plan
- [x] Build documentation locally with `jupyter-book build docs/en`
- [x] Verify Colab button appears in generated HTML for notebook pages
- [x] Verify Binder button appears in generated HTML for notebook pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)