### PR TITLE
Support Vector[Observable] kernel parameters

### DIFF
--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -637,17 +637,17 @@ class QKernel(Generic[P, R]):
             for name, param in self.signature.parameters.items():
                 param_type = param.annotation
 
-                # Observable types are always treated as parameters (resolved during emit)
-                if param_type is Observable:
-                    handle = self._create_parameter_input(param_type, name)
-                    tracked_parameters[name] = handle.value
-                # Unbound Vector[Observable]: keep as parameter so shape stays symbolic.
-                # Bound case falls through to _create_bound_input, which resolves shape.
-                elif (
+                # Scalar Observable is always a parameter; unbound
+                # Vector[Observable] is too so its shape stays symbolic
+                # (bound Vector[Observable] falls through to the kwargs
+                # branch below, which resolves the shape from the value).
+                is_scalar_observable = param_type is Observable
+                is_unbound_observable_array = (
                     is_array_type(param_type)
                     and _get_array_element_type(param_type) is Observable
                     and name not in kwargs
-                ):
+                )
+                if is_scalar_observable or is_unbound_observable_array:
                     handle = self._create_parameter_input(param_type, name)
                     tracked_parameters[name] = handle.value
                 elif name in parameters:

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -516,9 +516,22 @@ class QKernel(Generic[P, R]):
                         f"Only Vector[Observable] bindings are supported; "
                         f"got {param_type}"
                     )
+                if isinstance(value, np.ndarray) and value.ndim != 1:
+                    raise TypeError(
+                        f"Vector[Observable] binding '{name}' must be 1-D; "
+                        f"got ndarray with shape {value.shape}."
+                    )
+                items = list(value)
+                for i, item in enumerate(items):
+                    if isinstance(item, (list, tuple, np.ndarray)):
+                        raise TypeError(
+                            f"Vector[Observable] binding '{name}' must be a "
+                            f"flat sequence of Hamiltonians; element {i} is "
+                            f"{type(item).__name__}."
+                        )
                 ir_element_type = ObservableType()
-                shape = (len(value),)
-                const_data = list(value)
+                shape = (len(items),)
+                const_data = items
             else:
                 raise TypeError(
                     f"Unsupported element type for array binding: {element_type}"

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -399,15 +399,17 @@ class QKernel(Generic[P, R]):
             return UInt(value=value)
 
         if is_array_type(param_type):
-            # Restrict parameter arrays to scalar element types (Float/UInt).
-            # Qubit/Bit arrays are handled through other paths (qubit_sizes etc.).
+            # Restrict parameter arrays to scalar element types (Float/UInt)
+            # and Observable. Qubit/Bit arrays are handled through other paths
+            # (qubit_sizes etc.).
             if hasattr(param_type, "__args__") and param_type.__args__:
                 element_type = param_type.__args__[0]
             else:
                 element_type = getattr(param_type, "element_type", None)
-            if element_type not in (Float, float, UInt, int):
+            if element_type not in (Float, float, UInt, int, Observable):
                 raise TypeError(
-                    f"Array parameter must have Float or UInt element type, got {element_type}"
+                    f"Array parameter must have Float, UInt, or Observable "
+                    f"element type, got {element_type}"
                 )
 
             # Delegate to create_dummy_input so that parameter arrays get the
@@ -614,8 +616,12 @@ class QKernel(Generic[P, R]):
             for name, param in self.signature.parameters.items():
                 param_type = param.annotation
 
-                # Observable types are always treated as parameters (resolved during emit)
-                if param_type is Observable:
+                # Observable types are always treated as parameters (resolved during emit).
+                # This applies to scalar Observable and Vector/Matrix/Tensor[Observable].
+                if param_type is Observable or (
+                    is_array_type(param_type)
+                    and _get_array_element_type(param_type) is Observable
+                ):
                     handle = self._create_parameter_input(param_type, name)
                     tracked_parameters[name] = handle.value
                 elif name in parameters:

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -488,21 +488,28 @@ class QKernel(Generic[P, R]):
             else:
                 element_type = getattr(param_type, "element_type", None)
 
-            # Determine IR type for the element
+            # Determine IR type and extract shape/data. Observable is an
+            # arbitrary Python object so we avoid numpy (dtype=object arrays
+            # are fragile); Float/UInt go through numpy for multi-dim support.
             if element_type in (Float, float):
                 ir_element_type = FloatType()
+                arr = np.asarray(value)
+                shape = arr.shape
+                const_data: Any = arr.tolist()
             elif element_type in (UInt, int):
                 ir_element_type = UIntType()
+                arr = np.asarray(value)
+                shape = arr.shape
+                const_data = arr.tolist()
+            elif element_type is Observable:
+                ir_element_type = ObservableType()
+                shape = (len(value),)
+                const_data = list(value)
             else:
                 raise TypeError(
                     f"Unsupported element type for array binding: {element_type}"
                 )
 
-            # Convert to numpy array to handle multi-dimensional arrays
-            arr = np.asarray(value)
-
-            # Infer shape from the array
-            shape = arr.shape
             shape_values = tuple(
                 Value(type=UIntType(), name=f"dim_{i}").with_const(dim)
                 for i, dim in enumerate(shape)
@@ -512,7 +519,7 @@ class QKernel(Generic[P, R]):
                 type=ir_element_type,
                 name=name,
                 shape=shape_values,
-            ).with_array_runtime_metadata(const_array=arr.tolist())
+            ).with_array_runtime_metadata(const_array=const_data)
 
             # Create instance without calling __init__
             # For generic aliases, use __origin__ to get the actual class
@@ -616,11 +623,16 @@ class QKernel(Generic[P, R]):
             for name, param in self.signature.parameters.items():
                 param_type = param.annotation
 
