### PR TITLE
Unify UInt arithmetic to accept Float operands

### DIFF
--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import dataclasses
 
+from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind, CompOpKind
+from qamomile.circuit.ir.types import QFixedType
 from qamomile.circuit.ir.types.primitives import (
     BitType,
     FloatType,
-    UIntType,
     QubitType,
+    UIntType,
 )
-from qamomile.circuit.ir.types import QFixedType
 from qamomile.circuit.ir.value import Value
-from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind, CompOpKind
 
 from .handle import ArithmeticMixin, Handle, _emit_binop, _emit_compop
 
@@ -63,6 +63,12 @@ class UInt(ArithmeticMixin, Handle):
             )
         return other
 
+    def _result_for(self, other: "UInt | Float") -> "UInt | Float":
+        """Create the appropriate result type based on the coerced operand."""
+        if isinstance(other, Float):
+            return self._make_float_result()
+        return self._make_result()
+
     def __lt__(self, other) -> "Bit":
         if isinstance(other, int):
             other = self._make_uint(other)
@@ -91,46 +97,38 @@ class UInt(ArithmeticMixin, Handle):
         _emit_compop(self.value, other.value, result.value, CompOpKind.GE)
         return result
 
-    # Override arithmetic operations with proper type hints for UInt
-    def __add__(self, other: "int | UInt") -> "UInt":
+    def __add__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(self.value, other.value, result.value, BinOpKind.ADD)
         return result
 
-    def __radd__(self, other: "int | UInt") -> "UInt":
+    def __radd__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         return self.__add__(other)
 
-    def __sub__(self, other: "int | UInt") -> "UInt":
+    def __sub__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(self.value, other.value, result.value, BinOpKind.SUB)
         return result
 
-    def __rsub__(self, other: "int | UInt") -> "UInt":
+    def __rsub__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(other.value, self.value, result.value, BinOpKind.SUB)
         return result
 
-    # UInt-specific multiplication (handles float case differently)
-    def __mul__(self, other) -> "UInt | Float":
-        if isinstance(other, float):
-            other_value = Value(
-                type=FloatType(), name="float_const", params={"const": other}
-            )
-            result = self._make_float_result()
-            _emit_binop(self.value, other_value, result.value, BinOpKind.MUL)
-            return result
+    def __mul__(self, other: "int | float | UInt | Float") -> "UInt | Float":
+        other = self._coerce(other)
+        result = self._result_for(other)
+        _emit_binop(self.value, other.value, result.value, BinOpKind.MUL)
+        return result
 
-        # Use mixin's default implementation for int/UInt
-        return super().__mul__(other)  # type: ignore
-
-    def __rmul__(self, other) -> "UInt | Float":
+    def __rmul__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         return self.__mul__(other)
 
-    # UInt-specific true division (always returns Float)
     def __truediv__(self, other: "int | float | UInt | Float") -> "Float":
+        """UInt true division always returns Float."""
         other = self._coerce(other)
         result = self._make_float_result()
         _emit_binop(self.value, other.value, result.value, BinOpKind.DIV)
@@ -142,29 +140,27 @@ class UInt(ArithmeticMixin, Handle):
         _emit_binop(other.value, self.value, result.value, BinOpKind.DIV)
         return result
 
-    # UInt-specific floor division
-    def __floordiv__(self, other: "int | UInt") -> "UInt":
+    def __floordiv__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(self.value, other.value, result.value, BinOpKind.FLOORDIV)
         return result
 
-    def __rfloordiv__(self, other: "int | UInt") -> "UInt":
+    def __rfloordiv__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(other.value, self.value, result.value, BinOpKind.FLOORDIV)
         return result
 
-    # UInt-specific power operation
-    def __pow__(self, other: "int | UInt") -> "UInt":
+    def __pow__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(self.value, other.value, result.value, BinOpKind.POW)
         return result
 
-    def __rpow__(self, other: "int | UInt") -> "UInt":
+    def __rpow__(self, other: "int | float | UInt | Float") -> "UInt | Float":
         other = self._coerce(other)
-        result = self._make_result()
+        result = self._result_for(other)
         _emit_binop(other.value, self.value, result.value, BinOpKind.POW)
         return result
 

