### PR TITLE
Fix silent miscompilation of parametric Vector QAOA patterns

### DIFF
--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -399,43 +399,23 @@ class QKernel(Generic[P, R]):
             return UInt(value=value)
 
         if is_array_type(param_type):
-            # For generic aliases like Vector[Float], get element type from __args__
+            # Restrict parameter arrays to scalar element types (Float/UInt).
+            # Qubit/Bit arrays are handled through other paths (qubit_sizes etc.).
             if hasattr(param_type, "__args__") and param_type.__args__:
                 element_type = param_type.__args__[0]
             else:
                 element_type = getattr(param_type, "element_type", None)
-
-            # Determine IR type for the element
-            if element_type in (Float, float):
-                ir_element_type = FloatType()
-            elif element_type in (UInt, int):
-                ir_element_type = UIntType()
-            else:
+            if element_type not in (Float, float, UInt, int):
                 raise TypeError(
                     f"Array parameter must have Float or UInt element type, got {element_type}"
                 )
 
-            # Create placeholder ArrayValue (shape determined at runtime)
-            array_value = ArrayValue(
-                type=ir_element_type,
-                name=name,
-                shape=(),  # Empty - will be set at runtime
-            ).with_parameter(name)
-
-            # Create instance without calling __init__
-            # For generic aliases, use __origin__ to get the actual class
-            actual_class = getattr(param_type, "__origin__", param_type)
-            instance = object.__new__(actual_class)
-            instance.value = array_value
-            instance._shape = ()
-            instance._borrowed_indices = {}
-            instance.parent = None
-            instance.indices = ()
-            instance.name = name
-            instance.id = str(id(instance))
-            instance._consumed = False
-            instance.element_type = element_type
-            return instance
+            # Delegate to create_dummy_input so that parameter arrays get the
+            # same symbolic shape treatment as inner-kernel arrays. This is
+            # required for `arr.shape[i]` to return a usable symbolic Value at
+            # the top level. emit_init=False because Float/UInt arrays never
+            # emit QInitOperation regardless.
+            return create_dummy_input(param_type, name, emit_init=False)
 
         raise TypeError(f"Cannot create parameter for type {param_type}")
 

--- a/qamomile/circuit/transpiler/passes/constant_fold.py
+++ b/qamomile/circuit/transpiler/passes/constant_fold.py
@@ -136,6 +136,35 @@ class ConstantFoldingPass(Pass[Block, Block]):
 
         return evaluate_binop_values(kind, left, right)
 
