### PR TITLE
Add citation for IEEE QCE 2025 paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,20 @@ We welcome contributions! Please see our [Contributing Guide](docs/contribute.md
 ## License
 
 Qamomile is released under the [Apache 2.0 License](LICENSE.txt).
+
+## Citation
+
+If you use Qamomile in your research, please cite our paper:
+
+```bibtex
+@INPROCEEDINGS{11249901,
+  author={Huang, Wei-Hao and Matsuyama, Hiromichi and Tam, Wai-Hong and Sato, Keisuke and Yamashiro, Yu},
+  booktitle={2025 IEEE International Conference on Quantum Computing and Engineering (QCE)},
+  title={Qamomile: A Cross-SDK Bridge for Quantum Optimization},
+  year={2025},
+  volume={02},
+  number={},
+  pages={516-517},
+  keywords={Quantum computing;Quantum algorithm;Quantum advantage;Optimization models;Bridge circuits;Reproducibility of results;Hardware;Quantum circuit;Optimization;Software development management;Quantum optimization;QAOA;QRAO;intermediate representation;QUBO;quantum SDK;NISQ computing},
+  doi={10.1109/QCE65121.2025.10423}}
+```


### PR DESCRIPTION
## Summary
- Add citation section to README.md with BibTeX entry for the IEEE QCE 2025 paper "Qamomile: A Cross-SDK Bridge for Quantum Optimization"

Closes #240

## Test plan
- [x] Verify BibTeX entry is correctly formatted
- [x] Confirm paper link and DOI are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)