### PR TITLE
Support qBraid-style results in QiskitTranspiler decode path

### DIFF
--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -21,11 +21,13 @@ Usage:
 Note: This module requires both Qamomile and Qiskit to be installed.
 """
 
+from collections.abc import Mapping
 import numpy as np
-from typing import Any, Dict, Mapping
+from typing import Dict, Protocol, TypeAlias
 
 import qiskit
 import qiskit.circuit
+import qiskit.primitives as qk_primitives
 import qiskit.quantum_info as qk_ope
 
 import qamomile.core.bitssample as qm_bs
@@ -37,7 +39,24 @@ from .parameter_converter import convert_parameter
 from .exceptions import QamomileQiskitTranspileError
 
 
-class QiskitTranspiler(QuantumSDKTranspiler[Any]):
+CountsMapping: TypeAlias = Mapping[int, int] | Mapping[str, int]
+CountsResult: TypeAlias = CountsMapping | list[CountsMapping]
+
+
+class _SupportsCounts(Protocol):
+    def get_counts(self, decimal: bool = False) -> CountsResult: ...
+
+
+class _SupportsDataCounts(Protocol):
+    data: _SupportsCounts
+
+
+ResultType: TypeAlias = (
+    qk_primitives.BitArray | _SupportsCounts | _SupportsDataCounts | CountsMapping
+)
+
+
+class QiskitTranspiler(QuantumSDKTranspiler[ResultType]):
     """
     Transpiler class for converting between Qamomile and Qiskit quantum objects.
 
@@ -127,7 +146,7 @@ class QiskitTranspiler(QuantumSDKTranspiler[Any]):
                 )
         return qiskit_circuit
 
-    def convert_result(self, result: Any) -> qm_bs.BitsSampleSet:
+    def convert_result(self, result: ResultType) -> qm_bs.BitsSampleSet:
         """
         Convert measurement results to Qamomile BitsSampleSet.
 
@@ -147,12 +166,12 @@ class QiskitTranspiler(QuantumSDKTranspiler[Any]):
         return qm_bs.BitsSampleSet.from_int_counts(int_counts, bit_length)
 
     def _extract_int_counts_and_bit_length(
-        self, result: Any
+        self, result: ResultType
     ) -> tuple[dict[int, int], int]:
         if isinstance(result, Mapping):
             return self._counts_mapping_to_int_counts(result)
 
-        data = None
+        data: _SupportsCounts | None = None
         if hasattr(result, "data") and hasattr(result.data, "get_counts"):
             data = result.data
         elif hasattr(result, "get_counts"):
@@ -178,7 +197,7 @@ class QiskitTranspiler(QuantumSDKTranspiler[Any]):
         return self._counts_mapping_to_int_counts(counts)
 
     def _counts_mapping_to_int_counts(
-        self, counts: Mapping[Any, Any]
+        self, counts: CountsMapping
     ) -> tuple[dict[int, int], int]:
         if not counts:
             return {}, self.num_bits or 0
@@ -193,7 +212,9 @@ class QiskitTranspiler(QuantumSDKTranspiler[Any]):
         bit_length = self.num_bits or max(1, max(int_counts).bit_length())
         return int_counts, bit_length
 
-    def _infer_bit_length(self, data: Any, int_counts: dict[int, int]) -> int:
+    def _infer_bit_length(
+        self, data: _SupportsCounts, int_counts: dict[int, int]
+    ) -> int:
         if self.num_bits is not None:
             return self.num_bits
 

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -22,11 +22,10 @@ Note: This module requires both Qamomile and Qiskit to be installed.
 """
 
 import numpy as np
-from typing import Dict
+from typing import Any, Dict, Mapping
 
 import qiskit
 import qiskit.circuit
-import qiskit.primitives as qk_primitives
 import qiskit.quantum_info as qk_ope
 
 import qamomile.core.bitssample as qm_bs
@@ -38,13 +37,16 @@ from .parameter_converter import convert_parameter
 from .exceptions import QamomileQiskitTranspileError
 
 
-class QiskitTranspiler(QuantumSDKTranspiler[qk_primitives.BitArray]):
+class QiskitTranspiler(QuantumSDKTranspiler[Any]):
     """
     Transpiler class for converting between Qamomile and Qiskit quantum objects.
 
     This class implements the QuantumSDKTranspiler interface for Qiskit compatibility,
     providing methods to convert circuits, Hamiltonians, and measurement results.
     """
