### PR TITLE
Feature/alternating ansatz

### DIFF
--- a/qamomile/circuit/algorithm/__init__.py
+++ b/qamomile/circuit/algorithm/__init__.py
@@ -27,6 +27,13 @@ from .qaoa import (
     qaoa_state,
     x_mixer,
 )
+from .aoa import(
+    aoa_layers,
+    aoa_state,
+    hubo_aoa_layers,
+    hubo_aoa_state,
+    xy_mixer,
+)
 from .trotter import trotterized_time_evolution
 
 __all__ = [
@@ -38,6 +45,12 @@ __all__ = [
     "hubo_ising_cost",
     "hubo_qaoa_layers",
     "hubo_qaoa_state",
+    # AOA
+    "aoa_layers",
+    "aoa_state",
+    "hubo_aoa_layers",
+    "hubo_aoa_state",
+    "xy_mixer",
     # Basic layers
     "rx_layer",
     "ry_layer",

--- a/qamomile/circuit/algorithm/aoa.py
+++ b/qamomile/circuit/algorithm/aoa.py
@@ -1,0 +1,212 @@
+"""AOA (Alternating Operator Ansatz) circuit building blocks.
+
+This module provides the quantum circuit components for the Alternating Operator Ansatz (AOA), 
+including Givens circuit for efficient initial Dicke state preparation and xy mixer.
+
+All functions are decorated with ``@qm_c.qkernel`` and use Handle-typed
+parameters so they can be composed inside other ``@qkernel`` functions.
+"""
+
+import numpy as np
+
+import qamomile.circuit as qmc
+
+from . import basic as _basic
+from .qaoa import hubo_ising_cost, ising_cost
+
+@qmc.qkernel
+def xy_pair_rotation(
+    q: qmc.Vector[qmc.Qubit],
+    i: qmc.UInt,
+    j: qmc.UInt,
+    beta: qmc.Float,
+) -> qmc.Vector[qmc.Qubit]:
+    """
+    Apply exp(-i beta (X_i X_j + Y_i Y_j)) to qubits i and j.
+    The decomposition into CNOT,RX and RZ gates is exact.
+
+    Args:
+        q (qmc.Vector[qmc.Qubit]): Qubit register.
+        i (qmc.UInt): Index of the first qubit in the pair.
+        j (qmc.UInt): Index of the second qubit in the pair.
+        beta (qmc.Float): Rotation angle for the XY interaction.
+    
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register after applying the XY rotation.
+    """
+    q[i] = qmc.rx(q[i], -0.5 * np.pi)
+    q[j] = qmc.rx(q[j], 0.5 * np.pi)
+    q[i], q[j] = qmc.cx(q[i], q[j])
+    q[i] = qmc.rx(q[i], beta)
+    q[j] = qmc.rz(q[j], (-1.0) * beta)
+    q[i], q[j] = qmc.cx(q[i], q[j])
+    q[i] = qmc.rx(q[i], 0.5 * np.pi)
+    q[j] = qmc.rx(q[j], -0.5 * np.pi)
+    return q
+
+@qmc.qkernel
+def xy_mixer(
+    q: qmc.Vector[qmc.Qubit],
+    beta: qmc.Float,
+    pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """
+    Apply a parity XY mixer on each one-hot color register.
+
+    The Python side precomputes the qubit pairs for the parity schedule and
+    passes them as ``pair_indices``.
+
+    Args:
+        q (qmc.Vector[qmc.Qubit]): Qubit register.
+        beta (qmc.Float): Rotation angle for the XY interaction.
+        pair_indices (qmc.Matrix[qmc.UInt]): Matrix of shape (num_pairs, 2) containing the qubit index pairs for the XY mixer.
+    
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register after applying the XY mixer.
+    """
+    num_pairs = pair_indices.shape[0]
+
+    for pair_idx in qmc.range(num_pairs):
+        q = xy_pair_rotation(
+            q,
+            pair_indices[pair_idx, 0],
+            pair_indices[pair_idx, 1],
+            beta,
+        )
+
+    return q
+
+@qmc.qkernel
+def aoa_layers(
+    p: qmc.UInt,
+    quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+    linear: qmc.Dict[qmc.UInt, qmc.Float],
+    q: qmc.Vector[qmc.Qubit],
+    gammas: qmc.Vector[qmc.Float],
+    betas: qmc.Vector[qmc.Float],
+    pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Apply p layers of the AOA circuit (cost + XY mixer).
+
+    Each layer applies the Ising cost circuit followed by the XY mixer.
+
+    Args:
+        p (qmc.UInt): Number of AOA layers.
+        quad (qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float]):
+            Quadratic coefficients of the Ising model.
+        linear (qmc.Dict[qmc.UInt, qmc.Float]):
+            Linear coefficients of the Ising model.
+        q (qmc.Vector[qmc.Qubit]): Qubit register.
+        gammas (qmc.Vector[qmc.Float]): Cost-layer parameters, one per layer.
+        betas (qmc.Vector[qmc.Float]): Mixer-layer parameters, one per layer.
+        pair_indices (qmc.Matrix[qmc.UInt]): Qubit pairs for the XY mixer parity schedule.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register after all layers.
+    """
+    for layer in qmc.range(p):
+        q = ising_cost(quad, linear, q, gammas[layer])
+        q = xy_mixer(q, betas[layer], pair_indices)
+    return q
+
+@qmc.qkernel
+def aoa_state(
+    p: qmc.UInt,
+    quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+    linear: qmc.Dict[qmc.UInt, qmc.Float],
+    n: qmc.UInt,
+    gammas: qmc.Vector[qmc.Float],
+    betas: qmc.Vector[qmc.Float],
+    pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Generate AOA State for Ising model.
+
+    Args:
+        p (qmc.UInt): Number of AOA layers.
+        quad (qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float]):
+            Quadratic coefficients of the Ising model.
+        linear (qmc.Dict[qmc.UInt, qmc.Float]):
+            Linear coefficients of the Ising model.
+        n (qmc.UInt): Number of qubits.
+        gammas (qmc.Vector[qmc.Float]): Cost-layer parameters, one per layer.
+        betas (qmc.Vector[qmc.Float]): Mixer-layer parameters, one per layer.
+        pair_indices (qmc.Matrix[qmc.UInt]): Qubit pairs for the XY mixer parity schedule.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: AOA state vector.
+    """
+    q = _basic.superposition_vector(n)
+    q = aoa_layers(p, quad, linear, q, gammas, betas, pair_indices)
+    return q
+
+
+@qmc.qkernel
+def hubo_aoa_layers(
+    p: qmc.UInt,
+    quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+    linear: qmc.Dict[qmc.UInt, qmc.Float],
+    higher: qmc.Dict[qmc.Vector[qmc.UInt], qmc.Float],
+    q: qmc.Vector[qmc.Qubit],
+    gammas: qmc.Vector[qmc.Float],
+    betas: qmc.Vector[qmc.Float],
+    pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Apply p layers of the HUBO AOA circuit (cost + XY mixer).
+
+    Uses phase-gadget decomposition for higher-order terms in the cost layer,
+    then applies the XY mixer.
+
+    Args:
+        p (qmc.UInt): Number of AOA layers.
+        quad (qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float]):
+            Quadratic coefficients of the Ising model.
+        linear (qmc.Dict[qmc.UInt, qmc.Float]):
+            Linear coefficients of the Ising model.
+        higher (qmc.Dict[qmc.Vector[qmc.UInt], qmc.Float]):
+            Higher-order coefficients keyed by index vectors.
+        q (qmc.Vector[qmc.Qubit]): Qubit register.
+        gammas (qmc.Vector[qmc.Float]): Cost-layer parameters, one per layer.
+        betas (qmc.Vector[qmc.Float]): Mixer-layer parameters, one per layer.
+        pair_indices (qmc.Matrix[qmc.UInt]): Qubit pairs for the XY mixer parity schedule.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register after all layers.
+    """
+    for layer in qmc.range(p):
+        q = hubo_ising_cost(quad, linear, higher, q, gammas[layer])
+        q = xy_mixer(q, betas[layer], pair_indices)
+    return q
+
+
+@qmc.qkernel
+def hubo_aoa_state(
+    p: qmc.UInt,
+    quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+    linear: qmc.Dict[qmc.UInt, qmc.Float],
+    higher: qmc.Dict[qmc.Vector[qmc.UInt], qmc.Float],
+    n: qmc.UInt,
+    gammas: qmc.Vector[qmc.Float],
+    betas: qmc.Vector[qmc.Float],
+    pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Generate HUBO AOA state starting from the uniform superposition.
+
+    Args:
+        p (qmc.UInt): Number of AOA layers.
+        quad (qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float]):
+            Quadratic coefficients of the Ising model.
+        linear (qmc.Dict[qmc.UInt, qmc.Float]):
+            Linear coefficients of the Ising model.
+        higher (qmc.Dict[qmc.Vector[qmc.UInt], qmc.Float]):
+            Higher-order coefficients keyed by index vectors.
+        n (qmc.UInt): Number of qubits.
+        gammas (qmc.Vector[qmc.Float]): Cost-layer parameters, one per layer.
+        betas (qmc.Vector[qmc.Float]): Mixer-layer parameters, one per layer.
+        pair_indices (qmc.Matrix[qmc.UInt]): Qubit pairs for the XY mixer parity schedule.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: HUBO AOA state vector.
+    """
+    q = _basic.superposition_vector(n)
+    q = hubo_aoa_layers(p, quad, linear, higher, q, gammas, betas, pair_indices)
+    return q

--- a/qamomile/optimization/aoa.py
+++ b/qamomile/optimization/aoa.py
@@ -1,0 +1,354 @@
+"""Converter for the Alternating Operator Ansatz (AOA).
+
+AOA reuses the same Ising cost Hamiltonian as QAOA but replaces the standard
+X mixer with a constraint-aware XY mixer. The XY mixer schedule is encoded as a
+matrix of qubit pairs, which can either be supplied explicitly or generated
+from a named built-in schedule.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+import warnings
+
+import numpy as np
+
+import qamomile.circuit as qmc
+from qamomile.circuit.algorithm.aoa import aoa_state, hubo_aoa_state
+from qamomile.circuit.transpiler.executable import ExecutableProgram
+from qamomile.circuit.transpiler.transpiler import Transpiler
+
+from .qaoa import QAOAConverter
+
+MixerName = typ.Literal["ring", "fully-connected"]
+
+
+class AOAConverter(QAOAConverter):
+    """Converter for Alternating Operator Ansatz (AOA).
+
+    Extends :class:`QAOAConverter` by keeping the same Ising cost Hamiltonian
+    while replacing the X mixer with a configurable XY mixer schedule.
+
+    The mixer schedule can either be selected from built-in options such as a
+    ring mixer or a fully connected mixer, or passed explicitly as a matrix of
+    qubit index pairs.
+
+    Example:
+        >>> model = BinaryModel.from_hubo({(0, 1, 2): 1.0, (0,): -2.0})
+        >>> converter = AOAConverter(model)
+        >>> executable = converter.transpile(
+        ...     QiskitTranspiler(),
+        ...     p=2,
+        ...     mixer="ring",
+        ...     block_size=3,
+        ... )
+    """
+
+    def _normalize_pair_indices(self, pair_indices: np.ndarray) -> np.ndarray:
+        """Validate and normalize a user-provided pair schedule.
+
+        Args:
+            pair_indices: Array-like schedule of qubit pairs.
+
+        Returns:
+            numpy.ndarray: Pair schedule converted to ``uint64`` with shape
+            ``(num_pairs, 2)``.
+
+        Raises:
+            ValueError: If the provided schedule does not have shape
+                ``(num_pairs, 2)``.
+        """
+        normalized = np.asarray(pair_indices, dtype=np.uint64)
+        if normalized.ndim != 2 or normalized.shape[1] != 2:
+            raise ValueError("pair_indices must have shape (num_pairs, 2).")
+        return normalized
+
+    def _build_ring_pair_indices(self, num_blocks: int, block_size: int) -> np.ndarray:
+        """Build the parity-style ring XY mixer schedule.
+
+        Args:
+            num_blocks: Number of one-hot blocks.
+            block_size: Number of qubits per block.
+
+        Returns:
+            numpy.ndarray: Flattened list of qubit pairs implementing the ring
+            schedule over all blocks.
+        """
+        pairs: list[tuple[int, int]] = []
+        for block in range(num_blocks):
+            start = block * block_size
+            for i in range(0, block_size - 1, 2):
+                pairs.append((start + i, start + i + 1))
+            for i in range(1, block_size - 1, 2):
+                pairs.append((start + i, start + i + 1))
+            if block_size > 2:
+                pairs.append((start + block_size - 1, start))
+        return np.asarray(pairs, dtype=np.uint64)
+
+    def _partition_pairs(self, pair_indices: np.ndarray) -> list[list[tuple[int, int]]]:
+        """Greedily partition pairs into non-overlapping batches.
+
+        Args:
+            pair_indices: Array of qubit pairs with shape ``(num_pairs, 2)``.
+
+        Returns:
+            list[list[tuple[int, int]]]: List of partitions where pairs inside
+            each partition do not share any qubit.
+        """
+        partitions: list[list[tuple[int, int]]] = []
+        used_nodes_per_partition: list[set[int]] = []
+
+        for raw_left, raw_right in pair_indices:
+            left, right = int(raw_left), int(raw_right)
+            for partition, used_nodes in zip(partitions, used_nodes_per_partition):
+                if left not in used_nodes and right not in used_nodes:
+                    partition.append((left, right))
+                    used_nodes.update((left, right))
+                    break
+            else:
+                partitions.append([(left, right)])
+                used_nodes_per_partition.append({left, right})
+
+        return partitions
+
+    def _build_fully_connected_pair_indices(
+        self,
+        num_blocks: int,
+        block_size: int,
+    ) -> np.ndarray:
+        """Build a partitioned fully connected XY mixer schedule.
+
+        The method first enumerates all pairs inside each one-hot block, then
+        greedily partitions overlapping pairs into non-overlapping batches and
+        finally flattens those batches into a single execution order.
+
+        Args:
+            num_blocks: Number of one-hot blocks.
+            block_size: Number of qubits per block.
+
+        Returns:
+            numpy.ndarray: Flattened list of qubit pairs implementing the
+            fully connected schedule.
+        """
+        pairs: list[tuple[int, int]] = []
+        for block in range(num_blocks):
+            start = block * block_size
+            for i in range(block_size):
+                for j in range(i + 1, block_size):
+                    pairs.append((start + i, start + j))
+
+        partitions = self._partition_pairs(np.asarray(pairs, dtype=np.uint64))
+        flattened_pairs = [pair for partition in partitions for pair in partition]
+        return np.asarray(flattened_pairs, dtype=np.uint64)
+
+    def _resolve_pair_indices(
+        self,
+        *,
+        mixer: MixerName,
+        pair_indices: np.ndarray | None,
+        block_size: int | None,
+    ) -> np.ndarray:
+        """Resolve the XY mixer schedule into a validated pair matrix.
+
+        Args:
+            mixer: Name of the built-in mixer schedule to use when explicit
+                pair indices are not supplied.
+            pair_indices: Optional explicit array of qubit pairs with shape
+                ``(num_pairs, 2)``.
+            block_size: Size of each one-hot block used by the built-in mixer
+                schedule builders.
+
+        Returns:
+            numpy.ndarray: A validated ``uint64`` array of qubit pairs.
+
+        Raises:
+            ValueError: If neither explicit pairs nor a valid built-in mixer
+                configuration is provided.
+        """
+        if pair_indices is not None:
+            if mixer != "ring":
+                warnings.warn(
+                    f"pair_indices was provided; the mixer={mixer!r} argument is ignored.",
+                    stacklevel=3,
+                )
+            return self._normalize_pair_indices(pair_indices)
+
+        if block_size is None:
+            raise ValueError(
+                "block_size is required when pair_indices is not provided."
+            )
+
+        if block_size <= 1:
+            raise ValueError("block_size must be greater than 1.")
+
+        if self.spin_model.num_bits % block_size != 0:
+            raise ValueError(
+                "spin_model.num_bits must be divisible by block_size to build "
+                "a built-in AOA mixer schedule."
+            )
+
+        num_blocks = self.spin_model.num_bits // block_size
+        if mixer == "ring":
+            return self._build_ring_pair_indices(num_blocks, block_size)
+        if mixer == "fully-connected":
+            return self._build_fully_connected_pair_indices(num_blocks, block_size)
+        raise ValueError(
+            f"Unknown mixer {mixer!r}. Must be 'ring' or 'fully-connected' "
+            "when pair_indices is not provided."
+        )
+
+    def transpile(
+        self,
+        transpiler: Transpiler,
+        *,
+        p: int,
+        mixer: MixerName = "ring",
+        pair_indices: np.ndarray | None = None,
+        block_size: int | None = None,
+    ) -> ExecutableProgram:
+        """Transpile the model into an executable AOA circuit.
+
+        Dispatches to the quadratic-only fast path when no higher-order terms
+        are present, otherwise uses the HUBO path with phase-gadget
+        decomposition. The XY mixer schedule can be selected through a named
+        built-in mixer or provided directly as explicit qubit pairs.
+
+        Args:
+            transpiler (Transpiler): Backend transpiler to use.
+            p (int): Number of AOA layers.
+            mixer (Literal["ring", "fully-connected"]): Named built-in mixer
+                schedule to use when ``pair_indices`` is not provided.
+            pair_indices (numpy.ndarray | None): Explicit mixer schedule as an
+                array of shape ``(num_pairs, 2)``. When provided, ``mixer`` is
+                ignored.
+            block_size (int | None): Size of each one-hot block. Required when
+                ``pair_indices`` is not provided because built-in schedules need
+                the block structure.
+
+        Returns:
+            ExecutableProgram: The compiled circuit program.
+        """
+        resolved_pair_indices = self._resolve_pair_indices(
+            mixer=mixer,
+            pair_indices=pair_indices,
+            block_size=block_size,
+        )
+
+        if not self.spin_model.higher:
+            return self._transpile_quadratic(
+                transpiler,
+                p=p,
+                pair_indices=resolved_pair_indices,
+            )
+        return self._transpile_hubo(
+            transpiler,
+            p=p,
+            pair_indices=resolved_pair_indices,
+        )
+
+    def _transpile_quadratic(
+        self,
+        transpiler: Transpiler,
+        *,
+        p: int,
+        pair_indices: np.ndarray,
+    ) -> ExecutableProgram:
+        """Transpile a quadratic-only model using the AOA circuit.
+        
+        Args:
+            transpiler (Transpiler): Backend transpiler to use.
+            p (int): Number of AOA layers.
+            pair_indices (numpy.ndarray): Explicit mixer schedule as an array of
+                shape ``(num_pairs, 2)``.
+        
+        Returns:
+            ExecutableProgram: The compiled circuit program.
+        """
+
+        @qmc.qkernel
+        def aoa_sampling(
+            p: qmc.UInt,
+            quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            linear: qmc.Dict[qmc.UInt, qmc.Float],
+            gammas: qmc.Vector[qmc.Float],
+            betas: qmc.Vector[qmc.Float],
+            n: qmc.UInt,
+            pair_indices: qmc.Matrix[qmc.UInt],
+        ) -> qmc.Vector[qmc.Bit]:
+            q = aoa_state(
+                p=p,
+                quad=quad,
+                linear=linear,
+                n=n,
+                gammas=gammas,
+                betas=betas,
+                pair_indices=pair_indices,
+            )
+            return qmc.measure(q)
+
+        return transpiler.transpile(
+            aoa_sampling,
+            bindings={
+                "linear": self.spin_model.linear,
+                "quad": self.spin_model.quad,
+                "n": self.spin_model.num_bits,
+                "p": p,
+                "pair_indices": pair_indices,
+            },
+            parameters=["gammas", "betas"],
+        )
+
+    def _transpile_hubo(
+        self,
+        transpiler: Transpiler,
+        *,
+        p: int,
+        pair_indices: np.ndarray,
+    ) -> ExecutableProgram:
+        """Transpile a model with higher-order terms using the AOA circuit.
+        
+        Args:
+            transpiler (Transpiler): Backend transpiler to use.
+            p (int): Number of AOA layers.
+            pair_indices (numpy.ndarray): Explicit mixer schedule as an array of
+                shape ``(num_pairs, 2)``.
+
+        Returns:
+            ExecutableProgram: The compiled circuit program.
+        """
+
+        @qmc.qkernel
+        def aoa_sampling_hubo(
+            p: qmc.UInt,
+            quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            linear: qmc.Dict[qmc.UInt, qmc.Float],
+            higher: qmc.Dict[qmc.Vector[qmc.UInt], qmc.Float],
+            gammas: qmc.Vector[qmc.Float],
+            betas: qmc.Vector[qmc.Float],
+            n: qmc.UInt,
+            pair_indices: qmc.Matrix[qmc.UInt],
+        ) -> qmc.Vector[qmc.Bit]:
+            q = hubo_aoa_state(
+                p=p,
+                quad=quad,
+                linear=linear,
+                higher=higher,
+                n=n,
+                gammas=gammas,
+                betas=betas,
+                pair_indices=pair_indices,
+            )
+            return qmc.measure(q)
+
+        return transpiler.transpile(
+            aoa_sampling_hubo,
+            bindings={
+                "linear": self.spin_model.linear,
+                "quad": self.spin_model.quad,
+                "higher": self.spin_model.higher,
+                "n": self.spin_model.num_bits,
+                "p": p,
+                "pair_indices": pair_indices,
+            },
+            parameters=["gammas", "betas"],
+        )

--- a/tests/circuit/algorithm/test_aoa.py
+++ b/tests/circuit/algorithm/test_aoa.py
@@ -1,0 +1,114 @@
+"""Tests for qamomile/circuit/algorithm/aoa.py primitives."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("qiskit")
+
+import qamomile.circuit as qmc
+from qamomile.circuit.algorithm.aoa import aoa_state, xy_mixer, xy_pair_rotation
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _gate_counts(qc):
+	counts = {}
+	for inst in qc.data:
+		name = inst.operation.name
+		counts[name] = counts.get(name, 0) + 1
+	return counts
+
+
+@qmc.qkernel
+def _wrap_xy_pair_rotation(
+	n: qmc.UInt,
+	i: qmc.UInt,
+	j: qmc.UInt,
+	beta: qmc.Float,
+) -> qmc.Vector[qmc.Bit]:
+	q = qmc.qubit_array(n, name="q")
+	q = xy_pair_rotation(q, i, j, beta)
+	return qmc.measure(q)
+
+
+@qmc.qkernel
+def _wrap_xy_mixer(
+	n: qmc.UInt,
+	beta: qmc.Float,
+	pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Bit]:
+	q = qmc.qubit_array(n, name="q")
+	q = xy_mixer(q, beta, pair_indices)
+	return qmc.measure(q)
+
+
+@qmc.qkernel
+def _wrap_aoa_state(
+	p: qmc.UInt,
+	quad: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+	linear: qmc.Dict[qmc.UInt, qmc.Float],
+	n: qmc.UInt,
+	gammas: qmc.Vector[qmc.Float],
+	betas: qmc.Vector[qmc.Float],
+	pair_indices: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Bit]:
+	q = aoa_state(
+		p=p,
+		quad=quad,
+		linear=linear,
+		n=n,
+		gammas=gammas,
+		betas=betas,
+		pair_indices=pair_indices,
+	)
+	return qmc.measure(q)
+
+
+def test_xy_pair_rotation_gate_counts():
+	transpiler = QiskitTranspiler()
+	exe = transpiler.transpile(
+		_wrap_xy_pair_rotation,
+		bindings={"n": 2, "i": 0, "j": 1, "beta": 0.3},
+	)
+	qc = exe.compiled_quantum[0].circuit
+	counts = _gate_counts(qc)
+
+	assert counts.get("cx", 0) == 2
+	assert counts.get("rx", 0) == 5
+	assert counts.get("rz", 0) == 1
+
+
+def test_xy_mixer_gate_counts_scale_with_pairs():
+	pair_indices = np.asarray([(0, 1), (2, 3)], dtype=np.uint64)
+
+	transpiler = QiskitTranspiler()
+	exe = transpiler.transpile(
+		_wrap_xy_mixer,
+		bindings={"n": 4, "beta": 0.2, "pair_indices": pair_indices},
+	)
+	qc = exe.compiled_quantum[0].circuit
+	counts = _gate_counts(qc)
+
+	assert counts.get("cx", 0) == 2 * len(pair_indices)
+	assert counts.get("rx", 0) == 5 * len(pair_indices)
+	assert counts.get("rz", 0) == len(pair_indices)
+
+
+def test_aoa_state_includes_superposition_and_cost_layer():
+	transpiler = QiskitTranspiler()
+	exe = transpiler.transpile(
+		_wrap_aoa_state,
+		bindings={
+			"p": 1,
+			"quad": {(0, 1): 0.5},
+			"linear": {0: -0.2},
+			"n": 2,
+			"gammas": [0.3],
+			"betas": [0.2],
+			"pair_indices": np.asarray([(0, 1)], dtype=np.uint64),
+		},
+	)
+	qc = exe.compiled_quantum[0].circuit
+	counts = _gate_counts(qc)
+
+	assert counts.get("h", 0) == 2
+	assert counts.get("rzz", 0) == 1

--- a/tests/optimization/test_aoa.py
+++ b/tests/optimization/test_aoa.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("qiskit")
+
+from qamomile.optimization.aoa import AOAConverter
+from qamomile.optimization.binary_model import BinaryModel
+from qamomile.qiskit.transpiler import QiskitTranspiler
+
+
+def _make_4bit_quadratic_model() -> BinaryModel:
+	return BinaryModel.from_hubo(
+		{
+			(0, 1): 1.0,
+			(2, 3): -0.5,
+			(0,): 0.2,
+			(1,): -0.3,
+			(2,): 0.1,
+			(3,): -0.4,
+		}
+	)
+
+
+def test_ring_pair_indices_block_size_two_has_no_duplicates():
+	converter = AOAConverter(_make_4bit_quadratic_model())
+
+	pair_indices = converter._resolve_pair_indices(
+		mixer="ring",
+		pair_indices=None,
+		block_size=2,
+	)
+
+	expected = np.asarray([(0, 1), (2, 3)], dtype=np.uint64)
+	np.testing.assert_array_equal(pair_indices, expected)
+
+
+def test_explicit_pair_indices_warn_when_mixer_is_ignored():
+	converter = AOAConverter(_make_4bit_quadratic_model())
+	explicit = np.asarray([(0, 1), (2, 3)], dtype=np.uint64)
+
+	with pytest.warns(UserWarning, match="mixer=.*ignored"):
+		resolved = converter._resolve_pair_indices(
+			mixer="fully-connected",
+			pair_indices=explicit,
+			block_size=2,
+		)
+
+	assert resolved.dtype == np.uint64
+	np.testing.assert_array_equal(resolved, explicit)
+
+
+def test_invalid_mixer_error_contains_value():
+	converter = AOAConverter(_make_4bit_quadratic_model())
+
+	with pytest.raises(ValueError, match="Unknown mixer 'invalid'"):
+		converter._resolve_pair_indices(
+			mixer="invalid",  # type: ignore[arg-type]
+			pair_indices=None,
+			block_size=2,
+		)
+
+
+def test_transpile_with_custom_pair_indices_smoke():
+	model = BinaryModel.from_hubo({(0, 1): 1.0, (0,): -0.2})
+	converter = AOAConverter(model)
+	transpiler = QiskitTranspiler()
+
+	executable = converter.transpile(
+		transpiler,
+		p=1,
+		pair_indices=np.asarray([(0, 1)], dtype=np.uint64),
+	)
+
+	job = executable.sample(
+		transpiler.executor(),
+		shots=8,
+		bindings={"gammas": [0.2], "betas": [0.3]},
+	)
+	result = job.result()
+
+	assert len(result.results) > 0
+	for sample, count in result.results:
+		assert len(sample) == model.num_bits
+		assert count > 0


### PR DESCRIPTION
## Summary

Adds Qamomile support for the Alternating Operator Ansatz (AOA).

This includes:

* XY rotation mixers with different architectures
* Efficient preparation of Dicke states as initial states (in progress)

## Motivation

AOA extends QAOA by enabling constrained optimization via XY mixers and structured initial states (e.g., Dicke states).

## Files

* `qamomile/circuit/algorithm/aoa.py` — qkernel implementation for AOA using XY mixers
* `qamomile/optimization/aoa.py` — converter supporting different XY mixer architectures
* `tests/circuit/algorithm/test_aoa.py` — tests for AOA qkernel (partial)
* `tests/optimization/test_aoa.py` — tests for AOA converter (partial)

## Implementation choices

* `AOAConverter` subclasses `QAOAConverter`
* `get_cost_hamiltonian()` is reused from the parent class
* `transpile()` is overridden to support XY mixers

## Status

* [x] Implement XY mixers
* [ ] Implement Dicke state preparation
* [ ] Tests (in progress)
* [ ] Documentation / tutorial

## How to test

Example:

```python
from qamomile.optimization.aoa import AOAConverter

converter = AOAConverter(instance)
converter.transpile(transpiler, p=1, mixer="fully-connected", block_size=2)
```

Run tests:

```bash
uv run pytest tests/circuit/algorithm/test_aoa.py
uv run pytest tests/optimization/test_aoa.py
```

## Notes

* Opening as draft for early feedback on API and design
* Happy to adjust implementation if needed
