### PR TITLE
feat(frontend): support `bool` parameters in `_create_bound_input`

### DIFF
--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -611,7 +611,11 @@ class QKernel(Generic[P, R]):
                 init_value=float(value),
             )
 
-        # Scalar bool/Bit (must precede int because bool is a subclass of int)
+        # Scalar bool/Bit. Placed before the int/UInt branch for explicit
+        # intent; exact-type matching via ``param_type in (...)`` means bool
+        # would not fall into the int branch regardless of ordering, but
+        # keeping bool first stays future-proof if matching ever changes to
+        # isinstance/issubclass semantics.
         if param_type in (bool, Bit):
             return Bit(
                 value=Value(

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -32,11 +32,11 @@ from qamomile.circuit.frontend.func_to_block import (
 from qamomile.circuit.frontend.handle import Observable, Qubit
 from qamomile.circuit.frontend.handle.array import ArrayBase, Vector
 from qamomile.circuit.frontend.handle.containers import Dict
-from qamomile.circuit.frontend.handle.primitives import Float, Handle, UInt
+from qamomile.circuit.frontend.handle.primitives import Bit, Float, Handle, UInt
 from qamomile.circuit.frontend.tracer import Tracer, get_current_tracer, trace
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
-from qamomile.circuit.ir.types import FloatType, ObservableType, UIntType
+from qamomile.circuit.ir.types import BitType, FloatType, ObservableType, UIntType
 from qamomile.circuit.ir.value import ArrayValue, DictValue, Value
 from qamomile.circuit.transpiler.errors import FrontendTransformError
 
@@ -609,6 +609,16 @@ class QKernel(Generic[P, R]):
                     name=name,
                 ).with_const(float(value)),
                 init_value=float(value),
+            )
+
+        # Scalar bool/Bit (must precede int because bool is a subclass of int)
+        if param_type in (bool, Bit):
+            return Bit(
+                value=Value(
+                    type=BitType(),
+                    name=name,
+                ).with_const(bool(value)),
+                init_value=bool(value),
             )
 
         # Scalar int/UInt

--- a/tests/circuit/test_control_flow_if.py
+++ b/tests/circuit/test_control_flow_if.py
@@ -1634,3 +1634,103 @@ class TestIfSharedNewLocalLiveness:
         # Should not raise SyntaxError — q2 is only stored after the if
         graph = circuit.build()
         assert graph is not None
+
+
+class TestBoolBindingWithDynamicIf:
+    """Compile-time ``bool`` binding coexists with runtime measurement-driven ifs.
+
+    Guards the end-to-end path used by teleportation-style qkernels that mix:
+      * a compile-time ``if is_plus:`` branch folded by the lowering pass, and
+      * runtime ``if m0:`` / ``if m1:`` branches driven by mid-circuit
+        measurement results that must survive lowering.
+    """
+
+    @staticmethod
+    def _teleport_plus_minus():
+        @qkernel
+        def teleport_plus_minus(
+            is_plus: bool,
+        ) -> tuple[qm.Bit, qm.Bit, qm.Bit]:
+            psi = qm.qubit(name="psi")
+            alice = qm.qubit(name="alice")
+            bob = qm.qubit(name="bob")
+
+            if is_plus:
+                psi = qm.h(psi)
+            else:
+                psi = qm.h(psi)
+                psi = qm.z(psi)
+
+            alice = qm.h(alice)
+            alice, bob = qm.cx(alice, bob)
+            psi, alice = qm.cx(psi, alice)
+            psi = qm.h(psi)
+
+            m0 = qm.measure(psi)
+            m1 = qm.measure(alice)
+
+            if m1:
+                bob = qm.x(bob)
+            if m0:
+                bob = qm.z(bob)
+
+            bob = qm.h(bob)
+            return m0, m1, qm.measure(bob)
+
+        return teleport_plus_minus
+
+    @pytest.mark.parametrize("is_plus", [True, False])
+    def test_build_accepts_bool_binding(self, is_plus):
+        """Build must accept a Python bool binding and keep all three IfOps traced."""
+        kernel = self._teleport_plus_minus()
+        graph = kernel.build(is_plus=is_plus)
+        if_ops = [op for op in graph.operations if isinstance(op, IfOperation)]
+        # Build stage does not fold compile-time ifs; all three IfOps are present.
+        assert len(if_ops) == 3
+
+    @pytest.mark.parametrize("is_plus", [True, False])
+    def test_compile_time_lowering_keeps_only_dynamic_ifs(self, is_plus):
+        """After lowering, the ``is_plus`` branch is folded but ``m0``/``m1`` remain."""
+        qiskit = pytest.importorskip("qamomile.qiskit")
+        kernel = self._teleport_plus_minus()
+        transpiler = qiskit.QiskitTranspiler()
+        bindings = {"is_plus": is_plus}
+        block = transpiler.to_block(kernel, bindings=bindings)
+        block = transpiler.inline(transpiler.substitute(block))
+        block = transpiler.affine_validate(block)
+        block = transpiler.constant_fold(block, bindings=bindings)
+        block = transpiler.lower_compile_time_ifs(block, bindings=bindings)
+
+        if_ops = [op for op in block.operations if isinstance(op, IfOperation)]
+        assert len(if_ops) == 2, (
+            "Only the two measurement-conditioned IfOperations should survive "
+            "compile-time lowering; got "
+            f"{len(if_ops)}."
+        )
+
+    @pytest.mark.parametrize("is_plus", [True, False])
+    def test_qiskit_sample_gives_deterministic_x_basis_outcome(self, is_plus):
+        """Bob's X-basis outcome (third bit) is deterministic: 0 for |+>, 1 for |->."""
+        qiskit = pytest.importorskip("qamomile.qiskit")
+        kernel = self._teleport_plus_minus()
+        transpiler = qiskit.QiskitTranspiler()
+        executable = transpiler.transpile(kernel, bindings={"is_plus": is_plus})
+        result = executable.sample(transpiler.executor(), shots=1024).result()
+
+        expected_bob_bit = 0 if is_plus else 1
+        total_shots = sum(count for _, count in result.results)
+        assert total_shots == 1024
+        for outcome, _count in result.results:
+            assert outcome[2] == expected_bob_bit, (
+                f"Teleportation corrected the X-basis measurement incorrectly: "
+                f"is_plus={is_plus} produced outcome {outcome}, expected the "
+                f"third bit to be {expected_bob_bit}."
+            )
+        # Sanity check that m0/m1 actually vary (i.e., the dynamic ifs fire both
+        # code paths) — every teleportation run distributes across all four
+        # (m0, m1) combinations with non-trivial probability.
+        seen_m0_m1 = {(outcome[0], outcome[1]) for outcome, _ in result.results}
+        assert len(seen_m0_m1) >= 2, (
+            "Expected m0/m1 to vary across shots; the dynamic IfOperations "
+            "may not be executing."
+        )

--- a/tests/transpiler/test_compile_time_if_lowering.py
+++ b/tests/transpiler/test_compile_time_if_lowering.py
@@ -1297,3 +1297,67 @@ class TestCastProvenanceThroughSeparate:
             f"{arr_true.uuid}_0",
             f"{arr_true.uuid}_1",
         ]
