### PR TITLE
docs: execute tutorials 09, 10, 11 to generate output cells

### DIFF
--- a/docs/en/tutorial/09_compilation_and_transpilation.ipynb
+++ b/docs/en/tutorial/09_compilation_and_transpilation.ipynb
@@ -25,9 +25,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "34b31206",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.030345Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.030151Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.033735Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.032792Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Install the latest Qamomile through pip!\n",
@@ -164,9 +171,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "f7509df7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.035649Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.035489Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.388004Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.386997Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import qamomile.circuit as qmc\n",
@@ -199,9 +213,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "e8f404b8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.390362Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.390119Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.398040Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.397284Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -239,9 +259,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "4f7a87a2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.399834Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.399683Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.403319Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.402427Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def summarise(block):\n",
@@ -290,10 +317,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "58fa2c7e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.405035Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.404859Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.410991Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.410126Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after to_block:    kind=HIERARCHICAL  ops= 5 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'BinOp': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "parameters:        ['theta']\n",
+      "CallBlockOps:      0\n"
+     ]
+    }
+   ],
    "source": [
     "bindings = {\"n\": 3}\n",
     "parameters = [\"theta\"]\n",
@@ -318,10 +362,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "34dfa9fc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.412660Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.412485Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.415993Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.415127Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [HIERARCHICAL] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    call entangle_pair(%q[%i@v0]@v0, %q[%_@v0]@v0) -> (%q[%i@v0]@v1, %q[%_@v0]@v1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block))"
    ]
@@ -338,10 +411,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "1305ef2e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.417848Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.417675Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.421090Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.420235Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [HIERARCHICAL] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    call entangle_pair(%q[%i@v0]@v0, %q[%_@v0]@v0) -> (%q[%i@v0]@v1, %q[%_@v0]@v1) {\n",
+      "      %q0@v1 = h(%q0@v0)\n",
+      "      %q0@v2, %q1@v1 = cx(%q0@v1, %q1@v0)\n",
+      "      return %q0@v2, %q1@v1\n",
+      "    }\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block, depth=1))"
    ]
@@ -367,10 +473,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "dcd9760d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.422781Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.422622Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.429294Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.428411Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after inline:      kind=AFFINE        ops= 5 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'BinOp': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "CallBlockOps (deep): 0\n",
+      "is_affine:         True\n"
+     ]
+    }
+   ],
    "source": [
     "def count_calls(ops):\n",
     "    total = 0\n",
@@ -401,10 +524,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "37f7d3e2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.430844Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.430702Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.434011Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.433091Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [AFFINE] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q0@v1 = h(%q[%i@v0]@v0)\n",
+      "    %q0@v2, %q1@v1 = cx(%q0@v1, %q[%_@v0]@v0)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block))"
    ]
@@ -438,10 +591,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "ebf4b2a0",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.435709Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.435573Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.439735Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.438903Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after partial_eval: kind=AFFINE        ops= 4 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "ForOperations:     1\n"
+     ]
+    }
+   ],
    "source": [
     "block = transpiler.partial_eval(block, bindings=bindings)\n",
     "print(\"after partial_eval:\", summarise(block))\n",
@@ -483,10 +652,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "85f34d3a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.441382Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.441244Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.445009Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.444033Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after analyze:     kind=ANALYZED      ops= 4 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n"
+     ]
+    }
+   ],
    "source": [
     "block = transpiler.analyze(block)\n",
     "print(\"after analyze:    \", summarise(block))"
@@ -507,10 +691,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "ca82a3e6",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.446876Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.446717Z",
+     "iopub.status.idle": "2026-04-28T05:50:59.451293Z",
+     "shell.execute_reply": "2026-04-28T05:50:59.450303Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  step 0: QuantumStep (QuantumSegment, 4 ops)\n",
+      "total unbound parameters: ['theta']\n"
+     ]
+    }
+   ],
    "source": [
     "plan = transpiler.plan(block)\n",
     "for i, step in enumerate(plan.steps):\n",
@@ -538,12 +738,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "d9df30c6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:50:59.452994Z",
+     "iopub.status.busy": "2026-04-28T05:50:59.452865Z",
+     "iopub.status.idle": "2026-04-28T05:51:00.365790Z",
+     "shell.execute_reply": "2026-04-28T05:51:00.364665Z"
+    },
     "lines_to_next_cell": 1
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "parameter_names:   ['theta']\n",
+      "\n",
+      "     ┌───┐┌───┐                  ┌─┐                             \n",
+      "q_0: ┤ H ├┤ H ├──■───────────────┤M├─────────────────────────────\n",
+      "     └───┘└───┘┌─┴─┐┌───────────┐└╥┘┌───┐                  ┌─┐   \n",
+      "q_1: ──────────┤ X ├┤ Rz(theta) ├─╫─┤ H ├──■───────────────┤M├───\n",
+      "               └───┘└───────────┘ ║ └───┘┌─┴─┐┌───────────┐└╥┘┌─┐\n",
+      "q_2: ─────────────────────────────╫──────┤ X ├┤ Rz(theta) ├─╫─┤M├\n",
+      "                                  ║      └───┘└───────────┘ ║ └╥┘\n",
+      "q_3: ─────────────────────────────╫─────────────────────────╫──╫─\n",
+      "                                  ║                         ║  ║ \n",
+      "c: 3/═════════════════════════════╩═════════════════════════╩══╩═\n",
+      "                                  0                         1  2 \n"
+     ]
+    }
+   ],
    "source": [
     "executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)\n",
     "print(\"parameter_names:  \", executable.parameter_names)\n",
@@ -747,9 +973,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "c2b298ad",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:00.368034Z",
+     "iopub.status.busy": "2026-04-28T05:51:00.367809Z",
+     "iopub.status.idle": "2026-04-28T05:51:00.372814Z",
+     "shell.execute_reply": "2026-04-28T05:51:00.371791Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -771,10 +1004,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "a9ccc6b9",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:00.374634Z",
+     "iopub.status.busy": "2026-04-28T05:51:00.374476Z",
+     "iopub.status.idle": "2026-04-28T05:51:00.380434Z",
+     "shell.execute_reply": "2026-04-28T05:51:00.379454Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block qfixed_demo [ANALYZED] (n: UIntType) -> FloatType {\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  for %i in range(const(0), const(3), const(1)) {\n",
+      "    %q[%i@v0]@v1 = h(%q[%i@v0]@v0)\n",
+      "  }\n",
+      "  %q_as_qfixed@v0 = cast %q@v0 to QFixed[0.3]\n",
+      "  %qfixed_measured@v0 = measure_qfixed(%q_as_qfixed@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "qfixed_bindings = {\"n\": 3}\n",
     "qfixed_block = transpiler.to_block(qfixed_demo, bindings=qfixed_bindings)\n",
@@ -820,10 +1075,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "530a8cfc",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:00.382079Z",
+     "iopub.status.busy": "2026-04-28T05:51:00.381944Z",
+     "iopub.status.idle": "2026-04-28T05:51:00.385628Z",
+     "shell.execute_reply": "2026-04-28T05:51:00.384800Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block qfixed_demo [ANALYZED] (n: UIntType) -> FloatType {\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  for %i in range(const(0), const(3), const(1)) {\n",
+      "    %q[%i@v0]@v1 = h(%q[%i@v0]@v0)\n",
+      "  }\n",
+      "  %q_as_qfixed@v0 = cast %q@v0 to QFixed[0.3]\n",
+      "  %qfixed_bits@v0 = measure_vector(%qfixed_qubits@v0)\n",
+      "  %qfixed_measured@v0 = decode_qfixed(%qfixed_bits@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "from qamomile.circuit.transpiler.passes.separate import lower_operations\n",
     "\n",
@@ -915,10 +1193,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "ea061201",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:00.387440Z",
+     "iopub.status.busy": "2026-04-28T05:51:00.387293Z",
+     "iopub.status.idle": "2026-04-28T05:51:00.403373Z",
+     "shell.execute_reply": "2026-04-28T05:51:00.402551Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QURI Parts is not installed; skipping the side-by-side output.\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    from qamomile.quri_parts import QuriPartsTranspiler\n",
@@ -1041,6 +1334,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/en/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/en/tutorial/10_quantum_error_correction.ipynb
@@ -21,9 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b9d801ad",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:08.221658Z",
+     "iopub.status.busy": "2026-04-28T05:51:08.221435Z",
+     "iopub.status.idle": "2026-04-28T05:51:08.226178Z",
+     "shell.execute_reply": "2026-04-28T05:51:08.224970Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Install the latest Qamomile from pip.\n",
@@ -34,9 +41,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "bcd4216d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:08.228320Z",
+     "iopub.status.busy": "2026-04-28T05:51:08.228087Z",
+     "iopub.status.idle": "2026-04-28T05:51:08.384969Z",
+     "shell.execute_reply": "2026-04-28T05:51:08.384140Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -125,9 +138,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a7107567",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:08.387585Z",
+     "iopub.status.busy": "2026-04-28T05:51:08.387338Z",
+     "iopub.status.idle": "2026-04-28T05:51:08.394618Z",
+     "shell.execute_reply": "2026-04-28T05:51:08.393538Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -169,9 +188,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "bd229765",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:08.396894Z",
+     "iopub.status.busy": "2026-04-28T05:51:08.396555Z",
+     "iopub.status.idle": "2026-04-28T05:51:08.412112Z",
+     "shell.execute_reply": "2026-04-28T05:51:08.411055Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -219,10 +245,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "18b18bb7",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:08.414852Z",
+     "iopub.status.busy": "2026-04-28T05:51:08.414043Z",
+     "iopub.status.idle": "2026-04-28T05:51:09.248458Z",
+     "shell.execute_reply": "2026-04-28T05:51:09.247315Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3-qubit bit-flip code: logical |1>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  no error      : data[0]=0 ->   0, data[0]=1 -> 256\n",
+      "  X on data[0]  : data[0]=0 ->   0, data[0]=1 -> 256\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[1]  : data[0]=0 ->   0, data[0]=1 -> 256\n",
+      "  X on data[2]  : data[0]=0 ->   0, data[0]=1 -> 256\n"
+     ]
+    }
+   ],
    "source": [
     "bitflip_cases = [\n",
     "    (\"no error\", 3),\n",
@@ -256,10 +313,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "b6c7f7c2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:09.250469Z",
+     "iopub.status.busy": "2026-04-28T05:51:09.250209Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.188711Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.187317Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3-qubit bit-flip code: superposition input\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  no error      : P(data[0]=1) = 0.260\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[0]  : P(data[0]=1) = 0.265\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[1]  : P(data[0]=1) = 0.251\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[2]  : P(data[0]=1) = 0.233\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"3-qubit bit-flip code: superposition input\")\n",
     "for label, error_pos in bitflip_cases:\n",
@@ -297,9 +397,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "8aa6d30a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.191575Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.191387Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.197498Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.196327Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -334,9 +440,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "7475ae56",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.199497Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.199318Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.210899Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.210002Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -383,10 +496,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "8b5ef6ee",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.212791Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.212588Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.753459Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.752479Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3-qubit phase-flip code: logical |0_L> = |+++>\n",
+      "  no error      : data[0]=0 -> 256, data[0]=1 ->   0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z on data[0]  : data[0]=0 -> 256, data[0]=1 ->   0\n",
+      "  Z on data[1]  : data[0]=0 -> 256, data[0]=1 ->   0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z on data[2]  : data[0]=0 -> 256, data[0]=1 ->   0\n"
+     ]
+    }
+   ],
    "source": [
     "phaseflip_cases = [\n",
     "    (\"no error\", 3),\n",
@@ -431,9 +575,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "985ba9f3",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.755543Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.755365Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.761890Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.760945Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -465,9 +615,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "ff89b6cd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.763786Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.763634Z",
+     "iopub.status.idle": "2026-04-28T05:51:10.831760Z",
+     "shell.execute_reply": "2026-04-28T05:51:10.830538Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -590,10 +747,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "2260ff0b",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:10.833873Z",
+     "iopub.status.busy": "2026-04-28T05:51:10.833719Z",
+     "iopub.status.idle": "2026-04-28T05:51:54.465633Z",
+     "shell.execute_reply": "2026-04-28T05:51:54.464411Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shor 9-qubit code: logical |1>\n",
+      "  error  | pos   | P(q[0]=1)\n",
+      "  -------+-------+----------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X      | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y      | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z      | q[8]  | 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "shor_cases = [\n",
     "    (\"X\", 1, 0),\n",
@@ -664,6 +859,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/en/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/en/tutorial/10_quantum_error_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a425a70d",
+   "id": "f8bd2645",
    "metadata": {},
    "source": [
     "# Introduction to Quantum Error Correction\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "0f1a3365",
+   "id": "08d6ff45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:03.386098Z",
-     "iopub.status.busy": "2026-04-28T06:04:03.385912Z",
-     "iopub.status.idle": "2026-04-28T06:04:03.389626Z",
-     "shell.execute_reply": "2026-04-28T06:04:03.388550Z"
+     "iopub.execute_input": "2026-04-28T06:19:42.062239Z",
+     "iopub.status.busy": "2026-04-28T06:19:42.062076Z",
+     "iopub.status.idle": "2026-04-28T06:19:42.065988Z",
+     "shell.execute_reply": "2026-04-28T06:19:42.065046Z"
     }
    },
    "outputs": [],
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3550d17a",
+   "id": "56f69eb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:03.391771Z",
-     "iopub.status.busy": "2026-04-28T06:04:03.391574Z",
-     "iopub.status.idle": "2026-04-28T06:04:03.831033Z",
-     "shell.execute_reply": "2026-04-28T06:04:03.829692Z"
+     "iopub.execute_input": "2026-04-28T06:19:42.068320Z",
+     "iopub.status.busy": "2026-04-28T06:19:42.068161Z",
+     "iopub.status.idle": "2026-04-28T06:19:51.222560Z",
+     "shell.execute_reply": "2026-04-28T06:19:51.221423Z"
     },
     "lines_to_next_cell": 2
    },
@@ -64,7 +64,7 @@
     "# Create a seeded backend for reproducible documentation output\n",
     "from qiskit_aer import AerSimulator\n",
     "\n",
-    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)\n",
     "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8cbc198",
+   "id": "6860ae01",
    "metadata": {},
    "source": [
     "## 1. What We Need To Correct\n",
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f8548ef",
+   "id": "fff51177",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -145,13 +145,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c952898e",
+   "id": "038321a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:03.834252Z",
-     "iopub.status.busy": "2026-04-28T06:04:03.833980Z",
-     "iopub.status.idle": "2026-04-28T06:04:03.839697Z",
-     "shell.execute_reply": "2026-04-28T06:04:03.838466Z"
+     "iopub.execute_input": "2026-04-28T06:19:51.224832Z",
+     "iopub.status.busy": "2026-04-28T06:19:51.224625Z",
+     "iopub.status.idle": "2026-04-28T06:19:51.230147Z",
+     "shell.execute_reply": "2026-04-28T06:19:51.229338Z"
     },
     "lines_to_next_cell": 2
    },
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79c7e113",
+   "id": "b91ec693",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -195,13 +195,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1c30b66a",
+   "id": "4b08f8aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:03.841888Z",
-     "iopub.status.busy": "2026-04-28T06:04:03.841695Z",
-     "iopub.status.idle": "2026-04-28T06:04:03.855058Z",
-     "shell.execute_reply": "2026-04-28T06:04:03.853748Z"
+     "iopub.execute_input": "2026-04-28T06:19:51.232092Z",
+     "iopub.status.busy": "2026-04-28T06:19:51.231955Z",
+     "iopub.status.idle": "2026-04-28T06:19:51.246067Z",
+     "shell.execute_reply": "2026-04-28T06:19:51.244780Z"
     }
    },
    "outputs": [],
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d324c4af",
+   "id": "4adcf767",
    "metadata": {},
    "source": [
     "`error_pos` is a compile-time parameter. Values `0`, `1`, and `2` inject an $X$ error at that location. The value `3` does not match any branch, so it means no error.\n",
@@ -252,13 +252,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cd2d0192",
+   "id": "43a22092",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:03.857426Z",
-     "iopub.status.busy": "2026-04-28T06:04:03.857268Z",
-     "iopub.status.idle": "2026-04-28T06:04:04.358739Z",
-     "shell.execute_reply": "2026-04-28T06:04:04.357547Z"
+     "iopub.execute_input": "2026-04-28T06:19:51.248054Z",
+     "iopub.status.busy": "2026-04-28T06:19:51.247900Z",
+     "iopub.status.idle": "2026-04-28T06:19:51.796117Z",
+     "shell.execute_reply": "2026-04-28T06:19:51.794943Z"
     }
    },
    "outputs": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93e1eb38",
