### PR TITLE
Enforce disjoint bindings/parameters and unify classical op folding

### DIFF
--- a/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
+++ b/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
@@ -31,6 +31,7 @@ from qamomile.circuit.transpiler.value_resolver import (
 
 from . import Pass
 from .emit_support import resolve_if_condition
+from .eval_utils import FoldPolicy, fold_classical_op
 from .value_mapping import ValueSubstitutor
 
 
@@ -139,45 +140,29 @@ class CompileTimeIfLoweringPass(Pass[Block, Block]):
         - ``NotOp``   — logical negation
         - ``BinOp``   — arithmetic (+, -, *, /, //, %)
 
-        Other operation types are silently ignored.  If all operands of a
+        Delegates the actual fold to ``fold_classical_op`` under the
+        ``COMPILE_TIME`` policy, which bypasses the runtime-parameter
+        guard. At this stage there are no runtime parameters in the
+        concrete values map; everything in ``self._bindings`` is treated
+        as a real compile-time value.
+
+        Other operation types are silently ignored. If all operands of a
         supported op are concrete but evaluation still fails, the result
         is not recorded and downstream IfOperations referencing it will
         remain unresolved (emitted as runtime branches).
         """
-        if isinstance(op, CompOp):
-            lhs = self._resolve_operand(op.operands[0], concrete_values)
-            rhs = self._resolve_operand(op.operands[1], concrete_values)
-            if lhs is not None and rhs is not None and op.results:
-                result = self._eval_comp(op.kind, lhs, rhs)
-                if result is not None:
-                    concrete_values[op.results[0].uuid] = result
-
-        elif isinstance(op, CondOp):
-            lhs = self._resolve_operand(op.operands[0], concrete_values)
-            rhs = self._resolve_operand(op.operands[1], concrete_values)
-            if lhs is not None and rhs is not None and op.results:
-                result = self._eval_cond(op.kind, lhs, rhs)
-                if result is not None:
-                    concrete_values[op.results[0].uuid] = result
-
-        elif isinstance(op, NotOp):
-            operand = self._resolve_operand(op.operands[0], concrete_values)
-            if operand is not None and op.results:
-                from qamomile.circuit.transpiler.passes.eval_utils import (
-                    evaluate_notop_value,
-                )
-
-                result = evaluate_notop_value(operand)
-                if result is not None:
-                    concrete_values[op.results[0].uuid] = result
-
-        elif isinstance(op, BinOp):
-            lhs = self._resolve_operand(op.operands[0], concrete_values)
-            rhs = self._resolve_operand(op.operands[1], concrete_values)
-            if lhs is not None and rhs is not None and op.results:
-                result = self._eval_binop(op.kind, lhs, rhs)
-                if result is not None:
-                    concrete_values[op.results[0].uuid] = result
+        if not isinstance(op, (CompOp, CondOp, NotOp, BinOp)):
+            return
+        if not op.results:
+            return
+        result = fold_classical_op(
+            op,
+            lambda v: self._resolve_operand(v, concrete_values),
+            parameters=set(),
+            policy=FoldPolicy.COMPILE_TIME,
+        )
+        if result is not None:
+            concrete_values[op.results[0].uuid] = result
 
     def _resolve_operand(
         self,
@@ -188,32 +173,6 @@ class CompileTimeIfLoweringPass(Pass[Block, Block]):
         return UnifiedValueResolver(
             context=concrete_values, bindings=self._bindings
         ).resolve(value)
-
-    # Kind dispatch is delegated to ``eval_utils`` so all three transpiler
-    # passes that evaluate classical ops share one source of truth.
-    @staticmethod
-    def _eval_comp(kind: Any, lhs: Any, rhs: Any) -> bool | None:
-        from qamomile.circuit.transpiler.passes.eval_utils import (
-            evaluate_compop_values,
-        )
-
-        return evaluate_compop_values(kind, lhs, rhs)
-
-    @staticmethod
-    def _eval_cond(kind: Any, lhs: Any, rhs: Any) -> bool | None:
-        from qamomile.circuit.transpiler.passes.eval_utils import (
-            evaluate_condop_values,
-        )
-
-        return evaluate_condop_values(kind, lhs, rhs)
-
-    @staticmethod
-    def _eval_binop(kind: Any, lhs: Any, rhs: Any) -> Any:
-        from qamomile.circuit.transpiler.passes.eval_utils import (
-            evaluate_binop_values,
-        )
-
-        return evaluate_binop_values(kind, lhs, rhs)
 
     # ------------------------------------------------------------------
     # Operation lowering

--- a/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
@@ -21,10 +21,8 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
 )
 from qamomile.circuit.ir.operation.cast import CastOperation
 from qamomile.circuit.transpiler.passes.eval_utils import (
-    evaluate_binop_values,
-    evaluate_compop_values,
-    evaluate_condop_values,
-    evaluate_notop_value,
+    FoldPolicy,
+    fold_classical_op,
 )
 
 from .qubit_address import QubitAddress, QubitMap
@@ -99,23 +97,48 @@ def evaluate_binop(
 ) -> None:
     """Evaluate a BinOp and store the result in bindings.
 
-    Parameter-array elements take priority over their concrete
-    bindings: users often pass a concrete array alongside
-    ``parameters=[...]`` as a shape hint, and those elements must stay
-    symbolic so the emitted circuit carries backend parameters.
+    Tries the shared ``fold_classical_op`` first for a clean concrete
+    fold (which already encapsulates the runtime-parameter guard).
+    Falls back to creating backend ``Parameter`` symbols and doing
+    symbolic arithmetic when one or both operands are runtime
+    parameters — that's the path that lets ``rx(q, gamma * 2)`` produce
+    a circuit with a single ``Parameter("gamma") * 2`` expression rather
+    than baking in a placeholder.
     """
     parameters = emit_pass._resolver.parameters
-    lhs_is_param_elem = _is_param_array_element(op.lhs, parameters)
-    rhs_is_param_elem = _is_param_array_element(op.rhs, parameters)
 
-    if lhs_is_param_elem:
-        lhs = None
-    else:
-        lhs = emit_pass._resolver.resolve_classical_value(op.lhs, bindings)
-    if rhs_is_param_elem:
-        rhs = None
-    else:
-        rhs = emit_pass._resolver.resolve_classical_value(op.rhs, bindings)
+    # Phase 1: try the concrete fold path via the shared API.
+    folded = fold_classical_op(
+        op,
+        lambda v: emit_pass._resolver.resolve_classical_value(v, bindings),
+        parameters,
+        FoldPolicy.EMIT_RESPECT_PARAMS,
+    )
+    if folded is not None and op.results:
+        # Write by UUID only. Auto-generated tmp values share generic names
+        # (e.g. every UInt arithmetic result is named "uint_tmp"), so a
+        # name-keyed write would overwrite earlier tmps with the same name
+        # and cause stale-value lookups in chained expressions. UUID-keyed
+        # writes are unambiguous and the resolvers (value_resolver.py) check
+        # UUID before name, so legitimate name-based reads (parameters, loop
+        # variables) are unaffected.
+        _set_emit_value(bindings, op.results[0].uuid, folded)
+        return
+
+    # Phase 2: backend Parameter symbolic path. Operands that are either
+    # runtime-parameter array elements or top-level parameters become
+    # backend Parameter objects; the arithmetic is performed symbolically
+    # using the backend Parameter's overloaded ``__add__`` etc.
+    lhs = (
+        None
+        if _is_param_array_element(op.lhs, parameters)
+        else emit_pass._resolver.resolve_classical_value(op.lhs, bindings)
+    )
+    rhs = (
+        None
+        if _is_param_array_element(op.rhs, parameters)
+        else emit_pass._resolver.resolve_classical_value(op.rhs, bindings)
+    )
 
     lhs_param_key = emit_pass._resolver.get_parameter_key(op.lhs, bindings)
     rhs_param_key = emit_pass._resolver.get_parameter_key(op.rhs, bindings)
@@ -128,38 +151,28 @@ def evaluate_binop(
     if lhs is None or rhs is None:
         return
 
-    # For concrete numeric operands, use the shared evaluator.
-    # When operands may be symbolic backend parameters, fall back to
-    # direct arithmetic (which relies on the backend parameter type
-    # supporting __add__ etc.) and use 0-valued defaults for division.
-    if isinstance(lhs, (int, float)) and isinstance(rhs, (int, float)):
-        result = evaluate_binop_values(op.kind, lhs, rhs)
-    else:
-        result = None
-        match op.kind:
-            case BinOpKind.ADD:
-                result = lhs + rhs
-            case BinOpKind.SUB:
-                result = lhs - rhs
-            case BinOpKind.MUL:
-                result = lhs * rhs
-            case BinOpKind.DIV:
-                result = lhs / rhs if rhs != 0 else 0.0
-            case BinOpKind.FLOORDIV:
-                result = lhs // rhs if rhs != 0 else 0
-            case BinOpKind.POW:
-                result = lhs**rhs
+    # Symbolic arithmetic over backend Parameter objects. Concrete-only
+    # operands have already been handled by ``fold_classical_op`` above,
+    # so we land here only when at least one operand is a backend
+    # Parameter; ``0``-valued defaults guard against div-by-zero on the
+    # symbolic side without losing the symbolic result for the common case.
+    result = None
+    match op.kind:
+        case BinOpKind.ADD:
+            result = lhs + rhs
+        case BinOpKind.SUB:
+            result = lhs - rhs
+        case BinOpKind.MUL:
+            result = lhs * rhs
+        case BinOpKind.DIV:
+            result = lhs / rhs if rhs != 0 else 0.0
+        case BinOpKind.FLOORDIV:
+            result = lhs // rhs if rhs != 0 else 0
+        case BinOpKind.POW:
+            result = lhs**rhs
 
     if result is not None and op.results:
-        output = op.results[0]
-        # Write by UUID only. Auto-generated tmp values share generic names
-        # (e.g. every UInt arithmetic result is named "uint_tmp"), so a
-        # name-keyed write would overwrite earlier tmps with the same name
-        # and cause stale-value lookups in chained expressions. UUID-keyed
-        # writes are unambiguous and the resolvers (value_resolver.py) check
-        # UUID before name, so legitimate name-based reads (parameters, loop
-        # variables) are unaffected.
-        _set_emit_value(bindings, output.uuid, result)
+        _set_emit_value(bindings, op.results[0].uuid, result)
 
 
 def evaluate_classical_predicate(
@@ -176,12 +189,12 @@ def evaluate_classical_predicate(
     by ``emit_for_items`` / ``emit_for_unrolled`` — can still be resolved
     via ``resolve_if_condition``.
 
-    All three predicate kinds are handled together because the IR contract
-    treats them as a single family: ``CompOp`` is what the frontend
-    currently produces from ``==`` / ``<`` / ..., while ``CondOp`` and
-    ``NotOp`` are produced by other passes (and are reserved for future
-    handle overloads of ``&`` / ``|`` / ``~``). Skipping the latter would
-    leave emit as the only pass blind to those ops.
+    Delegates the actual fold (including runtime-parameter guard and
+    strict scalar typing) to ``fold_classical_op`` so that all three
+    callers of the same kind dispatch share one implementation. There
+    is no symbolic-Parameter fallback for predicates: a runtime classical
+    expression cannot be expressed as a folded scalar, so the op is left
+    unbound and downstream emit handles it as a runtime condition.
 
     Args:
         emit_pass: The active emit pass (for resolver access).
@@ -196,38 +209,15 @@ def evaluate_classical_predicate(
     if not op.results:
         return
 
-    # Defense-in-depth: only accept scalar Python values (bool / int /
-    # float) as resolved operands. A backend runtime expression
-    # (e.g. ``qiskit.circuit.classical.expr.Expr``) is a truthy Python
-    # object, and feeding it through ``bool(lhs and rhs)`` would spuriously
-    # fold the predicate to ``True``. The primary protection against this
-    # class of bug is the UUID-only binding policy (see ``evaluate_binop``
-    # comment above and the matching block at the end of this function) —
-    # without name-keyed writes, sub-predicate exprs no longer leak into
-    # bindings under colliding tmp names. This isinstance check is a belt-
-    # and-suspenders guard against future code paths that might inject
-    # non-scalar values into bindings by other means.
-    if isinstance(op, NotOp):
-        operand = emit_pass._resolver.resolve_classical_value(op.operands[0], bindings)
-        if not isinstance(operand, (bool, int, float)):
-            return
-        result = evaluate_notop_value(operand)
-    else:
-        lhs = emit_pass._resolver.resolve_classical_value(op.operands[0], bindings)
-        rhs = emit_pass._resolver.resolve_classical_value(op.operands[1], bindings)
-        if not isinstance(lhs, (bool, int, float)) or not isinstance(
-            rhs, (bool, int, float)
-        ):
-            return
-        if isinstance(op, CompOp):
-            result = evaluate_compop_values(op.kind, lhs, rhs)
-        else:  # CondOp
-            result = evaluate_condop_values(op.kind, lhs, rhs)
-
+    result = fold_classical_op(
+        op,
+        lambda v: emit_pass._resolver.resolve_classical_value(v, bindings),
+        emit_pass._resolver.parameters,
+        FoldPolicy.EMIT_RESPECT_PARAMS,
+    )
     if result is None:
         return
 
-    output = op.results[0]
     # Write by UUID only — see the matching comment in evaluate_binop above
     # for why name-keyed writes are unsafe for tmp values like "bit_tmp".
-    _set_emit_value(bindings, output.uuid, result)
+    _set_emit_value(bindings, op.results[0].uuid, result)

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -311,8 +311,23 @@ class ValueResolver:
         v: "Value",
         bindings: dict[str, Any],
     ) -> Any:
+        """Index into a bound array container at the operand's element indices.
+
+        Refuses to index when the parent array's name is in
+        ``self.parameters``. That short-circuit is the same invariant
+        ``fold_classical_op(... EMIT_RESPECT_PARAMS)`` enforces at the
+        op level: a runtime parameter array's "value" is symbolic, and
+        any concrete data the user supplied alongside is a placeholder
+        — silently indexing into the placeholder is exactly what
+        produced the silent miscompilation in Issue #354 B-series. This
+        guard is defense-in-depth: even if a future caller forgets the
+        op-level guard, array indexing for runtime parameters returns
+        ``None`` here.
+        """
         parent = v.parent_array
         if parent is None:
+            return None
+        if parent.name in self.parameters:
             return None
         container = bindings.get(parent.name)
         if container is None:

--- a/qamomile/circuit/transpiler/passes/eval_utils.py
+++ b/qamomile/circuit/transpiler/passes/eval_utils.py
@@ -10,26 +10,152 @@ same family of ops (``CompOp``, ``CondOp``, ``NotOp``, ``BinOp``):
 - ``cast_binop_emission`` (emit pass) — folds ops at emit time for
   inlining loop variables and parameter bindings into ``if`` conditions.
 
-Each pass differs in how it *resolves operands* (concrete_values map,
-results dict, bindings dict + resolver). They all share the same
-*kind → Python operation* dispatch. By centralizing the dispatch here,
-adding a new ``CompOpKind`` requires changing only this file.
+The low-level ``evaluate_*_values`` functions take fully resolved Python
+operands and return the computed value (or ``None`` if the op cannot be
+evaluated, e.g. division by zero, unknown kind, type mismatch). They
+never touch bindings or resolvers — those responsibilities stay with the
+caller.
 
-The functions below take fully resolved Python operands and return the
-computed value (or ``None`` if the op cannot be evaluated, e.g. division
-by zero, unknown kind, type mismatch). They never touch bindings or
-resolvers — those responsibilities stay with the caller.
+The high-level ``fold_classical_op`` adds a uniform parameter-respecting
+policy on top: callers supply a resolver callable and a ``FoldPolicy``,
+and the function returns either the folded scalar or ``None``. This is
+the layer that prevents the silent miscompilation class of bugs (Issue
+#354 B-series): the parameter-array-element guard is now structurally
+inside this function rather than re-implemented per call site.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import enum
+from typing import Any, Callable
 
 from qamomile.circuit.ir.operation.arithmetic_operations import (
+    BinOp,
     BinOpKind,
+    CompOp,
     CompOpKind,
+    CondOp,
     CondOpKind,
+    NotOp,
 )
+
+
+class FoldPolicy(enum.Enum):
+    """Policy controlling how ``fold_classical_op`` treats parameters.
+
+    ``COMPILE_TIME`` is for passes that have no notion of runtime
+    parameters (e.g. ``compile_time_if_lowering``); every operand the
+    resolver returns is treated as a real value to fold.
+
+    ``EMIT_RESPECT_PARAMS`` is for emit-time passes where some Values
+    may correspond to runtime backend parameters whose concrete values
+    are placeholders or absent. Operands whose Value or
+    ``parent_array.name`` is in the active ``parameters`` set are
+    treated as symbolic and the fold returns ``None`` rather than
+    producing an incorrect concrete result.
+    """
+
+    COMPILE_TIME = "compile_time"
+    EMIT_RESPECT_PARAMS = "emit_respect_params"
+
+
+def _is_runtime_parameter_operand(operand: Any, parameters: set[str]) -> bool:
+    """Return True when ``operand`` traces to a runtime parameter.
+
+    Two cases are recognised:
+    1. ``operand`` is an array element (``arr[idx]``) and ``arr`` is in
+       ``parameters``.
+    2. ``operand`` itself is a parameter Value whose name is in
+       ``parameters``.
+
+    Args:
+        operand: The IR operand to inspect (typically a ``Value``).
+        parameters: The set of names declared as runtime parameters.
+
+    Returns:
+        True if folding this operand would consume a placeholder rather
+        than a true compile-time value.
+    """
+    parent_array = getattr(operand, "parent_array", None)
+    if parent_array is not None and getattr(parent_array, "name", None) in parameters:
+        return True
+    is_parameter = getattr(operand, "is_parameter", None)
+    if callable(is_parameter) and is_parameter():
+        param_name_fn = getattr(operand, "parameter_name", None)
+        if callable(param_name_fn):
+            pname = param_name_fn()
+            if pname and pname in parameters:
+                return True
+    return False
+
+
+def fold_classical_op(
+    op: "BinOp | CompOp | CondOp | NotOp",
+    operand_resolver: Callable[[Any], Any],
+    parameters: set[str],
+    policy: FoldPolicy,
+) -> Any | None:
+    """Fold a classical op to a concrete value, respecting the given policy.
+
+    The caller supplies an ``operand_resolver`` callable that knows how
+    to look up a Value in the caller's context (a ``concrete_values``
+    map, an emit ``bindings`` dict + ``ValueResolver``, or any other
+    source). This function handles:
+
+    1. The parameter guard (skips folding when an operand is a runtime
+       parameter or parameter-array element under ``EMIT_RESPECT_PARAMS``).
+    2. Strict scalar-only typing (rejects backend ``Expr`` objects and
+       other non-numeric values that would spuriously fold to ``True``).
+    3. Kind dispatch via the underlying ``evaluate_*_values`` primitives.
+
+    Args:
+        op: The classical op to fold. Must be one of ``BinOp``,
+            ``CompOp``, ``CondOp``, ``NotOp``.
+        operand_resolver: Callable mapping each operand Value to a
+            resolved Python scalar (or ``None`` when unresolvable).
+        parameters: Set of runtime parameter names. Used only when
+            ``policy`` is ``EMIT_RESPECT_PARAMS``.
+        policy: Folding policy. See ``FoldPolicy`` docstring.
+
+    Returns:
+        The folded value (numeric for ``BinOp``, bool for predicates),
+        or ``None`` when any operand is symbolic, missing, or a runtime
+        parameter under the policy.
+    """
+    operands = op.operands
+
+    if policy is FoldPolicy.EMIT_RESPECT_PARAMS:
+        for opnd in operands:
+            if _is_runtime_parameter_operand(opnd, parameters):
+                return None
+
+    resolved = [operand_resolver(opnd) for opnd in operands]
+    if any(r is None for r in resolved):
+        return None
+
+    if not all(isinstance(r, (bool, int, float)) for r in resolved):
+        return None
+
+    if isinstance(op, BinOp):
+        if len(resolved) != 2:
+            return None
+        return evaluate_binop_values(op.kind, resolved[0], resolved[1])
+    if isinstance(op, CompOp):
+        if len(resolved) != 2:
+            return None
+        return evaluate_compop_values(op.kind, resolved[0], resolved[1])
+    if isinstance(op, CondOp):
+        if len(resolved) != 2:
+            return None
+        return evaluate_condop_values(op.kind, resolved[0], resolved[1])
+    if isinstance(op, NotOp):
+        if len(resolved) != 1:
+            return None
+        return evaluate_notop_value(resolved[0])
+
+    # All four op kinds in the signature are exhausted above; this guard
+    # only matters if a caller bypasses the type system at runtime.
+    return None  # type: ignore[unreachable]
 
 
 def evaluate_binop_values(

--- a/qamomile/circuit/transpiler/transpiler.py
+++ b/qamomile/circuit/transpiler/transpiler.py
@@ -437,13 +437,22 @@ class Transpiler(ABC, Generic[T]):
 
         Args:
             kernel: The QKernel to compile
-            bindings: Parameter values to bind (also resolves array shapes)
+            bindings: Parameter values to bind (also resolves array shapes).
+                Names in ``bindings`` and ``parameters`` must be disjoint —
+                a name is either compile-time bound or runtime symbolic,
+                never both.
             parameters: Parameter names to preserve as backend parameters
 
         Returns:
             ExecutableProgram ready for execution
 
         Raises:
+            ValueError: If a name appears in both ``bindings`` and
+                ``parameters``. A name being in both is ambiguous (placeholder
+                value vs runtime symbol) and used to silently miscompile
+                control-flow predicates that depended on parameter-array
+                elements; rejecting the overlap up front keeps the contract
+                unambiguous.
             QamomileCompileError: If compilation fails (validation, dependency errors)
 
         Note:
@@ -463,6 +472,19 @@ class Transpiler(ABC, Generic[T]):
             9. plan: Build ProgramPlan (segment into C->Q->C steps)
             10. emit: Generate backend-specific code
         """
+        if bindings and parameters:
+            overlap = set(parameters) & set(bindings.keys())
+            if overlap:
+                raise ValueError(
+                    f"Parameter name(s) {sorted(overlap)} appear in both "
+                    f"`parameters` and `bindings`. A name must be either "
+                    f"compile-time bound (in `bindings`) or runtime symbolic "
+                    f"(in `parameters`), not both. "
+                    f"If you want this value baked into the circuit, remove "
+                    f"it from `parameters`. If you want it as a runtime "
+                    f"parameter, remove it from `bindings`."
+                )
+
         entrypoint_validator = EntrypointValidationPass()
 
         # Pass bindings and parameters to to_block for proper shape resolution

--- a/tests/transpiler/test_param_bindings_disjoint.py
+++ b/tests/transpiler/test_param_bindings_disjoint.py
@@ -1,0 +1,149 @@
+"""Regression: ``Transpiler.transpile`` rejects ``parameters``/``bindings`` overlap.
+
+A parameter name appearing in both ``bindings`` and ``parameters`` is
+fundamentally ambiguous (placeholder value vs runtime symbol) and used to
+silently miscompile control-flow predicates that depended on the parameter
+array's elements (Issue #354 B-series). After Phase 1, the overlap raises
+``ValueError`` at the public API entry, eliminating the silent miscompilation
+class entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import qamomile.circuit as qmc
+
+
+@pytest.fixture
+def qiskit_transpiler():
+    """Return a QiskitTranspiler, skipping the test if qiskit is unavailable."""
+    pytest.importorskip("qiskit")
+    from qamomile.qiskit import QiskitTranspiler
+
+    return QiskitTranspiler()
+
+
+@qmc.qkernel
+def _identity_kernel(theta: qmc.Float) -> qmc.Bit:
+    """Trivial kernel used to exercise the disjointness check.
+
+    Returns:
+        Measurement of a Hadamard-prepared qubit.
+    """
+    q = qmc.qubit(name="q")
+    q = qmc.rx(q, theta)
+    return qmc.measure(q)
+
+
+class TestParamBindingsDisjoint:
+    """Validates the API-level disjointness contract."""
+
+    def test_overlap_single_name_rejected(self, qiskit_transpiler) -> None:
+        """A single shared name between bindings and parameters raises ValueError."""
+        with pytest.raises(ValueError, match=r"appear in both"):
+            qiskit_transpiler.transpile(
+                _identity_kernel,
+                bindings={"theta": 0.5},
+                parameters=["theta"],
+            )
+
+    def test_overlap_multiple_names_listed_in_message(self, qiskit_transpiler) -> None:
+        """Multiple shared names are surfaced in the error message for debuggability."""
+
+        @qmc.qkernel
+        def two_param(a: qmc.Float, b: qmc.Float) -> qmc.Bit:
+            """Two-parameter kernel for the multi-name overlap test."""
+            q = qmc.qubit(name="q")
+            q = qmc.rx(q, a)
+            q = qmc.ry(q, b)
+            return qmc.measure(q)
+
+        with pytest.raises(ValueError) as excinfo:
+            qiskit_transpiler.transpile(
+                two_param,
+                bindings={"a": 0.1, "b": 0.2},
+                parameters=["a", "b"],
+            )
+        message = str(excinfo.value)
+        assert "'a'" in message and "'b'" in message
+
+    def test_disjoint_bindings_and_parameters_compile(self, qiskit_transpiler) -> None:
+        """The QAOA-style pattern (compile-time scalar + runtime array) compiles cleanly."""
+
+        @qmc.qkernel
+        def qaoa_like(p: qmc.UInt, gamma: qmc.Float) -> qmc.Bit:
+            """Compile-time depth ``p`` plus runtime rotation angle ``gamma``."""
+            q = qmc.qubit(name="q")
+            for _ in qmc.range(p):
+                q = qmc.rx(q, gamma)
+            return qmc.measure(q)
+
+        # No overlap: ``p`` is compile-time bound, ``gamma`` is runtime symbolic.
+        exe = qiskit_transpiler.transpile(
+            qaoa_like,
+            bindings={"p": 2},
+            parameters=["gamma"],
+        )
+        # Sanity-check that the runtime parameter actually flows through.
+        result = exe.sample(
+            qiskit_transpiler.executor(),
+            shots=8,
+            bindings={"gamma": 0.5},
+        ).result()
+        assert sum(count for _, count in result.results) == 8
+
+    def test_only_bindings_no_overlap_check(self, qiskit_transpiler) -> None:
+        """``bindings`` alone (no ``parameters``) is unaffected by the disjointness check."""
+        exe = qiskit_transpiler.transpile(_identity_kernel, bindings={"theta": 0.0})
+        result = exe.sample(qiskit_transpiler.executor(), shots=4).result()
+        assert sum(count for _, count in result.results) == 4
+
+    def test_only_parameters_no_overlap_check(self, qiskit_transpiler) -> None:
+        """``parameters`` alone (no ``bindings``) is unaffected by the disjointness check."""
+        exe = qiskit_transpiler.transpile(_identity_kernel, parameters=["theta"])
+        result = exe.sample(
+            qiskit_transpiler.executor(),
+            shots=4,
+            bindings={"theta": 0.3},
+        ).result()
+        assert sum(count for _, count in result.results) == 4
+
+
+class TestIssue354BSeriesRepro:
+    """The exact repro from Issue #354 B-series no longer silently miscompiles.
+
+    Pre-fix: ``transpile(basis_only, bindings={'input': [0]*4}, parameters=['input'])``
+    silently dropped the X gates (sample returned ``[((0,0,0,0), shots)]`` regardless
+    of the runtime ``input`` binding). Post-fix: the same call raises ``ValueError``
+    at the API boundary, making the silent-wrong-answer impossible.
+    """
+
+    def test_repro_now_raises_value_error(self, qiskit_transpiler) -> None:
+        """The B-series pattern is rejected with a clear ValueError."""
+
+        @qmc.qkernel
+        def computational_basis_state(
+            q: qmc.Vector[qmc.Qubit],
+            input: qmc.Vector[qmc.UInt],
+        ) -> qmc.Vector[qmc.Qubit]:
+            """Apply X to qubits where the corresponding input bit is 1."""
+            n = q.shape[0]
+            for i in qmc.range(n):
+                if input[i] == 1:
+                    q[i] = qmc.x(q[i])
+            return q
+
+        @qmc.qkernel
+        def basis_only(input: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+            """Wrap ``computational_basis_state`` in a measure-all entrypoint."""
+            q = qmc.qubit_array(input.shape[0], name="q")
+            q = computational_basis_state(q, input)
+            return qmc.measure(q)
+
+        with pytest.raises(ValueError, match=r"appear in both"):
+            qiskit_transpiler.transpile(
+                basis_only,
+                bindings={"input": [0] * 4},
+                parameters=["input"],
+            )

--- a/tests/transpiler/test_pauli_evolve_parametric.py
+++ b/tests/transpiler/test_pauli_evolve_parametric.py
@@ -62,15 +62,25 @@ class TestScalarParametricGamma:
 
 class TestArrayElementParametricGamma:
     def test_parametric_gamma_per_layer(self):
+        """Shape comes from a compile-time scalar; gamma stays runtime-symbolic.
+
+        Pre-disjointness this test passed ``gamma=[0,0,0]`` in bindings as
+        a shape hint while also marking ``gamma`` as a runtime parameter. That
+        overlap pattern is now rejected by ``Transpiler.transpile``; the
+        QAOA-style pattern (separate compile-time depth + runtime array)
+        is the supported alternative.
+        """
+
         @qmc.qkernel
         def kernel(
             n: qmc.UInt,
+            p: qmc.UInt,
             gamma: qmc.Vector[qmc.Float],
             hamiltonian: qmc.Observable,
         ) -> qmc.Vector[qmc.Bit]:
             q = superposition_vector(n)
-            for p in qmc.range(gamma.shape[0]):
-                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
+            for k in qmc.range(p):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[k])
             return qmc.measure(q)
 
         H = _make_zz_h()
@@ -79,8 +89,8 @@ class TestArrayElementParametricGamma:
             kernel,
             bindings={
                 "n": H.num_qubits,
+                "p": 3,
                 "hamiltonian": H,
-                "gamma": [0.0, 0.0, 0.0],  # shape hint for p=3
             },
             parameters=["gamma"],
         )
@@ -94,27 +104,40 @@ class TestFullQAOAExecution:
     """End-to-end: user's ipynb pattern with parametric gamma AND beta."""
 
     def _kernels(self):
+        """Build a QAOA expval kernel with compile-time depth ``p``.
+
+        Migrated from the pre-disjointness pattern that passed
+        ``gamma=[0.0]*p`` as a shape hint while also marking ``gamma`` as
+        a runtime parameter; the new contract takes the depth as its own
+        compile-time scalar so ``gamma``/``beta`` stay purely runtime-symbolic.
+
+        Returns:
+            The compiled-once expval kernel parameterized over ``p``.
+        """
+
         @qmc.qkernel
         def qaoa_circuit(
             n: qmc.UInt,
+            p: qmc.UInt,
             gamma: qmc.Vector[qmc.Float],
             beta: qmc.Vector[qmc.Float],
             hamiltonian: qmc.Observable,
         ) -> qmc.Vector[qmc.Qubit]:
             q = superposition_vector(n)
-            for p in qmc.range(gamma.shape[0]):
-                q = qmc.pauli_evolve(q, hamiltonian, gamma[p])
-                q = x_mixer(q, beta[p])
+            for k in qmc.range(p):
+                q = qmc.pauli_evolve(q, hamiltonian, gamma[k])
+                q = x_mixer(q, beta[k])
             return q
 
         @qmc.qkernel
         def qaoa_exp(
             n: qmc.UInt,
+            p: qmc.UInt,
             gamma: qmc.Vector[qmc.Float],
             beta: qmc.Vector[qmc.Float],
             hamiltonian: qmc.Observable,
         ) -> qmc.Float:
-            q = qaoa_circuit(n, gamma, beta, hamiltonian)
+            q = qaoa_circuit(n, p, gamma, beta, hamiltonian)
             return qmc.expval(q, hamiltonian)
 
         return qaoa_exp
@@ -129,9 +152,8 @@ class TestFullQAOAExecution:
             qaoa_exp,
             bindings={
                 "n": H.num_qubits,
+                "p": 2,
                 "hamiltonian": H,
-                "gamma": [0.0, 0.0],  # shape hint for p=2
-                "beta": [0.0, 0.0],
             },
             parameters=["gamma", "beta"],
         )