+
+
+# ---------------------------------------------------------------------------
+# Test: bool parameter binding
+# ---------------------------------------------------------------------------
+
+
+class TestBoolBinding:
+    """Compile-time binding of ``bool`` parameters folds `if flag:` branches."""
+
+    def test_bool_true_selects_true_branch(self):
+        """flag=True: IfOperation removed, H gate from true branch present."""
+
+        @qm.qkernel
+        def kernel(flag: bool) -> qm.Vector[qm.Bit]:
+            q = qm.qubit_array(1, "q")
+            if flag:
+                q[0] = qm.h(q[0])
+            else:
+                q[0] = qm.x(q[0])
+            return qm.measure(q)
+
+        lowered = _lower(kernel, bindings={"flag": True})
+
+        assert not _find_ops(lowered.operations, IfOperation), (
+            "IfOperation should be removed after lowering"
+        )
+        h_gates = _find_gates(lowered.operations, GateOperationType.H)
+        x_gates = _find_gates(lowered.operations, GateOperationType.X)
+        assert len(h_gates) >= 1, "H gate from true branch should be present"
+        assert len(x_gates) == 0, "X gate from false branch must be dropped"
+
+    def test_bool_false_selects_false_branch(self):
+        """flag=False: IfOperation removed, X gate from false branch present."""
+
+        @qm.qkernel
+        def kernel(flag: bool) -> qm.Vector[qm.Bit]:
+            q = qm.qubit_array(1, "q")
+            if flag:
+                q[0] = qm.h(q[0])
+            else:
+                q[0] = qm.x(q[0])
+            return qm.measure(q)
+
+        lowered = _lower(kernel, bindings={"flag": False})
+
+        assert not _find_ops(lowered.operations, IfOperation)
+        h_gates = _find_gates(lowered.operations, GateOperationType.H)
+        x_gates = _find_gates(lowered.operations, GateOperationType.X)
+        assert len(h_gates) == 0, "H gate from true branch must be dropped"
+        assert len(x_gates) >= 1, "X gate from false branch should be present"
+
+    def test_bool_build_only_no_bindings_error(self):
+        """``kernel.build(flag=True)`` must accept a Python bool without error."""
+
+        @qm.qkernel
+        def kernel(flag: bool) -> qm.Vector[qm.Bit]:
+            q = qm.qubit_array(1, "q")
+            if flag:
+                q[0] = qm.h(q[0])
+            return qm.measure(q)
+
+        kernel.build(flag=True)
+        kernel.build(flag=False)