+   "id": "c7b19383",
    "metadata": {},
    "source": [
     "The code also preserves amplitudes. With $\\theta=\\pi/3$, the prepared state has\n",
@@ -320,13 +320,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c547cc62",
+   "id": "3593d0dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:04.360821Z",
-     "iopub.status.busy": "2026-04-28T06:04:04.360597Z",
-     "iopub.status.idle": "2026-04-28T06:04:04.951257Z",
-     "shell.execute_reply": "2026-04-28T06:04:04.949944Z"
+     "iopub.execute_input": "2026-04-28T06:19:51.798093Z",
+     "iopub.status.busy": "2026-04-28T06:19:51.797934Z",
+     "iopub.status.idle": "2026-04-28T06:19:52.727749Z",
+     "shell.execute_reply": "2026-04-28T06:19:52.726559Z"
     }
    },
    "outputs": [
@@ -334,7 +334,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3-qubit bit-flip code: superposition input\n",
+      "3-qubit bit-flip code: superposition input\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  no error      : P(data[0]=1) = 0.269\n"
      ]
     },
@@ -342,7 +348,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[0]  : P(data[0]=1) = 0.269\n",
+      "  X on data[0]  : P(data[0]=1) = 0.269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  X on data[1]  : P(data[0]=1) = 0.269\n"
      ]
     },
@@ -370,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "575b84d3",
+   "id": "3c5aaf28",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -392,13 +404,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b15f7ac5",
+   "id": "bf0d5c40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:04.953562Z",
-     "iopub.status.busy": "2026-04-28T06:04:04.953382Z",
-     "iopub.status.idle": "2026-04-28T06:04:04.959623Z",
-     "shell.execute_reply": "2026-04-28T06:04:04.958507Z"
+     "iopub.execute_input": "2026-04-28T06:19:52.729692Z",
+     "iopub.status.busy": "2026-04-28T06:19:52.729525Z",
+     "iopub.status.idle": "2026-04-28T06:19:52.734730Z",
+     "shell.execute_reply": "2026-04-28T06:19:52.733821Z"
     },
     "lines_to_next_cell": 2
    },
@@ -417,7 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e15d3236",
+   "id": "58f887c5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -435,13 +447,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d3273df1",
+   "id": "9b4f26b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:04.961701Z",
-     "iopub.status.busy": "2026-04-28T06:04:04.961528Z",
-     "iopub.status.idle": "2026-04-28T06:04:04.973536Z",
-     "shell.execute_reply": "2026-04-28T06:04:04.972134Z"
+     "iopub.execute_input": "2026-04-28T06:19:52.736557Z",
+     "iopub.status.busy": "2026-04-28T06:19:52.736411Z",
+     "iopub.status.idle": "2026-04-28T06:19:52.748282Z",
+     "shell.execute_reply": "2026-04-28T06:19:52.747358Z"
     }
    },
    "outputs": [],
@@ -482,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d01df2f9",
+   "id": "290f9d78",
    "metadata": {},
    "source": [
     "We prepare logical $\\lvert0_L\\rangle=\\lvert+++\\rangle$. After correction, `data[0]` is back in $\\lvert+\\rangle$, so applying one final $H$ makes it measure as 0."
@@ -491,13 +503,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a6229265",
+   "id": "c3a07b99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:04.975456Z",
-     "iopub.status.busy": "2026-04-28T06:04:04.975286Z",
-     "iopub.status.idle": "2026-04-28T06:04:05.472092Z",
-     "shell.execute_reply": "2026-04-28T06:04:05.470892Z"
+     "iopub.execute_input": "2026-04-28T06:19:52.750408Z",
+     "iopub.status.busy": "2026-04-28T06:19:52.750247Z",
+     "iopub.status.idle": "2026-04-28T06:19:53.297200Z",
+     "shell.execute_reply": "2026-04-28T06:19:53.295715Z"
     }
    },
    "outputs": [
@@ -544,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7d8e602",
+   "id": "e70a03e1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -570,13 +582,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "9d55db0a",
+   "id": "7c3666a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:05.474286Z",
-     "iopub.status.busy": "2026-04-28T06:04:05.474096Z",
-     "iopub.status.idle": "2026-04-28T06:04:05.480421Z",
-     "shell.execute_reply": "2026-04-28T06:04:05.479516Z"
+     "iopub.execute_input": "2026-04-28T06:19:53.299719Z",
+     "iopub.status.busy": "2026-04-28T06:19:53.299553Z",
+     "iopub.status.idle": "2026-04-28T06:19:53.306269Z",
+     "shell.execute_reply": "2026-04-28T06:19:53.305136Z"
     },
     "lines_to_next_cell": 2
    },
@@ -594,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30346aea",
+   "id": "1bf8267a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -610,13 +622,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a08f81ca",
+   "id": "ba66587b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:05.482015Z",
-     "iopub.status.busy": "2026-04-28T06:04:05.481874Z",
-     "iopub.status.idle": "2026-04-28T06:04:05.553716Z",
-     "shell.execute_reply": "2026-04-28T06:04:05.552439Z"
+     "iopub.execute_input": "2026-04-28T06:19:53.308170Z",
+     "iopub.status.busy": "2026-04-28T06:19:53.308024Z",
+     "iopub.status.idle": "2026-04-28T06:19:53.379825Z",
+     "shell.execute_reply": "2026-04-28T06:19:53.378391Z"
     }
    },
    "outputs": [],
@@ -733,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f271d3c",
+   "id": "42d894b9",
    "metadata": {},
    "source": [
     "We test one representative qubit from each block. If the logical $\\lvert1\\rangle$ is preserved, `q[0]` is always 1."
@@ -742,13 +754,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "483efecc",
+   "id": "ce274da2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:05.555672Z",
-     "iopub.status.busy": "2026-04-28T06:04:05.555514Z",
-     "iopub.status.idle": "2026-04-28T06:04:17.111100Z",
-     "shell.execute_reply": "2026-04-28T06:04:17.109836Z"
+     "iopub.execute_input": "2026-04-28T06:19:53.382327Z",
+     "iopub.status.busy": "2026-04-28T06:19:53.382181Z",
+     "iopub.status.idle": "2026-04-28T06:20:37.883289Z",
+     "shell.execute_reply": "2026-04-28T06:20:37.881797Z"
     }
    },
    "outputs": [
@@ -772,7 +784,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y      | q[4]  | 1.000\n",
+      "  Y      | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Z      | q[8]  | 1.000\n"
      ]
     }
@@ -800,7 +818,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e68b921c",
+   "id": "eafe9360",
    "metadata": {},
    "source": [
     "Shor's code corrects any single-qubit Pauli error. Since small general noise can be expanded in the Pauli basis, correcting Pauli errors is the starting point for quantum error correction."
@@ -808,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a37c376e",
+   "id": "aab6af38",
    "metadata": {},
    "source": [
     "## 5. Stabilizer View\n",
@@ -826,7 +844,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9522abde",
+   "id": "18d1d98e",
    "metadata": {},
    "source": [
     "## 6. Summary\n",

--- a/docs/en/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/en/tutorial/10_quantum_error_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ee81f79a",
+   "id": "a425a70d",
    "metadata": {},
    "source": [
     "# Introduction to Quantum Error Correction\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b9d801ad",
+   "id": "0f1a3365",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:08.221658Z",
-     "iopub.status.busy": "2026-04-28T05:51:08.221435Z",
-     "iopub.status.idle": "2026-04-28T05:51:08.226178Z",
-     "shell.execute_reply": "2026-04-28T05:51:08.224970Z"
+     "iopub.execute_input": "2026-04-28T06:04:03.386098Z",
+     "iopub.status.busy": "2026-04-28T06:04:03.385912Z",
+     "iopub.status.idle": "2026-04-28T06:04:03.389626Z",
+     "shell.execute_reply": "2026-04-28T06:04:03.388550Z"
     }
    },
    "outputs": [],
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "bcd4216d",
+   "id": "3550d17a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:08.228320Z",
-     "iopub.status.busy": "2026-04-28T05:51:08.228087Z",
-     "iopub.status.idle": "2026-04-28T05:51:08.384969Z",
-     "shell.execute_reply": "2026-04-28T05:51:08.384140Z"
+     "iopub.execute_input": "2026-04-28T06:04:03.391771Z",
+     "iopub.status.busy": "2026-04-28T06:04:03.391574Z",
+     "iopub.status.idle": "2026-04-28T06:04:03.831033Z",
+     "shell.execute_reply": "2026-04-28T06:04:03.829692Z"
     },
     "lines_to_next_cell": 2
    },
@@ -60,6 +60,12 @@
     "from qamomile.qiskit import QiskitTranspiler\n",
     "\n",
     "transpiler = QiskitTranspiler()\n",
+    "\n",
+    "# Create a seeded backend for reproducible documentation output\n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
     "def _first_bit_distribution(result) -> dict[int, int]:\n",
@@ -86,7 +92,7 @@
     "        parameters=parameters or [],\n",
     "    )\n",
     "    job = executable.sample(\n",
-    "        transpiler.executor(),\n",
+    "        _seeded_executor,\n",
     "        shots=shots,\n",
     "        bindings=runtime_bindings or {},\n",
     "    )\n",
@@ -95,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b5f6e6b",
+   "id": "d8cbc198",
    "metadata": {},
    "source": [
     "## 1. What We Need To Correct\n",
@@ -116,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59aab1ea",
+   "id": "0f8548ef",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -139,13 +145,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a7107567",
+   "id": "c952898e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:08.387585Z",
-     "iopub.status.busy": "2026-04-28T05:51:08.387338Z",
-     "iopub.status.idle": "2026-04-28T05:51:08.394618Z",
-     "shell.execute_reply": "2026-04-28T05:51:08.393538Z"
+     "iopub.execute_input": "2026-04-28T06:04:03.834252Z",
+     "iopub.status.busy": "2026-04-28T06:04:03.833980Z",
+     "iopub.status.idle": "2026-04-28T06:04:03.839697Z",
+     "shell.execute_reply": "2026-04-28T06:04:03.838466Z"
     },
     "lines_to_next_cell": 2
    },
@@ -162,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b46f84bb",
+   "id": "79c7e113",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -189,13 +195,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "bd229765",
+   "id": "1c30b66a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:08.396894Z",
-     "iopub.status.busy": "2026-04-28T05:51:08.396555Z",
-     "iopub.status.idle": "2026-04-28T05:51:08.412112Z",
-     "shell.execute_reply": "2026-04-28T05:51:08.411055Z"
+     "iopub.execute_input": "2026-04-28T06:04:03.841888Z",
+     "iopub.status.busy": "2026-04-28T06:04:03.841695Z",
+     "iopub.status.idle": "2026-04-28T06:04:03.855058Z",
+     "shell.execute_reply": "2026-04-28T06:04:03.853748Z"
     }
    },
    "outputs": [],
@@ -235,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07ff3408",
+   "id": "d324c4af",
    "metadata": {},
    "source": [
     "`error_pos` is a compile-time parameter. Values `0`, `1`, and `2` inject an $X$ error at that location. The value `3` does not match any branch, so it means no error.\n",
@@ -246,13 +252,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "18b18bb7",
+   "id": "cd2d0192",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:08.414852Z",
-     "iopub.status.busy": "2026-04-28T05:51:08.414043Z",
-     "iopub.status.idle": "2026-04-28T05:51:09.248458Z",
-     "shell.execute_reply": "2026-04-28T05:51:09.247315Z"
+     "iopub.execute_input": "2026-04-28T06:04:03.857426Z",
+     "iopub.status.busy": "2026-04-28T06:04:03.857268Z",
+     "iopub.status.idle": "2026-04-28T06:04:04.358739Z",
+     "shell.execute_reply": "2026-04-28T06:04:04.357547Z"
     }
    },
    "outputs": [
@@ -260,22 +266,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3-qubit bit-flip code: logical |1>\n"
+      "3-qubit bit-flip code: logical |1>\n",
+      "  no error      : data[0]=0 ->   0, data[0]=1 -> 256\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  no error      : data[0]=0 ->   0, data[0]=1 -> 256\n",
-      "  X on data[0]  : data[0]=0 ->   0, data[0]=1 -> 256\n"
+      "  X on data[0]  : data[0]=0 ->   0, data[0]=1 -> 256\n",
+      "  X on data[1]  : data[0]=0 ->   0, data[0]=1 -> 256\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[1]  : data[0]=0 ->   0, data[0]=1 -> 256\n",
       "  X on data[2]  : data[0]=0 ->   0, data[0]=1 -> 256\n"
      ]
     }
@@ -301,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3f2e18d",
+   "id": "93e1eb38",
    "metadata": {},
    "source": [
     "The code also preserves amplitudes. With $\\theta=\\pi/3$, the prepared state has\n",
@@ -314,13 +320,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b6c7f7c2",
+   "id": "c547cc62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:09.250469Z",
-     "iopub.status.busy": "2026-04-28T05:51:09.250209Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.188711Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.187317Z"
+     "iopub.execute_input": "2026-04-28T06:04:04.360821Z",
+     "iopub.status.busy": "2026-04-28T06:04:04.360597Z",
+     "iopub.status.idle": "2026-04-28T06:04:04.951257Z",
+     "shell.execute_reply": "2026-04-28T06:04:04.949944Z"
     }
    },
    "outputs": [
@@ -328,35 +334,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3-qubit bit-flip code: superposition input\n"
+      "3-qubit bit-flip code: superposition input\n",
+      "  no error      : P(data[0]=1) = 0.269\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  no error      : P(data[0]=1) = 0.260\n"
+      "  X on data[0]  : P(data[0]=1) = 0.269\n",
+      "  X on data[1]  : P(data[0]=1) = 0.269\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[0]  : P(data[0]=1) = 0.265\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  X on data[1]  : P(data[0]=1) = 0.251\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  X on data[2]  : P(data[0]=1) = 0.233\n"
+      "  X on data[2]  : P(data[0]=1) = 0.269\n"
      ]
     }
    ],
@@ -376,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c0b1873",
+   "id": "575b84d3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -398,13 +392,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "8aa6d30a",
+   "id": "b15f7ac5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.191575Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.191387Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.197498Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.196327Z"
+     "iopub.execute_input": "2026-04-28T06:04:04.953562Z",
+     "iopub.status.busy": "2026-04-28T06:04:04.953382Z",
+     "iopub.status.idle": "2026-04-28T06:04:04.959623Z",
+     "shell.execute_reply": "2026-04-28T06:04:04.958507Z"
     },
     "lines_to_next_cell": 2
    },
@@ -423,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e84436f1",
+   "id": "e15d3236",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -441,13 +435,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "7475ae56",
+   "id": "d3273df1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.199497Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.199318Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.210899Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.210002Z"
+     "iopub.execute_input": "2026-04-28T06:04:04.961701Z",
+     "iopub.status.busy": "2026-04-28T06:04:04.961528Z",
+     "iopub.status.idle": "2026-04-28T06:04:04.973536Z",
+     "shell.execute_reply": "2026-04-28T06:04:04.972134Z"
     }
    },
    "outputs": [],
@@ -488,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10b8f310",
+   "id": "d01df2f9",
    "metadata": {},
    "source": [
     "We prepare logical $\\lvert0_L\\rangle=\\lvert+++\\rangle$. After correction, `data[0]` is back in $\\lvert+\\rangle$, so applying one final $H$ makes it measure as 0."
@@ -497,13 +491,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8b5ef6ee",
+   "id": "a6229265",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.212791Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.212588Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.753459Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.752479Z"
+     "iopub.execute_input": "2026-04-28T06:04:04.975456Z",
+     "iopub.status.busy": "2026-04-28T06:04:04.975286Z",
+     "iopub.status.idle": "2026-04-28T06:04:05.472092Z",
+     "shell.execute_reply": "2026-04-28T06:04:05.470892Z"
     }
    },
    "outputs": [
@@ -550,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8878d75a",
+   "id": "f7d8e602",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -576,13 +570,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "985ba9f3",
+   "id": "9d55db0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.755543Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.755365Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.761890Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.760945Z"
+     "iopub.execute_input": "2026-04-28T06:04:05.474286Z",
+     "iopub.status.busy": "2026-04-28T06:04:05.474096Z",
+     "iopub.status.idle": "2026-04-28T06:04:05.480421Z",
+     "shell.execute_reply": "2026-04-28T06:04:05.479516Z"
     },
     "lines_to_next_cell": 2
    },