@@ -165,9 +187,8 @@ class TestFullQAOAExecution:
             qaoa_exp,
             bindings={
                 "n": H.num_qubits,
+                "p": 1,
                 "hamiltonian": H,
-                "gamma": [0.0],
-                "beta": [0.0],
             },
             parameters=["gamma", "beta"],
         )


### PR DESCRIPTION
## Summary

This PR addresses Issue #354 B-series by enforcing that parameter names cannot appear in both `bindings` and `parameters` at the public API level, eliminating a class of silent miscompilation bugs. It also refactors classical operation folding into a unified `fold_classical_op` function that centralizes the parameter-respecting policy across all transpiler passes.

## Key Changes

- **API-level disjointness check**: `Transpiler.transpile()` now raises `ValueError` if any name appears in both `bindings` and `parameters`, making the ambiguity explicit rather than silently miscompiling control-flow predicates.

- **Unified classical op folding**: Introduced `fold_classical_op()` in `eval_utils.py` that:
  - Centralizes operand resolution, parameter guards, and scalar-type validation
  - Supports two policies: `COMPILE_TIME` (no parameter guard) and `EMIT_RESPECT_PARAMS` (skips folding when operands are runtime parameters)
  - Replaces scattered per-pass implementations with a single source of truth

- **Two-phase emit-time evaluation**: `evaluate_binop()` and `evaluate_classical_predicate()` now:
  - Phase 1: Attempt concrete fold via `fold_classical_op` (handles all-concrete operands)
  - Phase 2: Fall back to symbolic arithmetic with backend `Parameter` objects (for mixed concrete/symbolic operands)

- **Defense-in-depth parameter guards**:
  - `fold_classical_op` checks if operands are runtime parameters or parameter-array elements
  - `ValueResolver._index_into_array()` refuses to index runtime parameter arrays, preventing placeholder data from leaking into bindings

- **Test coverage**: Added `test_param_bindings_disjoint.py` with regression tests for the Issue #354 B-series pattern and validation of the QAOA-style compile-time depth + runtime array pattern.

- **Test migration**: Updated `test_pauli_evolve_parametric.py` and `test_qaoa_execution.py` to use the new disjoint pattern (separate compile-time `p` parameter for loop depth instead of using array shape as a hint).

## Implementation Details

- The parameter guard in `fold_classical_op` checks both `parent_array.name` (for array elements) and `Value.parameter_name()` (for top-level parameters) against the active `parameters` set.
- UUID-keyed binding writes (not name-keyed) prevent auto-generated tmp values from colliding and causing stale-value lookups in chained expressions.
- `compile_time_if_lowering.py` simplified by delegating all op evaluation to `fold_classical_op` under `COMPILE_TIME` policy, removing per-kind dispatch methods.

https://claude.ai/code/session_01VjcUCM3DKvnqDLMuUhsjwc