+
+    def __init__(self, num_bits: int | None = None):
+        self.num_bits = num_bits
 
     def transpile_circuit(
         self, qamomile_circuit: qm_c.QuantumCircuit
@@ -125,18 +127,86 @@ class QiskitTranspiler(QuantumSDKTranspiler[qk_primitives.BitArray]):
                 )
         return qiskit_circuit
 
-    def convert_result(self, result: qk_primitives.BitArray) -> qm_bs.BitsSampleSet:
+    def convert_result(self, result: Any) -> qm_bs.BitsSampleSet:
         """
-        Convert Qiskit measurement results to Qamomile BitsSampleSet.
+        Convert measurement results to Qamomile BitsSampleSet.
 
         Args:
-            result (qk_primitives.BitArray): Qiskit measurement results.
+            result: Measurement results from Qiskit BitArray, qBraid Result/ResultData,
+                or raw counts mapping.
 
         Returns:
             qm.BitsSampleSet: Converted Qamomile BitsSampleSet.
         """
-        int_counts = result.get_int_counts()
-        return qm_bs.BitsSampleSet.from_int_counts(int_counts, result.num_bits)
+        # Native Qiskit primitives path
+        if hasattr(result, "get_int_counts") and hasattr(result, "num_bits"):
+            int_counts = result.get_int_counts()
+            return qm_bs.BitsSampleSet.from_int_counts(int_counts, result.num_bits)
+
+        int_counts, bit_length = self._extract_int_counts_and_bit_length(result)
+        return qm_bs.BitsSampleSet.from_int_counts(int_counts, bit_length)
+
+    def _extract_int_counts_and_bit_length(
+        self, result: Any
+    ) -> tuple[dict[int, int], int]:
+        if isinstance(result, Mapping):
+            return self._counts_mapping_to_int_counts(result)
+
+        data = None
+        if hasattr(result, "data") and hasattr(result.data, "get_counts"):
+            data = result.data
+        elif hasattr(result, "get_counts"):
+            data = result
+
+        if data is None:
+            raise TypeError(f"Unsupported result type for conversion: {type(result)!r}")
+
+        try:
+            counts_decimal = data.get_counts(decimal=True)
+            if isinstance(counts_decimal, list):
+                counts_decimal = counts_decimal[0]
+            if isinstance(counts_decimal, Mapping) and counts_decimal:
+                int_counts = {int(k): int(v) for k, v in counts_decimal.items()}
+                return int_counts, self._infer_bit_length(data, int_counts)
+        except TypeError:
+            # Some SDKs may not support the decimal argument.
+            pass
+
+        counts = data.get_counts()
+        if isinstance(counts, list):
+            counts = counts[0]
+        return self._counts_mapping_to_int_counts(counts)
+
+    def _counts_mapping_to_int_counts(
+        self, counts: Mapping[Any, Any]
+    ) -> tuple[dict[int, int], int]:
+        if not counts:
+            return {}, self.num_bits or 0
+
+        first_key = next(iter(counts.keys()))
+        if isinstance(first_key, str):
+            int_counts = {int(k, 2): int(v) for k, v in counts.items()}
+            bit_length = self.num_bits or max(len(k) for k in counts)
+            return int_counts, bit_length
+
+        int_counts = {int(k): int(v) for k, v in counts.items()}
+        bit_length = self.num_bits or max(1, max(int_counts).bit_length())
+        return int_counts, bit_length
+
+    def _infer_bit_length(self, data: Any, int_counts: dict[int, int]) -> int:
+        if self.num_bits is not None:
+            return self.num_bits
+
+        try:
+            counts_binary = data.get_counts()
+            if isinstance(counts_binary, list):
+                counts_binary = counts_binary[0]
+            if counts_binary and isinstance(next(iter(counts_binary.keys())), str):
+                return max(len(k) for k in counts_binary)
+        except Exception:
+            pass
+
+        return max(1, max(int_counts).bit_length())
 
     def transpile_hamiltonian(self, operator: qm_o.Hamiltonian) -> qk_ope.SparsePauliOp:
         """

--- a/tests/qiskit/test_transpiler.py
+++ b/tests/qiskit/test_transpiler.py
@@ -184,6 +184,34 @@ def test_convert_result(transpiler: QiskitTranspiler):
     assert result.total_samples() == 1000
 
 
+def test_convert_result_from_counts_mapping():
+    transpiler = QiskitTranspiler(num_bits=2)
+    result = transpiler.convert_result({"00": 500, "11": 500})
+
+    assert isinstance(result, qm_bs.BitsSampleSet)
+    assert result.get_int_counts() == {0: 500, 3: 500}
+    assert result.total_samples() == 1000
+
+
+def test_convert_result_from_qbraid_like_result():
+    class MockResultData:
+        def get_counts(self, decimal=False):
+            if decimal:
+                return {0: 500, 3: 500}
+            return {"00": 500, "11": 500}
+
+    class MockQbraidResult:
+        def __init__(self):
+            self.data = MockResultData()
+
+    transpiler = QiskitTranspiler(num_bits=2)
+    result = transpiler.convert_result(MockQbraidResult())
+
+    assert isinstance(result, qm_bs.BitsSampleSet)
+    assert result.get_int_counts() == {0: 500, 3: 500}
+    assert result.total_samples() == 1000
+
+
 def test_transpile_hamiltonian(transpiler: QiskitTranspiler):
     hamiltonian = Hamiltonian()
     hamiltonian.add_term((PauliOperator(Pauli.X, 0),), 1.0)
@@ -226,6 +254,45 @@ def test_coloring_sample_decode():
     bit_array = job_result[0].data.meas
     sampleset = qaoa_converter.decode(qk_transpiler, bit_array)
     nonzero_results = {k: v for k, v in sampleset.extract_decision_variables("x", 0).items() if v != 0}
+    assert nonzero_results == {(0, 0): 1, (1, 0): 1, (2, 0): 1, (3, 0): 1}
+    assert len(sampleset.sample_ids) == 1024
+
+
+def test_coloring_sample_decode_qbraid_like_result():
+    problem = graph_coloring_problem()
+    instance_data = graph_coloring_instance()
+    compiled_instance = jm.Interpreter(instance_data).eval_problem(problem)
+    apply_vars = [(0, 0), (1, 0), (2, 0), (3, 0)]
+    initial_circuit = create_graph_coloring_operator_ansatz_initial_state(
+        compiled_instance, instance_data["V"], instance_data["N"], apply_vars
+    )
+    qaoa_converter = qm.qaoa.QAOAConverter(compiled_instance)
+    qaoa_converter.ising_encode(multipliers={"one-color": 1})
+
+    sampler = qk_pr.StatevectorSampler()
+    qk_transpiler = QiskitTranspiler(num_bits=initial_circuit.num_qubits)
+    qk_circ = qk_transpiler.transpile_circuit(initial_circuit)
+    qk_circ.measure_all()
+    bit_array = sampler.run([qk_circ]).result()[0].data.meas
+    counts = bit_array.get_counts()
+
+    class MockResultData:
+        def __init__(self, counts):
+            self._counts = counts
+
+        def get_counts(self, decimal=False):
+            if decimal:
+                return {int(k, 2): v for k, v in self._counts.items()}
+            return self._counts
+
+    class MockQbraidResult:
+        def __init__(self, counts):
+            self.data = MockResultData(counts)
+
+    sampleset = qaoa_converter.decode(qk_transpiler, MockQbraidResult(counts))
+    nonzero_results = {
+        k: v for k, v in sampleset.extract_decision_variables("x", 0).items() if v != 0
+    }
     assert nonzero_results == {(0, 0): 1, (1, 0): 1, (2, 0): 1, (3, 0): 1}
     assert len(sampleset.sample_ids) == 1024
 


### PR DESCRIPTION
## Summary
- extend `QiskitTranspiler.convert_result` to accept qBraid-style result payloads in addition to Qiskit `BitArray`
- support conversion from:
  - Qiskit `BitArray` (`get_int_counts`, `num_bits`)
  - result objects exposing `data.get_counts(...)` (qBraid `Result`)
  - result-data objects exposing `get_counts(...)`
  - raw counts mappings with binary or decimal keys
- preserve existing Qiskit behavior while enabling `qaoa_converter.decode(...)` with qBraid SDK v0.11.0 measurement results

## Tests
- add tests for counts mapping conversion
- add tests for qBraid-like result object conversion
- add end-to-end decode test using graph-coloring and a qBraid-like wrapped measurement result

Local run:
- `NUMBA_CACHE_DIR=/tmp/numba_cache PYTHONPATH=/tmp/Qamomile /Users/rickyyoung/opt/anaconda3/envs/qbjij/bin/python -m pytest /tmp/Qamomile/tests/qiskit/test_transpiler.py -q`
- result: `14 passed`