@@ -600,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5da97058",
+   "id": "30346aea",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -616,13 +610,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ff89b6cd",
+   "id": "a08f81ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.763786Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.763634Z",
-     "iopub.status.idle": "2026-04-28T05:51:10.831760Z",
-     "shell.execute_reply": "2026-04-28T05:51:10.830538Z"
+     "iopub.execute_input": "2026-04-28T06:04:05.482015Z",
+     "iopub.status.busy": "2026-04-28T06:04:05.481874Z",
+     "iopub.status.idle": "2026-04-28T06:04:05.553716Z",
+     "shell.execute_reply": "2026-04-28T06:04:05.552439Z"
     }
    },
    "outputs": [],
@@ -739,7 +733,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9629938c",
+   "id": "5f271d3c",
    "metadata": {},
    "source": [
     "We test one representative qubit from each block. If the logical $\\lvert1\\rangle$ is preserved, `q[0]` is always 1."
@@ -748,13 +742,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "2260ff0b",
+   "id": "483efecc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:10.833873Z",
-     "iopub.status.busy": "2026-04-28T05:51:10.833719Z",
-     "iopub.status.idle": "2026-04-28T05:51:54.465633Z",
-     "shell.execute_reply": "2026-04-28T05:51:54.464411Z"
+     "iopub.execute_input": "2026-04-28T06:04:05.555672Z",
+     "iopub.status.busy": "2026-04-28T06:04:05.555514Z",
+     "iopub.status.idle": "2026-04-28T06:04:17.111100Z",
+     "shell.execute_reply": "2026-04-28T06:04:17.109836Z"
     }
    },
    "outputs": [
@@ -778,13 +772,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y      | q[4]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y      | q[4]  | 1.000\n",
       "  Z      | q[8]  | 1.000\n"
      ]
     }
@@ -812,7 +800,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82d7c109",
+   "id": "e68b921c",
    "metadata": {},
    "source": [
     "Shor's code corrects any single-qubit Pauli error. Since small general noise can be expanded in the Pauli basis, correcting Pauli errors is the starting point for quantum error correction."
@@ -820,7 +808,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6221aeb",
+   "id": "a37c376e",
    "metadata": {},
    "source": [
     "## 5. Stabilizer View\n",
@@ -838,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c4ea05b",
+   "id": "9522abde",
    "metadata": {},
    "source": [
     "## 6. Summary\n",

--- a/docs/en/tutorial/10_quantum_error_correction.py
+++ b/docs/en/tutorial/10_quantum_error_correction.py
@@ -43,7 +43,7 @@ transpiler = QiskitTranspiler()
 # Create a seeded backend for reproducible documentation output
 from qiskit_aer import AerSimulator
 
-_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)
 _seeded_executor = transpiler.executor(backend=_seeded_backend)
 
 

--- a/docs/en/tutorial/10_quantum_error_correction.py
+++ b/docs/en/tutorial/10_quantum_error_correction.py
@@ -40,6 +40,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 transpiler = QiskitTranspiler()
 
+# Create a seeded backend for reproducible documentation output
+from qiskit_aer import AerSimulator
+
+_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_executor = transpiler.executor(backend=_seeded_backend)
+
 
 def _first_bit_distribution(result) -> dict[int, int]:
     """Return counts for the first measured bit."""
@@ -65,7 +71,7 @@ def _sample_first_bit(
         parameters=parameters or [],
     )
     job = executable.sample(
-        transpiler.executor(),
+        _seeded_executor,
         shots=shots,
         bindings=runtime_bindings or {},
     )

--- a/docs/en/tutorial/11_steane_code.ipynb
+++ b/docs/en/tutorial/11_steane_code.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bd8e8914",
+   "id": "d54b0fb5",
    "metadata": {},
    "source": [
     "# Quantum Error Correction (2): Steane [[7,1,3]] Code\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "cde0104b",
+   "id": "8f2b4221",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:20.626949Z",
-     "iopub.status.busy": "2026-04-28T06:04:20.626744Z",
-     "iopub.status.idle": "2026-04-28T06:04:20.630985Z",
-     "shell.execute_reply": "2026-04-28T06:04:20.629809Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.084697Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.084539Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.088189Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.087244Z"
     }
    },
    "outputs": [],
@@ -41,13 +41,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "771c3c87",
+   "id": "c22e62a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:20.633431Z",
-     "iopub.status.busy": "2026-04-28T06:04:20.633239Z",
-     "iopub.status.idle": "2026-04-28T06:04:20.973545Z",
-     "shell.execute_reply": "2026-04-28T06:04:20.972468Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.089963Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.089789Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.422225Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.421390Z"
     },
     "lines_to_next_cell": 2
    },
@@ -61,7 +61,7 @@
     "# Create a seeded backend for reproducible documentation output\n",
     "from qiskit_aer import AerSimulator\n",
     "\n",
-    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)\n",
     "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af4c96d1",
+   "id": "93e6a102",
    "metadata": {},
    "source": [
     "## 1. From Hamming Codes to CSS Codes\n",
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84b4c23d",
+   "id": "fb87664b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -143,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "655d5e0d",
+   "id": "b46eb03f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:20.976209Z",
-     "iopub.status.busy": "2026-04-28T06:04:20.975950Z",
-     "iopub.status.idle": "2026-04-28T06:04:20.985735Z",
-     "shell.execute_reply": "2026-04-28T06:04:20.984748Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.425312Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.425057Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.438091Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.436794Z"
     }
    },
    "outputs": [],
@@ -177,13 +177,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "67ae0196",
+   "id": "780d462c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:20.987495Z",
-     "iopub.status.busy": "2026-04-28T06:04:20.987349Z",
-     "iopub.status.idle": "2026-04-28T06:04:20.991808Z",
-     "shell.execute_reply": "2026-04-28T06:04:20.990636Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.440067Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.439863Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.443850Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.443021Z"
     }
    },
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a7a1d4d",
+   "id": "28a787f6",
    "metadata": {},
    "source": [
     "Measure the encoder output and check that all observed bitstrings are even Hamming codewords."
@@ -206,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "36cef05e",
+   "id": "5db2ea50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:20.993693Z",
-     "iopub.status.busy": "2026-04-28T06:04:20.993529Z",
-     "iopub.status.idle": "2026-04-28T06:04:21.120101Z",
-     "shell.execute_reply": "2026-04-28T06:04:21.118934Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.445838Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.445687Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.579905Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.578909Z"
     }
    },
    "outputs": [
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34281aa5",
+   "id": "aba3b5c1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -269,13 +269,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "56ff5526",
+   "id": "2e6ecc7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:21.122658Z",
-     "iopub.status.busy": "2026-04-28T06:04:21.122492Z",
-     "iopub.status.idle": "2026-04-28T06:04:21.153202Z",
-     "shell.execute_reply": "2026-04-28T06:04:21.151821Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.582289Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.582116Z",
+     "iopub.status.idle": "2026-04-28T06:20:39.620999Z",
+     "shell.execute_reply": "2026-04-28T06:20:39.620125Z"
     }
    },
    "outputs": [],
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0430e1f",
+   "id": "e61d0bf5",
    "metadata": {},
    "source": [
     "Run all 21 single errors: $X$, $Y$, and $Z$ on each of the seven physical qubits. After correction, every measured bitstring should still be a $\\lvert0_L\\rangle$ codeword."
@@ -386,13 +386,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6c834321",
+   "id": "635c7515",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:21.155363Z",
-     "iopub.status.busy": "2026-04-28T06:04:21.155207Z",
-     "iopub.status.idle": "2026-04-28T06:04:25.031896Z",
-     "shell.execute_reply": "2026-04-28T06:04:25.030812Z"
+     "iopub.execute_input": "2026-04-28T06:20:39.622904Z",
+     "iopub.status.busy": "2026-04-28T06:20:39.622710Z",
+     "iopub.status.idle": "2026-04-28T06:20:43.371134Z",
+     "shell.execute_reply": "2026-04-28T06:20:43.370034Z"
     }
    },
    "outputs": [
@@ -526,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40575ac9",
+   "id": "bf6ebb44",
    "metadata": {},
    "source": [
     "A ratio of 1.000 means the state returns to the $\\lvert0_L\\rangle$ code space for every single-qubit Pauli error. A $Y=iXZ$ error triggers both the $X$-component and $Z$-component corrections."
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b375712",
+   "id": "20161fd4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -553,13 +553,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "aae013d2",
+   "id": "181a24d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:25.034142Z",
-     "iopub.status.busy": "2026-04-28T06:04:25.033961Z",
-     "iopub.status.idle": "2026-04-28T06:04:25.042653Z",
-     "shell.execute_reply": "2026-04-28T06:04:25.041671Z"
+     "iopub.execute_input": "2026-04-28T06:20:43.373383Z",
+     "iopub.status.busy": "2026-04-28T06:20:43.373202Z",
+     "iopub.status.idle": "2026-04-28T06:20:43.381279Z",
+     "shell.execute_reply": "2026-04-28T06:20:43.380351Z"
     }
    },
    "outputs": [],
@@ -599,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f2f7113",
+   "id": "b96d5c27",
    "metadata": {},
    "source": [
     "First check that $\\bar{H}\\lvert0_L\\rangle=\\lvert+_L\\rangle$. The state $\\lvert+_L\\rangle$ is a +1 eigenstate of logical $X$, so measuring in the $X$ basis should give $q_0 \\oplus q_1 \\oplus q_2 = 0$."
@@ -608,13 +608,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e468bc9d",
+   "id": "e52d443e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:25.045528Z",
-     "iopub.status.busy": "2026-04-28T06:04:25.045362Z",
-     "iopub.status.idle": "2026-04-28T06:04:25.159956Z",
-     "shell.execute_reply": "2026-04-28T06:04:25.159029Z"
+     "iopub.execute_input": "2026-04-28T06:20:43.383338Z",
+     "iopub.status.busy": "2026-04-28T06:20:43.383178Z",
+     "iopub.status.idle": "2026-04-28T06:20:43.497736Z",
+     "shell.execute_reply": "2026-04-28T06:20:43.496579Z"
     }
    },
    "outputs": [
@@ -640,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4fdfdd9",
+   "id": "899942ab",
    "metadata": {},
    "source": [
     "Next check the round trip. Applying transversal $H$ twice should return to $\\lvert0_L\\rangle$ because $\\bar{H}^2=I$."
@@ -649,13 +649,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e60b2f0e",
+   "id": "3f3a11d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:25.163892Z",
-     "iopub.status.busy": "2026-04-28T06:04:25.163720Z",
-     "iopub.status.idle": "2026-04-28T06:04:25.284340Z",
-     "shell.execute_reply": "2026-04-28T06:04:25.283027Z"
+     "iopub.execute_input": "2026-04-28T06:20:43.500366Z",
+     "iopub.status.busy": "2026-04-28T06:20:43.500200Z",
+     "iopub.status.idle": "2026-04-28T06:20:43.623422Z",
+     "shell.execute_reply": "2026-04-28T06:20:43.621566Z"
     }
    },
    "outputs": [
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "819bfaf7",
+   "id": "1f907182",
    "metadata": {},
    "source": [
     "## 5. Summary\n",

--- a/docs/en/tutorial/11_steane_code.ipynb
+++ b/docs/en/tutorial/11_steane_code.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3752a85b",
+   "id": "bd8e8914",
    "metadata": {},
    "source": [
     "# Quantum Error Correction (2): Steane [[7,1,3]] Code\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "77e2c12a",
+   "id": "cde0104b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.107366Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.107189Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.111434Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.110572Z"
+     "iopub.execute_input": "2026-04-28T06:04:20.626949Z",
+     "iopub.status.busy": "2026-04-28T06:04:20.626744Z",
+     "iopub.status.idle": "2026-04-28T06:04:20.630985Z",
+     "shell.execute_reply": "2026-04-28T06:04:20.629809Z"
     }
    },
    "outputs": [],
@@ -41,13 +41,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "49337725",
+   "id": "771c3c87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.113609Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.113459Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.227356Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.226753Z"
+     "iopub.execute_input": "2026-04-28T06:04:20.633431Z",
+     "iopub.status.busy": "2026-04-28T06:04:20.633239Z",
+     "iopub.status.idle": "2026-04-28T06:04:20.973545Z",
+     "shell.execute_reply": "2026-04-28T06:04:20.972468Z"
     },
     "lines_to_next_cell": 2
    },
@@ -57,6 +57,12 @@
     "from qamomile.qiskit import QiskitTranspiler\n",
     "\n",
     "transpiler = QiskitTranspiler()\n",
+    "\n",
+    "# Create a seeded backend for reproducible documentation output\n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
     "def _bits7(outcome) -> list[int]:\n",
@@ -79,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d7533f3",
+   "id": "af4c96d1",
    "metadata": {},
    "source": [
     "## 1. From Hamming Codes to CSS Codes\n",
@@ -116,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21aa1afa",
+   "id": "84b4c23d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -137,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9ebfe1bd",
+   "id": "655d5e0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.232787Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.232549Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.242004Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.241452Z"
+     "iopub.execute_input": "2026-04-28T06:04:20.976209Z",
+     "iopub.status.busy": "2026-04-28T06:04:20.975950Z",
+     "iopub.status.idle": "2026-04-28T06:04:20.985735Z",
+     "shell.execute_reply": "2026-04-28T06:04:20.984748Z"
     }
    },
    "outputs": [],
@@ -171,13 +177,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3237aef7",
+   "id": "67ae0196",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.244063Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.243950Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.248275Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.246743Z"
+     "iopub.execute_input": "2026-04-28T06:04:20.987495Z",
+     "iopub.status.busy": "2026-04-28T06:04:20.987349Z",
+     "iopub.status.idle": "2026-04-28T06:04:20.991808Z",
+     "shell.execute_reply": "2026-04-28T06:04:20.990636Z"
     }
    },
    "outputs": [],
@@ -191,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "543ef832",
+   "id": "0a7a1d4d",
    "metadata": {},
    "source": [
     "Measure the encoder output and check that all observed bitstrings are even Hamming codewords."
@@ -200,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cac5b2e4",
+   "id": "36cef05e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.249925Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.249659Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.581820Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.580888Z"
+     "iopub.execute_input": "2026-04-28T06:04:20.993693Z",
+     "iopub.status.busy": "2026-04-28T06:04:20.993529Z",
+     "iopub.status.idle": "2026-04-28T06:04:21.120101Z",
+     "shell.execute_reply": "2026-04-28T06:04:21.118934Z"
     }
    },
    "outputs": [
@@ -214,13 +220,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Encode and measure |0_L>\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Encode and measure |0_L>\n",
       "  even Hamming codeword ratio: 1.000\n",
       "  observed codewords: 8\n"
      ]
@@ -229,7 +229,7 @@
    "source": [
     "print(\"Encode and measure |0_L>\")\n",
     "exe = transpiler.transpile(encode_zero_and_measure)\n",
-    "result = exe.sample(transpiler.executor(), shots=1024).result()\n",
+    "result = exe.sample(_seeded_executor, shots=1024).result()\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
     "total = sum(count for _, count in result.results)\n",
     "print(f\"  even Hamming codeword ratio: {valid / total:.3f}\")\n",
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecfd8796",
+   "id": "34281aa5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -269,13 +269,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6f4184ba",
+   "id": "56ff5526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.583661Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.583462Z",
-     "iopub.status.idle": "2026-04-28T05:51:58.613222Z",
-     "shell.execute_reply": "2026-04-28T05:51:58.612338Z"
+     "iopub.execute_input": "2026-04-28T06:04:21.122658Z",
+     "iopub.status.busy": "2026-04-28T06:04:21.122492Z",
+     "iopub.status.idle": "2026-04-28T06:04:21.153202Z",
+     "shell.execute_reply": "2026-04-28T06:04:21.151821Z"
     }
    },
    "outputs": [],
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81064ce2",
+   "id": "c0430e1f",
    "metadata": {},
    "source": [
     "Run all 21 single errors: $X$, $Y$, and $Z$ on each of the seven physical qubits. After correction, every measured bitstring should still be a $\\lvert0_L\\rangle$ codeword."
@@ -386,13 +386,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "740471cd",
+   "id": "6c834321",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:51:58.615098Z",
-     "iopub.status.busy": "2026-04-28T05:51:58.614953Z",
-     "iopub.status.idle": "2026-04-28T05:52:02.326721Z",
-     "shell.execute_reply": "2026-04-28T05:52:02.325564Z"
+     "iopub.execute_input": "2026-04-28T06:04:21.155363Z",
+     "iopub.status.busy": "2026-04-28T06:04:21.155207Z",
+     "iopub.status.idle": "2026-04-28T06:04:25.031896Z",
+     "shell.execute_reply": "2026-04-28T06:04:25.030812Z"
     }
    },
    "outputs": [
@@ -430,14 +430,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X    | q[3]  | 1.000"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "  X    | q[3]  | 1.000\n",
       "  X    | q[4]  | 1.000\n"
      ]
     },