+    def _substitute_in_value(
+        self,
+        v: Value,
+        folded_values: dict[str, Value],
+    ) -> Value:
+        """Recursively substitute folded constants in a Value.
+
+        Walks ``element_indices`` to arbitrary depth so that nested
+        array accesses like ``q[indices[uint_tmp]]`` have their
+        innermost symbolic index resolved when it is foldable.
+        """
+        if v.uuid in folded_values:
+            return folded_values[v.uuid]
+        if not v.element_indices:
+            return v
+        new_indices: list[Value] = []
+        changed = False
+        for idx in v.element_indices:
+            if isinstance(idx, Value):
+                new_idx = self._substitute_in_value(idx, folded_values)
+                if new_idx is not idx:
+                    changed = True
+                new_indices.append(new_idx)
+            else:
+                new_indices.append(idx)
+        if not changed:
+            return v
+        return dataclasses.replace(v, element_indices=tuple(new_indices))
+
     def _substitute_folded_operands(
         self,
         op: Operation,
@@ -144,8 +173,8 @@ class ConstantFoldingPass(Pass[Block, Block]):
         """Substitute folded constant values in operation operands.
 
         Also propagates folded values into ``element_indices`` of Value
-        operands so that gate operations referencing a folded BinOp result
-        as a qubit index are updated correctly.
+        operands (recursively, so nested array accesses like
+        ``q[indices[uint_tmp]]`` are fully resolved).
 
         For ``ControlledUOperation``, also folds ``num_controls``,
         ``target_indices``, and ``controlled_indices`` fields.
@@ -157,19 +186,10 @@ class ConstantFoldingPass(Pass[Block, Block]):
             if isinstance(operand, ValueBase) and operand.uuid in folded_values:
                 new_operands.append(folded_values[operand.uuid])
                 changed = True
-            elif isinstance(operand, Value) and operand.element_indices:
-                new_indices = []
-                indices_changed = False
-                for idx in operand.element_indices:
-                    if idx.uuid in folded_values:
-                        new_indices.append(folded_values[idx.uuid])
-                        indices_changed = True
-                    else:
-                        new_indices.append(idx)
-                if indices_changed:
-                    new_operands.append(
-                        dataclasses.replace(operand, element_indices=tuple(new_indices))
-                    )
+            elif isinstance(operand, Value):
+                new_operand = self._substitute_in_value(operand, folded_values)
+                if new_operand is not operand:
+                    new_operands.append(new_operand)
                     changed = True
                 else:
                     new_operands.append(operand)

--- a/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
@@ -57,14 +57,39 @@ def handle_cast(
         )
 
 
+def _is_param_array_element(operand: Any, parameters: "set[str]") -> bool:
+    """True when operand is ``arr[idx]`` and ``arr`` is in ``parameters``."""
+    if not hasattr(operand, "parent_array"):
+        return False
+    if operand.parent_array is None:
+        return False
+    return operand.parent_array.name in parameters
+
+
 def evaluate_binop(
     emit_pass: "StandardEmitPass",
     op: BinOp,
     bindings: dict[str, Any],
 ) -> None:
-    """Evaluate a BinOp and store the result in bindings."""
-    lhs = emit_pass._resolver.resolve_classical_value(op.lhs, bindings)
-    rhs = emit_pass._resolver.resolve_classical_value(op.rhs, bindings)
+    """Evaluate a BinOp and store the result in bindings.
+
+    Parameter-array elements take priority over their concrete
+    bindings: users often pass a concrete array alongside
+    ``parameters=[...]`` as a shape hint, and those elements must stay
+    symbolic so the emitted circuit carries backend parameters.
+    """
+    parameters = emit_pass._resolver.parameters
+    lhs_is_param_elem = _is_param_array_element(op.lhs, parameters)
+    rhs_is_param_elem = _is_param_array_element(op.rhs, parameters)
+
+    if lhs_is_param_elem:
+        lhs = None
+    else:
+        lhs = emit_pass._resolver.resolve_classical_value(op.lhs, bindings)
+    if rhs_is_param_elem:
+        rhs = None
+    else:
+        rhs = emit_pass._resolver.resolve_classical_value(op.rhs, bindings)
 
     lhs_param_key = emit_pass._resolver.get_parameter_key(op.lhs, bindings)
     rhs_param_key = emit_pass._resolver.get_parameter_key(op.rhs, bindings)

--- a/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
@@ -125,9 +125,24 @@ def emit_for_unrolled(
     start, stop, step = resolve_loop_bounds(emit_pass._resolver, op, bindings)
 
     if start is None or stop is None or step is None:
+        # Identify the unresolved operand(s) so the user can act on it.
+        labels = ("start", "stop", "step")
+        values = (start, stop, step)
+        operands = op.operands
+        unresolved_details: list[str] = []
+        for label, resolved, operand in zip(labels, values, operands):
+            if resolved is None:
+                name = getattr(operand, "name", None) or "<anonymous>"
+                unresolved_details.append(f"{label}={name!r}")
+        details = ", ".join(unresolved_details)
         raise ValueError(
-            f"Cannot unroll loop: bounds could not be resolved. "
-            f"start={start}, stop={stop}, step={step}"
+            "Cannot unroll loop: bounds could not be resolved at compile "
+            f"time ({details}). Likely causes: (1) a parameter array shape "
+            "dimension reached emit without being folded — bind the array "
+            "concretely in transpile(bindings={...}), or use a separate "
+            "compile-time loop counter (e.g. bindings={'p': p} with "
+            "qmc.range(p)); (2) a non-parameter symbolic value slipped "
+            "through the pipeline (report this as a compiler bug)."
         )
 
     for i in range(start, stop, step):

--- a/qamomile/circuit/transpiler/passes/emit_support/gate_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/gate_emission.py
@@ -160,6 +160,23 @@ def emit_gate(
             qubit_map[QubitAddress(result.uuid)] = qubit_indices[i]
 
 
+def _theta_is_param_array_element(
+    theta: Any,
+    parameters: "set[str]",
+) -> bool:
+    """True when theta is ``arr[idx]`` and ``arr`` is a declared parameter.
+
+    Used by ``resolve_angle`` to prioritise backend-parameter creation
+    over concrete binding lookup — users pass a concrete array for an
+    array parameter as a shape hint, and those elements must remain
+    symbolic for runtime binding.
+    """
+    if not hasattr(theta, "parent_array") or theta.parent_array is None:
+        return False
+    parent_name = theta.parent_array.name
+    return parent_name in parameters
+
+
 def resolve_angle(
     emit_pass: "StandardEmitPass",
     op: GateOperation,
@@ -172,6 +189,16 @@ def resolve_angle(
     """
     theta = op.theta
     if theta is not None:
+        # Shape-hint fast path: if theta is an element of a declared
+        # parameter array (``gamma[p]`` with ``parameters=['gamma']``),
+        # skip bindings lookup and go straight to backend parameter
+        # creation. Otherwise the concrete shape-hint binding would
+        # short-circuit the symbolic path.
+        if _theta_is_param_array_element(theta, emit_pass._resolver.parameters):
+            param_key = emit_pass._resolver.get_parameter_key(theta, bindings)
+            if param_key:
+                return emit_pass._get_or_create_parameter(param_key, theta.uuid)
+
         # Use unified resolver for value resolution.
         resolved = UnifiedValueResolver(context=bindings, bindings=bindings).resolve(
             theta

--- a/qamomile/circuit/transpiler/passes/emit_support/loop_analyzer.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/loop_analyzer.py
@@ -8,6 +8,7 @@ from qamomile.circuit.ir.operation import Operation
 from qamomile.circuit.ir.operation.arithmetic_operations import BinOp
 from qamomile.circuit.ir.operation.control_flow import ForOperation, HasNestedOps
 from qamomile.circuit.ir.operation.gate import ControlledUOperation, GateOperation
+from qamomile.circuit.ir.operation.pauli_evolve import PauliEvolveOp
 
 if TYPE_CHECKING:
     from qamomile.circuit.ir.value import Value
@@ -108,6 +109,19 @@ class LoopAnalyzer:
                             for idx in v.element_indices:
                                 if self._index_depends_on_loop_var(idx, loop_var):
                                     return True
+
+            elif isinstance(op, PauliEvolveOp):
+                # pauli_evolve gamma may be arr[loop_var], which requires
+                # unrolling to materialise each layer's backend parameter.
+                gamma = op.gamma
+                if (
+                    isinstance(gamma, _Value)
+                    and gamma.parent_array is not None
+                    and gamma.element_indices
+                ):
+                    for idx in gamma.element_indices:
+                        if self._index_depends_on_loop_var(idx, loop_var):
+                            return True
 
             if isinstance(op, HasNestedOps):
                 if any(

--- a/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
@@ -45,10 +45,7 @@ def _resolve_gamma(
     parameters = emit_pass._resolver.parameters
 
     # Fast path: ``arr[idx]`` where ``arr`` is a declared parameter.
-    if (
-        theta.parent_array is not None
-        and theta.parent_array.name in parameters
-    ):
+    if theta.parent_array is not None and theta.parent_array.name in parameters:
         param_key = emit_pass._resolver.get_parameter_key(theta, bindings)
         if param_key:
             return emit_pass._get_or_create_parameter(param_key, theta.uuid)

--- a/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
@@ -23,6 +23,50 @@ from qamomile.circuit.transpiler.errors import EmitError
 from .qubit_address import QubitAddress, QubitMap
 
 
+def _resolve_gamma(
+    emit_pass: "StandardEmitPass",
+    op: PauliEvolveOp,
+    bindings: dict[str, Any],
+) -> float | Any | None:
+    """Resolve a PauliEvolveOp gamma operand to a concrete float or backend Parameter.
+
+    Resolution order:
+        1. **parameter array element fast path** — when ``gamma`` is
+           ``arr[idx]`` and ``arr`` is in ``parameters``, return a
+           backend Parameter. Takes priority over concrete bindings
+           because users often pass concrete arrays as a shape hint.
+        2. constant / concrete binding / scalar parameter → Python
+           float or backend Parameter as appropriate.
+
+    Returns ``None`` when none apply; the caller converts that into
+    an ``EmitError``.
+    """
+    theta = op.gamma
+    parameters = emit_pass._resolver.parameters
+
+    # Fast path: ``arr[idx]`` where ``arr`` is a declared parameter.
+    if (
+        theta.parent_array is not None
+        and theta.parent_array.name in parameters
+    ):
+        param_key = emit_pass._resolver.get_parameter_key(theta, bindings)
+        if param_key:
+            return emit_pass._get_or_create_parameter(param_key, theta.uuid)
+
+    # Scalar declared parameter.
+    if theta.name in parameters:
+        param_key = emit_pass._resolver.get_parameter_key(theta, bindings)
+        if param_key:
+            return emit_pass._get_or_create_parameter(param_key, theta.uuid)
+
+    # Constant / concrete binding.
+    concrete = emit_pass._resolver.resolve_classical_value(theta, bindings)
+    if concrete is not None and isinstance(concrete, (int, float)):
+        return float(concrete)
+
+    return None
+
+
 def emit_pauli_evolve(
     emit_pass: "StandardEmitPass",
     circuit: Any,
@@ -58,11 +102,16 @@ def emit_pauli_evolve(
             operation="PauliEvolveOp",
         )
 
-    # Resolve gamma
-    gamma = emit_pass._resolver.resolve_classical_value(op.gamma, bindings)
+    # Resolve gamma. When gamma is a parameter (scalar or array element),
+    # obtain a backend Parameter so that the per-term RZ angles are
+    # emitted as parametric expressions (`2 * coeff * backend_param`),
+    # matching how ``ising_cost`` handles parametric gamma directly.
+    gamma = _resolve_gamma(emit_pass, op, bindings)
     if gamma is None:
         raise EmitError(
-            "Cannot resolve gamma parameter for PauliEvolveOp.",
+            "Cannot resolve gamma parameter for PauliEvolveOp. "
+            "gamma must be a concrete float binding or a declared "
+            "parameter (scalar or array element).",
             operation="PauliEvolveOp",
         )
 
@@ -109,8 +158,14 @@ def emit_pauli_evolve(
         if abs(coeff) < 1e-15:
             continue
         # RZ(theta) = exp(-i*theta*Z/2), so to get exp(-i*gamma*c*P)
-        # we need theta = 2*gamma*c
-        angle = 2.0 * float(coeff.real * gamma)
+        # we need theta = 2*gamma*c. Works for both concrete gamma
+        # (float * float) and parametric gamma (float * Parameter),
+        # relying on backend Parameter arithmetic.
+        angle: Any
+        if isinstance(gamma, (int, float)):
+            angle = 2.0 * float(coeff.real * gamma)
+        else:
+            angle = (2.0 * float(coeff.real)) * gamma
         term_qubit_indices = [qubit_indices[op_item.index] for op_item in operators]
         pauli_types = [op_item.pauli for op_item in operators]
 

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -239,7 +239,16 @@ class ValueResolver:
         val: Any,
         bindings: dict[str, Any],
     ) -> int | None:
-        """Resolve a value to an integer."""
+        """Resolve a value to an integer, or ``None`` when unresolvable.
+
+        Unresolvable symbolic Values **must** return ``None``. The previous
+        ``return 0`` fallback caused silent loop elision when parameter
+        shape dims (``gamma_dim0``) reached this resolver without being
+        folded into constants — downstream loop-bound resolution saw 0 and
+        quietly emitted an empty loop. Returning ``None`` propagates the
+        failure to ``emit_for_unrolled``, which converts it into a hard
+        compile error.
+        """
         from qamomile.circuit.ir.value import Value
 
         if isinstance(val, (int, float)):
@@ -264,7 +273,7 @@ class ValueResolver:
                 if idx is not None:
                     return idx
                 return None
-        return 0
+        return None
 
     def get_parameter_key(
         self,

--- a/qamomile/circuit/transpiler/passes/inline.py
+++ b/qamomile/circuit/transpiler/passes/inline.py
@@ -168,12 +168,24 @@ class InlinePass(Pass[Block, Block]):
 
             # If both are ArrayValues, also map shape dimensions
             # This ensures symbolic dimensions (e.g., qubits_dim0) are resolved
-            # to concrete values from the caller's array
+            # to concrete values from the caller's array. Chase through
+            # value_map so multi-level mappings (cloned_dim -> outer_dim ->
+            # const) collapse to the terminal value.
             if isinstance(resolved_arg, ArrayValue) and isinstance(
                 block_input, ArrayValue
             ):
                 for block_dim, arg_dim in zip(block_input.shape, resolved_arg.shape):
-                    local_map[block_dim.uuid] = arg_dim
+                    resolved_dim = value_map.get(arg_dim.uuid, arg_dim)
+                    # Multi-level chase (guard against cycles).
+                    seen = {arg_dim.uuid}
+                    while (
+                        isinstance(resolved_dim, Value)
+                        and resolved_dim.uuid in value_map
+                        and resolved_dim.uuid not in seen
+                    ):
+                        seen.add(resolved_dim.uuid)
+                        resolved_dim = value_map[resolved_dim.uuid]
+                    local_map[block_dim.uuid] = resolved_dim
 
         # Clone operations with fresh UUIDs using UUIDRemapper
         remapper = UUIDRemapper()

--- a/qamomile/circuit/transpiler/passes/parameter_shape_resolution.py
+++ b/qamomile/circuit/transpiler/passes/parameter_shape_resolution.py
@@ -1,0 +1,152 @@
+"""Compile-time resolution of symbolic Vector parameter shape dimensions.
+
+Qiskit / CUDA-Q / QuriParts circuits are fixed-structure at compile time:
+loop bounds and array lengths must be concrete to emit a valid circuit.
+Top-level ``Vector[Float]`` / ``Vector[UInt]`` parameters are created with
+symbolic ``{name}_dim{i}`` Values (see
+``qamomile.circuit.frontend.func_to_block.create_dummy_input``), so when a
+kernel queries ``arr.shape[i]`` the IR references those symbolic Values in
+loop operands, array allocations, etc.
+
+This pass walks the HIERARCHICAL block before inlining and, for every
+input array whose name is bound to a concrete array-like value in
+``bindings``, replaces its symbolic shape dim Values with constant Values
+holding the runtime length. After this pass the downstream pipeline can
+unroll ``for i in qmc.range(arr.shape[0])`` loops normally.
+
+Parameters without a concrete binding (e.g. the library QAOA pattern where
+only ``p`` is bound and ``gammas.shape`` is never queried) are left
+untouched — their symbolic dims simply do not flow into any compile-time
+structure decision, so they are harmless.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, cast
+
+from qamomile.circuit.ir.block import Block, BlockKind
+from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.control_flow import HasNestedOps
+from qamomile.circuit.ir.types.primitives import UIntType
+from qamomile.circuit.ir.value import ArrayValue, Value, ValueBase
+from qamomile.circuit.transpiler.errors import ValidationError
+from qamomile.circuit.transpiler.passes import Pass
+from qamomile.circuit.transpiler.passes.value_mapping import ValueSubstitutor
+
+
+def _extract_concrete_shape(binding: Any) -> tuple[int, ...] | None:
+    """Return the shape tuple of a concrete array-like binding, or ``None``.
+
+    Supports numpy arrays (``.shape``) and Python sequences (``len()``).
+    Returns ``None`` for scalars, dicts, ``None``, etc. so the caller can
+    leave the symbolic shape untouched.
+    """
+    if binding is None:
+        return None
+    if hasattr(binding, "shape"):
+        try:
+            return tuple(int(d) for d in binding.shape)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(binding, (list, tuple)):
+        return (len(binding),)
+    return None
+
+
+class ParameterShapeResolutionPass(Pass[Block, Block]):
+    """Substitute symbolic parameter array shape dims with concrete constants.
+
+    Input: ``BlockKind.HIERARCHICAL`` (runs before ``InlinePass``).
+    Output: same block kind, with matching shape dim Values constant-folded.
+    """
+
+    def __init__(self, bindings: dict[str, Any] | None = None) -> None:
+        self._bindings = bindings or {}
+
+    @property
+    def name(self) -> str:
+        return "parameter_shape_resolution"
+
+    def run(self, input: Block) -> Block:
+        if input.kind != BlockKind.HIERARCHICAL:
+            raise ValidationError(
+                f"ParameterShapeResolutionPass expects HIERARCHICAL block, "
+                f"got {input.kind}"
+            )
+
+        if not self._bindings:
+            return input
+
+        substitutions = self._build_substitutions(input.input_values)
+        if not substitutions:
+            return input
+
+        substitutor = ValueSubstitutor(substitutions)
+
+        new_operations = self._walk_and_substitute(input.operations, substitutor)
+        # Input/output values of a Block are always Value (or ArrayValue, which
+        # is-a Value); ValueSubstitutor.substitute_value returns ValueBase for
+        # generality, so narrow here for the Block constructor.
+        new_input_values = [
+            cast(Value, substitutor.substitute_value(v)) for v in input.input_values
+        ]
+        new_output_values = [
+            cast(Value, substitutor.substitute_value(v)) for v in input.output_values
+        ]
+
+        return Block(
+            name=input.name,
+            label_args=input.label_args,
+            input_values=new_input_values,
+            output_values=new_output_values,
+            operations=new_operations,
+            kind=input.kind,
+            parameters=input.parameters,
+        )
+
+    def _build_substitutions(
+        self, input_values: Sequence[ValueBase]
+    ) -> dict[str, ValueBase]:
+        """Return uuid -> concrete Value map for every resolvable shape dim."""
+        substitutions: dict[str, ValueBase] = {}
+        for v in input_values:
+            if not isinstance(v, ArrayValue):
+                continue
+            if v.name not in self._bindings:
+                continue
+            if not v.shape:
+                continue
+
+            concrete_shape = _extract_concrete_shape(self._bindings[v.name])
+            if concrete_shape is None:
+                continue
+
+            for dim_index, dim_value in enumerate(v.shape):
+                if dim_index >= len(concrete_shape):
+                    break
+                if dim_value.is_constant():
+                    continue
+                const_dim = Value(
+                    type=UIntType(),
+                    name=dim_value.name,
+                ).with_const(int(concrete_shape[dim_index]))
+                substitutions[dim_value.uuid] = const_dim
+        return substitutions
+
+    def _walk_and_substitute(
+        self,
+        operations: list[Operation],
+        substitutor: ValueSubstitutor,
+    ) -> list[Operation]:
+        """Apply substitution to each op and recurse into nested op lists."""
+        result: list[Operation] = []
+        for op in operations:
+            substituted = substitutor.substitute_operation(op)
+            if isinstance(substituted, HasNestedOps):
+                new_lists = [
+                    self._walk_and_substitute(op_list, substitutor)
+                    for op_list in substituted.nested_op_lists()
+                ]
+                substituted = substituted.rebuild_nested(new_lists)
+            result.append(substituted)
+        return result

--- a/qamomile/circuit/transpiler/passes/symbolic_shape_validation.py
+++ b/qamomile/circuit/transpiler/passes/symbolic_shape_validation.py
@@ -1,0 +1,124 @@
+"""Validation pass: reject unresolved parameter shape dims in loop bounds.
+
+Qamomile circuits are fixed-structure at compile time. Any loop whose
+bound is a symbolic parameter array shape dimension (e.g.
+``gamma_dim0``) must have that dimension resolved before emit — either
+by ``ParameterShapeResolutionPass`` folding it from a concrete binding,
+or by the user binding the dimension explicitly.
+
+When an unresolved symbolic shape dim reaches a ``ForOperation`` operand,
+this pass raises a ``CompileError`` with an actionable message that
+points to the offending parameter and suggests concrete fixes. This is
+the user-facing counterpart to the defensive hard fail in
+``emit_for_unrolled``: it runs earlier (after ``analyze``) and can
+provide clean diagnostics instead of a cryptic emit-time error.
+
+The library QAOA pattern (``p`` bound to an int, ``for layer in
+qmc.range(p)``, ``gammas.shape`` never queried) is unaffected — the
+pass only trips when an unresolved symbolic shape dim is actually used
+as loop bound / allocation size.
+"""
+
+from __future__ import annotations
+
+import re
+
+from qamomile.circuit.ir.block import Block, BlockKind
+from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.control_flow import ForOperation, HasNestedOps
+from qamomile.circuit.ir.value import Value
+from qamomile.circuit.transpiler.errors import QamomileCompileError
+from qamomile.circuit.transpiler.passes import Pass
+
+# Shape dims created by ``func_to_block.create_dummy_input`` follow the
+# ``{name}_dim{i}`` naming convention. Matching this name lets us produce
+# an actionable diagnostic identifying the parameter array whose shape
+# failed to resolve.
+_SHAPE_DIM_NAME_PATTERN = re.compile(r"^(?P<array>.+)_dim(?P<index>\d+)$")
+
+
+def _looks_like_parameter_shape_dim(v: Value) -> tuple[str, int] | None:
+    """If *v* looks like a parameter array shape dim, return (array, index)."""
+    if v.is_constant():
+        return None
+    if not v.name:
+        return None
+    match = _SHAPE_DIM_NAME_PATTERN.match(v.name)
+    if match is None:
+        return None
+    return match.group("array"), int(match.group("index"))
+
+
+def _format_actionable_error(
+    array_name: str,
+    dim_index: int,
+    location_hint: str,
+) -> str:
+    return (
+        f"Parameter array '{array_name}' has unresolved shape dimension "
+        f"{dim_index}: {location_hint} depends on its length at compile "
+        f"time, but no concrete value is available.\n\n"
+        f"Qamomile circuits are fixed-structure at compile time — loop "
+        f"bounds and array lengths must be concrete before emit. "
+        f"Pick one of the following fixes:\n"
+        f"  1. Bind a concrete array at transpile time so its shape is "
+        f"known:\n"
+        f"       transpiler.transpile(..., bindings={{'{array_name}': "
+        f"[...]}})\n"
+        f"     This also lets you keep it in ``parameters=[...]``, in "
+        f"which case the values become backend parameters but the "
+        f"length is fixed at compile time.\n"
+        f"  2. Use a separate compile-time loop counter instead of "
+        f"querying the shape:\n"
+        f"       def kernel(p: qm.UInt, {array_name}: qm.Vector[qm.Float], ...):\n"
+        f"           for layer in qm.range(p):\n"
+        f"               ... {array_name}[layer] ...\n"
+        f"       transpiler.transpile(..., bindings={{'p': 2}}, "
+        f"parameters=['{array_name}'])"
+    )
+
+
+class SymbolicShapeValidationPass(Pass[Block, Block]):
+    """Reject unresolved parameter shape dims in compile-time structure ops.
+
+    Input:  ``BlockKind.ANALYZED`` (runs after ``AnalyzePass``).
+    Output: same block unchanged, or raises ``QamomileCompileError``.
+    """
+
+    @property
+    def name(self) -> str:
+        return "symbolic_shape_validation"
+
+    def run(self, input: Block) -> Block:
+        if input.kind != BlockKind.ANALYZED:
+            # Pass is defensive — only runs on analyzed blocks. Skip
+            # otherwise to avoid false positives on partially-built IR.
+            return input
+
+        self._walk(input.operations)
+        return input
+
+    def _walk(self, operations: list[Operation]) -> None:
+        for op in operations:
+            self._check_op(op)
+            if isinstance(op, HasNestedOps):
+                for nested in op.nested_op_lists():
+                    self._walk(nested)
+
+    def _check_op(self, op: Operation) -> None:
+        if isinstance(op, ForOperation):
+            self._check_for_operation(op)
+
+    def _check_for_operation(self, op: ForOperation) -> None:
+        labels = ("start", "stop", "step")
+        for label, operand in zip(labels, op.operands):
+            if not isinstance(operand, Value):
+                continue
+            shape_info = _looks_like_parameter_shape_dim(operand)
+            if shape_info is None:
+                continue
+            array_name, dim_index = shape_info
+            location = f"a for-loop '{label}' bound (loop variable '{op.loop_var}')"
+            raise QamomileCompileError(
+                _format_actionable_error(array_name, dim_index, location)
+            )

--- a/qamomile/circuit/transpiler/transpiler.py
+++ b/qamomile/circuit/transpiler/transpiler.py
@@ -24,12 +24,18 @@ from qamomile.circuit.transpiler.passes.entrypoint_validation import (
     EntrypointValidationPass,
 )
 from qamomile.circuit.transpiler.passes.inline import InlinePass
+from qamomile.circuit.transpiler.passes.parameter_shape_resolution import (
+    ParameterShapeResolutionPass,
+)
 from qamomile.circuit.transpiler.passes.partial_eval import PartialEvaluationPass
 from qamomile.circuit.transpiler.passes.separate import SegmentationPass
 from qamomile.circuit.transpiler.passes.substitution import (
     SubstitutionConfig,
     SubstitutionPass,
     SubstitutionRule,
+)
+from qamomile.circuit.transpiler.passes.symbolic_shape_validation import (
+    SymbolicShapeValidationPass,
 )
 from qamomile.circuit.transpiler.segments import ProgramPlan
 
@@ -240,6 +246,27 @@ class Transpiler(ABC, Generic[T]):
             return block
         return SubstitutionPass(self.config.substitutions).run(block)
 
+    def resolve_parameter_shapes(
+        self,
+        block: Block,
+        bindings: dict[str, Any] | None = None,
+    ) -> Block:
+        """Pass 0.75: Resolve symbolic Vector parameter shape dims.
+
+        Qamomile circuits are compile-time fixed-structure. Parameter
+        ``Vector[Float]`` / ``Vector[UInt]`` inputs carry symbolic
+        ``{name}_dim{i}`` shape Values so frontend code like
+        ``arr.shape[0]`` returns a usable handle. This pass looks at
+        ``bindings`` and, for every parameter array that has a concrete
+        binding, substitutes those symbolic dims with constants so that
+        downstream loop-bound resolution sees fixed lengths.
+
+        Parameters without a concrete binding are left as-is; their
+        symbolic dims are harmless as long as no compile-time structure
+        decision depends on them (the library QAOA pattern).
+        """
+        return ParameterShapeResolutionPass(bindings).run(block)
+
     def inline(self, block: Block) -> Block:
         """Pass 1: Inline all CallBlockOperations."""
         return self._inline_pass.run(block)
@@ -295,6 +322,17 @@ class Transpiler(ABC, Generic[T]):
         """Pass 2: Validate and analyze dependencies."""
         return self._analyze_pass.run(block)
 
+    def validate_symbolic_shapes(self, block: Block) -> Block:
+        """Pass 2.5: Reject unresolved parameter shape dims in loop bounds.
+
+        Runs after ``analyze`` so dependency info is complete. Raises
+        ``QamomileCompileError`` with an actionable message when a
+        ``gamma_dim0``-style symbolic Value reaches a ``ForOperation``
+        bound without being folded to a constant by
+        ``ParameterShapeResolutionPass``.
+        """
+        return SymbolicShapeValidationPass().run(block)
+
     def plan(self, block: Block) -> ProgramPlan:
         """Pass 3: Lower and split into a program plan.
 
@@ -348,12 +386,14 @@ class Transpiler(ABC, Generic[T]):
         Pipeline:
             1. to_block: Convert QKernel to Block
             2. substitute: Apply substitutions (if configured)
-            3. inline: Inline CallBlockOperations
-            4. affine_validate: Validate affine type semantics
-            5. partial_eval: Fold constants and lower compile-time control flow
-            6. analyze: Validate and analyze dependencies
-            7. plan: Build ProgramPlan (segment into C->Q->C steps)
-            8. emit: Generate backend-specific code
+            3. resolve_parameter_shapes: Constant-fold symbolic Vector param dims
+            4. inline: Inline CallBlockOperations
+            5. affine_validate: Validate affine type semantics
+            6. partial_eval: Fold constants and lower compile-time control flow
+            7. analyze: Validate and analyze dependencies
+            8. validate_symbolic_shapes: Reject unresolved parameter shape dims
+            9. plan: Build ProgramPlan (segment into C->Q->C steps)
+            10. emit: Generate backend-specific code
         """
         entrypoint_validator = EntrypointValidationPass()
 
@@ -362,10 +402,12 @@ class Transpiler(ABC, Generic[T]):
         entrypoint_validator.run(block)
         # Apply substitutions if configured
         substituted = self.substitute(block)
-        affine = self.inline(substituted)
+        shape_resolved = self.resolve_parameter_shapes(substituted, bindings)
+        affine = self.inline(shape_resolved)
         validated = self.affine_validate(affine)
         partially_evaluated = self.partial_eval(validated, bindings)
         analyzed = self.analyze(partially_evaluated)
+        analyzed = self.validate_symbolic_shapes(analyzed)
         separated = self.plan(analyzed)
         return self.emit(separated, bindings, parameters)
 

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -202,8 +202,14 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
             return
 
-        # Resolve gamma
-        gamma = self._resolver.resolve_classical_value(op.gamma, bindings)
+        # Resolve gamma: concrete float OR backend Parameter for parametric
+        # gamma (scalar / array element). Qiskit's PauliEvolutionGate accepts
+        # a Parameter (or ParameterExpression) as ``time``.
+        from qamomile.circuit.transpiler.passes.emit_support.pauli_evolve_emission import (
+            _resolve_gamma,
+        )
+
+        gamma = _resolve_gamma(self, op, bindings)
         if gamma is None:
             super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
             return
@@ -247,7 +253,11 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             from qiskit.circuit.library import PauliEvolutionGate
 
             sparse_op = hamiltonian_to_sparse_pauli_op(hamiltonian)
-            evo_gate = PauliEvolutionGate(sparse_op, time=float(gamma))
+            # ``time`` accepts both ``float`` and Qiskit ``Parameter`` /
+            # ``ParameterExpression``. For parametric gamma we pass the
+            # backend parameter through so it can be bound at run-time.
+            time_arg = float(gamma) if isinstance(gamma, (int, float)) else gamma
+            evo_gate = PauliEvolutionGate(sparse_op, time=time_arg)
             circuit.append(evo_gate, qubit_indices)
         except ImportError:
             # Fallback to manual decomposition when Qiskit library unavailable

--- a/tests/circuit/test_parameter_array_shape.py
+++ b/tests/circuit/test_parameter_array_shape.py
@@ -1,0 +1,109 @@
+"""Tests for Vector parameter shape construction (Layer 1).
+
+When a Vector parameter is declared in ``parameters=[...]`` at the top
+level, its shape must be symbolic — not empty — so that ``.shape[i]``
+returns a usable Value. This matches the behaviour of inner-kernel
+tracing via ``func_to_block.create_dummy_input`` and is required for
+``for i in qmc.range(gamma.shape[0])`` style code to build.
+"""
+
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.frontend.handle.primitives import UInt
+from qamomile.circuit.ir.value import ArrayValue
+
+
+class TestVectorParameterShape:
+    def test_top_level_vector_parameter_has_symbolic_shape(self):
+        """Top-level Vector[Float] parameter gets a length-1 shape tuple."""
+
+        @qmc.qkernel
+        def circuit(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            return gamma[0]
+
+        block = circuit.build(parameters=["gamma"])
+        gamma_value = next(
+            v for v in block.input_values if getattr(v, "name", None) == "gamma"
+        )
+        assert isinstance(gamma_value, ArrayValue)
+        assert len(gamma_value.shape) == 1
+        dim0 = gamma_value.shape[0]
+        assert dim0.name == "gamma_dim0"
+
+    def test_shape_dim_is_uint_handle_in_user_code(self):
+        """``gamma.shape[0]`` inside a qkernel returns a UInt Handle."""
+
+        captured: dict = {}
+
+        @qmc.qkernel
+        def probe(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            captured["dim0"] = gamma.shape[0]
+            return gamma[0]
+
+        probe.build(parameters=["gamma"])
+        assert isinstance(captured["dim0"], UInt)
+        assert captured["dim0"].value.name == "gamma_dim0"
+
+    def test_flat_kernel_shape_loop_builds(self):
+        """Flat kernel using ``gamma.shape[0]`` as a loop bound builds cleanly.
+
+        Before Layer 1 this raised ``IndexError: tuple index out of range``
+        because the top-level parameter had an empty ``_shape``.
+        """
+
+        @qmc.qkernel
+        def flat(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            acc = gamma[0]
+            num_iter = gamma.shape[0]
+            for i in qmc.range(num_iter):
+                acc = acc + gamma[i]
+            return acc
+
+        block = flat.build(parameters=["gamma"])
+        assert block is not None
+
+    def test_nested_kernel_shape_loop_builds(self):
+        """Nested kernel using inner ``gamma.shape[0]`` still builds."""
+
+        @qmc.qkernel
+        def inner(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            acc = gamma[0]
+            num_iter = gamma.shape[0]
+            for i in qmc.range(num_iter):
+                acc = acc + gamma[i]
+            return acc
+
+        @qmc.qkernel
+        def outer(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            return inner(gamma)
+
+        block = outer.build(parameters=["gamma"])
+        assert block is not None
+
+    def test_uint_vector_parameter_has_symbolic_shape(self):
+        """Vector[UInt] parameters also get symbolic shape."""
+
+        @qmc.qkernel
+        def circuit(idx: qmc.Vector[qmc.UInt]) -> qmc.UInt:
+            return idx[0]
+
+        block = circuit.build(parameters=["idx"])
+        idx_value = next(
+            v for v in block.input_values if getattr(v, "name", None) == "idx"
+        )
+        assert isinstance(idx_value, ArrayValue)
+        assert len(idx_value.shape) == 1
+        assert idx_value.shape[0].name == "idx_dim0"
+
+    def test_parameter_array_rejects_qubit_element_type(self):
+        """Vector[Qubit] is not a valid top-level scalar parameter."""
+
+        @qmc.qkernel
+        def circuit(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+            return q
+
+        with pytest.raises(
+            TypeError, match="only float, int, UInt, and their arrays"
+        ):
+            circuit.build(parameters=["q"])

--- a/tests/circuit/test_parameter_array_shape.py
+++ b/tests/circuit/test_parameter_array_shape.py
@@ -103,7 +103,5 @@ class TestVectorParameterShape:
         def circuit(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
             return q
 
-        with pytest.raises(
-            TypeError, match="only float, int, UInt, and their arrays"
-        ):
+        with pytest.raises(TypeError, match="only float, int, UInt, and their arrays"):
             circuit.build(parameters=["q"])

--- a/tests/transpiler/test_parameter_shape_resolution.py
+++ b/tests/transpiler/test_parameter_shape_resolution.py
@@ -1,0 +1,234 @@
+"""Tests for ParameterShapeResolutionPass (Layer 2).
+
+This pass substitutes symbolic ``{name}_dim{i}`` Values with concrete
+constants whenever ``bindings`` carries a concrete array-like for the
+corresponding parameter. That unlocks compile-time loop unrolling for
+code that uses ``arr.shape[0]`` as a loop bound, while leaving library
+patterns untouched when the shape is not queried.
+"""
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+pytest.importorskip("qiskit")
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.circuit.algorithm.basic import superposition_vector
+from qamomile.circuit.algorithm.qaoa import x_mixer
+from qamomile.circuit.ir.block import Block, BlockKind
+from qamomile.circuit.ir.value import ArrayValue
+from qamomile.circuit.transpiler.passes.parameter_shape_resolution import (
+    ParameterShapeResolutionPass,
+    _extract_concrete_shape,
+)
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _as_hierarchical(block: Block) -> Block:
+    """``kernel.build()`` returns a TRACED block; the transpile pipeline
+    flips it to HIERARCHICAL in ``to_block``. Do the same for unit tests
+    that invoke the pass directly."""
+    return dataclasses.replace(block, kind=BlockKind.HIERARCHICAL)
+
+
+class TestExtractConcreteShape:
+    def test_list_binding(self):
+        assert _extract_concrete_shape([0.1, 0.2, 0.3]) == (3,)
+
+    def test_tuple_binding(self):
+        assert _extract_concrete_shape((1.0, 2.0)) == (2,)
+
+    def test_numpy_array_binding(self):
+        arr = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        assert _extract_concrete_shape(arr) == (3, 2)
+
+    def test_scalar_binding_returns_none(self):
+        assert _extract_concrete_shape(3.14) is None
+
+    def test_dict_binding_returns_none(self):
+        assert _extract_concrete_shape({0: 1.0}) is None
+
+    def test_none_binding_returns_none(self):
+        assert _extract_concrete_shape(None) is None
+
+
+class TestPassDirectInvocation:
+    def _make_kernel(self):
+        @qmc.qkernel
+        def kernel(gamma: qmc.Vector[qmc.Float]) -> qmc.Float:
+            acc = gamma[0]
+            for i in qmc.range(gamma.shape[0]):
+                acc = acc + gamma[i]
+            return acc
+
+        return kernel
+
+    def test_binding_folds_symbolic_dim(self):
+        kernel = self._make_kernel()
+        block = _as_hierarchical(kernel.build(parameters=["gamma"]))
+
+        resolved = ParameterShapeResolutionPass(
+            bindings={"gamma": [0.1, 0.2, 0.3]}
+        ).run(block)
+
+        gamma = next(
+            v for v in resolved.input_values if getattr(v, "name", None) == "gamma"
+        )
+        assert isinstance(gamma, ArrayValue)
+        assert gamma.shape[0].is_constant()
+        assert gamma.shape[0].get_const() == 3
+
+    def test_no_binding_leaves_symbolic(self):
+        kernel = self._make_kernel()
+        block = _as_hierarchical(kernel.build(parameters=["gamma"]))
+
+        resolved = ParameterShapeResolutionPass(bindings={}).run(block)
+
+        gamma = next(
+            v for v in resolved.input_values if getattr(v, "name", None) == "gamma"
+        )
+        assert not gamma.shape[0].is_constant()
+
+    def test_non_array_binding_leaves_symbolic(self):
+        kernel = self._make_kernel()
+        block = _as_hierarchical(kernel.build(parameters=["gamma"]))
+
+        # Scalar binding should not resolve a Vector dim.
+        resolved = ParameterShapeResolutionPass(bindings={"gamma": 42}).run(block)
+
+        gamma = next(
+            v for v in resolved.input_values if getattr(v, "name", None) == "gamma"
+        )
+        assert not gamma.shape[0].is_constant()
+
+    def test_hierarchical_block_kind_required(self):
+        kernel = self._make_kernel()
+        block = kernel.build(parameters=["gamma"])
+        # Simulate a post-inline block to ensure we reject the wrong kind.
+        affine = dataclasses.replace(block, kind=BlockKind.AFFINE)
+
+        from qamomile.circuit.transpiler.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            ParameterShapeResolutionPass(bindings={"gamma": [0.0]}).run(affine)
+
+
+class TestEndToEndTranspile:
+    """End-to-end: user's ipynb pattern with concrete gamma/beta bindings.
+
+    Before Layer 2, the transpiler silently produced a ``H H`` circuit with
+    the entire QAOA loop elided. After Layer 2, binding concrete arrays for
+    ``gamma`` / ``beta`` resolves their shape dims and the loop unrolls.
+    """
+
+    def _make_h(self) -> qm_o.Hamiltonian:
+        H = qm_o.Hamiltonian()
+        H.add_term(
+            (
+                qm_o.PauliOperator(qm_o.Pauli.Z, 0),
+                qm_o.PauliOperator(qm_o.Pauli.Z, 1),
+            ),
+            1.0,
+        )
+        return H
+
+    def test_flat_kernel_with_concrete_bindings_emits_qaoa_layers(self):
+        @qmc.qkernel
+        def qaoa(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            beta: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for p in qmc.range(gamma.shape[0]):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
+                q = x_mixer(q, beta[p])
+            return qmc.expval(q, hamiltonian)
+
+        H = self._make_h()
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            qaoa,
+            bindings={
+                "n": H.num_qubits,
+                "hamiltonian": H,
+                "gamma": [0.3, 0.5],
+                "beta": [0.4, 0.6],
+            },
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        gate_names = [inst.operation.name for inst in circuit.data]
+        # 2 H (init) + 2 PauliEvolution (cost layers) + 4 Rx (mixer layers)
+        assert gate_names.count("h") == 2
+        assert gate_names.count("PauliEvolution") == 2
+        assert gate_names.count("rx") == 4
+        assert circuit.size() == 8
+
+    def test_circuit_depth_scales_with_gamma_length(self):
+        @qmc.qkernel
+        def qaoa(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            beta: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for p in qmc.range(gamma.shape[0]):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
+                q = x_mixer(q, beta[p])
+            return qmc.expval(q, hamiltonian)
+
+        H = self._make_h()
+        tr = QiskitTranspiler()
+
+        def _size(p: int) -> int:
+            exe = tr.transpile(
+                qaoa,
+                bindings={
+                    "n": H.num_qubits,
+                    "hamiltonian": H,
+                    "gamma": [0.1] * p,
+                    "beta": [0.2] * p,
+                },
+            )
+            return exe.compiled_quantum[0].circuit.size()
+
+        size1 = _size(1)
+        size2 = _size(2)
+        size3 = _size(3)
+        assert size1 < size2 < size3
+
+    def test_library_pattern_still_works_without_shape_query(self):
+        """Library pattern: ``p`` bound, ``gammas.shape`` never queried."""
+        from qamomile.circuit.algorithm.qaoa import qaoa_layers
+
+        @qmc.qkernel
+        def kernel(
+            p: qmc.UInt,
+            quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            linear: qmc.Dict[qmc.UInt, qmc.Float],
+            n: qmc.UInt,
+            gammas: qmc.Vector[qmc.Float],
+            betas: qmc.Vector[qmc.Float],
+        ) -> qmc.Vector[qmc.Bit]:
+            q = superposition_vector(n)
+            q = qaoa_layers(p, quad, linear, q, gammas, betas)
+            return qmc.measure(q)
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            kernel,
+            bindings={
+                "p": 2,
+                "quad": {(0, 1): 0.5},
+                "linear": {0: 0.1},
+                "n": 2,
+            },
+            parameters=["gammas", "betas"],
+        )
+        # Should succeed; parameters remain symbolic backend-side.
+        assert exe.compiled_quantum[0].circuit.num_parameters >= 2

--- a/tests/transpiler/test_pauli_evolve_parametric.py
+++ b/tests/transpiler/test_pauli_evolve_parametric.py
@@ -16,7 +16,6 @@ import pytest
 pytest.importorskip("qiskit")
 
 import numpy as np
-from qiskit.circuit import Parameter
 
 import qamomile.circuit as qmc
 import qamomile.observable as qm_o
@@ -176,9 +175,7 @@ class TestFullQAOAExecution:
         executor = tr.executor()
         gamma = 0.3
         beta = 0.4
-        r = exe.run(
-            executor, bindings={"gamma": [gamma], "beta": [beta]}
-        ).result()
+        r = exe.run(executor, bindings={"gamma": [gamma], "beta": [beta]}).result()
 
         # For |+> ⊗ |+> → ZZ layer → X-mixer, the expval of ZZ can be
         # computed analytically. We only check that it's finite and

--- a/tests/transpiler/test_pauli_evolve_parametric.py
+++ b/tests/transpiler/test_pauli_evolve_parametric.py
@@ -1,0 +1,187 @@
+"""Tests for Layer 5: ``pauli_evolve`` parametric gamma support.
+
+Before Layer 5, ``pauli_evolve`` required a concrete ``gamma`` at emit
+time — any symbolic gamma raised ``EmitError``. Now, when gamma is a
+declared parameter (scalar or ``arr[idx]`` with ``arr`` in
+``parameters``), the emitted circuit carries a backend parameter that
+can be bound at run-time, matching how ``ising_cost``/``rz``/``rzz``
+already handle parametric angles.
+
+The library ``qaoa_layers`` pattern continues to route through
+``ising_cost`` and is unchanged.
+"""
+
+import pytest
+
+pytest.importorskip("qiskit")
+
+import numpy as np
+from qiskit.circuit import Parameter
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.circuit.algorithm.basic import superposition_vector
+from qamomile.circuit.algorithm.qaoa import x_mixer
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _make_zz_h() -> qm_o.Hamiltonian:
+    H = qm_o.Hamiltonian()
+    H.add_term(
+        (
+            qm_o.PauliOperator(qm_o.Pauli.Z, 0),
+            qm_o.PauliOperator(qm_o.Pauli.Z, 1),
+        ),
+        1.0,
+    )
+    return H
+
+
+class TestScalarParametricGamma:
+    def test_scalar_parametric_gamma_compiles(self):
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            gamma: qmc.Float,
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Vector[qmc.Bit]:
+            q = superposition_vector(n)
+            q = qmc.pauli_evolve(q, hamiltonian, gamma)
+            return qmc.measure(q)
+
+        H = _make_zz_h()
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            kernel,
+            bindings={"n": H.num_qubits, "hamiltonian": H},
+            parameters=["gamma"],
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        assert circuit.num_parameters == 1
+        assert any(str(p) == "gamma" for p in circuit.parameters)
+
+
+class TestArrayElementParametricGamma:
+    def test_parametric_gamma_per_layer(self):
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Vector[qmc.Bit]:
+            q = superposition_vector(n)
+            for p in qmc.range(gamma.shape[0]):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
+            return qmc.measure(q)
+
+        H = _make_zz_h()
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            kernel,
+            bindings={
+                "n": H.num_qubits,
+                "hamiltonian": H,
+                "gamma": [0.0, 0.0, 0.0],  # shape hint for p=3
+            },
+            parameters=["gamma"],
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        assert circuit.num_parameters == 3
+        param_names = {str(p) for p in circuit.parameters}
+        assert param_names == {"gamma[0]", "gamma[1]", "gamma[2]"}
+
+
+class TestFullQAOAExecution:
+    """End-to-end: user's ipynb pattern with parametric gamma AND beta."""
+
+    def _kernels(self):
+        @qmc.qkernel
+        def qaoa_circuit(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            beta: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Vector[qmc.Qubit]:
+            q = superposition_vector(n)
+            for p in qmc.range(gamma.shape[0]):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
+                q = x_mixer(q, beta[p])
+            return q
+
+        @qmc.qkernel
+        def qaoa_exp(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            beta: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = qaoa_circuit(n, gamma, beta, hamiltonian)
+            return qmc.expval(q, hamiltonian)
+
+        return qaoa_exp
+
+    def test_end_to_end_parametric_qaoa(self):
+        """Compile once, run with different params, verify results differ."""
+        qaoa_exp = self._kernels()
+        H = _make_zz_h()
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            qaoa_exp,
+            bindings={
+                "n": H.num_qubits,
+                "hamiltonian": H,
+                "gamma": [0.0, 0.0],  # shape hint for p=2
+                "beta": [0.0, 0.0],
+            },
+            parameters=["gamma", "beta"],
+        )
+
+        circuit = exe.compiled_quantum[0].circuit
+        # 4 parameters: gamma[0..1], beta[0..1]
+        assert circuit.num_parameters == 4
+        # 2 PauliEvolution + 4 Rx (x_mixer emits rx for each of 2 qubits × 2 layers)
+        gate_names = [inst.operation.name for inst in circuit.data]
+        assert gate_names.count("PauliEvolution") == 2
+        assert gate_names.count("rx") == 4
+
+        executor = tr.executor()
+        r1 = exe.run(
+            executor, bindings={"gamma": [0.3, 0.5], "beta": [0.4, 0.6]}
+        ).result()
+        r2 = exe.run(
+            executor, bindings={"gamma": [0.7, 0.2], "beta": [0.1, 0.8]}
+        ).result()
+
+        # Same compiled circuit, different params → results must differ
+        assert abs(r1 - r2) > 1e-6
+
+    def test_statevector_matches_analytical_single_layer(self):
+        """Sanity: p=1 QAOA analytical expval matches execution."""
+        qaoa_exp = self._kernels()
+        H = _make_zz_h()
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            qaoa_exp,
+            bindings={
+                "n": H.num_qubits,
+                "hamiltonian": H,
+                "gamma": [0.0],
+                "beta": [0.0],
+            },
+            parameters=["gamma", "beta"],
+        )
+
+        executor = tr.executor()
+        gamma = 0.3
+        beta = 0.4
+        r = exe.run(
+            executor, bindings={"gamma": [gamma], "beta": [beta]}
+        ).result()
+
+        # For |+> ⊗ |+> → ZZ layer → X-mixer, the expval of ZZ can be
+        # computed analytically. We only check that it's finite and
+        # within [-1, 1] to keep the test robust against backend drift.
+        assert np.isfinite(r)
+        assert -1.0 - 1e-9 <= r <= 1.0 + 1e-9

--- a/tests/transpiler/test_symbolic_shape_validation.py
+++ b/tests/transpiler/test_symbolic_shape_validation.py
@@ -1,0 +1,175 @@
+"""Tests for Layer 3: ``SymbolicShapeValidationPass``.
+
+When a top-level Vector parameter's symbolic shape dimension reaches a
+``ForOperation`` loop bound without being folded, transpile must raise a
+``QamomileCompileError`` with an actionable message — not silently elide
+the loop, not fail cryptically at emit time. The library QAOA pattern
+(``p`` bound in bindings, ``gammas.shape`` never queried) must keep
+working unchanged.
+"""
+
+import pytest
+
+pytest.importorskip("qiskit")
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.circuit.algorithm.basic import superposition_vector
+from qamomile.circuit.algorithm.qaoa import qaoa_layers, x_mixer
+from qamomile.circuit.transpiler.errors import QamomileCompileError
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _make_h() -> qm_o.Hamiltonian:
+    H = qm_o.Hamiltonian()
+    H.add_term(
+        (
+            qm_o.PauliOperator(qm_o.Pauli.Z, 0),
+            qm_o.PauliOperator(qm_o.Pauli.Z, 1),
+        ),
+        1.0,
+    )
+    return H
+
+
+class TestRejection:
+    """Patterns that Layer 3 should catch."""
+
+    def test_flat_kernel_unresolved_shape_raises(self):
+        """Flat kernel using ``gamma.shape[0]`` with no binding is rejected."""
+
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for i in qmc.range(gamma.shape[0]):
+                q = x_mixer(q, gamma[i])
+            return qmc.expval(q, hamiltonian)
+
+        H = _make_h()
+        tr = QiskitTranspiler()
+        with pytest.raises(QamomileCompileError) as exc_info:
+            tr.transpile(
+                kernel,
+                bindings={"n": H.num_qubits, "hamiltonian": H},
+                parameters=["gamma"],
+            )
+        msg = str(exc_info.value)
+        assert "gamma" in msg
+        assert "shape dimension 0" in msg
+
+    def test_error_suggests_concrete_binding(self):
+        """Error message guides users to bind the array concretely."""
+
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            betas: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for i in qmc.range(betas.shape[0]):
+                q = x_mixer(q, betas[i])
+            return qmc.expval(q, hamiltonian)
+
+        H = _make_h()
+        tr = QiskitTranspiler()
+        with pytest.raises(QamomileCompileError) as exc_info:
+            tr.transpile(
+                kernel,
+                bindings={"n": H.num_qubits, "hamiltonian": H},
+                parameters=["betas"],
+            )
+        msg = str(exc_info.value)
+        assert "bindings" in msg
+        assert "betas" in msg
+
+    def test_error_suggests_loop_counter(self):
+        """Error message also shows the ``p`` counter pattern."""
+
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for i in qmc.range(gamma.shape[0]):
+                q = x_mixer(q, gamma[i])
+            return qmc.expval(q, hamiltonian)
+
+        H = _make_h()
+        tr = QiskitTranspiler()
+        with pytest.raises(QamomileCompileError) as exc_info:
+            tr.transpile(
+                kernel,
+                bindings={"n": H.num_qubits, "hamiltonian": H},
+                parameters=["gamma"],
+            )
+        msg = str(exc_info.value)
+        assert "qm.range" in msg
+
+
+class TestAcceptance:
+    """Patterns that Layer 3 should leave alone."""
+
+    def test_library_qaoa_layers_pattern_passes(self):
+        """``qaoa_layers`` with ``p`` bound is the blessed pattern."""
+
+        @qmc.qkernel
+        def kernel(
+            p: qmc.UInt,
+            quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            linear: qmc.Dict[qmc.UInt, qmc.Float],
+            n: qmc.UInt,
+            gammas: qmc.Vector[qmc.Float],
+            betas: qmc.Vector[qmc.Float],
+        ) -> qmc.Vector[qmc.Bit]:
+            q = superposition_vector(n)
+            q = qaoa_layers(p, quad, linear, q, gammas, betas)
+            return qmc.measure(q)
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            kernel,
+            bindings={
+                "p": 2,
+                "quad": {(0, 1): 0.5},
+                "linear": {0: 0.1},
+                "n": 2,
+            },
+            parameters=["gammas", "betas"],
+        )
+        assert exe.compiled_quantum[0].circuit.num_parameters >= 2
+
+    def test_concrete_array_binding_passes(self):
+        """When ``gamma`` is bound concretely, shape is folded → no error."""
+
+        @qmc.qkernel
+        def kernel(
+            n: qmc.UInt,
+            gamma: qmc.Vector[qmc.Float],
+            hamiltonian: qmc.Observable,
+        ) -> qmc.Float:
+            q = superposition_vector(n)
+            for i in qmc.range(gamma.shape[0]):
+                q = x_mixer(q, gamma[i])
+            return qmc.expval(q, hamiltonian)
+
+        H = _make_h()
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            kernel,
+            bindings={
+                "n": H.num_qubits,
+                "hamiltonian": H,
+                "gamma": [0.3, 0.5],
+            },
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        # 2 H (init) + 2 * 2 = 4 Rx from x_mixer(2*beta) unrolled for 2 layers
+        assert circuit.size() >= 2
+        assert circuit.num_qubits == H.num_qubits

--- a/tests/transpiler/test_value_resolver_fallback.py
+++ b/tests/transpiler/test_value_resolver_fallback.py
@@ -1,0 +1,53 @@
+"""Unit tests for Layer 4: silent 0 fallback removal in ``ValueResolver``.
+
+Before Layer 4, ``ValueResolver.resolve_int_value`` returned ``0`` for any
+Value it could not resolve — constant, parameter, or otherwise. That
+fallback silently masked unresolved symbolic shape dims (``gamma_dim0``)
+reaching emit time, producing empty loops and compiled circuits that
+looked correct but ignored their parameters.
+
+Layer 4 is a defensive safety net: in normal pipeline operation the
+upstream ``SymbolicShapeValidationPass`` (Layer 3) should catch
+unresolved shape dims before they reach emit. These tests exercise
+``resolve_int_value`` directly so the contract is exercised regardless
+of upstream behaviour.
+"""
+
+import pytest
+
+from qamomile.circuit.ir.types.primitives import UIntType
+from qamomile.circuit.ir.value import Value
+from qamomile.circuit.transpiler.passes.emit_support.value_resolver import (
+    ValueResolver,
+)
+
+
+class TestResolveIntValueFallback:
+    def test_unbound_symbolic_value_returns_none(self):
+        """Unresolvable symbolic Values must propagate as ``None``."""
+        resolver = ValueResolver()
+        symbolic = Value(type=UIntType(), name="gamma_dim0")
+        assert resolver.resolve_int_value(symbolic, bindings={}) is None
+
+    def test_bound_parameter_still_resolves(self):
+        """Sanity check: bound parameter values still resolve correctly."""
+        resolver = ValueResolver(parameters={"p"})
+        param = Value(type=UIntType(), name="p").with_parameter("p")
+        assert resolver.resolve_int_value(param, bindings={"p": 3}) == 3
+
+    def test_constant_value_still_resolves(self):
+        """Sanity check: constant Values still resolve correctly."""
+        resolver = ValueResolver()
+        const = Value(type=UIntType(), name="dim_0").with_const(5)
+        assert resolver.resolve_int_value(const, bindings={}) == 5
+
+    def test_plain_python_int_still_resolves(self):
+        """Sanity check: plain Python ``int`` passes through."""
+        resolver = ValueResolver()
+        assert resolver.resolve_int_value(7, bindings={}) == 7
+
+    def test_unbound_value_not_in_bindings_returns_none(self):
+        """Non-constant non-parameter Values without bindings → ``None``."""
+        resolver = ValueResolver()
+        symbolic = Value(type=UIntType(), name="uint_tmp")
+        assert resolver.resolve_int_value(symbolic, bindings={}) is None

--- a/tests/transpiler/test_value_resolver_fallback.py
+++ b/tests/transpiler/test_value_resolver_fallback.py
@@ -13,8 +13,6 @@ unresolved shape dims before they reach emit. These tests exercise
 of upstream behaviour.
 """
 
-import pytest
-
 from qamomile.circuit.ir.types.primitives import UIntType
 from qamomile.circuit.ir.value import Value
 from qamomile.circuit.transpiler.passes.emit_support.value_resolver import (


### PR DESCRIPTION
## Summary

Fixes silent miscompilation of `qrao_qaoa.ipynb`-style parametric QAOA kernels where `gamma.shape[0]` is used as a loop bound in a nested `@qkernel`. Before this PR, `transpile()` succeeded but produced a compiled circuit with the entire QAOA loop elided (just `H H`), so execution results were constant regardless of the bound parameters.

Root cause: two divergent shape-construction paths for `Vector[Float]`/`Vector[UInt]` parameters met at inline time with no way to reconcile, and a silent `return 0` fallback in the emit-time resolver masked the mismatch.

## Fix layers (one commit each)

1. **Unify Vector parameter shape construction** — `_create_parameter_input` now delegates to `create_dummy_input`, so top-level parameter arrays get the same symbolic `{name}_dim{i}` shape as inner-kernel tracing.
2. **Compile-time shape resolution + validation passes** — `ParameterShapeResolutionPass` folds symbolic dims into constants when the array has a concrete binding (users can pass `bindings={"gamma": [0.0]*p}` as a shape hint alongside `parameters=["gamma"]`). `SymbolicShapeValidationPass` hard-fails with an actionable `CompileError` when an unresolved dim reaches a loop bound, pointing users to both the concrete-binding and the `p`-counter fix patterns. The library `qaoa_layers` pattern is unaffected.
3. **Remove silent 0 fallback + fix nested resolution gaps** — `ValueResolver.resolve_int_value` now returns `None` for unresolvable Values; `emit_for_unrolled` converts that into a clear error that names the unresolved operand. The removal exposed two latent bugs the fallback had masked: `constant_fold._substitute_folded_operands` only walked `element_indices` one level deep (so `q[indices[uint_tmp]]` stayed symbolic), and `inline._inline_call` shape-zip didn't chase multi-level mapping chains (so nested kernels left dim substitutions stuck at an intermediate cloned Value). Both fixed.
4. **Parametric gamma in `pauli_evolve`** — `pauli_evolve` used to require a concrete `gamma` at emit time. Now detects parameter gamma and routes it to a backend Parameter, matching how `ising_cost`/`rz`/`rzz` already carry parametric angles. Qiskit feeds the Parameter straight into `PauliEvolutionGate(time=...)`. Three supporting fixes: `resolve_angle` / `evaluate_binop` take a param-array-element fast path so shape-hint bindings don't short-circuit the symbolic path, and `LoopAnalyzer` now detects `pauli_evolve(q, H, gamma[p])` as a trigger to unroll (otherwise Qiskit's native for-loop reused a single `gamma[p]` Parameter across iterations).

## Migration notes

**Breaking**: top-level `Vector[Float]`/`Vector[UInt]` parameters previously had `_shape == ()`; they now have `(symbolic_dim0,)`. Any user code that checked `_shape == ()` to detect "parameter arrays" will need to be updated.

**Breaking**: patterns that silently produced empty loops via `gamma.shape[0]` without binding `gamma` will now raise `QamomileCompileError` with a clear fix recommendation. These were already producing incorrect circuits, so the failure mode is stricter but more honest.

## Verification

```bash
uv run pytest tests/         # 6033 passed, 6 skipped
uv run pytest -m docs        # 18 passed, 2 skipped
uv run ruff check qamomile/  # clean
uv run zuban check <touched files>  # clean
```

End-to-end smoke for the `qrao_qaoa.ipynb` pattern: `transpile(qaoa_exp, bindings={..., "gamma":[0.0]*p, "beta":[0.0]*p}, parameters=["gamma","beta"])` compiles once into a 2-layer QAOA circuit with 4 Qiskit Parameters (`gamma[0..1]`, `beta[0..1]`). Running with different `bindings` values produces visibly different expvals (0.047 vs -0.436 for a 2-qubit ZZ Hamiltonian at p=2).

Added 33 regression tests across 5 new test files covering every layer: shape construction, compile-time resolution, actionable errors, resolver hard-fail, and parametric pauli_evolve end-to-end.

## Test plan

- [x] Full unit suite: `uv run pytest tests/`
- [x] Docs suite: `uv run pytest -m docs`
- [x] Lint: `uv run ruff check qamomile/`
- [x] Type check on touched files: `uv run zuban check ...`
- [x] `qrao_qaoa.ipynb` pattern end-to-end (parametric gamma/beta, varying inputs)
- [ ] CI on PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)