-                # Observable types are always treated as parameters (resolved during emit).
-                # This applies to scalar Observable and Vector/Matrix/Tensor[Observable].
-                if param_type is Observable or (
+                # Observable types are always treated as parameters (resolved during emit)
+                if param_type is Observable:
+                    handle = self._create_parameter_input(param_type, name)
+                    tracked_parameters[name] = handle.value
+                # Unbound Vector[Observable]: keep as parameter so shape stays symbolic.
+                # Bound case falls through to _create_bound_input, which resolves shape.
+                elif (
                     is_array_type(param_type)
                     and _get_array_element_type(param_type) is Observable
+                    and name not in kwargs
                 ):
                     handle = self._create_parameter_input(param_type, name)
                     tracked_parameters[name] = handle.value

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -29,7 +29,7 @@ from qamomile.circuit.frontend.func_to_block import (
     is_tuple_type,
 )
 from qamomile.circuit.frontend.handle import Observable, Qubit
-from qamomile.circuit.frontend.handle.array import ArrayBase
+from qamomile.circuit.frontend.handle.array import ArrayBase, Vector
 from qamomile.circuit.frontend.handle.containers import Dict
 from qamomile.circuit.frontend.handle.primitives import Float, Handle, UInt
 from qamomile.circuit.frontend.tracer import Tracer, get_current_tracer, trace
@@ -367,6 +367,9 @@ class QKernel(Generic[P, R]):
                     element_type = getattr(param_type, "element_type", None)
                 if element_type is Qubit:
                     continue
+                # Vector[Observable] may be left unbound (resolved at emit).
+                if element_type is Observable:
+                    continue
 
             # Observable types are provided via bindings
             if param_type is Observable:
@@ -410,6 +413,12 @@ class QKernel(Generic[P, R]):
                 raise TypeError(
                     f"Array parameter must have Float, UInt, or Observable "
                     f"element type, got {element_type}"
+                )
+            if element_type is Observable and (
+                getattr(param_type, "__origin__", param_type) is not Vector
+            ):
+                raise TypeError(
+                    f"Only Vector[Observable] is supported; got {param_type}"
                 )
 
             # Delegate to create_dummy_input so that parameter arrays get the
@@ -502,6 +511,11 @@ class QKernel(Generic[P, R]):
                 shape = arr.shape
                 const_data = arr.tolist()
             elif element_type is Observable:
+                if getattr(param_type, "__origin__", param_type) is not Vector:
+                    raise TypeError(
+                        f"Only Vector[Observable] bindings are supported; "
+                        f"got {param_type}"
+                    )
                 ir_element_type = ObservableType()
                 shape = (len(value),)
                 const_data = list(value)

--- a/qamomile/circuit/transpiler/passes/emit.py
+++ b/qamomile/circuit/transpiler/passes/emit.py
@@ -25,6 +25,9 @@ from qamomile.circuit.transpiler.passes.emit_support.qubit_address import (
     QubitAddress,
     QubitMap,
 )
+from qamomile.circuit.transpiler.passes.emit_support.value_resolver import (
+    ValueResolver,
+)
 from qamomile.circuit.transpiler.segments import (
     ClassicalSegment,
     ClassicalStep,
@@ -123,6 +126,7 @@ class EmitPass(Pass[ProgramPlan, ExecutableProgram[T]], Generic[T]):
         """
         self.bindings = bindings or {}
         self.parameters = set(parameters) if parameters else set()
+        self._resolver = ValueResolver(self.parameters)
 
     def run(self, input: ProgramPlan) -> ExecutableProgram[T]:
         """Emit backend code from a program plan."""
@@ -258,31 +262,16 @@ class EmitPass(Pass[ProgramPlan, ExecutableProgram[T]], Generic[T]):
         )
 
     def _resolve_observable_binding(self, observable_value: Value) -> Any:
-        """Resolve an observable Value to its bound Hamiltonian.
-
-        Handles both scalar Observable parameters (looked up by name) and
-        elements of ``Vector[Observable]`` parameters (looked up via
-        parent_array + constant element_indices).
-        """
-        if observable_value.name in self.bindings:
-            return self.bindings[observable_value.name]
-
-        parent = observable_value.parent_array
-        if parent is not None and parent.name in self.bindings:
-            container = self.bindings[parent.name]
-            for idx_value in observable_value.element_indices:
-                if not idx_value.is_constant():
-                    raise RuntimeError(
-                        f"Observable element '{observable_value.name}' has "
-                        f"non-constant index; indices must be resolved before emit."
-                    )
-                container = container[int(idx_value.get_const())]
-            return container
-
-        raise RuntimeError(
-            f"Observable '{observable_value.name}' not found in bindings. "
-            f"Hamiltonians must be provided as bindings."
+        """Resolve an observable Value to its bound Hamiltonian."""
+        hamiltonian = self._resolver.resolve_bound_value(
+            observable_value, self.bindings
         )
+        if hamiltonian is None:
+            raise RuntimeError(
+                f"Observable '{observable_value.name}' not found in bindings. "
+                f"Hamiltonians must be provided as bindings."
+            )
+        return hamiltonian
 
     def _build_qubit_map(
         self,

--- a/qamomile/circuit/transpiler/passes/emit.py
+++ b/qamomile/circuit/transpiler/passes/emit.py
@@ -261,8 +261,8 @@ class EmitPass(Pass[ProgramPlan, ExecutableProgram[T]], Generic[T]):
         """Resolve an observable Value to its bound Hamiltonian.
 
         Handles both scalar Observable parameters (looked up by name) and
-        elements of Vector/Matrix/Tensor[Observable] parameters (looked up
-        via parent_array + constant element_indices).
+        elements of ``Vector[Observable]`` parameters (looked up via
+        parent_array + constant element_indices).
         """
         if observable_value.name in self.bindings:
             return self.bindings[observable_value.name]

--- a/qamomile/circuit/transpiler/passes/emit.py
+++ b/qamomile/circuit/transpiler/passes/emit.py
@@ -229,13 +229,7 @@ class EmitPass(Pass[ProgramPlan, ExecutableProgram[T]], Generic[T]):
         if observable_value is None:
             raise RuntimeError("ExpvalSegment has no hamiltonian_value set.")
 
-        if observable_value.name not in self.bindings:
-            raise RuntimeError(
-                f"Observable '{observable_value.name}' not found in bindings. "
-                f"Hamiltonians must be provided as bindings."
-            )
-
-        hamiltonian = self.bindings[observable_value.name]
+        hamiltonian = self._resolve_observable_binding(observable_value)
 
         # Validate type
         if not isinstance(hamiltonian, qm_o.Hamiltonian):
@@ -261,6 +255,33 @@ class EmitPass(Pass[ProgramPlan, ExecutableProgram[T]], Generic[T]):
             quantum_segment_index=quantum_segment_index,
             result_ref=segment.result_ref,
             qubit_map=qubit_map,
+        )
+
+    def _resolve_observable_binding(self, observable_value: Value) -> Any:
+        """Resolve an observable Value to its bound Hamiltonian.
+
+        Handles both scalar Observable parameters (looked up by name) and
+        elements of Vector/Matrix/Tensor[Observable] parameters (looked up
+        via parent_array + constant element_indices).
+        """
+        if observable_value.name in self.bindings:
+            return self.bindings[observable_value.name]
+
+        parent = observable_value.parent_array
+        if parent is not None and parent.name in self.bindings:
+            container = self.bindings[parent.name]
+            for idx_value in observable_value.element_indices:
+                if not idx_value.is_constant():
+                    raise RuntimeError(
+                        f"Observable element '{observable_value.name}' has "
+                        f"non-constant index; indices must be resolved before emit."
+                    )
+                container = container[int(idx_value.get_const())]
+            return container
+
+        raise RuntimeError(
+            f"Observable '{observable_value.name}' not found in bindings. "
+            f"Hamiltonians must be provided as bindings."
         )
 
     def _build_qubit_map(

--- a/qamomile/circuit/transpiler/passes/emit_support/loop_analyzer.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/loop_analyzer.py
@@ -122,6 +122,17 @@ class LoopAnalyzer:
                     for idx in gamma.element_indices:
                         if self._index_depends_on_loop_var(idx, loop_var):
                             return True
+                # The observable operand may be Hs[loop_var] — a concrete
+                # Hamiltonian is required at emit, so unroll too.
+                observable = op.observable
+                if (
+                    isinstance(observable, _Value)
+                    and observable.parent_array is not None
+                    and observable.element_indices
+                ):
+                    for idx in observable.element_indices:
+                        if self._index_depends_on_loop_var(idx, loop_var):
+                            return True
 
             if isinstance(op, HasNestedOps):
                 if any(

--- a/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from qamomile.circuit.transpiler.passes.standard_emit import StandardEmitPass
 
 from qamomile.circuit.ir.operation.pauli_evolve import PauliEvolveOp
-from qamomile.circuit.ir.value import ArrayValue, Value
+from qamomile.circuit.ir.value import ArrayValue
 from qamomile.circuit.transpiler.errors import EmitError
 
 from .qubit_address import QubitAddress, QubitMap
@@ -64,47 +64,6 @@ def _resolve_gamma(
     return None
 
 
-def _resolve_observable(
-    emit_pass: "StandardEmitPass",
-    obs_value: Value,
-    bindings: dict[str, Any],
-) -> Any:
-    """Resolve an observable operand to a concrete Hamiltonian.
-
-    Handles direct binding lookup by name/uuid, and Vector[Observable]
-    element access via parent_array + element_indices (indices must be
-    resolvable to ints against ``bindings``, e.g. after loop unroll).
-    """
-    # Kernel-parameter observable: user passes ``bindings={"H": ...}``.
-    if obs_value.name in bindings:
-        return bindings[obs_value.name]
-    # Observable constructed inside the qkernel: tracked by uuid,
-    # same convention as other emit-time intermediates.
-    if obs_value.uuid in bindings:
-        return bindings[obs_value.uuid]
-
-    parent = obs_value.parent_array
-    if parent is None or not obs_value.element_indices:
-        return None
-
-    # Parent Vector[Observable]: same name-then-uuid lookup.
-    container = bindings.get(parent.name)
-    if container is None:
-        container = bindings.get(parent.uuid)
-    if container is None:
-        return None
-
-    for idx in obs_value.element_indices:
-        idx_val = emit_pass._resolver.resolve_int_value(idx, bindings)
-        if idx_val is None:
-            return None
-        try:
-            container = container[idx_val]
-        except (IndexError, KeyError, TypeError):
-            return None
-    return container
-
-
 def emit_pauli_evolve(
     emit_pass: "StandardEmitPass",
     circuit: Any,
@@ -125,14 +84,13 @@ def emit_pauli_evolve(
     """
     import qamomile.observable as qm_o
 
-    # Resolve Hamiltonian from bindings
+    # Resolve Hamiltonian from bindings via the shared resolver.
     obs_value = op.observable
-    hamiltonian = _resolve_observable(emit_pass, obs_value, bindings)
+    hamiltonian = emit_pass._resolver.resolve_bound_value(obs_value, bindings)
     if not isinstance(hamiltonian, qm_o.Hamiltonian):
         raise EmitError(
             f"PauliEvolveOp requires a Hamiltonian binding. "
-            f"Observable '{getattr(obs_value, 'name', '?')}' not found or "
-            f"not a Hamiltonian.",
+            f"Observable '{obs_value.name}' not found or not a Hamiltonian.",
             operation="PauliEvolveOp",
         )
 

--- a/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from qamomile.circuit.transpiler.passes.standard_emit import StandardEmitPass
 
 from qamomile.circuit.ir.operation.pauli_evolve import PauliEvolveOp
-from qamomile.circuit.ir.value import ArrayValue
+from qamomile.circuit.ir.value import ArrayValue, Value
 from qamomile.circuit.transpiler.errors import EmitError
 
 from .qubit_address import QubitAddress, QubitMap
@@ -66,7 +66,7 @@ def _resolve_gamma(
 
 def _resolve_observable(
     emit_pass: "StandardEmitPass",
-    obs_value: Any,
+    obs_value: Value,
     bindings: dict[str, Any],
 ) -> Any:
     """Resolve an observable operand to a concrete Hamiltonian.
@@ -75,29 +75,34 @@ def _resolve_observable(
     element access via parent_array + element_indices (indices must be
     resolvable to ints against ``bindings``, e.g. after loop unroll).
     """
-    if hasattr(obs_value, "name") and obs_value.name in bindings:
+    # Kernel-parameter observable: user passes ``bindings={"H": ...}``.
+    if obs_value.name in bindings:
         return bindings[obs_value.name]
-    if hasattr(obs_value, "uuid") and obs_value.uuid in bindings:
+    # Observable constructed inside the qkernel: tracked by uuid,
+    # same convention as other emit-time intermediates.
+    if obs_value.uuid in bindings:
         return bindings[obs_value.uuid]
 
-    parent = getattr(obs_value, "parent_array", None)
-    element_indices = getattr(obs_value, "element_indices", ())
-    if parent is not None and element_indices:
-        container = bindings.get(parent.name)
-        if container is None and parent.uuid in bindings:
-            container = bindings[parent.uuid]
-        if container is None:
+    parent = obs_value.parent_array
+    if parent is None or not obs_value.element_indices:
+        return None
+
+    # Parent Vector[Observable]: same name-then-uuid lookup.
+    container = bindings.get(parent.name)
+    if container is None:
+        container = bindings.get(parent.uuid)
+    if container is None:
+        return None
+
+    for idx in obs_value.element_indices:
+        idx_val = emit_pass._resolver.resolve_int_value(idx, bindings)
+        if idx_val is None:
             return None
-        for idx in element_indices:
-            idx_val = emit_pass._resolver.resolve_int_value(idx, bindings)
-            if idx_val is None:
-                return None
-            try:
-                container = container[idx_val]
-            except (IndexError, KeyError, TypeError):
-                return None
-        return container
-    return None
+        try:
+            container = container[idx_val]
+        except (IndexError, KeyError, TypeError):
+            return None
+    return container
 
 
 def emit_pauli_evolve(

--- a/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/pauli_evolve_emission.py
@@ -64,6 +64,42 @@ def _resolve_gamma(
     return None
 
 
+def _resolve_observable(
+    emit_pass: "StandardEmitPass",
+    obs_value: Any,
+    bindings: dict[str, Any],
+) -> Any:
+    """Resolve an observable operand to a concrete Hamiltonian.
+
+    Handles direct binding lookup by name/uuid, and Vector[Observable]
+    element access via parent_array + element_indices (indices must be
+    resolvable to ints against ``bindings``, e.g. after loop unroll).
+    """
+    if hasattr(obs_value, "name") and obs_value.name in bindings:
+        return bindings[obs_value.name]
+    if hasattr(obs_value, "uuid") and obs_value.uuid in bindings:
+        return bindings[obs_value.uuid]
+
+    parent = getattr(obs_value, "parent_array", None)
+    element_indices = getattr(obs_value, "element_indices", ())
+    if parent is not None and element_indices:
+        container = bindings.get(parent.name)
+        if container is None and parent.uuid in bindings:
+            container = bindings[parent.uuid]
+        if container is None:
+            return None
+        for idx in element_indices:
+            idx_val = emit_pass._resolver.resolve_int_value(idx, bindings)
+            if idx_val is None:
+                return None
+            try:
+                container = container[idx_val]
+            except (IndexError, KeyError, TypeError):
+                return None
+        return container
+    return None
+
+
 def emit_pauli_evolve(
     emit_pass: "StandardEmitPass",
     circuit: Any,
@@ -86,11 +122,7 @@ def emit_pauli_evolve(
 
     # Resolve Hamiltonian from bindings
     obs_value = op.observable
-    hamiltonian = None
-    if hasattr(obs_value, "name") and obs_value.name in bindings:
-        hamiltonian = bindings[obs_value.name]
-    if hamiltonian is None and hasattr(obs_value, "uuid"):
-        hamiltonian = bindings.get(obs_value.uuid)
+    hamiltonian = _resolve_observable(emit_pass, obs_value, bindings)
     if not isinstance(hamiltonian, qm_o.Hamiltonian):
         raise EmitError(
             f"PauliEvolveOp requires a Hamiltonian binding. "

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -222,16 +222,19 @@ class ValueResolver:
     ) -> Any:
         """Resolve a classical Value to a concrete Python value.
 
-        Array-element lookups often return a numpy scalar; this
-        variant normalizes to a Python scalar. Non-array bindings are
-        passed through as-is.
+        Numeric bindings are normalized to native Python scalars
+        regardless of whether they come from a direct binding or from
+        array-element indexing, so downstream ``isinstance(x, (int,
+        float))`` checks are stable when callers bind ``np.pi/4`` or
+        the like. ``bool`` is preserved (not coerced to ``int``).
+        Non-numeric values (Hamiltonians, strings, dict values, …)
+        pass through unchanged.
         """
         raw = self.resolve_bound_value(value, bindings)
-        if raw is None:
-            return None
-        if value.parent_array is not None and value.element_indices:
-            return self._resolve_numeric_value(raw)
-        return raw
+        if raw is None or isinstance(raw, bool):
+            return raw
+        coerced = self._resolve_numeric_value(raw)
+        return coerced if coerced is not None else raw
 
     def _index_into_array(
         self,

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -95,7 +95,7 @@ class ValueResolver:
                         ),
                     )
             elif idx_value.parent_array is not None:
-                nested_result = self._resolve_array_element_value(idx_value, bindings)
+                nested_result = self.resolve_classical_value(idx_value, bindings)
                 if nested_result is None:
                     array_name = idx_value.parent_array.name
                     return QubitResolutionResult(
@@ -190,12 +190,21 @@ class ValueResolver:
                 local_bindings[param_inputs[i].name] = resolved
         return local_bindings
 
-    def resolve_classical_value(
+    def resolve_bound_value(
         self,
         value: "Value",
         bindings: dict[str, Any],
     ) -> Any:
-        """Resolve a classical Value to a concrete Python value."""
+        """Resolve a Value to its raw bound Python object.
+
+        Looks up in order: scalar constant, ``bindings[uuid]``
+        (emit-time intermediates such as BinOp results and in-kernel
+        Observables), ``bindings[name]`` (kernel parameters), then
+        parent-array element access when ``value`` is ``arr[i]``.
+        Returns ``None`` when no binding matches. Does **not** coerce
+        the result — callers that need a numeric scalar should go
+        through :meth:`resolve_classical_value`.
+        """
         if value.is_constant():
             return value.get_const()
         if value.uuid in bindings:
@@ -203,36 +212,50 @@ class ValueResolver:
         if value.name in bindings:
             return bindings[value.name]
         if value.parent_array is not None and value.element_indices:
-            return self._resolve_array_element_value(value, bindings)
+            return self._index_into_array(value, bindings)
         return None
 
-    def _resolve_array_element_value(
+    def resolve_classical_value(
+        self,
+        value: "Value",
+        bindings: dict[str, Any],
+    ) -> Any:
+        """Resolve a classical Value to a concrete Python value.
+
+        Array-element lookups often return a numpy scalar; this
+        variant normalizes to a Python scalar. Non-array bindings are
+        passed through as-is.
+        """
+        raw = self.resolve_bound_value(value, bindings)
+        if raw is None:
+            return None
+        if value.parent_array is not None and value.element_indices:
+            return self._resolve_numeric_value(raw)
+        return raw
+
+    def _index_into_array(
         self,
         v: "Value",
         bindings: dict[str, Any],
-    ) -> int | float | None:
-        if v.parent_array is None or not v.element_indices:
+    ) -> Any:
+        parent = v.parent_array
+        if parent is None:
+            return None
+        container = bindings.get(parent.name)
+        if container is None:
+            container = bindings.get(parent.uuid)
+        if container is None:
             return None
 
-        array_name = v.parent_array.name
-        if array_name not in bindings:
-            return None
-
-        array_data = bindings[array_name]
-        indices = []
         for idx in v.element_indices:
-            idx_val = self.resolve_int_value(idx, bindings)
-            if idx_val is None:
+            i = self.resolve_int_value(idx, bindings)
+            if i is None:
                 return None
-            indices.append(idx_val)
-
-        try:
-            result = array_data
-            for idx in indices:
-                result = result[idx]
-            return self._resolve_numeric_value(result)
-        except (IndexError, TypeError, KeyError):
-            return None
+            try:
+                container = container[i]
+            except (IndexError, KeyError, TypeError):
+                return None
+        return container
 
     def resolve_int_value(
         self,

--- a/qamomile/circuit/transpiler/passes/standard_emit.py
+++ b/qamomile/circuit/transpiler/passes/standard_emit.py
@@ -43,7 +43,6 @@ from qamomile.circuit.transpiler.passes.emit_support import (
     LoopAnalyzer,
     QubitMap,
     ResourceAllocator,
-    ValueResolver,
 )
 from qamomile.circuit.transpiler.passes.emit_support.cast_binop_emission import (
     evaluate_binop,
@@ -104,9 +103,8 @@ class StandardEmitPass(EmitPass[T], Generic[T]):
         self._emitter = gate_emitter
         self._composite_emitters = composite_emitters or []
 
-        # Helper classes
+        # Helper classes (``_resolver`` is built by ``EmitPass.__init__``).
         self._allocator = ResourceAllocator()
-        self._resolver = ValueResolver(self.parameters)
         self._loop_analyzer = LoopAnalyzer()
         self._decomposer = CompositeDecomposer()
 

--- a/tests/circuit/hamiltonian/test_expval.py
+++ b/tests/circuit/hamiltonian/test_expval.py
@@ -226,6 +226,19 @@ class TestExpvalTranspiler:
         has_expval = any(isinstance(op, ExpvalOp) for op in block.operations)
         assert has_expval
 
+    def test_vector_observable_binding_resolves_shape(self):
+        """Binding Vector[Observable] must resolve .shape[i] to a constant."""
+
+        @qm.qkernel
+        def vqe(Hs: qm.Vector[qm.Observable]) -> qm.UInt:
+            return Hs.shape[0]
+
+        block = vqe.build(Hs=[qm_o.Z(0), qm_o.X(0), qm_o.Y(0)])
+        hs_input = next(v for v in block.input_values if v.name == "Hs")
+        dim0 = hs_input.shape[0]
+        assert dim0.is_constant()
+        assert dim0.get_const() == 3
+
 
 class TestHamiltonianRemapQubits:
     """Test Hamiltonian.remap_qubits method."""

--- a/tests/circuit/hamiltonian/test_expval.py
+++ b/tests/circuit/hamiltonian/test_expval.py
@@ -193,6 +193,39 @@ class TestExpvalTranspiler:
         with pytest.raises(RuntimeError, match="Observable.*not found in bindings"):
             transpiler.transpile(vqe, bindings={"n": 2})
 
+    def test_transpile_with_observable_vector_binding(self):
+        """Vector[Observable] binding resolves element-wise via parent_array."""
+        pytest.importorskip("qiskit")
+        from qamomile.qiskit import QiskitTranspiler
+
+        H0 = qm_o.Z(0) * qm_o.Z(1)
+        H1 = qm_o.X(0)
+
+        @qm.qkernel
+        def vqe(Hs: qm.Vector[qm.Observable]) -> qm.Float:
+            q = qm.qubit_array(2, "q")
+            q[0] = qm.h(q[0])
+            q[0], q[1] = qm.cx(q[0], q[1])
+            return qm.expval(q, Hs[1])
+
+        transpiler = QiskitTranspiler()
+        executable = transpiler.transpile(vqe, bindings={"Hs": [H0, H1]})
+
+        assert len(executable.compiled_expval) == 1
+        assert executable.compiled_expval[0].hamiltonian == H1
+
+    def test_vector_observable_builds_block(self):
+        """Vector[Observable] annotation produces a well-formed Block."""
+
+        @qm.qkernel
+        def vqe(Hs: qm.Vector[qm.Observable]) -> qm.Float:
+            q = qm.qubit_array(2, "q")
+            return qm.expval(q, Hs[0])
+
+        block = vqe.build(Hs=[qm_o.Z(0), qm_o.X(0)])
+        has_expval = any(isinstance(op, ExpvalOp) for op in block.operations)
+        assert has_expval
+
 
 class TestHamiltonianRemapQubits:
     """Test Hamiltonian.remap_qubits method."""

--- a/tests/circuit/hamiltonian/test_expval.py
+++ b/tests/circuit/hamiltonian/test_expval.py
@@ -265,6 +265,24 @@ class TestExpvalTranspiler:
         with pytest.raises(TypeError, match="Only Vector\\[Observable\\]"):
             bad.build(Hs=[[qm_o.Z(0)]])
 
+    def test_nested_vector_observable_binding_rejected(self):
+        """A nested sequence bound to Vector[Observable] must raise.
+
+        Without this guard, ``len([[H]])`` silently reports 1 and
+        ``Hs[0]`` resolves to a list instead of a Hamiltonian.
+        """
+        import numpy as np
+
+        @qm.qkernel
+        def k(Hs: qm.Vector[qm.Observable]) -> qm.Float:
+            q = qm.qubit_array(1, "q")
+            return qm.expval(q, Hs[0])
+
+        with pytest.raises(TypeError, match="flat sequence of Hamiltonians"):
+            k.build(Hs=[[qm_o.Z(0)]])
+        with pytest.raises(TypeError, match="must be 1-D"):
+            k.build(Hs=np.array([[qm_o.Z(0)]], dtype=object))
+
 
 class TestHamiltonianRemapQubits:
     """Test Hamiltonian.remap_qubits method."""

--- a/tests/circuit/hamiltonian/test_expval.py
+++ b/tests/circuit/hamiltonian/test_expval.py
@@ -239,6 +239,32 @@ class TestExpvalTranspiler:
         assert dim0.is_constant()
         assert dim0.get_const() == 3
 
+    def test_vector_observable_allowed_unbound(self):
+        """Vector[Observable] can be left unbound at build() time."""
+
+        @qm.qkernel
+        def vqe(Hs: qm.Vector[qm.Observable]) -> qm.Float:
+            q = qm.qubit_array(1, "q")
+            return qm.expval(q, Hs[0])
+
+        # Should not raise during build; shape stays symbolic.
+        block = vqe.build()
+        hs_input = next(v for v in block.input_values if v.name == "Hs")
+        assert not hs_input.shape[0].is_constant()
+
+    def test_matrix_observable_rejected(self):
+        """Matrix/Tensor[Observable] is explicitly unsupported."""
+
+        @qm.qkernel
+        def bad(Hs: qm.Matrix[qm.Observable]) -> qm.Float:
+            q = qm.qubit_array(1, "q")
+            return qm.expval(q, Hs[0, 0])
+
+        with pytest.raises(TypeError, match="Only Vector\\[Observable\\]"):
+            bad.build()
+        with pytest.raises(TypeError, match="Only Vector\\[Observable\\]"):
+            bad.build(Hs=[[qm_o.Z(0)]])
+
 
 class TestHamiltonianRemapQubits:
     """Test Hamiltonian.remap_qubits method."""

--- a/tests/circuit/test_resolve_int_value.py
+++ b/tests/circuit/test_resolve_int_value.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from qamomile.circuit.ir.types.primitives import UIntType
+from qamomile.circuit.ir.types.primitives import FloatType, UIntType
 from qamomile.circuit.ir.value import ArrayValue, Value
 from qamomile.circuit.transpiler.passes.emit_support import ValueResolver
 
@@ -90,3 +90,48 @@ class TestResolveArrayElementValue:
 
         assert result == 1
         assert isinstance(result, int)
+
+
+class TestResolveClassicalScalarNormalization:
+    """Scalar bindings should be normalized the same as array elements."""
+
+    def test_numpy_float_scalar_binding_normalized(self):
+        """np.float64 binding resolves to native Python float."""
+        resolver = ValueResolver()
+        theta = Value(type=FloatType(), name="theta")
+        bindings = {"theta": np.float64(np.pi / 4)}
+
+        result = resolver.resolve_classical_value(theta, bindings)
+
+        assert type(result) is float
+        assert result == np.pi / 4
+
+    def test_numpy_int_scalar_binding_normalized(self):
+        """np.int64 binding resolves to native Python int."""
+        resolver = ValueResolver()
+        n = Value(type=UIntType(), name="n")
+        bindings = {"n": np.int64(7)}
+
+        result = resolver.resolve_classical_value(n, bindings)
+
+        assert type(result) is int
+        assert result == 7
+
+    def test_bool_binding_preserved(self):
+        """bool bindings must not be coerced to int."""
+        resolver = ValueResolver()
+        flag = Value(type=UIntType(), name="flag")
+        bindings = {"flag": True}
+
+        result = resolver.resolve_classical_value(flag, bindings)
+
+        assert result is True
+
+    def test_non_numeric_binding_passes_through(self):
+        """Non-numeric bindings (e.g. Hamiltonian-like) are returned as-is."""
+        resolver = ValueResolver()
+        obs = Value(type=UIntType(), name="obs")
+        marker = object()
+        bindings = {"obs": marker}
+
+        assert resolver.resolve_classical_value(obs, bindings) is marker

--- a/tests/circuit/test_resolve_int_value.py
+++ b/tests/circuit/test_resolve_int_value.py
@@ -86,7 +86,7 @@ class TestResolveArrayElementValue:
             "e": 1,
         }
 
-        result = resolver._resolve_array_element_value(nested, bindings)
+        result = resolver.resolve_classical_value(nested, bindings)
 
         assert result == 1
         assert isinstance(result, int)

--- a/tests/transpiler/test_pauli_evolve_vector_observable.py
+++ b/tests/transpiler/test_pauli_evolve_vector_observable.py
@@ -10,6 +10,7 @@ match a direct ``pauli_evolve(q, sum(Hs), gamma)`` for commuting terms.
 import pytest
 
 pytest.importorskip("qiskit")
+pytest.importorskip("qiskit_aer")
 
 import numpy as np
 from qiskit_aer import AerSimulator

--- a/tests/transpiler/test_pauli_evolve_vector_observable.py
+++ b/tests/transpiler/test_pauli_evolve_vector_observable.py
@@ -48,9 +48,7 @@ def _statevector(circuit) -> np.ndarray:
 
 
 @qmc.qkernel
-def _trotter(
-    Hs: qmc.Vector[qmc.Observable], gamma: qmc.Float
-) -> qmc.Vector[qmc.Qubit]:
+def _trotter(Hs: qmc.Vector[qmc.Observable], gamma: qmc.Float) -> qmc.Vector[qmc.Qubit]:
     q = qmc.qubit_array(2, "q")
     q[0] = qmc.h(q[0])
     q[1] = qmc.h(q[1])
@@ -98,9 +96,7 @@ class TestTrotterViaVectorObservable:
         H3 = _pad_to(2, qm_o.X(0))
 
         tr = QiskitTranspiler()
-        exe = tr.transpile(
-            _trotter_meas, bindings={"Hs": [H1, H2, H3], "gamma": 0.4}
-        )
+        exe = tr.transpile(_trotter_meas, bindings={"Hs": [H1, H2, H3], "gamma": 0.4})
         circuit = exe.compiled_quantum[0].circuit
         gate_names = [inst.operation.name for inst in circuit.data]
         assert "for_loop" not in gate_names
@@ -118,9 +114,7 @@ class TestTrotterViaVectorObservable:
         exe_trotter = tr.transpile(
             _trotter_meas, bindings={"Hs": [H1, H2], "gamma": gamma}
         )
-        exe_direct = tr.transpile(
-            _direct_meas, bindings={"H": H1 + H2, "gamma": gamma}
-        )
+        exe_direct = tr.transpile(_direct_meas, bindings={"H": H1 + H2, "gamma": gamma})
 
         sv_trotter = _statevector(exe_trotter.compiled_quantum[0].circuit)
         sv_direct = _statevector(exe_direct.compiled_quantum[0].circuit)

--- a/tests/transpiler/test_pauli_evolve_vector_observable.py
+++ b/tests/transpiler/test_pauli_evolve_vector_observable.py
@@ -1,0 +1,241 @@
+"""Suzuki-Trotter expansion via ``Vector[Observable]``.
+
+Exercises the end-to-end path where a kernel receives a list of
+Hamiltonians ``Hs`` and applies ``pauli_evolve(q, Hs[i], gamma)`` in a
+loop over ``Hs.shape[0]``. The loop must unroll because each iteration
+needs a concrete Hamiltonian at emit time; the resulting circuit must
+match a direct ``pauli_evolve(q, sum(Hs), gamma)`` for commuting terms.
+"""
+
+import pytest
+
+pytest.importorskip("qiskit")
+
+import numpy as np
+from qiskit_aer import AerSimulator
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _pad_to(num_qubits: int, term: qm_o.Hamiltonian) -> qm_o.Hamiltonian:
+    """Pad a Hamiltonian with a zero-coefficient identity on the highest
+    qubit so it declares the full register width. ``pauli_evolve`` expects
+    ``Hamiltonian.num_qubits`` to equal the qubit register size."""
+    padded = term + 0.0 * qm_o.Z(num_qubits - 1)
+    assert padded.num_qubits == num_qubits
+    return padded
+
+
+def _statevector(circuit) -> np.ndarray:
+    from qiskit import QuantumCircuit, transpile as qk_transpile
+
+    # Strip measurements — we want the pre-measurement state.
+    stripped = QuantumCircuit(*circuit.qregs)
+    for instr in circuit.data:
+        if instr.operation.name not in ("measure", "save_statevector"):
+            stripped.append(instr)
+    # PauliEvolutionGate is not a basis gate for AerSimulator; lower it.
+    stripped = qk_transpile(
+        stripped,
+        basis_gates=["u", "cx", "rx", "ry", "rz", "h", "p", "sx", "x", "y", "z"],
+    )
+    stripped.save_statevector()
+    sim = AerSimulator(method="statevector")
+    result = sim.run(stripped).result()
+    return np.asarray(result.get_statevector())
+
+
+@qmc.qkernel
+def _trotter(
+    Hs: qmc.Vector[qmc.Observable], gamma: qmc.Float
+) -> qmc.Vector[qmc.Qubit]:
+    q = qmc.qubit_array(2, "q")
+    q[0] = qmc.h(q[0])
+    q[1] = qmc.h(q[1])
+    n = Hs.shape[0]
+    for i in qmc.range(n):
+        q = qmc.pauli_evolve(q, Hs[i], gamma)
+    return q
+
+
+@qmc.qkernel
+def _trotter_meas(
+    Hs: qmc.Vector[qmc.Observable], gamma: qmc.Float
+) -> qmc.Vector[qmc.Bit]:
+    q = _trotter(Hs, gamma)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def _direct(H: qmc.Observable, gamma: qmc.Float) -> qmc.Vector[qmc.Qubit]:
+    q = qmc.qubit_array(2, "q")
+    q[0] = qmc.h(q[0])
+    q[1] = qmc.h(q[1])
+    q = qmc.pauli_evolve(q, H, gamma)
+    return q
+
+
+@qmc.qkernel
+def _direct_meas(H: qmc.Observable, gamma: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    q = _direct(H, gamma)
+    return qmc.measure(q)
+
+
+class TestTrotterViaVectorObservable:
+    """Verify the Vector[Observable] → Trotter decomposition pipeline."""
+
+    def test_loop_unrolls_to_per_term_pauli_evolve(self):
+        """Each Hs[i] iteration must be emitted separately.
+
+        The for-loop over Hs.shape[0] must NOT survive emit (no concrete
+        Hamiltonian exists for a symbolic ``Hs[i]``). The decomposed
+        circuit has one RZ per non-zero single-Pauli term.
+        """
+        H1 = _pad_to(2, qm_o.Z(0))
+        H2 = _pad_to(2, qm_o.Z(1))
+        H3 = _pad_to(2, qm_o.X(0))
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            _trotter_meas, bindings={"Hs": [H1, H2, H3], "gamma": 0.4}
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        gate_names = [inst.operation.name for inst in circuit.data]
+        assert "for_loop" not in gate_names
+        # Each term is decomposed to an RZ (with basis change for X).
+        assert gate_names.count("rz") == 3
+
+    def test_commuting_trotter_matches_direct_sum(self):
+        """For commuting terms, product of exponentials equals exp of sum."""
+        # Z_0 and Z_1 commute, so exp(-i g Z0) exp(-i g Z1) = exp(-i g (Z0+Z1))
+        H1 = _pad_to(2, qm_o.Z(0))
+        H2 = _pad_to(2, qm_o.Z(1))
+        gamma = 0.37
+
+        tr = QiskitTranspiler()
+        exe_trotter = tr.transpile(
+            _trotter_meas, bindings={"Hs": [H1, H2], "gamma": gamma}
+        )
+        exe_direct = tr.transpile(
+            _direct_meas, bindings={"H": H1 + H2, "gamma": gamma}
+        )
+
+        sv_trotter = _statevector(exe_trotter.compiled_quantum[0].circuit)
+        sv_direct = _statevector(exe_direct.compiled_quantum[0].circuit)
+
+        # Compare up to global phase (inner product magnitude ≈ 1).
+        overlap = abs(np.vdot(sv_direct, sv_trotter))
+        assert overlap == pytest.approx(1.0, abs=1e-9)
+
+    def test_noncommuting_trotter_converges_with_steps(self):
+        """First-order Trotter error shrinks as we refine the step size.
+
+        exp(-i t (X + Z)) ≈ (exp(-i t/N X) exp(-i t/N Z))^N
+        converges to the true propagator (computed via scipy) as N → ∞.
+        """
+        from scipy.linalg import expm
+
+        t = 0.8
+
+        @qmc.qkernel
+        def trotter_steps(
+            Hs: qmc.Vector[qmc.Observable], step_gamma: qmc.Float, reps: qmc.UInt
+        ) -> qmc.Vector[qmc.Qubit]:
+            q = qmc.qubit_array(1, "q")
+            for _ in qmc.range(reps):
+                for i in qmc.range(Hs.shape[0]):
+                    q = qmc.pauli_evolve(q, Hs[i], step_gamma)
+            return q
+
+        @qmc.qkernel
+        def trotter_meas(
+            Hs: qmc.Vector[qmc.Observable], step_gamma: qmc.Float, reps: qmc.UInt
+        ) -> qmc.Vector[qmc.Bit]:
+            q = trotter_steps(Hs, step_gamma, reps)
+            return qmc.measure(q)
+
+        # Reference: exp(-i t (X+Z)) |0> computed directly.
+        X = np.array([[0, 1], [1, 0]], dtype=complex)
+        Z = np.array([[1, 0], [0, -1]], dtype=complex)
+        U_exact = expm(-1j * t * (X + Z))
+        sv_exact = U_exact @ np.array([1.0, 0.0], dtype=complex)
+
+        tr = QiskitTranspiler()
+        Hs = [qm_o.X(0), qm_o.Z(0)]
+
+        errors = []
+        for reps in (1, 4, 16):
+            exe = tr.transpile(
+                trotter_meas,
+                bindings={"Hs": Hs, "step_gamma": t / reps, "reps": reps},
+            )
+            sv = _statevector(exe.compiled_quantum[0].circuit)
+            err = 1.0 - abs(np.vdot(sv_exact, sv))
+            errors.append(err)
+
+        # First-order Trotter error is O(1/N). Refining strictly reduces it.
+        assert errors[0] > errors[1] > errors[2]
+        # At reps=16, error should be small (<1e-2).
+        assert errors[-1] < 1e-2
+
+
+class TestTrotterBackendPortability:
+    """Vector[Observable] + pauli_evolve must transpile on every backend.
+
+    We only check that each backend produces a non-empty program with the
+    expected number of per-term quantum operations; the numerical check is
+    already covered on Qiskit above. These tests skip when the optional
+    backend package is not installed.
+    """
+
+    def _build_kernel(self):
+        return _trotter_meas
+
+    def test_qiskit(self):
+        H1 = _pad_to(2, qm_o.Z(0))
+        H2 = _pad_to(2, qm_o.Z(1))
+        H3 = _pad_to(2, qm_o.X(0))
+
+        tr = QiskitTranspiler()
+        exe = tr.transpile(
+            self._build_kernel(), bindings={"Hs": [H1, H2, H3], "gamma": 0.4}
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        names = [inst.operation.name for inst in circuit.data]
+        assert "for_loop" not in names
+        assert names.count("rz") == 3
+
+    def test_quri_parts(self):
+        pytest.importorskip("quri_parts")
+        from qamomile.quri_parts.transpiler import QuriPartsTranspiler
+
+        H1 = _pad_to(2, qm_o.Z(0))
+        H2 = _pad_to(2, qm_o.Z(1))
+        H3 = _pad_to(2, qm_o.X(0))
+
+        tr = QuriPartsTranspiler()
+        exe = tr.transpile(
+            self._build_kernel(), bindings={"Hs": [H1, H2, H3], "gamma": 0.4}
+        )
+        circuit = exe.compiled_quantum[0].circuit
+        # PauliRotation is QuriParts' native exp(-i*theta/2 * P_string),
+        # which the default emitter lowers per term.
+        gate_names = [type(g).__name__ for g in getattr(circuit, "gates", ())]
+        assert gate_names, "QuriParts circuit should contain gates"
+
+    def test_cudaq(self):
+        pytest.importorskip("cudaq")
+        from qamomile.cudaq.transpiler import CudaqTranspiler  # noqa: I001
+
+        H1 = _pad_to(2, qm_o.Z(0))
+        H2 = _pad_to(2, qm_o.Z(1))
+        H3 = _pad_to(2, qm_o.X(0))
+
+        tr = CudaqTranspiler()
+        exe = tr.transpile(
+            self._build_kernel(), bindings={"Hs": [H1, H2, H3], "gamma": 0.4}
+        )
+        # Just confirm the pipeline produced a compiled quantum segment.
+        assert exe.compiled_quantum


### PR DESCRIPTION
Allow Observable as an array element type so kernels can accept
Vector[Observable] (and Matrix/Tensor[Observable]) parameters. The
parameter is routed through the always-parameter path used by scalar
Observable, and the emit pass resolves element accesses (e.g. Hs[0])
via parent_array + constant element_indices.