@@ -485,23 +478,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[1]  | 1.000\n",
-      "  Z    | q[2]  | 1.000\n"
+      "  Z    | q[1]  | 1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[3]  | 1.000\n",
-      "  Z    | q[4]  | 1.000\n"
+      "  Z    | q[2]  | 1.000\n",
+      "  Z    | q[3]  | 1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[5]  | 1.000\n",
+      "  Z    | q[4]  | 1.000\n",
+      "  Z    | q[5]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Z    | q[6]  | 1.000\n"
      ]
     }
@@ -517,7 +516,7 @@
     "            steane_run,\n",
     "            bindings={\"error_type\": error_type, \"error_pos\": pos},\n",
     "        )\n",
-    "        result = exe.sample(transpiler.executor(), shots=128).result()\n",
+    "        result = exe.sample(_seeded_executor, shots=128).result()\n",
     "        valid = sum(\n",
     "            count for outcome, count in result.results if _is_steane_zero_word(outcome)\n",
     "        )\n",
@@ -527,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2cc5b09",
+   "id": "40575ac9",
    "metadata": {},
    "source": [
     "A ratio of 1.000 means the state returns to the $\\lvert0_L\\rangle$ code space for every single-qubit Pauli error. A $Y=iXZ$ error triggers both the $X$-component and $Z$-component corrections."
@@ -535,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17b2b138",
+   "id": "6b375712",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -554,13 +553,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "dc9046bb",
+   "id": "aae013d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:02.328646Z",
-     "iopub.status.busy": "2026-04-28T05:52:02.328444Z",
-     "iopub.status.idle": "2026-04-28T05:52:02.336493Z",
-     "shell.execute_reply": "2026-04-28T05:52:02.335651Z"
+     "iopub.execute_input": "2026-04-28T06:04:25.034142Z",
+     "iopub.status.busy": "2026-04-28T06:04:25.033961Z",
+     "iopub.status.idle": "2026-04-28T06:04:25.042653Z",
+     "shell.execute_reply": "2026-04-28T06:04:25.041671Z"
     }
    },
    "outputs": [],
@@ -600,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d4c7417",
+   "id": "3f2f7113",
    "metadata": {},
    "source": [
     "First check that $\\bar{H}\\lvert0_L\\rangle=\\lvert+_L\\rangle$. The state $\\lvert+_L\\rangle$ is a +1 eigenstate of logical $X$, so measuring in the $X$ basis should give $q_0 \\oplus q_1 \\oplus q_2 = 0$."
@@ -609,13 +608,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "ed00fccd",
+   "id": "e468bc9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:02.338243Z",
-     "iopub.status.busy": "2026-04-28T05:52:02.338070Z",
-     "iopub.status.idle": "2026-04-28T05:52:02.449638Z",
-     "shell.execute_reply": "2026-04-28T05:52:02.448702Z"
+     "iopub.execute_input": "2026-04-28T06:04:25.045528Z",
+     "iopub.status.busy": "2026-04-28T06:04:25.045362Z",
+     "iopub.status.idle": "2026-04-28T06:04:25.159956Z",
+     "shell.execute_reply": "2026-04-28T06:04:25.159029Z"
     }
    },
    "outputs": [
@@ -623,13 +622,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transversal H: |0_L> -> |+_L>\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Transversal H: |0_L> -> |+_L>\n",
       "  q[0] xor q[1] xor q[2] = 0 ratio: 1.000\n"
      ]
     }
@@ -637,7 +630,7 @@
    "source": [
     "print(\"Transversal H: |0_L> -> |+_L>\")\n",
     "exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)\n",
-    "result_plus = exe_plus.sample(transpiler.executor(), shots=1024).result()\n",
+    "result_plus = exe_plus.sample(_seeded_executor, shots=1024).result()\n",
     "parity_zero = sum(\n",
     "    count for outcome, count in result_plus.results if _logical_x_parity(outcome) == 0\n",
     ")\n",
@@ -647,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ef1d860",
+   "id": "c4fdfdd9",
    "metadata": {},
    "source": [
     "Next check the round trip. Applying transversal $H$ twice should return to $\\lvert0_L\\rangle$ because $\\bar{H}^2=I$."
@@ -656,13 +649,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "4bf0797f",
+   "id": "e60b2f0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:02.451469Z",
-     "iopub.status.busy": "2026-04-28T05:52:02.451317Z",
-     "iopub.status.idle": "2026-04-28T05:52:02.561817Z",
-     "shell.execute_reply": "2026-04-28T05:52:02.560646Z"
+     "iopub.execute_input": "2026-04-28T06:04:25.163892Z",
+     "iopub.status.busy": "2026-04-28T06:04:25.163720Z",
+     "iopub.status.idle": "2026-04-28T06:04:25.284340Z",
+     "shell.execute_reply": "2026-04-28T06:04:25.283027Z"
     }
    },
    "outputs": [
@@ -684,7 +677,7 @@
    "source": [
     "print(\"Transversal H round trip: |0_L> -> H -> H -> |0_L>\")\n",
     "exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)\n",
-    "result_round_trip = exe_round_trip.sample(transpiler.executor(), shots=1024).result()\n",
+    "result_round_trip = exe_round_trip.sample(_seeded_executor, shots=1024).result()\n",
     "valid = sum(\n",
     "    count\n",
     "    for outcome, count in result_round_trip.results\n",
@@ -696,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0f5753f",
+   "id": "819bfaf7",
    "metadata": {},
    "source": [
     "## 5. Summary\n",

--- a/docs/en/tutorial/11_steane_code.ipynb
+++ b/docs/en/tutorial/11_steane_code.ipynb
@@ -20,9 +20,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "77e2c12a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.107366Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.107189Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.111434Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.110572Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Install the latest Qamomile from pip.\n",
@@ -33,9 +40,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "49337725",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.113609Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.113459Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.227356Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.226753Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -123,9 +136,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9ebfe1bd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.232787Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.232549Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.242004Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.241452Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -150,9 +170,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "3237aef7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.244063Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.243950Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.248275Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.246743Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -172,10 +199,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "cac5b2e4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.249925Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.249659Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.581820Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.580888Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Encode and measure |0_L>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  even Hamming codeword ratio: 1.000\n",
+      "  observed codewords: 8\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Encode and measure |0_L>\")\n",
     "exe = transpiler.transpile(encode_zero_and_measure)\n",
@@ -218,9 +268,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6f4184ba",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.583661Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.583462Z",
+     "iopub.status.idle": "2026-04-28T05:51:58.613222Z",
+     "shell.execute_reply": "2026-04-28T05:51:58.612338Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -328,10 +385,127 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "740471cd",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:51:58.615098Z",
+     "iopub.status.busy": "2026-04-28T05:51:58.614953Z",
+     "iopub.status.idle": "2026-04-28T05:52:02.326721Z",
+     "shell.execute_reply": "2026-04-28T05:52:02.325564Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Steane code: correct X/Y/Z on all 7 locations\n",
+      "  err  | pos   | |0_L> codeword\n",
+      "  -----+-------+---------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[1]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[2]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[3]  | 1.000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  X    | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[5]  | 1.000\n",
+      "  X    | q[6]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[0]  | 1.000\n",
+      "  Y    | q[1]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[2]  | 1.000\n",
+      "  Y    | q[3]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[4]  | 1.000\n",
+      "  Y    | q[5]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[6]  | 1.000\n",
+      "  Z    | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[1]  | 1.000\n",
+      "  Z    | q[2]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[3]  | 1.000\n",
+      "  Z    | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[5]  | 1.000\n",
+      "  Z    | q[6]  | 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Steane code: correct X/Y/Z on all 7 locations\")\n",
     "print(f\"  {'err':4s} | {'pos':5s} | |0_L> codeword\")\n",
@@ -379,9 +553,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "dc9046bb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:02.328646Z",
+     "iopub.status.busy": "2026-04-28T05:52:02.328444Z",
+     "iopub.status.idle": "2026-04-28T05:52:02.336493Z",
+     "shell.execute_reply": "2026-04-28T05:52:02.335651Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -427,10 +608,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "ed00fccd",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:02.338243Z",
+     "iopub.status.busy": "2026-04-28T05:52:02.338070Z",
+     "iopub.status.idle": "2026-04-28T05:52:02.449638Z",
+     "shell.execute_reply": "2026-04-28T05:52:02.448702Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transversal H: |0_L> -> |+_L>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  q[0] xor q[1] xor q[2] = 0 ratio: 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Transversal H: |0_L> -> |+_L>\")\n",
     "exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)\n",
@@ -452,10 +655,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "4bf0797f",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:02.451469Z",
+     "iopub.status.busy": "2026-04-28T05:52:02.451317Z",
+     "iopub.status.idle": "2026-04-28T05:52:02.561817Z",
+     "shell.execute_reply": "2026-04-28T05:52:02.560646Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transversal H round trip: |0_L> -> H -> H -> |0_L>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  |0_L> codeword ratio: 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Transversal H round trip: |0_L> -> H -> H -> |0_L>\")\n",
     "exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)\n",
@@ -497,6 +722,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/en/tutorial/11_steane_code.py
+++ b/docs/en/tutorial/11_steane_code.py
@@ -40,7 +40,7 @@ transpiler = QiskitTranspiler()
 # Create a seeded backend for reproducible documentation output
 from qiskit_aer import AerSimulator
 
-_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)
 _seeded_executor = transpiler.executor(backend=_seeded_backend)
 
 

--- a/docs/en/tutorial/11_steane_code.py
+++ b/docs/en/tutorial/11_steane_code.py
@@ -37,6 +37,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 transpiler = QiskitTranspiler()
 
+# Create a seeded backend for reproducible documentation output
+from qiskit_aer import AerSimulator
+
+_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_executor = transpiler.executor(backend=_seeded_backend)
+
 
 def _bits7(outcome) -> list[int]:
     """Return seven measured bits in qubit-index order."""
@@ -137,7 +143,7 @@ def encode_zero_and_measure() -> qmc.Vector[qmc.Bit]:
 # %%
 print("Encode and measure |0_L>")
 exe = transpiler.transpile(encode_zero_and_measure)
-result = exe.sample(transpiler.executor(), shots=1024).result()
+result = exe.sample(_seeded_executor, shots=1024).result()
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 total = sum(count for _, count in result.results)
 print(f"  even Hamming codeword ratio: {valid / total:.3f}")
@@ -277,7 +283,7 @@ for name, error_type in [("X", 1), ("Y", 2), ("Z", 3)]:
             steane_run,
             bindings={"error_type": error_type, "error_pos": pos},
         )
-        result = exe.sample(transpiler.executor(), shots=128).result()
+        result = exe.sample(_seeded_executor, shots=128).result()
         valid = sum(
             count for outcome, count in result.results if _is_steane_zero_word(outcome)
         )
@@ -339,7 +345,7 @@ def _logical_x_parity(outcome) -> int:
 # %%
 print("Transversal H: |0_L> -> |+_L>")
 exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)
-result_plus = exe_plus.sample(transpiler.executor(), shots=1024).result()
+result_plus = exe_plus.sample(_seeded_executor, shots=1024).result()
 parity_zero = sum(
     count for outcome, count in result_plus.results if _logical_x_parity(outcome) == 0
 )
@@ -352,7 +358,7 @@ print(f"  q[0] xor q[1] xor q[2] = 0 ratio: {parity_zero / total_plus:.3f}")
 # %%
 print("Transversal H round trip: |0_L> -> H -> H -> |0_L>")
 exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)
-result_round_trip = exe_round_trip.sample(transpiler.executor(), shots=1024).result()
+result_round_trip = exe_round_trip.sample(_seeded_executor, shots=1024).result()
 valid = sum(
     count
     for outcome, count in result_round_trip.results

--- a/docs/ja/tutorial/09_compilation_and_transpilation.ipynb
+++ b/docs/ja/tutorial/09_compilation_and_transpilation.ipynb
@@ -21,9 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3186bd65",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.514598Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.514427Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.518456Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.517420Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# 最新のQamomileをpipからインストールします！\n",
@@ -136,9 +143,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "dcdcb191",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.520604Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.520444Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.627789Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.627277Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import qamomile.circuit as qmc\n",
@@ -169,9 +183,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "0191c2bd",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.631104Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.630920Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.638711Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.638242Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -208,9 +228,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "f1c5a375",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.640108Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.639848Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.642945Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.642471Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def summarise(block):\n",
@@ -249,10 +276,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "11782158",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.644343Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.644199Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.649643Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.649154Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after to_block:    kind=HIERARCHICAL  ops= 5 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'BinOp': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "parameters:        ['theta']\n",
+      "CallBlockOps:      0\n"
+     ]
+    }
+   ],
    "source": [
     "bindings = {\"n\": 3}\n",
     "parameters = [\"theta\"]\n",
@@ -276,10 +320,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "91fffc9c",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.651107Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.650853Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.653861Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.653260Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [HIERARCHICAL] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    call entangle_pair(%q[%i@v0]@v0, %q[%_@v0]@v0) -> (%q[%i@v0]@v1, %q[%_@v0]@v1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block))"
    ]
@@ -294,10 +367,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "53bcde2d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.655099Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.654989Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.657904Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.657441Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [HIERARCHICAL] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    call entangle_pair(%q[%i@v0]@v0, %q[%_@v0]@v0) -> (%q[%i@v0]@v1, %q[%_@v0]@v1) {\n",
+      "      %q0@v1 = h(%q0@v0)\n",
+      "      %q0@v2, %q1@v1 = cx(%q0@v1, %q1@v0)\n",
+      "      return %q0@v2, %q1@v1\n",
+      "    }\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block, depth=1))"
    ]