### PR DESCRIPTION
## Summary

- Adds a `bool`/`Bit` branch to `_create_bound_input` in [qamomile/circuit/frontend/qkernel.py](qamomile/circuit/frontend/qkernel.py) so that `@qkernel` arguments annotated as `bool` can be bound at compile time via `kernel.build(flag=True)` / `transpiler.transpile(kernel, bindings={"flag": True})`. Previously this raised `TypeError: Cannot create bound value for type <class 'bool'>`.
- Adds regression coverage for both the pure compile-time folding path and the **mixed case** where a `bool` binding coexists with measurement-driven dynamic `if` operations (teleportation-style qkernel).

## Why

All the supporting infrastructure already worked for `bool`:

- `func_to_block.handle_type_map` maps `bool → BitType`.
- `Value.with_const` accepts Python `bool`.
- `Bit` handle class exists with an `init_value: bool = False` field.
- `compile_time_if_lowering` resolves conditions via UUID without any type-specific branching — BitType constants fold identically to UIntType constants.

Only the binding-time entry point (`_create_bound_input`) was missing the branch. Adding it unlocks ergonomic compile-time branch selection, e.g. a `teleport_plus_minus(is_plus: bool)` kernel where `if is_plus:` folds away at lowering and `if m0:` / `if m1:` remain as dynamic control flow emitted as Qiskit `IfElseOp`.

## What changed

### `qamomile/circuit/frontend/qkernel.py`

- New import: `Bit` from `frontend.handle.primitives`, `BitType` from `ir.types`.
- New `bool`/`Bit` branch in `_create_bound_input`, placed **before** the `int`/`UInt` branch. Placement matters because `bool` is a subclass of `int` in Python, and we want `: bool` annotations to land in the BitType path rather than the UIntType path.

```python
# Scalar bool/Bit (must precede int because bool is a subclass of int)
if param_type in (bool, Bit):
    return Bit(
        value=Value(
            type=BitType(),
            name=name,
        ).with_const(bool(value)),
        init_value=bool(value),
    )
```

### Tests

**`tests/transpiler/test_compile_time_if_lowering.py::TestBoolBinding`** (3 tests)

Verifies that `bool` bindings participate in compile-time if lowering just like `UInt` flags:

- `flag=True`: `IfOperation` removed, true-branch gate present, false-branch gate dropped.
- `flag=False`: `IfOperation` removed, false-branch gate present, true-branch gate dropped.
- `kernel.build(flag=True/False)` completes without error.

**`tests/circuit/test_control_flow_if.py::TestBoolBindingWithDynamicIf`** (6 parametrized tests)

Covers the full teleportation-like path — a `bool` binding **plus** two measurement-driven dynamic `if`s living in the same kernel:

- `build()` accepts the bool binding; all 3 `IfOperation`s are traced.
- After `constant_fold` + `lower_compile_time_ifs`, only the 2 measurement-driven `IfOperation`s survive — the `is_plus` one is folded.
- Qiskit `sample(shots=1024)` on Aer produces a deterministic third bit: `0` for `is_plus=True` (teleported |+> measured in X basis), `1` for `is_plus=False` (|->). This is a direct end-to-end verification that the emitted Qiskit circuit uses native `IfElseOp` with classical feedforward correctly — if the feedforward were broken, the third bit would be random because `m0`/`m1` are.

## Backend behavior

Only compile-time folding changes here; the dynamic-if emit path is unchanged. For reference:

- **Qiskit**: emits `IfElseOp` via `QuantumCircuit.if_test`; Aer executes feedforward — all paths work.
- **QuriParts**: `supports_if_else() == False`. Compile-time `bool` bindings still work (the if is folded before emit). Runtime measurement-driven ifs raise `EmitError: Backend does not support native if/else control flow` at transpile time — unchanged.
- **CUDA-Q**: `supports_if_else()` is True only in `MeasurementMode.RUNNABLE` — unchanged.

## Test plan

- [x] `uv run pytest tests/transpiler/test_compile_time_if_lowering.py::TestBoolBinding -v` (3 passed)
- [x] `uv run pytest tests/circuit/test_control_flow_if.py::TestBoolBindingWithDynamicIf -v` (6 passed)
- [x] `uv run pytest tests/circuit/` (4035 passed, no regressions)
- [x] `uv run pytest tests/transpiler/test_compile_time_if_lowering.py tests/circuit/test_control_flow_if.py` (111 passed)
- [x] `uv run ruff check qamomile/circuit/frontend/qkernel.py tests/transpiler/test_compile_time_if_lowering.py tests/circuit/test_control_flow_if.py` (clean)
- [x] `uv run zuban check qamomile/circuit/frontend/qkernel.py` (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)