--- a/tests/circuit/test_uint_float_arithmetic.py
+++ b/tests/circuit/test_uint_float_arithmetic.py
@@ -1,0 +1,108 @@
+"""Tests for UInt arithmetic with float/Float operands."""
+
+import pytest
+
+from qamomile.circuit.frontend.handle.primitives import Float, UInt
+from qamomile.circuit.frontend.tracer import Tracer, trace
+from qamomile.circuit.ir.operation.arithmetic_operations import BinOp, BinOpKind
+from qamomile.circuit.ir.types.primitives import FloatType, UIntType
+from qamomile.circuit.ir.value import Value
+
+
+def _make_uint(val: int = 0) -> UInt:
+    return UInt(value=Value(type=UIntType(), name="u"), init_value=val)
+
+
+def _make_float(val: float = 0.0) -> Float:
+    return Float(value=Value(type=FloatType(), name="f"), init_value=val)
+
+
+class TestUIntWithIntOperand:
+    """UInt op int should return UInt."""
+
+    @pytest.mark.parametrize("op", ["__add__", "__sub__", "__mul__", "__floordiv__", "__pow__"])
+    def test_returns_uint(self, op: str) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = getattr(_make_uint(3), op)(2)
+        assert isinstance(result, UInt)
+
+    @pytest.mark.parametrize("op", ["__radd__", "__rsub__", "__rmul__", "__rfloordiv__", "__rpow__"])
+    def test_reflected_returns_uint(self, op: str) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = getattr(_make_uint(3), op)(2)
+        assert isinstance(result, UInt)
+
+
+class TestUIntWithFloatOperand:
+    """UInt op float should return Float."""
+
+    @pytest.mark.parametrize("op", ["__add__", "__sub__", "__mul__", "__floordiv__", "__pow__"])
+    def test_returns_float(self, op: str) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = getattr(_make_uint(3), op)(1.5)
+        assert isinstance(result, Float)
+
+    @pytest.mark.parametrize("op", ["__radd__", "__rsub__", "__rmul__", "__rfloordiv__", "__rpow__"])
+    def test_reflected_returns_float(self, op: str) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = getattr(_make_uint(3), op)(1.5)
+        assert isinstance(result, Float)
+
+
+class TestUIntWithFloatHandle:
+    """UInt op Float (handle) should return Float."""
+
+    @pytest.mark.parametrize("op", ["__add__", "__sub__", "__mul__", "__floordiv__", "__pow__"])
+    def test_returns_float(self, op: str) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = getattr(_make_uint(3), op)(_make_float(1.5))
+        assert isinstance(result, Float)
+
+
+class TestUIntTruediv:
+    """UInt truediv always returns Float regardless of operand type."""
+
+    def test_truediv_int(self) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = _make_uint(6).__truediv__(2)
+        assert isinstance(result, Float)
+
+    def test_truediv_float(self) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = _make_uint(6).__truediv__(1.5)
+        assert isinstance(result, Float)
+
+    def test_rtruediv_int(self) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            result = _make_uint(6).__rtruediv__(2)
+        assert isinstance(result, Float)
+
+
+class TestEmittedOperations:
+    """Verify that BinOp operations are correctly emitted."""
+
+    def test_add_float_emits_binop(self) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            _make_uint(3).__add__(1.5)
+        assert len(tracer.operations) == 1
+        op = tracer.operations[0]
+        assert isinstance(op, BinOp)
+        assert op.kind == BinOpKind.ADD
+
+    def test_mul_float_emits_binop(self) -> None:
+        tracer = Tracer()
+        with trace(tracer):
+            _make_uint(3).__mul__(2.0)
+        assert len(tracer.operations) == 1
+        op = tracer.operations[0]
+        assert isinstance(op, BinOp)
+        assert op.kind == BinOpKind.MUL


### PR DESCRIPTION
## Summary
- All `UInt` arithmetic methods (`__add__`, `__sub__`, `__mul__`, `__floordiv__`, `__pow__` and their reflected variants) now accept `float`/`Float` operands via `_coerce`, returning `Float` when the other operand is `Float`
- Removes inconsistency where only `__mul__` and `__truediv__` handled float operands
- Refactors `__mul__` to use `_coerce` instead of manual `isinstance` + `Value` construction
- Extracts `_result_for()` helper to eliminate repeated inline ternary for result type selection
- Sorts imports alphabetically

## Test plan
- [x] `uv run ruff check` passes
- [x] All 165 existing circuit tests pass
- [x] 30 new tests verify `UInt op float` returns `Float` and `UInt op int` returns `UInt` for all operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)