@@ -318,10 +424,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "838ca7b2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.659077Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.658962Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.663668Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.663202Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after inline:      kind=AFFINE        ops= 5 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'BinOp': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "CallBlockOps (deep): 0\n",
+      "is_affine:         True\n"
+     ]
+    }
+   ],
    "source": [
     "def count_calls(ops):\n",
     "    total = 0\n",
@@ -350,10 +473,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "98572ad6",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.665136Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.664870Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.667661Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.667204Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block demo_kernel [AFFINE] (n: UIntType, theta: FloatType) -> BitType {\n",
+      "  parameters: [theta]\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  %q[const(0)]@v1 = h(%q[const(0)]@v0)\n",
+      "  %_@v0 = const(3) - const(1)\n",
+      "  for %i in range(const(0), %_@v0, const(1)) {\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q0@v1 = h(%q[%i@v0]@v0)\n",
+      "    %q0@v2, %q1@v1 = cx(%q0@v1, %q[%_@v0]@v0)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "    %q[%_@v0]@v1 = rz(%q[%_@v0]@v0, θ=param(theta))\n",
+      "    %_@v0 = %i@v0 + const(1)\n",
+      "  }\n",
+      "  %q_measured@v0 = measure_vector(%q@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(pretty_print_block(block))"
    ]
@@ -377,10 +530,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a08c5695",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.669040Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.668855Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.673242Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.672703Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after partial_eval: kind=AFFINE        ops= 4 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n",
+      "ForOperations:     1\n"
+     ]
+    }
+   ],
    "source": [
     "block = transpiler.partial_eval(block, bindings=bindings)\n",
     "print(\"after partial_eval:\", summarise(block))\n",
@@ -408,10 +577,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "d760d275",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.674704Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.674441Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.677945Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.677256Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after analyze:     kind=ANALYZED      ops= 4 breakdown={'QInitOperation': 1, 'GateOperation': 1, 'ForOperation': 1, 'MeasureVectorOperation': 1}\n"
+     ]
+    }
+   ],
    "source": [
     "block = transpiler.analyze(block)\n",
     "print(\"after analyze:    \", summarise(block))"
@@ -429,10 +613,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "cc6aa9a4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.679473Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.679331Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.684942Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.684641Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  step 0: QuantumStep (QuantumSegment, 4 ops)\n",
+      "total unbound parameters: ['theta']\n"
+     ]
+    }
+   ],
    "source": [
     "plan = transpiler.plan(block)\n",
     "for i, step in enumerate(plan.steps):\n",
@@ -455,12 +655,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "a44453a4",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.686735Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.686613Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.892893Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.891772Z"
+    },
     "lines_to_next_cell": 1
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "parameter_names:   ['theta']\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     ┌───┐┌───┐                  ┌─┐                             \n",
+      "q_0: ┤ H ├┤ H ├──■───────────────┤M├─────────────────────────────\n",
+      "     └───┘└───┘┌─┴─┐┌───────────┐└╥┘┌───┐                  ┌─┐   \n",
+      "q_1: ──────────┤ X ├┤ Rz(theta) ├─╫─┤ H ├──■───────────────┤M├───\n",
+      "               └───┘└───────────┘ ║ └───┘┌─┴─┐┌───────────┐└╥┘┌─┐\n",
+      "q_2: ─────────────────────────────╫──────┤ X ├┤ Rz(theta) ├─╫─┤M├\n",
+      "                                  ║      └───┘└───────────┘ ║ └╥┘\n",
+      "q_3: ─────────────────────────────╫─────────────────────────╫──╫─\n",
+      "                                  ║                         ║  ║ \n",
+      "c: 3/═════════════════════════════╩═════════════════════════╩══╩═\n",
+      "                                  0                         1  2 \n"
+     ]
+    }
+   ],
    "source": [
     "executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)\n",
     "print(\"parameter_names:  \", executable.parameter_names)\n",
@@ -609,9 +841,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "ed76e8d8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.895318Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.895081Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.899952Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.899066Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -633,10 +872,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "f658dfb0",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.901762Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.901607Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.907360Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.906377Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block qfixed_demo [ANALYZED] (n: UIntType) -> FloatType {\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  for %i in range(const(0), const(3), const(1)) {\n",
+      "    %q[%i@v0]@v1 = h(%q[%i@v0]@v0)\n",
+      "  }\n",
+      "  %q_as_qfixed@v0 = cast %q@v0 to QFixed[0.3]\n",
+      "  %qfixed_measured@v0 = measure_qfixed(%q_as_qfixed@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "qfixed_bindings = {\"n\": 3}\n",
     "qfixed_block = transpiler.to_block(qfixed_demo, bindings=qfixed_bindings)\n",
@@ -667,10 +928,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "ead42859",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.909370Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.909203Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.912993Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.912013Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block qfixed_demo [ANALYZED] (n: UIntType) -> FloatType {\n",
+      "  %q@v0 = QInitOperation()\n",
+      "  for %i in range(const(0), const(3), const(1)) {\n",
+      "    %q[%i@v0]@v1 = h(%q[%i@v0]@v0)\n",
+      "  }\n",
+      "  %q_as_qfixed@v0 = cast %q@v0 to QFixed[0.3]\n",
+      "  %qfixed_bits@v0 = measure_vector(%qfixed_qubits@v0)\n",
+      "  %qfixed_measured@v0 = decode_qfixed(%qfixed_bits@v0)\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "from qamomile.circuit.transpiler.passes.separate import lower_operations\n",
     "\n",
@@ -733,10 +1017,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "f487c588",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:11.914839Z",
+     "iopub.status.busy": "2026-04-28T05:52:11.914625Z",
+     "iopub.status.idle": "2026-04-28T05:52:11.929569Z",
+     "shell.execute_reply": "2026-04-28T05:52:11.928329Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QURI Parts is not installed; skipping the side-by-side output.\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    from qamomile.quri_parts import QuriPartsTranspiler\n",
@@ -836,6 +1135,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/ja/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/ja/tutorial/10_quantum_error_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0919c321",
+   "id": "dc71961b",
    "metadata": {},
    "source": [
     "# 量子誤り訂正入門\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9858496d",
+   "id": "2595d7cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:15.618639Z",
-     "iopub.status.busy": "2026-04-28T05:52:15.618464Z",
-     "iopub.status.idle": "2026-04-28T05:52:15.622117Z",
-     "shell.execute_reply": "2026-04-28T05:52:15.621118Z"
+     "iopub.execute_input": "2026-04-28T06:04:29.075600Z",
+     "iopub.status.busy": "2026-04-28T06:04:29.075373Z",
+     "iopub.status.idle": "2026-04-28T06:04:29.081576Z",
+     "shell.execute_reply": "2026-04-28T06:04:29.080258Z"
     }
    },
    "outputs": [],
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3724f3b1",
+   "id": "021d4cae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:15.623864Z",
-     "iopub.status.busy": "2026-04-28T05:52:15.623720Z",
-     "iopub.status.idle": "2026-04-28T05:52:15.730657Z",
-     "shell.execute_reply": "2026-04-28T05:52:15.730063Z"
+     "iopub.execute_input": "2026-04-28T06:04:29.083998Z",
+     "iopub.status.busy": "2026-04-28T06:04:29.083797Z",
+     "iopub.status.idle": "2026-04-28T06:04:29.410239Z",
+     "shell.execute_reply": "2026-04-28T06:04:29.408699Z"
     },
     "lines_to_next_cell": 2
    },
@@ -60,6 +60,12 @@
     "from qamomile.qiskit import QiskitTranspiler\n",
     "\n",
     "transpiler = QiskitTranspiler()\n",
+    "\n",
+    "# Create a seeded backend for reproducible documentation output\n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
     "def _first_bit_distribution(result) -> dict[int, int]:\n",
@@ -86,7 +92,7 @@
     "        parameters=parameters or [],\n",
     "    )\n",
     "    job = executable.sample(\n",
-    "        transpiler.executor(),\n",
+    "        _seeded_executor,\n",
     "        shots=shots,\n",
     "        bindings=runtime_bindings or {},\n",
     "    )\n",
@@ -95,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79d76a7c",
+   "id": "35c773c4",
    "metadata": {},
    "source": [
     "## 1. 何を訂正したいのか\n",
@@ -116,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "307e63e9",
+   "id": "00444c80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -137,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d75670f8",
+   "id": "74f10875",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:15.734633Z",
-     "iopub.status.busy": "2026-04-28T05:52:15.734429Z",
-     "iopub.status.idle": "2026-04-28T05:52:15.740091Z",
-     "shell.execute_reply": "2026-04-28T05:52:15.739259Z"
+     "iopub.execute_input": "2026-04-28T06:04:29.413120Z",
+     "iopub.status.busy": "2026-04-28T06:04:29.412897Z",
+     "iopub.status.idle": "2026-04-28T06:04:29.418950Z",
+     "shell.execute_reply": "2026-04-28T06:04:29.417711Z"
     },
     "lines_to_next_cell": 2
    },
@@ -160,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e57c3f88",
+   "id": "571514d9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -187,13 +193,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a0551288",
+   "id": "7f54feb6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:15.742145Z",
-     "iopub.status.busy": "2026-04-28T05:52:15.741589Z",
-     "iopub.status.idle": "2026-04-28T05:52:15.752074Z",
-     "shell.execute_reply": "2026-04-28T05:52:15.751314Z"
+     "iopub.execute_input": "2026-04-28T06:04:29.421364Z",
+     "iopub.status.busy": "2026-04-28T06:04:29.421146Z",
+     "iopub.status.idle": "2026-04-28T06:04:29.432440Z",
+     "shell.execute_reply": "2026-04-28T06:04:29.431197Z"
     }
    },
    "outputs": [],
@@ -233,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e09049e",
+   "id": "efeb0288",
    "metadata": {},
    "source": [
     "`error_pos` はコンパイル時パラメータです。`0`, `1`, `2` のいずれかならその位置に $X$ を注入し、`3` ならどの分岐にも入らないのでエラーなしとして扱います。\n",
@@ -244,13 +250,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7dcd7e43",
+   "id": "90d68de1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:15.754119Z",
-     "iopub.status.busy": "2026-04-28T05:52:15.753574Z",
-     "iopub.status.idle": "2026-04-28T05:52:16.479393Z",
-     "shell.execute_reply": "2026-04-28T05:52:16.478092Z"
+     "iopub.execute_input": "2026-04-28T06:04:29.434720Z",
+     "iopub.status.busy": "2026-04-28T06:04:29.434551Z",
+     "iopub.status.idle": "2026-04-28T06:04:30.009400Z",
+     "shell.execute_reply": "2026-04-28T06:04:30.007522Z"
     }
    },
    "outputs": [
@@ -258,22 +264,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3量子ビット bit-flip 符号: 論理 |1⟩\n"
+      "3量子ビット bit-flip 符号: 論理 |1⟩\n",
+      "  エラーなし         : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  エラーなし         : data[0]=0 が   0 回, data[0]=1 が 256 回\n",
-      "  X on data[0]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
+      "  X on data[0]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n",
+      "  X on data[1]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[1]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n",
       "  X on data[2]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
      ]
     }
@@ -301,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55d9e021",
+   "id": "3eae1eed",
    "metadata": {},
    "source": [
     "重ね合わせでも同じです。$\\theta=\\pi/3$ で\n",
@@ -314,13 +320,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fc05696a",
+   "id": "7fdf2f29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:16.481750Z",
-     "iopub.status.busy": "2026-04-28T05:52:16.481496Z",
-     "iopub.status.idle": "2026-04-28T05:52:17.417600Z",
-     "shell.execute_reply": "2026-04-28T05:52:17.416404Z"
+     "iopub.execute_input": "2026-04-28T06:04:30.011877Z",
+     "iopub.status.busy": "2026-04-28T06:04:30.011694Z",
+     "iopub.status.idle": "2026-04-28T06:04:30.712345Z",
+     "shell.execute_reply": "2026-04-28T06:04:30.710842Z"
     }
    },
    "outputs": [
@@ -328,35 +334,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3量子ビット bit-flip 符号: 重ね合わせ状態\n"
+      "3量子ビット bit-flip 符号: 重ね合わせ状態\n",
+      "  エラーなし         : P(data[0]=1) = 0.269\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  エラーなし         : P(data[0]=1) = 0.240\n"
+      "  X on data[0]  : P(data[0]=1) = 0.269\n",
+      "  X on data[1]  : P(data[0]=1) = 0.269\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[0]  : P(data[0]=1) = 0.242\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  X on data[1]  : P(data[0]=1) = 0.243\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  X on data[2]  : P(data[0]=1) = 0.244\n"
+      "  X on data[2]  : P(data[0]=1) = 0.269\n"
      ]
     }
    ],
@@ -376,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cca116e",
+   "id": "85eb92ff",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -400,13 +394,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "11487ec0",
+   "id": "d7244e6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:17.419724Z",
-     "iopub.status.busy": "2026-04-28T05:52:17.419555Z",
-     "iopub.status.idle": "2026-04-28T05:52:17.424932Z",
-     "shell.execute_reply": "2026-04-28T05:52:17.423986Z"
+     "iopub.execute_input": "2026-04-28T06:04:30.714925Z",
+     "iopub.status.busy": "2026-04-28T06:04:30.714751Z",
+     "iopub.status.idle": "2026-04-28T06:04:30.720324Z",
+     "shell.execute_reply": "2026-04-28T06:04:30.719220Z"
     },
     "lines_to_next_cell": 2
    },
@@ -425,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9195ef6",
+   "id": "97b6130a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -443,13 +437,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f9154233",
+   "id": "1aaf1056",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:17.426715Z",
-     "iopub.status.busy": "2026-04-28T05:52:17.426565Z",
-     "iopub.status.idle": "2026-04-28T05:52:17.437439Z",
-     "shell.execute_reply": "2026-04-28T05:52:17.436569Z"
+     "iopub.execute_input": "2026-04-28T06:04:30.722362Z",
+     "iopub.status.busy": "2026-04-28T06:04:30.722123Z",
+     "iopub.status.idle": "2026-04-28T06:04:30.737987Z",
+     "shell.execute_reply": "2026-04-28T06:04:30.736928Z"
     }
    },
    "outputs": [],
@@ -490,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8748f80b",
+   "id": "8cb9a0e6",
    "metadata": {},
    "source": [
     "ここでは論理 $\\lvert0_L\\rangle=\\lvert+++\\rangle$ を使います。訂正後の `data[0]` は $\\lvert+\\rangle$ に戻るので、最後に $H$ を当ててから測れば常に0になります。"
@@ -499,13 +493,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c31e5cab",
+   "id": "6c1d9d26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:17.439107Z",
-     "iopub.status.busy": "2026-04-28T05:52:17.438968Z",
-     "iopub.status.idle": "2026-04-28T05:52:17.964468Z",
-     "shell.execute_reply": "2026-04-28T05:52:17.963488Z"
+     "iopub.execute_input": "2026-04-28T06:04:30.739991Z",
+     "iopub.status.busy": "2026-04-28T06:04:30.739808Z",
+     "iopub.status.idle": "2026-04-28T06:04:31.288066Z",
+     "shell.execute_reply": "2026-04-28T06:04:31.286775Z"
     }
    },
    "outputs": [
@@ -554,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8622bed3",
+   "id": "5b9b9139",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -580,13 +574,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "488dfb5e",
+   "id": "baf1f598",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:17.966909Z",
-     "iopub.status.busy": "2026-04-28T05:52:17.966745Z",
-     "iopub.status.idle": "2026-04-28T05:52:17.973431Z",
-     "shell.execute_reply": "2026-04-28T05:52:17.972345Z"
+     "iopub.execute_input": "2026-04-28T06:04:31.290735Z",
+     "iopub.status.busy": "2026-04-28T06:04:31.290544Z",
+     "iopub.status.idle": "2026-04-28T06:04:31.297753Z",
+     "shell.execute_reply": "2026-04-28T06:04:31.296805Z"
     },
     "lines_to_next_cell": 2
    },
@@ -604,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be76896b",
+   "id": "ab1fdd72",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -620,13 +614,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "84208fef",
+   "id": "813c92c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:17.975131Z",
-     "iopub.status.busy": "2026-04-28T05:52:17.974995Z",
-     "iopub.status.idle": "2026-04-28T05:52:18.042763Z",
-     "shell.execute_reply": "2026-04-28T05:52:18.041695Z"
+     "iopub.execute_input": "2026-04-28T06:04:31.299878Z",
+     "iopub.status.busy": "2026-04-28T06:04:31.299716Z",
+     "iopub.status.idle": "2026-04-28T06:04:31.368002Z",
+     "shell.execute_reply": "2026-04-28T06:04:31.366766Z"
     }
    },
    "outputs": [],
@@ -743,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3fbbf97",
+   "id": "690ed0a2",
    "metadata": {},
    "source": [
     "代表として、3つのブロックから1つずつ位置を選び、$X$, $Y$, $Z$ エラーを注入します。論理 $\\lvert1\\rangle$ が保たれていれば、すべて `q[0]=1` になります。"
@@ -752,13 +746,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c188f67a",
+   "id": "443c91f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:52:18.044672Z",
-     "iopub.status.busy": "2026-04-28T05:52:18.044468Z",
-     "iopub.status.idle": "2026-04-28T05:53:01.595090Z",
-     "shell.execute_reply": "2026-04-28T05:53:01.593924Z"
+     "iopub.execute_input": "2026-04-28T06:04:31.370129Z",
+     "iopub.status.busy": "2026-04-28T06:04:31.369969Z",
+     "iopub.status.idle": "2026-04-28T06:04:43.015719Z",
+     "shell.execute_reply": "2026-04-28T06:04:43.014783Z"
     }
    },
    "outputs": [
@@ -782,20 +776,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y      | q[4]  | 1.000"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y      | q[4]  | 1.000\n",
       "  Z      | q[8]  | 1.000\n"
      ]
     }
