### PR TITLE
Remove redundant _DictValueType class

### DIFF
--- a/qamomile/circuit/ir/types/primitives.py
+++ b/qamomile/circuit/ir/types/primitives.py
@@ -107,12 +107,15 @@ class DictType(ClassicalTypeMixin, ValueType):
 
     Unlike simple types, DictType stores the key and value types,
     so equality and hashing depend on those types.
+    When key_type and value_type are None, represents a generic Dict type.
     """
 
-    key_type: "ValueType"
-    value_type: "ValueType"
+    key_type: "ValueType | None" = None
+    value_type: "ValueType | None" = None
 
     def label(self) -> str:
+        if self.key_type is None or self.value_type is None:
+            return "Dict"
         return f"Dict[{self.key_type.label()}, {self.value_type.label()}]"
 
     def __eq__(self, other: object) -> bool:

--- a/qamomile/circuit/ir/value.py
+++ b/qamomile/circuit/ir/value.py
@@ -13,7 +13,7 @@ import dataclasses
 import typing
 import uuid
 
-from .types import ValueType
+from .types import DictType, ValueType
 
 T = typing.TypeVar("T", bound=ValueType)
 
@@ -271,22 +271,6 @@ class TupleValue:
 # =============================================================================
 
 
-class _DictValueType:
-    """Placeholder type for DictValue that satisfies the type interface.
-
-    DictValue is always classical (stores key-value pairs for data like Ising coefficients).
-    """
-
-    def is_quantum(self) -> bool:
-        return False
-
-    def is_classical(self) -> bool:
-        return True
-
-    def label(self) -> str:
-        return "Dict"
-
-
 @dataclasses.dataclass
 class DictValue:
     """A dictionary mapping keys to values.
@@ -315,9 +299,9 @@ class DictValue:
         )
 
     @property
-    def type(self) -> _DictValueType:
+    def type(self) -> DictType:
         """Return type interface for compatibility with Value."""
-        return _DictValueType()
+        return DictType()
 
     def is_parameter(self) -> bool:
         """Check if this dict is a parameter (bound at transpile time)."""


### PR DESCRIPTION
## Summary

- Remove the `_DictValueType` placeholder class from `value.py`
- Update `DictValue.type` property to use `DictType` from `primitives.py`
- Make `DictType.key_type` and `value_type` optional with default `None`

## Why is `_DictValueType` unnecessary?

The `_DictValueType` class was a private placeholder that existed solely to provide a type interface for `DictValue.type`. However, `DictType` already exists in `primitives.py` with full `ValueType` inheritance and proper classical type semantics:

| Class | Location | Inheritance |
|-------|----------|-------------|
| `_DictValueType` | `value.py` | None (ad-hoc interface) |
| `DictType` | `primitives.py` | `ClassicalTypeMixin`, `ValueType` ✓ |

The `_DictValueType`:
- Did not inherit from `ValueType`, making it inconsistent with the type system
- Duplicated the `is_classical()`, `is_quantum()`, and `label()` methods
- Was likely added before `DictType` existed, or they were added at different times without consolidation

Using `DictType` directly ensures type system consistency and eliminates code duplication.

## Changes

1. **`value.py`**: 
   - Remove `_DictValueType` class
   - Import `DictType` from `.types`
   - Update `DictValue.type` to return `DictType()`

2. **`primitives.py`**:
   - Make `key_type` and `value_type` optional (default `None`) to support generic Dict without specific type parameters
   - Update `label()` to return `"Dict"` when types are not specified

## Test plan

- [x] All circuit tests pass (`pytest tests/circuit/`)
- [x] Ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)