### PR TITLE
Fix the colour when the keyword hits

### DIFF
--- a/docs/assets/custom-theme.css
+++ b/docs/assets/custom-theme.css
@@ -67,9 +67,10 @@
   background-color: #A87430 !important;
 }
 
-/* Search hits use text-blue-* on top of the selected result background.
- * Our blue->amber remap uses !important, so we need an explicit selected-state
- * override to preserve contrast inside the active search result card.
+/* Search hits add text-blue-* classes, while the selected result also applies
+ * group-aria-selected:text-white. Our blue->amber remap uses !important on the
+ * text-blue-* utilities, so it overrides that selected-state white text unless
+ * we restate the group-aria-selected:text-white rule with !important here.
  */
 .group[aria-selected=true] .group-aria-selected\:text-white {
   color: #FDF8F0 !important;

--- a/docs/assets/custom-theme.css
+++ b/docs/assets/custom-theme.css
@@ -67,6 +67,14 @@
   background-color: #A87430 !important;
 }
 
+/* Search hits use text-blue-* on top of the selected result background.
+ * Our blue->amber remap uses !important, so we need an explicit selected-state
+ * override to preserve contrast inside the active search result card.
+ */
+.group[aria-selected=true] .group-aria-selected\:text-white {
+  color: #FDF8F0 !important;
+}
+
 /* === Dark mode === */
 .dark\:border-blue-500\/60:is(.dark *) { border-color: rgba(192, 138, 64, 0.6) !important; }
 .dark\:border-blue-800:is(.dark *) { border-color: #6E4A1C !important; }


### PR DESCRIPTION
## Description
The current search functionality on the documentation page highlights the word in the search box with the same colour as the background, which is invisible, see the image below.

<img width="638" height="292" alt="image" src="https://github.com/user-attachments/assets/cd2262ca-e64b-4bec-8b57-4c1d064290c6" />

This PR fixes the highlight colour as follows.

<img width="623" height="282" alt="image" src="https://github.com/user-attachments/assets/e9b9ddd3-846b-464d-8abe-695f1ab1058b" />