@@ -823,7 +804,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fe10eac",
+   "id": "4cf3a079",
    "metadata": {},
    "source": [
     "Shor 符号は、単一量子ビットの任意の Pauli エラーを訂正できます。一般の小さなノイズも Pauli エラーの線形結合として扱えるため、まず Pauli エラーを直せることが量子誤り訂正の出発点になります。"
@@ -831,7 +812,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4ca79f8",
+   "id": "39ea64a1",
    "metadata": {},
    "source": [
     "## 5. スタビライザー形式で見る\n",
@@ -849,7 +830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4636b6db",
+   "id": "5b60843c",
    "metadata": {},
    "source": [
     "## 6. まとめ\n",

--- a/docs/ja/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/ja/tutorial/10_quantum_error_correction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dc71961b",
+   "id": "4d85bc24",
    "metadata": {},
    "source": [
     "# 量子誤り訂正入門\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2595d7cb",
+   "id": "2a7a45b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:29.075600Z",
-     "iopub.status.busy": "2026-04-28T06:04:29.075373Z",
-     "iopub.status.idle": "2026-04-28T06:04:29.081576Z",
-     "shell.execute_reply": "2026-04-28T06:04:29.080258Z"
+     "iopub.execute_input": "2026-04-28T06:20:44.774951Z",
+     "iopub.status.busy": "2026-04-28T06:20:44.774656Z",
+     "iopub.status.idle": "2026-04-28T06:20:44.778436Z",
+     "shell.execute_reply": "2026-04-28T06:20:44.777403Z"
     }
    },
    "outputs": [],
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "021d4cae",
+   "id": "5fec83c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:29.083998Z",
-     "iopub.status.busy": "2026-04-28T06:04:29.083797Z",
-     "iopub.status.idle": "2026-04-28T06:04:29.410239Z",
-     "shell.execute_reply": "2026-04-28T06:04:29.408699Z"
+     "iopub.execute_input": "2026-04-28T06:20:44.780692Z",
+     "iopub.status.busy": "2026-04-28T06:20:44.780479Z",
+     "iopub.status.idle": "2026-04-28T06:20:45.162482Z",
+     "shell.execute_reply": "2026-04-28T06:20:45.161424Z"
     },
     "lines_to_next_cell": 2
    },
@@ -64,7 +64,7 @@
     "# Create a seeded backend for reproducible documentation output\n",
     "from qiskit_aer import AerSimulator\n",
     "\n",
-    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)\n",
     "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35c773c4",
+   "id": "3eaf6d1d",
    "metadata": {},
    "source": [
     "## 1. 何を訂正したいのか\n",
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00444c80",
+   "id": "30b839cf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -143,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "74f10875",
+   "id": "e7b1baaf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:29.413120Z",
-     "iopub.status.busy": "2026-04-28T06:04:29.412897Z",
-     "iopub.status.idle": "2026-04-28T06:04:29.418950Z",
-     "shell.execute_reply": "2026-04-28T06:04:29.417711Z"
+     "iopub.execute_input": "2026-04-28T06:20:45.165345Z",
+     "iopub.status.busy": "2026-04-28T06:20:45.165114Z",
+     "iopub.status.idle": "2026-04-28T06:20:45.170708Z",
+     "shell.execute_reply": "2026-04-28T06:20:45.169771Z"
     },
     "lines_to_next_cell": 2
    },
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "571514d9",
+   "id": "b625489a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -193,13 +193,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7f54feb6",
+   "id": "da0c2676",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:29.421364Z",
-     "iopub.status.busy": "2026-04-28T06:04:29.421146Z",
-     "iopub.status.idle": "2026-04-28T06:04:29.432440Z",
-     "shell.execute_reply": "2026-04-28T06:04:29.431197Z"
+     "iopub.execute_input": "2026-04-28T06:20:45.173171Z",
+     "iopub.status.busy": "2026-04-28T06:20:45.172968Z",
+     "iopub.status.idle": "2026-04-28T06:20:45.185754Z",
+     "shell.execute_reply": "2026-04-28T06:20:45.184508Z"
     }
    },
    "outputs": [],
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efeb0288",
+   "id": "ee9e27bc",
    "metadata": {},
    "source": [
     "`error_pos` はコンパイル時パラメータです。`0`, `1`, `2` のいずれかならその位置に $X$ を注入し、`3` ならどの分岐にも入らないのでエラーなしとして扱います。\n",
@@ -250,13 +250,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "90d68de1",
+   "id": "aa32cb92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:29.434720Z",
-     "iopub.status.busy": "2026-04-28T06:04:29.434551Z",
-     "iopub.status.idle": "2026-04-28T06:04:30.009400Z",
-     "shell.execute_reply": "2026-04-28T06:04:30.007522Z"
+     "iopub.execute_input": "2026-04-28T06:20:45.187771Z",
+     "iopub.status.busy": "2026-04-28T06:20:45.187607Z",
+     "iopub.status.idle": "2026-04-28T06:20:45.724113Z",
+     "shell.execute_reply": "2026-04-28T06:20:45.722831Z"
     }
    },
    "outputs": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eae1eed",
+   "id": "c07f1dbf",
    "metadata": {},
    "source": [
     "重ね合わせでも同じです。$\\theta=\\pi/3$ で\n",
@@ -320,13 +320,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "7fdf2f29",
+   "id": "29c1c15a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:30.011877Z",
-     "iopub.status.busy": "2026-04-28T06:04:30.011694Z",
-     "iopub.status.idle": "2026-04-28T06:04:30.712345Z",
-     "shell.execute_reply": "2026-04-28T06:04:30.710842Z"
+     "iopub.execute_input": "2026-04-28T06:20:45.726566Z",
+     "iopub.status.busy": "2026-04-28T06:20:45.726291Z",
+     "iopub.status.idle": "2026-04-28T06:20:46.717342Z",
+     "shell.execute_reply": "2026-04-28T06:20:46.716427Z"
     }
    },
    "outputs": [
@@ -334,7 +334,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3量子ビット bit-flip 符号: 重ね合わせ状態\n",
+      "3量子ビット bit-flip 符号: 重ね合わせ状態\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  エラーなし         : P(data[0]=1) = 0.269\n"
      ]
     },
@@ -342,7 +348,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X on data[0]  : P(data[0]=1) = 0.269\n",
+      "  X on data[0]  : P(data[0]=1) = 0.269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  X on data[1]  : P(data[0]=1) = 0.269\n"
      ]
     },
@@ -370,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85eb92ff",
+   "id": "c92c0195",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -394,13 +406,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "d7244e6e",
+   "id": "594aff30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:30.714925Z",
-     "iopub.status.busy": "2026-04-28T06:04:30.714751Z",
-     "iopub.status.idle": "2026-04-28T06:04:30.720324Z",
-     "shell.execute_reply": "2026-04-28T06:04:30.719220Z"
+     "iopub.execute_input": "2026-04-28T06:20:46.719988Z",
+     "iopub.status.busy": "2026-04-28T06:20:46.719798Z",
+     "iopub.status.idle": "2026-04-28T06:20:46.725439Z",
+     "shell.execute_reply": "2026-04-28T06:20:46.724321Z"
     },
     "lines_to_next_cell": 2
    },
@@ -419,7 +431,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97b6130a",
+   "id": "4f3b0de6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -437,13 +449,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1aaf1056",
+   "id": "f28b2c8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:30.722362Z",
-     "iopub.status.busy": "2026-04-28T06:04:30.722123Z",
-     "iopub.status.idle": "2026-04-28T06:04:30.737987Z",
-     "shell.execute_reply": "2026-04-28T06:04:30.736928Z"
+     "iopub.execute_input": "2026-04-28T06:20:46.727384Z",
+     "iopub.status.busy": "2026-04-28T06:20:46.727215Z",
+     "iopub.status.idle": "2026-04-28T06:20:46.738219Z",
+     "shell.execute_reply": "2026-04-28T06:20:46.737228Z"
     }
    },
    "outputs": [],
@@ -484,7 +496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cb9a0e6",
+   "id": "734d1fae",
    "metadata": {},
    "source": [
     "ここでは論理 $\\lvert0_L\\rangle=\\lvert+++\\rangle$ を使います。訂正後の `data[0]` は $\\lvert+\\rangle$ に戻るので、最後に $H$ を当ててから測れば常に0になります。"
@@ -493,13 +505,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "6c1d9d26",
+   "id": "52606d40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:30.739991Z",
-     "iopub.status.busy": "2026-04-28T06:04:30.739808Z",
-     "iopub.status.idle": "2026-04-28T06:04:31.288066Z",
-     "shell.execute_reply": "2026-04-28T06:04:31.286775Z"
+     "iopub.execute_input": "2026-04-28T06:20:46.739954Z",
+     "iopub.status.busy": "2026-04-28T06:20:46.739791Z",
+     "iopub.status.idle": "2026-04-28T06:20:47.279459Z",
+     "shell.execute_reply": "2026-04-28T06:20:47.278306Z"
     }
    },
    "outputs": [
@@ -548,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b9b9139",
+   "id": "9bf00238",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -574,13 +586,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "baf1f598",
+   "id": "9ea46bea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:31.290735Z",
-     "iopub.status.busy": "2026-04-28T06:04:31.290544Z",
-     "iopub.status.idle": "2026-04-28T06:04:31.297753Z",
-     "shell.execute_reply": "2026-04-28T06:04:31.296805Z"
+     "iopub.execute_input": "2026-04-28T06:20:47.281684Z",
+     "iopub.status.busy": "2026-04-28T06:20:47.281514Z",
+     "iopub.status.idle": "2026-04-28T06:20:47.287909Z",
+     "shell.execute_reply": "2026-04-28T06:20:47.286994Z"
     },
     "lines_to_next_cell": 2
    },
@@ -598,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab1fdd72",
+   "id": "66ec5d48",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -614,13 +626,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "813c92c0",
+   "id": "cf803471",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:31.299878Z",
-     "iopub.status.busy": "2026-04-28T06:04:31.299716Z",
-     "iopub.status.idle": "2026-04-28T06:04:31.368002Z",
-     "shell.execute_reply": "2026-04-28T06:04:31.366766Z"
+     "iopub.execute_input": "2026-04-28T06:20:47.289651Z",
+     "iopub.status.busy": "2026-04-28T06:20:47.289507Z",
+     "iopub.status.idle": "2026-04-28T06:20:47.355040Z",
+     "shell.execute_reply": "2026-04-28T06:20:47.353952Z"
     }
    },
    "outputs": [],
@@ -737,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "690ed0a2",
+   "id": "ee95dc5f",
    "metadata": {},
    "source": [
     "代表として、3つのブロックから1つずつ位置を選び、$X$, $Y$, $Z$ エラーを注入します。論理 $\\lvert1\\rangle$ が保たれていれば、すべて `q[0]=1` になります。"
@@ -746,13 +758,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "443c91f6",
+   "id": "7fe9f4bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:31.370129Z",
-     "iopub.status.busy": "2026-04-28T06:04:31.369969Z",
-     "iopub.status.idle": "2026-04-28T06:04:43.015719Z",
-     "shell.execute_reply": "2026-04-28T06:04:43.014783Z"
+     "iopub.execute_input": "2026-04-28T06:20:47.356836Z",
+     "iopub.status.busy": "2026-04-28T06:20:47.356690Z",
+     "iopub.status.idle": "2026-04-28T06:21:30.716184Z",
+     "shell.execute_reply": "2026-04-28T06:21:30.714923Z"
     }
    },
    "outputs": [
@@ -769,14 +781,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X      | q[0]  | 1.000\n"
+      "  X      | q[0]  | 1.000\n",
+      "  Y      | q[4]  | 1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y      | q[4]  | 1.000\n",
       "  Z      | q[8]  | 1.000\n"
      ]
     }
@@ -804,7 +816,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cf3a079",
+   "id": "c9407afc",
    "metadata": {},
    "source": [
     "Shor 符号は、単一量子ビットの任意の Pauli エラーを訂正できます。一般の小さなノイズも Pauli エラーの線形結合として扱えるため、まず Pauli エラーを直せることが量子誤り訂正の出発点になります。"
@@ -812,7 +824,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39ea64a1",
+   "id": "76da7a0d",
    "metadata": {},
    "source": [
     "## 5. スタビライザー形式で見る\n",
@@ -830,7 +842,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b60843c",
+   "id": "78f35b09",
    "metadata": {},
    "source": [
     "## 6. まとめ\n",

--- a/docs/ja/tutorial/10_quantum_error_correction.ipynb
+++ b/docs/ja/tutorial/10_quantum_error_correction.ipynb
@@ -21,9 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "9858496d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:15.618639Z",
+     "iopub.status.busy": "2026-04-28T05:52:15.618464Z",
+     "iopub.status.idle": "2026-04-28T05:52:15.622117Z",
+     "shell.execute_reply": "2026-04-28T05:52:15.621118Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# 最新のQamomileをpipからインストールします。\n",
@@ -34,9 +41,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "3724f3b1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:15.623864Z",
+     "iopub.status.busy": "2026-04-28T05:52:15.623720Z",
+     "iopub.status.idle": "2026-04-28T05:52:15.730657Z",
+     "shell.execute_reply": "2026-04-28T05:52:15.730063Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -123,9 +136,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d75670f8",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:15.734633Z",
+     "iopub.status.busy": "2026-04-28T05:52:15.734429Z",
+     "iopub.status.idle": "2026-04-28T05:52:15.740091Z",
+     "shell.execute_reply": "2026-04-28T05:52:15.739259Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -167,9 +186,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "a0551288",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:15.742145Z",
+     "iopub.status.busy": "2026-04-28T05:52:15.741589Z",
+     "iopub.status.idle": "2026-04-28T05:52:15.752074Z",
+     "shell.execute_reply": "2026-04-28T05:52:15.751314Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -217,10 +243,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "7dcd7e43",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:15.754119Z",
+     "iopub.status.busy": "2026-04-28T05:52:15.753574Z",
+     "iopub.status.idle": "2026-04-28T05:52:16.479393Z",
+     "shell.execute_reply": "2026-04-28T05:52:16.478092Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3量子ビット bit-flip 符号: 論理 |1⟩\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  エラーなし         : data[0]=0 が   0 回, data[0]=1 が 256 回\n",
+      "  X on data[0]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[1]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n",
+      "  X on data[2]  : data[0]=0 が   0 回, data[0]=1 が 256 回\n"
+     ]
+    }
+   ],
    "source": [
     "bitflip_cases = [\n",
     "    (\"エラーなし\", 3),\n",
@@ -256,10 +313,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "fc05696a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:16.481750Z",
+     "iopub.status.busy": "2026-04-28T05:52:16.481496Z",
+     "iopub.status.idle": "2026-04-28T05:52:17.417600Z",
+     "shell.execute_reply": "2026-04-28T05:52:17.416404Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3量子ビット bit-flip 符号: 重ね合わせ状態\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  エラーなし         : P(data[0]=1) = 0.240\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[0]  : P(data[0]=1) = 0.242\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[1]  : P(data[0]=1) = 0.243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X on data[2]  : P(data[0]=1) = 0.244\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"3量子ビット bit-flip 符号: 重ね合わせ状態\")\n",
     "for label, error_pos in bitflip_cases:\n",
@@ -299,9 +399,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "11487ec0",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:17.419724Z",
+     "iopub.status.busy": "2026-04-28T05:52:17.419555Z",
+     "iopub.status.idle": "2026-04-28T05:52:17.424932Z",
+     "shell.execute_reply": "2026-04-28T05:52:17.423986Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -336,9 +442,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "f9154233",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:17.426715Z",
+     "iopub.status.busy": "2026-04-28T05:52:17.426565Z",
+     "iopub.status.idle": "2026-04-28T05:52:17.437439Z",
+     "shell.execute_reply": "2026-04-28T05:52:17.436569Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -385,10 +498,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "c31e5cab",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:17.439107Z",
+     "iopub.status.busy": "2026-04-28T05:52:17.438968Z",
+     "iopub.status.idle": "2026-04-28T05:52:17.964468Z",
+     "shell.execute_reply": "2026-04-28T05:52:17.963488Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3量子ビット phase-flip 符号: 論理 |0_L⟩ = |+++⟩\n",
+      "  エラーなし         : data[0]=0 が 256 回, data[0]=1 が   0 回\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z on data[0]  : data[0]=0 が 256 回, data[0]=1 が   0 回\n",
+      "  Z on data[1]  : data[0]=0 が 256 回, data[0]=1 が   0 回\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z on data[2]  : data[0]=0 が 256 回, data[0]=1 が   0 回\n"
+     ]
+    }
+   ],
    "source": [
     "phaseflip_cases = [\n",
     "    (\"エラーなし\", 3),\n",
@@ -435,9 +579,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "488dfb5e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:17.966909Z",
+     "iopub.status.busy": "2026-04-28T05:52:17.966745Z",
+     "iopub.status.idle": "2026-04-28T05:52:17.973431Z",
+     "shell.execute_reply": "2026-04-28T05:52:17.972345Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -469,9 +619,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "84208fef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:17.975131Z",
+     "iopub.status.busy": "2026-04-28T05:52:17.974995Z",
+     "iopub.status.idle": "2026-04-28T05:52:18.042763Z",
+     "shell.execute_reply": "2026-04-28T05:52:18.041695Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -594,10 +751,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c188f67a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:52:18.044672Z",
+     "iopub.status.busy": "2026-04-28T05:52:18.044468Z",
+     "iopub.status.idle": "2026-04-28T05:53:01.595090Z",
+     "shell.execute_reply": "2026-04-28T05:53:01.593924Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shor 9量子ビット符号: 論理 |1⟩\n",
+      "  エラー    | 位置    | P(q[0]=1)\n",
+      "  -------+-------+----------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X      | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y      | q[4]  | 1.000"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z      | q[8]  | 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "shor_cases = [\n",
     "    (\"X\", 1, 0),\n",
@@ -668,6 +870,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/ja/tutorial/10_quantum_error_correction.py
+++ b/docs/ja/tutorial/10_quantum_error_correction.py
@@ -43,7 +43,7 @@ transpiler = QiskitTranspiler()
 # Create a seeded backend for reproducible documentation output
 from qiskit_aer import AerSimulator
 
-_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)
 _seeded_executor = transpiler.executor(backend=_seeded_backend)
 
 

--- a/docs/ja/tutorial/10_quantum_error_correction.py
+++ b/docs/ja/tutorial/10_quantum_error_correction.py
@@ -40,6 +40,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 transpiler = QiskitTranspiler()
 
+# Create a seeded backend for reproducible documentation output
+from qiskit_aer import AerSimulator
+
+_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_executor = transpiler.executor(backend=_seeded_backend)
+
 
 def _first_bit_distribution(result) -> dict[int, int]:
     """Return counts for the first measured bit."""
@@ -65,7 +71,7 @@ def _sample_first_bit(
         parameters=parameters or [],
     )
     job = executable.sample(
-        transpiler.executor(),
+        _seeded_executor,
         shots=shots,
         bindings=runtime_bindings or {},
     )

--- a/docs/ja/tutorial/11_steane_code.ipynb
+++ b/docs/ja/tutorial/11_steane_code.ipynb
@@ -20,9 +20,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "e0ba9ca5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.185929Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.185778Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.189419Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.188471Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# 最新のQamomileをpipからインストールします。\n",
@@ -33,9 +40,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "6e4a8152",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.191380Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.191199Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.318802Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.318068Z"
+    },
     "lines_to_next_cell": 2
    },
    "outputs": [],
@@ -123,9 +136,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "4412868f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.322772Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.322541Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.334347Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.333706Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -150,9 +170,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "fdd01ad7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.336658Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.335907Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.341369Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.340342Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -172,10 +199,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "8712d0ae",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.343007Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.342876Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.705101Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.703958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|0_L⟩ をエンコードして測定\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  偶重み Hamming 符号語の割合: 1.000\n",
+      "  観測された符号語数: 8\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"|0_L⟩ をエンコードして測定\")\n",
     "exe = transpiler.transpile(encode_zero_and_measure)\n",
@@ -218,9 +268,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6a4f4119",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.707890Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.707675Z",
+     "iopub.status.idle": "2026-04-28T05:53:05.738761Z",
+     "shell.execute_reply": "2026-04-28T05:53:05.737685Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -328,10 +385,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "f4f18801",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:05.741056Z",
+     "iopub.status.busy": "2026-04-28T05:53:05.740902Z",
+     "iopub.status.idle": "2026-04-28T05:53:09.799388Z",
+     "shell.execute_reply": "2026-04-28T05:53:09.798071Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Steane 符号: X/Y/Z × 7 位置の単一エラーを訂正\n",
+      "  誤り   | 位置    | |0_L⟩ 符号語\n",
+      "  -----+-------+-------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[1]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[2]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[3]  | 1.000\n",
+      "  X    | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  X    | q[5]  | 1.000\n",
+      "  X    | q[6]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[0]  | 1.000\n",
+      "  Y    | q[1]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[2]  | 1.000\n",
+      "  Y    | q[3]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Y    | q[5]  | 1.000\n",
+      "  Y    | q[6]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[0]  | 1.000\n",
+      "  Z    | q[1]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[2]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[3]  | 1.000\n",
+      "  Z    | q[4]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[5]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Z    | q[6]  | 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Steane 符号: X/Y/Z × 7 位置の単一エラーを訂正\")\n",
     "print(f\"  {'誤り':4s} | {'位置':5s} | |0_L⟩ 符号語\")\n",
@@ -379,9 +558,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0abf195c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:09.801420Z",
+     "iopub.status.busy": "2026-04-28T05:53:09.801239Z",
+     "iopub.status.idle": "2026-04-28T05:53:09.809694Z",
+     "shell.execute_reply": "2026-04-28T05:53:09.808768Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@qmc.qkernel\n",
@@ -427,10 +613,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "72224337",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:09.811913Z",
+     "iopub.status.busy": "2026-04-28T05:53:09.811765Z",
+     "iopub.status.idle": "2026-04-28T05:53:09.929583Z",
+     "shell.execute_reply": "2026-04-28T05:53:09.928585Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "横断的 H: |0_L⟩ -> |+_L⟩\n",
+      "  q[0]⊕q[1]⊕q[2] = 0 の割合: 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"横断的 H: |0_L⟩ -> |+_L⟩\")\n",
     "exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)\n",
@@ -452,10 +654,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "84ad8218",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T05:53:09.931440Z",
+     "iopub.status.busy": "2026-04-28T05:53:09.931281Z",
+     "iopub.status.idle": "2026-04-28T05:53:10.047294Z",
+     "shell.execute_reply": "2026-04-28T05:53:10.046320Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "横断的 H の round trip: |0_L⟩ -> H -> H -> |0_L⟩\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  |0_L⟩ 符号語の割合: 1.000\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"横断的 H の round trip: |0_L⟩ -> H -> H -> |0_L⟩\")\n",
     "exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)\n",
@@ -497,6 +721,18 @@
    "display_name": "qamomile",
    "language": "python",
    "name": "qamomile"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/docs/ja/tutorial/11_steane_code.ipynb
+++ b/docs/ja/tutorial/11_steane_code.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7427dcca",
+   "id": "50084bd6",
    "metadata": {},
    "source": [
     "# 量子誤り訂正(2): Steane [[7,1,3]] 符号\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e0ba9ca5",
+   "id": "f1a08acd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.185929Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.185778Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.189419Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.188471Z"
+     "iopub.execute_input": "2026-04-28T06:04:46.622868Z",
+     "iopub.status.busy": "2026-04-28T06:04:46.622720Z",
+     "iopub.status.idle": "2026-04-28T06:04:46.626537Z",
+     "shell.execute_reply": "2026-04-28T06:04:46.625386Z"
     }
    },
    "outputs": [],
@@ -41,13 +41,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6e4a8152",
+   "id": "2c91a161",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.191380Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.191199Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.318802Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.318068Z"
+     "iopub.execute_input": "2026-04-28T06:04:46.628425Z",
+     "iopub.status.busy": "2026-04-28T06:04:46.628265Z",
+     "iopub.status.idle": "2026-04-28T06:04:46.982651Z",
+     "shell.execute_reply": "2026-04-28T06:04:46.981427Z"
     },
     "lines_to_next_cell": 2
    },
@@ -57,6 +57,12 @@
     "from qamomile.qiskit import QiskitTranspiler\n",
     "\n",
     "transpiler = QiskitTranspiler()\n",
+    "\n",
+    "# Create a seeded backend for reproducible documentation output\n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
     "def _bits7(outcome) -> list[int]:\n",
@@ -79,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd21de65",
+   "id": "048e943b",
    "metadata": {},
    "source": [
     "## 1. Hamming 符号から CSS 符号へ\n",
@@ -116,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96752689",
+   "id": "39a395c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -137,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4412868f",
+   "id": "f6d477d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.322772Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.322541Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.334347Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.333706Z"
+     "iopub.execute_input": "2026-04-28T06:04:46.985012Z",
+     "iopub.status.busy": "2026-04-28T06:04:46.984809Z",
+     "iopub.status.idle": "2026-04-28T06:04:46.994739Z",
+     "shell.execute_reply": "2026-04-28T06:04:46.993432Z"
     }
    },
    "outputs": [],
@@ -171,13 +177,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fdd01ad7",
+   "id": "8a3d8695",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.336658Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.335907Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.341369Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.340342Z"
+     "iopub.execute_input": "2026-04-28T06:04:46.996848Z",
+     "iopub.status.busy": "2026-04-28T06:04:46.996689Z",
+     "iopub.status.idle": "2026-04-28T06:04:47.000769Z",
+     "shell.execute_reply": "2026-04-28T06:04:46.999754Z"
     }
    },
    "outputs": [],
@@ -191,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac5611dc",
+   "id": "b84aa626",
    "metadata": {},
    "source": [
     "エンコーダを測定して、出てくるビット列が偶重み Hamming 符号語だけになっているか確認します。"
@@ -200,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8712d0ae",
+   "id": "71f0f086",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.343007Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.342876Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.705101Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.703958Z"
+     "iopub.execute_input": "2026-04-28T06:04:47.002677Z",
+     "iopub.status.busy": "2026-04-28T06:04:47.002513Z",
+     "iopub.status.idle": "2026-04-28T06:04:47.131991Z",
+     "shell.execute_reply": "2026-04-28T06:04:47.130627Z"
     }
    },
    "outputs": [
@@ -214,13 +220,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "|0_L⟩ をエンコードして測定\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "|0_L⟩ をエンコードして測定\n",
       "  偶重み Hamming 符号語の割合: 1.000\n",
       "  観測された符号語数: 8\n"
      ]
@@ -229,7 +229,7 @@
    "source": [
     "print(\"|0_L⟩ をエンコードして測定\")\n",
     "exe = transpiler.transpile(encode_zero_and_measure)\n",
-    "result = exe.sample(transpiler.executor(), shots=1024).result()\n",
+    "result = exe.sample(_seeded_executor, shots=1024).result()\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
     "total = sum(count for _, count in result.results)\n",
     "print(f\"  偶重み Hamming 符号語の割合: {valid / total:.3f}\")\n",
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5dd1863c",
+   "id": "ab65ac1f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -269,13 +269,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6a4f4119",
+   "id": "fe743389",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.707890Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.707675Z",
-     "iopub.status.idle": "2026-04-28T05:53:05.738761Z",
-     "shell.execute_reply": "2026-04-28T05:53:05.737685Z"
+     "iopub.execute_input": "2026-04-28T06:04:47.134356Z",
+     "iopub.status.busy": "2026-04-28T06:04:47.134115Z",
+     "iopub.status.idle": "2026-04-28T06:04:47.164953Z",
+     "shell.execute_reply": "2026-04-28T06:04:47.163679Z"
     }
    },
    "outputs": [],
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9227b34a",
+   "id": "424d49e7",
    "metadata": {},
    "source": [
     "$X$, $Y$, $Z$ の全単一エラー、つまり 21 通りを実行します。訂正後に測定したビット列がすべて $\\lvert0_L\\rangle$ の符号語であれば成功です。"
@@ -386,13 +386,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f4f18801",
+   "id": "58253329",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:05.741056Z",
-     "iopub.status.busy": "2026-04-28T05:53:05.740902Z",
-     "iopub.status.idle": "2026-04-28T05:53:09.799388Z",
-     "shell.execute_reply": "2026-04-28T05:53:09.798071Z"
+     "iopub.execute_input": "2026-04-28T06:04:47.167067Z",
+     "iopub.status.busy": "2026-04-28T06:04:47.166911Z",
+     "iopub.status.idle": "2026-04-28T06:04:50.864278Z",
+     "shell.execute_reply": "2026-04-28T06:04:50.862957Z"
     }
    },
    "outputs": [
@@ -430,7 +430,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X    | q[3]  | 1.000\n",
+      "  X    | q[3]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  X    | q[4]  | 1.000\n"
      ]
     },
@@ -438,7 +444,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X    | q[5]  | 1.000\n",
+      "  X    | q[5]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  X    | q[6]  | 1.000\n"
      ]
     },
@@ -446,7 +458,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[0]  | 1.000\n",
+      "  Y    | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Y    | q[1]  | 1.000\n"
      ]
     },
@@ -454,7 +472,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[2]  | 1.000\n",
+      "  Y    | q[2]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Y    | q[3]  | 1.000\n"
      ]
     },
@@ -469,7 +493,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[5]  | 1.000\n",
+      "  Y    | q[5]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Y    | q[6]  | 1.000\n"
      ]
     },
@@ -477,7 +507,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[0]  | 1.000\n",
+      "  Z    | q[0]  | 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Z    | q[1]  | 1.000\n"
      ]
     },
@@ -485,21 +521,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[2]  | 1.000\n"
+      "  Z    | q[2]  | 1.000\n",
+      "  Z    | q[3]  | 1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z    | q[3]  | 1.000\n",
-      "  Z    | q[4]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Z    | q[4]  | 1.000\n",
       "  Z    | q[5]  | 1.000\n"
      ]
     },
@@ -522,7 +552,7 @@
     "            steane_run,\n",
     "            bindings={\"error_type\": error_type, \"error_pos\": pos},\n",
     "        )\n",
-    "        result = exe.sample(transpiler.executor(), shots=128).result()\n",
+    "        result = exe.sample(_seeded_executor, shots=128).result()\n",
     "        valid = sum(\n",
     "            count for outcome, count in result.results if _is_steane_zero_word(outcome)\n",
     "        )\n",
@@ -532,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebaaaa6b",
+   "id": "f9ec506f",
    "metadata": {},
    "source": [
     "すべて 1.000 になれば、どの位置の $X$, $Y$, $Z$ エラーでも $\\lvert0_L\\rangle$ の符号空間へ戻せています。$Y=iXZ$ なので、$Y$ エラーでは $X$ 成分と $Z$ 成分の両方が検出され、両方の訂正が入ります。"
@@ -540,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27298e17",
+   "id": "1029a836",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -559,13 +589,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0abf195c",
+   "id": "8f7138a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:09.801420Z",
-     "iopub.status.busy": "2026-04-28T05:53:09.801239Z",
-     "iopub.status.idle": "2026-04-28T05:53:09.809694Z",
-     "shell.execute_reply": "2026-04-28T05:53:09.808768Z"
+     "iopub.execute_input": "2026-04-28T06:04:50.866653Z",
+     "iopub.status.busy": "2026-04-28T06:04:50.866461Z",
+     "iopub.status.idle": "2026-04-28T06:04:50.874943Z",
+     "shell.execute_reply": "2026-04-28T06:04:50.873815Z"
     }
    },
    "outputs": [],
@@ -605,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c2bf487",
+   "id": "0bb90fb1",
    "metadata": {},
    "source": [
     "まず、$\\bar{H}\\lvert0_L\\rangle=\\lvert+_L\\rangle$ になっていることを確認します。$\\lvert+_L\\rangle$ は論理 $X$ の +1 固有状態なので、$X$ 基底で測ると $q_0 \\oplus q_1 \\oplus q_2 = 0$ になります。"
@@ -614,13 +644,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "72224337",
+   "id": "1fbd7cf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:09.811913Z",
-     "iopub.status.busy": "2026-04-28T05:53:09.811765Z",
-     "iopub.status.idle": "2026-04-28T05:53:09.929583Z",
-     "shell.execute_reply": "2026-04-28T05:53:09.928585Z"
+     "iopub.execute_input": "2026-04-28T06:04:50.876913Z",
+     "iopub.status.busy": "2026-04-28T06:04:50.876751Z",
+     "iopub.status.idle": "2026-04-28T06:04:50.996059Z",
+     "shell.execute_reply": "2026-04-28T06:04:50.994832Z"
     }
    },
    "outputs": [
@@ -636,7 +666,7 @@
    "source": [
     "print(\"横断的 H: |0_L⟩ -> |+_L⟩\")\n",
     "exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)\n",
-    "result_plus = exe_plus.sample(transpiler.executor(), shots=1024).result()\n",
+    "result_plus = exe_plus.sample(_seeded_executor, shots=1024).result()\n",
     "parity_zero = sum(\n",
     "    count for outcome, count in result_plus.results if _logical_x_parity(outcome) == 0\n",
     ")\n",
@@ -646,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a95031da",
+   "id": "c4dd05d1",
    "metadata": {},
    "source": [
     "次に、横断的 $H$ を2回当てると $\\bar{H}^2=I$ なので $\\lvert0_L\\rangle$ に戻ることを確認します。"
@@ -655,13 +685,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "84ad8218",
+   "id": "100ad95c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T05:53:09.931440Z",
-     "iopub.status.busy": "2026-04-28T05:53:09.931281Z",
-     "iopub.status.idle": "2026-04-28T05:53:10.047294Z",
-     "shell.execute_reply": "2026-04-28T05:53:10.046320Z"
+     "iopub.execute_input": "2026-04-28T06:04:50.998207Z",
+     "iopub.status.busy": "2026-04-28T06:04:50.998022Z",
+     "iopub.status.idle": "2026-04-28T06:04:51.111988Z",
+     "shell.execute_reply": "2026-04-28T06:04:51.111060Z"
     }
    },
    "outputs": [
@@ -683,7 +713,7 @@
    "source": [
     "print(\"横断的 H の round trip: |0_L⟩ -> H -> H -> |0_L⟩\")\n",
     "exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)\n",
-    "result_round_trip = exe_round_trip.sample(transpiler.executor(), shots=1024).result()\n",
+    "result_round_trip = exe_round_trip.sample(_seeded_executor, shots=1024).result()\n",
     "valid = sum(\n",
     "    count\n",
     "    for outcome, count in result_round_trip.results\n",
@@ -695,7 +725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffa692b4",
+   "id": "c404653c",
    "metadata": {},
    "source": [
     "## 5. まとめ\n",

--- a/docs/ja/tutorial/11_steane_code.ipynb
+++ b/docs/ja/tutorial/11_steane_code.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "50084bd6",
+   "id": "339f8bb8",
    "metadata": {},
    "source": [
     "# 量子誤り訂正(2): Steane [[7,1,3]] 符号\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f1a08acd",
+   "id": "ded2cdb6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:46.622868Z",
-     "iopub.status.busy": "2026-04-28T06:04:46.622720Z",
-     "iopub.status.idle": "2026-04-28T06:04:46.626537Z",
-     "shell.execute_reply": "2026-04-28T06:04:46.625386Z"
+     "iopub.execute_input": "2026-04-28T06:21:31.825856Z",
+     "iopub.status.busy": "2026-04-28T06:21:31.825707Z",
+     "iopub.status.idle": "2026-04-28T06:21:31.829518Z",
+     "shell.execute_reply": "2026-04-28T06:21:31.828644Z"
     }
    },
    "outputs": [],
@@ -41,13 +41,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2c91a161",
+   "id": "fedc343e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:46.628425Z",
-     "iopub.status.busy": "2026-04-28T06:04:46.628265Z",
-     "iopub.status.idle": "2026-04-28T06:04:46.982651Z",
-     "shell.execute_reply": "2026-04-28T06:04:46.981427Z"
+     "iopub.execute_input": "2026-04-28T06:21:31.831309Z",
+     "iopub.status.busy": "2026-04-28T06:21:31.831160Z",
+     "iopub.status.idle": "2026-04-28T06:21:32.152488Z",
+     "shell.execute_reply": "2026-04-28T06:21:32.150932Z"
     },
     "lines_to_next_cell": 2
    },
@@ -61,7 +61,7 @@
     "# Create a seeded backend for reproducible documentation output\n",
     "from qiskit_aer import AerSimulator\n",
     "\n",
-    "_seeded_backend = AerSimulator(seed_simulator=42)\n",
+    "_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)\n",
     "_seeded_executor = transpiler.executor(backend=_seeded_backend)\n",
     "\n",
     "\n",
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "048e943b",
+   "id": "ed171c29",
    "metadata": {},
    "source": [
     "## 1. Hamming 符号から CSS 符号へ\n",
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39a395c6",
+   "id": "fb6225f9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -143,13 +143,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f6d477d1",
+   "id": "be7c65fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:46.985012Z",
-     "iopub.status.busy": "2026-04-28T06:04:46.984809Z",
-     "iopub.status.idle": "2026-04-28T06:04:46.994739Z",
-     "shell.execute_reply": "2026-04-28T06:04:46.993432Z"
+     "iopub.execute_input": "2026-04-28T06:21:32.155107Z",
+     "iopub.status.busy": "2026-04-28T06:21:32.154812Z",
+     "iopub.status.idle": "2026-04-28T06:21:32.164529Z",
+     "shell.execute_reply": "2026-04-28T06:21:32.163436Z"
     }
    },
    "outputs": [],
@@ -177,13 +177,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8a3d8695",
+   "id": "c7f7b371",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:46.996848Z",
-     "iopub.status.busy": "2026-04-28T06:04:46.996689Z",
-     "iopub.status.idle": "2026-04-28T06:04:47.000769Z",
-     "shell.execute_reply": "2026-04-28T06:04:46.999754Z"
+     "iopub.execute_input": "2026-04-28T06:21:32.166521Z",
+     "iopub.status.busy": "2026-04-28T06:21:32.166303Z",
+     "iopub.status.idle": "2026-04-28T06:21:32.170716Z",
+     "shell.execute_reply": "2026-04-28T06:21:32.169915Z"
     }
    },
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b84aa626",
+   "id": "4783c8d4",
    "metadata": {},
    "source": [
     "エンコーダを測定して、出てくるビット列が偶重み Hamming 符号語だけになっているか確認します。"
@@ -206,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "71f0f086",
+   "id": "1c7a3dc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:47.002677Z",
-     "iopub.status.busy": "2026-04-28T06:04:47.002513Z",
-     "iopub.status.idle": "2026-04-28T06:04:47.131991Z",
-     "shell.execute_reply": "2026-04-28T06:04:47.130627Z"
+     "iopub.execute_input": "2026-04-28T06:21:32.172680Z",
+     "iopub.status.busy": "2026-04-28T06:21:32.172530Z",
+     "iopub.status.idle": "2026-04-28T06:21:32.295368Z",
+     "shell.execute_reply": "2026-04-28T06:21:32.294362Z"
     }
    },
    "outputs": [
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab65ac1f",
+   "id": "4e8428ea",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -269,13 +269,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fe743389",
+   "id": "af5d6afb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:47.134356Z",
-     "iopub.status.busy": "2026-04-28T06:04:47.134115Z",
-     "iopub.status.idle": "2026-04-28T06:04:47.164953Z",
-     "shell.execute_reply": "2026-04-28T06:04:47.163679Z"
+     "iopub.execute_input": "2026-04-28T06:21:32.297559Z",
+     "iopub.status.busy": "2026-04-28T06:21:32.297387Z",
+     "iopub.status.idle": "2026-04-28T06:21:32.327314Z",
+     "shell.execute_reply": "2026-04-28T06:21:32.326321Z"
     }
    },
    "outputs": [],
@@ -377,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "424d49e7",
+   "id": "5d8ee0c8",
    "metadata": {},
    "source": [
     "$X$, $Y$, $Z$ の全単一エラー、つまり 21 通りを実行します。訂正後に測定したビット列がすべて $\\lvert0_L\\rangle$ の符号語であれば成功です。"
@@ -386,13 +386,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "58253329",
+   "id": "921684d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:47.167067Z",
-     "iopub.status.busy": "2026-04-28T06:04:47.166911Z",
-     "iopub.status.idle": "2026-04-28T06:04:50.864278Z",
-     "shell.execute_reply": "2026-04-28T06:04:50.862957Z"
+     "iopub.execute_input": "2026-04-28T06:21:32.329410Z",
+     "iopub.status.busy": "2026-04-28T06:21:32.329246Z",
+     "iopub.status.idle": "2026-04-28T06:21:36.116461Z",
+     "shell.execute_reply": "2026-04-28T06:21:36.115389Z"
     }
    },
    "outputs": [
@@ -430,13 +430,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X    | q[3]  | 1.000\n"
+      "  X    | q[3]  | 1.000"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
       "  X    | q[4]  | 1.000\n"
      ]
     },
@@ -444,13 +445,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  X    | q[5]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  X    | q[5]  | 1.000\n",
       "  X    | q[6]  | 1.000\n"
      ]
     },
@@ -458,13 +453,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[0]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y    | q[0]  | 1.000\n",
       "  Y    | q[1]  | 1.000\n"
      ]
     },
@@ -472,13 +461,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[2]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y    | q[2]  | 1.000\n",
       "  Y    | q[3]  | 1.000\n"
      ]
     },
@@ -486,13 +469,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[4]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y    | q[4]  | 1.000\n",
       "  Y    | q[5]  | 1.000\n"
      ]
     },
@@ -500,13 +477,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Y    | q[6]  | 1.000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Y    | q[6]  | 1.000\n",
       "  Z    | q[0]  | 1.000\n"
      ]
     },
@@ -562,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9ec506f",
+   "id": "91dc1c6d",
    "metadata": {},
    "source": [
     "すべて 1.000 になれば、どの位置の $X$, $Y$, $Z$ エラーでも $\\lvert0_L\\rangle$ の符号空間へ戻せています。$Y=iXZ$ なので、$Y$ エラーでは $X$ 成分と $Z$ 成分の両方が検出され、両方の訂正が入ります。"
@@ -570,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1029a836",
+   "id": "9687008a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -589,13 +560,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "8f7138a8",
+   "id": "1c78f98e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:50.866653Z",
-     "iopub.status.busy": "2026-04-28T06:04:50.866461Z",
-     "iopub.status.idle": "2026-04-28T06:04:50.874943Z",
-     "shell.execute_reply": "2026-04-28T06:04:50.873815Z"
+     "iopub.execute_input": "2026-04-28T06:21:36.118368Z",
+     "iopub.status.busy": "2026-04-28T06:21:36.118207Z",
+     "iopub.status.idle": "2026-04-28T06:21:36.126370Z",
+     "shell.execute_reply": "2026-04-28T06:21:36.125408Z"
     }
    },
    "outputs": [],
@@ -635,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bb90fb1",
+   "id": "303561de",
    "metadata": {},
    "source": [
     "まず、$\\bar{H}\\lvert0_L\\rangle=\\lvert+_L\\rangle$ になっていることを確認します。$\\lvert+_L\\rangle$ は論理 $X$ の +1 固有状態なので、$X$ 基底で測ると $q_0 \\oplus q_1 \\oplus q_2 = 0$ になります。"
@@ -644,13 +615,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1fbd7cf4",
+   "id": "29b08678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:50.876913Z",
-     "iopub.status.busy": "2026-04-28T06:04:50.876751Z",
-     "iopub.status.idle": "2026-04-28T06:04:50.996059Z",
-     "shell.execute_reply": "2026-04-28T06:04:50.994832Z"
+     "iopub.execute_input": "2026-04-28T06:21:36.128605Z",
+     "iopub.status.busy": "2026-04-28T06:21:36.128463Z",
+     "iopub.status.idle": "2026-04-28T06:21:36.239321Z",
+     "shell.execute_reply": "2026-04-28T06:21:36.238226Z"
     }
    },
    "outputs": [
@@ -676,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4dd05d1",
+   "id": "082bc844",
    "metadata": {},
    "source": [
     "次に、横断的 $H$ を2回当てると $\\bar{H}^2=I$ なので $\\lvert0_L\\rangle$ に戻ることを確認します。"
@@ -685,13 +656,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "100ad95c",
+   "id": "e705542a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T06:04:50.998207Z",
-     "iopub.status.busy": "2026-04-28T06:04:50.998022Z",
-     "iopub.status.idle": "2026-04-28T06:04:51.111988Z",
-     "shell.execute_reply": "2026-04-28T06:04:51.111060Z"
+     "iopub.execute_input": "2026-04-28T06:21:36.241186Z",
+     "iopub.status.busy": "2026-04-28T06:21:36.241044Z",
+     "iopub.status.idle": "2026-04-28T06:21:36.353314Z",
+     "shell.execute_reply": "2026-04-28T06:21:36.352373Z"
     }
    },
    "outputs": [
@@ -725,7 +696,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c404653c",
+   "id": "2dc9b3f0",
    "metadata": {},
    "source": [
     "## 5. まとめ\n",

--- a/docs/ja/tutorial/11_steane_code.py
+++ b/docs/ja/tutorial/11_steane_code.py
@@ -40,7 +40,7 @@ transpiler = QiskitTranspiler()
 # Create a seeded backend for reproducible documentation output
 from qiskit_aer import AerSimulator
 
-_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_backend = AerSimulator(seed_simulator=42, max_parallel_threads=1)
 _seeded_executor = transpiler.executor(backend=_seeded_backend)
 
 

--- a/docs/ja/tutorial/11_steane_code.py
+++ b/docs/ja/tutorial/11_steane_code.py
@@ -37,6 +37,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 transpiler = QiskitTranspiler()
 
+# Create a seeded backend for reproducible documentation output
+from qiskit_aer import AerSimulator
+
+_seeded_backend = AerSimulator(seed_simulator=42)
+_seeded_executor = transpiler.executor(backend=_seeded_backend)
+
 
 def _bits7(outcome) -> list[int]:
     """Return seven measured bits in qubit-index order."""
@@ -137,7 +143,7 @@ def encode_zero_and_measure() -> qmc.Vector[qmc.Bit]:
 # %%
 print("|0_L⟩ をエンコードして測定")
 exe = transpiler.transpile(encode_zero_and_measure)
-result = exe.sample(transpiler.executor(), shots=1024).result()
+result = exe.sample(_seeded_executor, shots=1024).result()
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 total = sum(count for _, count in result.results)
 print(f"  偶重み Hamming 符号語の割合: {valid / total:.3f}")
@@ -277,7 +283,7 @@ for name, error_type in [("X", 1), ("Y", 2), ("Z", 3)]:
             steane_run,
             bindings={"error_type": error_type, "error_pos": pos},
         )
-        result = exe.sample(transpiler.executor(), shots=128).result()
+        result = exe.sample(_seeded_executor, shots=128).result()
         valid = sum(
             count for outcome, count in result.results if _is_steane_zero_word(outcome)
         )
@@ -339,7 +345,7 @@ def _logical_x_parity(outcome) -> int:
 # %%
 print("横断的 H: |0_L⟩ -> |+_L⟩")
 exe_plus = transpiler.transpile(transversal_hadamard_to_plus_l)
-result_plus = exe_plus.sample(transpiler.executor(), shots=1024).result()
+result_plus = exe_plus.sample(_seeded_executor, shots=1024).result()
 parity_zero = sum(
     count for outcome, count in result_plus.results if _logical_x_parity(outcome) == 0
 )
@@ -352,7 +358,7 @@ print(f"  q[0]⊕q[1]⊕q[2] = 0 の割合: {parity_zero / total_plus:.3f}")
 # %%
 print("横断的 H の round trip: |0_L⟩ -> H -> H -> |0_L⟩")
 exe_round_trip = transpiler.transpile(transversal_hadamard_round_trip)
-result_round_trip = exe_round_trip.sample(transpiler.executor(), shots=1024).result()
+result_round_trip = exe_round_trip.sample(_seeded_executor, shots=1024).result()
 valid = sum(
     count
     for outcome, count in result_round_trip.results


### PR DESCRIPTION
## Summary

- Execute tutorial notebooks that had no output cells to populate them with execution results
- Add seeded `AerSimulator` backend for reproducible documentation output
- Tutorials updated:
  - `09_compilation_and_transpilation.ipynb` (EN/JA) - executed only
  - `10_quantum_error_correction.ipynb` (EN/JA) - executed + seeded backend
  - `11_steane_code.ipynb` (EN/JA) - executed + seeded backend

## Details

These 6 tutorial notebooks had 0 cells with output. Ran them using `jupyter nbconvert --execute` to generate outputs for better documentation rendering.

For tutorials 10 and 11, added `AerSimulator(seed_simulator=42, max_parallel_threads=1)` to ensure reproducible sampling outputs across re-executions, matching the project's default `QiskitExecutor` settings.

## Test plan

- [x] Notebooks execute without errors
- [x] Output cells are properly populated
- [x] Seeded backend produces deterministic outputs

Slack thread: https://jij-inc.slack.com/archives/C092AL0MGTW/p1777355373800639

https://claude.ai/code/session_01GmHaDvbyJSrxS2Q3bHDYMU