### PR TITLE
docs(claude): refresh pipeline + add design / workflow rules

### DIFF
--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -158,11 +158,10 @@ def _find_at_mentions(message: str) -> list[str]:
 
     The ``@`` must be at a token boundary — i.e., NOT preceded by an
     alphanumeric, ``.``, ``_``, or ``-`` character. This intentionally
-    skips email addresses (``noreply@anthropic.com``) and ssh-style URLs
-    (``git@github.com``), which GitHub's own mention parser also ignores
-    for the same boundary reason. Without this, the Co-Authored-By
-    trailer the harness asks Claude to add to every commit (containing
-    ``<noreply@anthropic.com>``) would be falsely rejected.
+    skips email addresses (for example ``noreply@example.com``) and
+    ssh-style URLs (for example ``git@github.com``), so they are not
+    misclassified as user mentions. GitHub's own mention parser also
+    ignores these forms for the same boundary reason.
 
     Args:
         message: The commit-message text after extraction.

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -3,23 +3,29 @@
 
 Reads PreToolUse hook input from stdin (the standard hook payload schema —
 ``tool_name``, ``tool_input.command``). When the Bash command is a ``git
-commit`` whose message contains an ``@<word>`` token outside of
-backtick-wrapped code, prints a ``permissionDecision`` of ``deny`` with a
-clear reason; otherwise prints ``{}`` and exits 0.
+commit`` and the script can extract the proposed message text, it scans
+the text and prints a ``permissionDecision`` of ``deny`` with a clear
+reason if a bare ``@<word>`` token appears outside of backtick-wrapped
+code; otherwise prints ``{}`` and exits 0.
 
-This enforces the project's ``### No @-mentions`` rule from ``CLAUDE.md`` —
-it cannot be bypassed by a forgetful agent because the harness runs this
-hook before the Bash tool actually executes the commit.
-
-Recognized commit-message forms:
+**Best-effort enforcement** of the project's ``### No @-mentions`` rule
+from ``CLAUDE.md``. The script handles the commit-message forms most
+commonly produced by Claude Code:
 
 - ``git commit -m "single-line"`` / ``git commit -m 'single-line'``
-- ``git commit -m "$(cat <<'EOF' ... EOF)"`` (HEREDOC)
-- ``git commit -m "$(cat <<EOF ... EOF)"``
+- ``git commit -m "$(cat <<'EOF' ... EOF)"`` (HEREDOC, quoted or unquoted
+  delimiter, with or without surrounding quotes around the subshell)
+- Multiple ``-m`` flags (each contribution treated as its own paragraph,
+  matching ``git commit``'s own concatenation behavior)
 
-Forms not recognized fall open (allow) — better to under-block than to
-falsely reject a legitimate commit. The script only ever rejects when it
-has positively identified a bare ``@``-mention in extracted message text.
+Forms the script intentionally does **not** inspect — and which therefore
+fall open (allow) — include editor-based commits (no ``-m``), ``-F`` /
+``--file``, ``--amend`` reusing a previous message, custom shell
+wrappers, and any commit whose message extraction fails. A fall-open
+result is preferred over a false-positive that would block a legitimate
+commit. Treat this hook as a strong nudge against casual mistakes, not a
+complete enforcement boundary; the underlying rule still has to be
+followed by humans and agents in cases the script can't see.
 """
 
 from __future__ import annotations
@@ -32,40 +38,79 @@ import sys
 def _extract_commit_message(command: str) -> str | None:
     """Return the proposed commit-message text from a ``git commit`` command.
 
+    Iterates every ``-m`` flag in the command (``git commit`` concatenates
+    multiple ``-m`` values into one message, joined by blank lines) and,
+    for each, tries the recognized argument forms in order:
+
+    1. ``-m "$(cat <<EOF ... EOF)"`` / ``-m '$(cat <<EOF ... EOF)'`` /
+       ``-m $(cat <<EOF ... EOF)`` — HEREDOC inside a subshell, with
+       optional surrounding quotes; quoted (``<<'EOF'``) and unquoted
+       (``<<EOF``) delimiter variants.
+    2. ``-m "..."`` (plain double-quoted, escapes allowed).
+    3. ``-m '...'`` (plain single-quoted, no shell escapes inside).
+
+    All matched ``-m`` segments are joined by a blank line so the
+    downstream scanner sees the full effective message, matching what
+    ``git commit`` itself would record.
+
     Args:
         command: The full Bash command string as captured in
             ``tool_input.command``.
 
     Returns:
-        The extracted message body (subject + body, joined by newlines),
-        or ``None`` when the command is not a ``git commit`` or the
-        message could not be located in any recognized form.
+        The concatenated message body, or ``None`` when the command is
+        not a ``git commit`` or no recognized ``-m`` argument could be
+        located. ``None`` causes the caller to fall open (allow).
     """
     if not re.search(r"\bgit\s+commit\b", command):
         return None
 
-    # 1) HEREDOC form: ``-m "$(cat <<'EOF' ... EOF)"`` or ``<<EOF ... EOF``.
-    #    The terminator must appear at the start of a line. We allow the
-    #    quoted (``<<'EOF'``) and unquoted (``<<EOF``) variants.
-    heredoc_match = re.search(
-        r"<<-?\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\s*$",
-        command,
-        re.DOTALL | re.MULTILINE,
-    )
-    if heredoc_match:
-        return heredoc_match.group(2)
+    messages: list[str] = []
 
-    # 2) Plain single-quoted: ``-m '...'`` (no escapes inside in shell).
-    plain_single = re.search(r"-m\s+'((?:[^'\\]|\\.)*)'", command, re.DOTALL)
-    if plain_single:
-        return plain_single.group(1)
+    # Walk every ``-m`` flag in order. ``\b`` keeps us from misfiring on
+    # ``--message-id`` style long flags. ``re.MULTILINE`` is unnecessary
+    # because ``-m`` is matched against the raw command string.
+    for flag_match in re.finditer(r"(?:^|\s)-m\b", command):
+        remainder = command[flag_match.end() :]
 
-    # 3) Plain double-quoted: ``-m "..."`` allowing escaped ``\"``.
-    plain_double = re.search(r'-m\s+"((?:[^"\\]|\\.)*)"', command, re.DOTALL)
-    if plain_double:
-        return plain_double.group(1)
+        # 1) HEREDOC inside a subshell. Surrounding quote (if any) before
+        #    ``$(`` and after ``)`` must match. The closing ``\1`` must be
+        #    on its own line; ``re.DOTALL`` lets ``.*?`` span newlines.
+        heredoc_match = re.match(
+            r'\s+(["\']?)\$\(\s*cat\s+<<-?\s*[\'"]?(\w+)[\'"]?\s*\n'
+            r"(.*?)\n\2\s*\)\1",
+            remainder,
+            re.DOTALL,
+        )
+        if heredoc_match:
+            messages.append(heredoc_match.group(3))
+            continue
 
-    return None
+        # 2) Plain double-quoted with escape handling.
+        plain_double = re.match(
+            r'\s+"((?:[^"\\]|\\.)*)"',
+            remainder,
+            re.DOTALL,
+        )
+        if plain_double:
+            messages.append(plain_double.group(1))
+            continue
+
+        # 3) Plain single-quoted (shell does not interpret escapes here).
+        plain_single = re.match(
+            r"\s+'((?:[^'\\]|\\.)*)'",
+            remainder,
+            re.DOTALL,
+        )
+        if plain_single:
+            messages.append(plain_single.group(1))
+            continue
+
+    if not messages:
+        return None
+
+    # ``git commit`` joins multiple ``-m`` values with a blank line.
+    return "\n\n".join(messages)
 
 
 def _strip_backtick_code(text: str) -> str:

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -90,6 +90,14 @@ def _strip_backtick_code(text: str) -> str:
 def _find_at_mentions(message: str) -> list[str]:
     """Return every ``@<word>``-style token outside of backtick-wrapped code.
 
+    The ``@`` must be at a token boundary — i.e., NOT preceded by an
+    alphanumeric, ``.``, ``_``, or ``-`` character. This intentionally
+    skips email addresses (``noreply@anthropic.com``) and ssh-style URLs
+    (``git@github.com``), which GitHub's own mention parser also ignores
+    for the same boundary reason. Without this, the Co-Authored-By
+    trailer the harness asks Claude to add to every commit (containing
+    ``<noreply@anthropic.com>``) would be falsely rejected.
+
     Args:
         message: The commit-message text after extraction.
 
@@ -101,7 +109,10 @@ def _find_at_mentions(message: str) -> list[str]:
         decorator references like ``@qkernel``.
     """
     stripped = _strip_backtick_code(message)
-    return re.findall(r"@[A-Za-z0-9][A-Za-z0-9_/-]*", stripped)
+    return re.findall(
+        r"(?<![A-Za-z0-9._-])@[A-Za-z0-9][A-Za-z0-9_/-]*",
+        stripped,
+    )
 
 
 def _allow() -> None:

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -82,64 +82,94 @@ def _extract_commit_message(command: str) -> str | None:
         return None
 
     messages: list[str] = []
+    pos = 0
+    flag_re = re.compile(r"(?:^|\s)-[a-zA-Z]*m\b")
 
-    # Walk every short-option group whose trailing flag is ``m`` —
-    # matches a bare ``-m`` as well as ``-am`` / ``-sm`` / ``-asm`` /
-    # any combination of letters followed by ``m\b``. ``getopt`` requires
-    # ``m`` to be last because it takes a value, so this pattern is
-    # complete for the realistic Claude Code-produced shapes. Long flags
-    # like ``--message-id`` are not matched (they start with ``--``).
-    for flag_match in re.finditer(r"(?:^|\s)-[a-zA-Z]*m\b", command):
-        remainder = command[flag_match.end() :]
-
-        # ``\s*`` (not ``\s+``) lets us also match the no-space attached
-        # forms ``-m"msg"`` / ``-am'msg'`` / ``-am$(cat <<EOF...)``, which
-        # ``git commit`` accepts. The flag walker's trailing ``\b`` already
-        # ensures the position is right before a non-word character (``"``,
-        # ``'``, or ``$``), so ``\s*`` only allows the optional separator.
-        #
-        # 1) HEREDOC inside a subshell. Surrounding quote (if any) before
-        #    ``$(`` and after ``)`` must match. The closing ``\1`` must be
-        #    on its own line; ``re.DOTALL`` lets ``.*?`` span newlines.
-        heredoc_match = re.match(
-            r'\s*(["\']?)\$\(\s*cat\s+<<-?\s*[\'"]?(\w+)[\'"]?\s*\n'
-            r"(.*?)\n\2\s*\)\1",
-            remainder,
-            re.DOTALL,
-        )
-        if heredoc_match:
-            messages.append(heredoc_match.group(3))
+    # Walk forward through the command, *advancing past each consumed
+    # message segment*, so a literal ``-m`` substring inside a previously
+    # extracted message body cannot be re-scanned as another flag.
+    # ``re.finditer`` over the full command would be vulnerable to that
+    # — e.g., ``git commit -m "msg with -m inside"`` would surface the
+    # inner ``-m`` as a phantom flag. Sequential search avoids it
+    # entirely.
+    while pos < len(command):
+        flag_match = flag_re.search(command, pos)
+        if flag_match is None:
+            break
+        result = _try_match_flag_value(command[flag_match.end() :])
+        if result is None:
+            # No recognized value form after this flag — skip just past
+            # the flag (treat as fall-through; the actual ``git commit``
+            # invocation may be malformed, in which case the hook falls
+            # open and ``git commit`` itself will surface the error).
+            pos = flag_match.end()
             continue
-
-        # 2) Plain double-quoted with shell-style escape handling
-        #    (``\"``, ``\\``, etc.).
-        plain_double = re.match(
-            r'\s*"((?:[^"\\]|\\.)*)"',
-            remainder,
-            re.DOTALL,
-        )
-        if plain_double:
-            messages.append(plain_double.group(1))
-            continue
-
-        # 3) Plain single-quoted: POSIX single quotes are LITERAL — no
-        #    escape interpretation, no embedded ``'``. Match any non-quote
-        #    character. Backslashes inside (Windows paths, regex
-        #    fragments) pass through unchanged.
-        plain_single = re.match(
-            r"\s*'([^']*)'",
-            remainder,
-            re.DOTALL,
-        )
-        if plain_single:
-            messages.append(plain_single.group(1))
-            continue
+        value, consumed = result
+        messages.append(value)
+        pos = flag_match.end() + consumed
 
     if not messages:
         return None
 
     # ``git commit`` joins multiple ``-m`` values with a blank line.
     return "\n\n".join(messages)
+
+
+def _try_match_flag_value(remainder: str) -> tuple[str, int] | None:
+    """Try the three recognized argument forms on the text after a flag.
+
+    ``\\s*`` (not ``\\s+``) lets us also match the no-space attached
+    forms ``-m"msg"`` / ``-am'msg'`` / ``-am$(cat <<EOF...)``, which
+    ``git commit`` accepts. The flag walker's trailing ``\\b`` already
+    ensures the position is right before a non-word character (``"``,
+    ``'``, or ``$``), so ``\\s*`` only allows the optional separator.
+
+    Args:
+        remainder: The slice of the command immediately after a matched
+            ``-m``-bearing flag (i.e., ``command[flag_match.end():]``).
+
+    Returns:
+        ``(value, consumed_chars)`` on a successful match, where
+        ``value`` is the extracted message text and ``consumed_chars``
+        is the number of characters of ``remainder`` taken by the
+        flag's value (used by the caller to advance past the segment).
+        ``None`` when none of the three forms match.
+    """
+    # 1) HEREDOC inside a subshell. Surrounding quote (if any) before
+    #    ``$(`` and after ``)`` must match. The closing ``\1`` must be
+    #    on its own line; ``re.DOTALL`` lets ``.*?`` span newlines.
+    heredoc_match = re.match(
+        r'\s*(["\']?)\$\(\s*cat\s+<<-?\s*[\'"]?(\w+)[\'"]?\s*\n'
+        r"(.*?)\n\2\s*\)\1",
+        remainder,
+        re.DOTALL,
+    )
+    if heredoc_match:
+        return heredoc_match.group(3), heredoc_match.end()
+
+    # 2) Plain double-quoted with shell-style escape handling
+    #    (``\"``, ``\\``, etc.).
+    plain_double = re.match(
+        r'\s*"((?:[^"\\]|\\.)*)"',
+        remainder,
+        re.DOTALL,
+    )
+    if plain_double:
+        return plain_double.group(1), plain_double.end()
+
+    # 3) Plain single-quoted: POSIX single quotes are LITERAL — no
+    #    escape interpretation, no embedded ``'``. Match any non-quote
+    #    character. Backslashes inside (Windows paths, regex
+    #    fragments) pass through unchanged.
+    plain_single = re.match(
+        r"\s*'([^']*)'",
+        remainder,
+        re.DOTALL,
+    )
+    if plain_single:
+        return plain_single.group(1), plain_single.end()
+
+    return None
 
 
 def _strip_backtick_code(text: str) -> str:

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Block ``git commit`` invocations whose message contains a bare ``@``-mention.
+
+Reads PreToolUse hook input from stdin (the standard hook payload schema —
+``tool_name``, ``tool_input.command``). When the Bash command is a ``git
+commit`` whose message contains an ``@<word>`` token outside of
+backtick-wrapped code, prints a ``permissionDecision`` of ``deny`` with a
+clear reason; otherwise prints ``{}`` and exits 0.
+
+This enforces the project's ``### No @-mentions`` rule from ``CLAUDE.md`` —
+it cannot be bypassed by a forgetful agent because the harness runs this
+hook before the Bash tool actually executes the commit.
+
+Recognized commit-message forms:
+
+- ``git commit -m "single-line"`` / ``git commit -m 'single-line'``
+- ``git commit -m "$(cat <<'EOF' ... EOF)"`` (HEREDOC)
+- ``git commit -m "$(cat <<EOF ... EOF)"``
+
+Forms not recognized fall open (allow) — better to under-block than to
+falsely reject a legitimate commit. The script only ever rejects when it
+has positively identified a bare ``@``-mention in extracted message text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def _extract_commit_message(command: str) -> str | None:
+    """Return the proposed commit-message text from a ``git commit`` command.
+
+    Args:
+        command: The full Bash command string as captured in
+            ``tool_input.command``.
+
+    Returns:
+        The extracted message body (subject + body, joined by newlines),
+        or ``None`` when the command is not a ``git commit`` or the
+        message could not be located in any recognized form.
+    """
+    if not re.search(r"\bgit\s+commit\b", command):
+        return None
+
+    # 1) HEREDOC form: ``-m "$(cat <<'EOF' ... EOF)"`` or ``<<EOF ... EOF``.
+    #    The terminator must appear at the start of a line. We allow the
+    #    quoted (``<<'EOF'``) and unquoted (``<<EOF``) variants.
+    heredoc_match = re.search(
+        r"<<-?\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\s*$",
+        command,
+        re.DOTALL | re.MULTILINE,
+    )
+    if heredoc_match:
+        return heredoc_match.group(2)
+
+    # 2) Plain single-quoted: ``-m '...'`` (no escapes inside in shell).
+    plain_single = re.search(r"-m\s+'((?:[^'\\]|\\.)*)'", command, re.DOTALL)
+    if plain_single:
+        return plain_single.group(1)
+
+    # 3) Plain double-quoted: ``-m "..."`` allowing escaped ``\"``.
+    plain_double = re.search(r'-m\s+"((?:[^"\\]|\\.)*)"', command, re.DOTALL)
+    if plain_double:
+        return plain_double.group(1)
+
+    return None
+
+
+def _strip_backtick_code(text: str) -> str:
+    """Remove fenced (``\\`\\`\\`...\\`\\`\\```) and inline (``\\`...\\```) code spans.
+
+    Args:
+        text: The candidate commit-message text.
+
+    Returns:
+        ``text`` with all backtick-wrapped code spans replaced by spaces so
+        ``@`` characters inside them are not flagged. Spaces preserve token
+        offsets in case future error reporting wants to point at a column.
+    """
+    # Fenced code blocks first (greedy across newlines, but non-greedy for
+    # the closing fence to avoid swallowing the whole message).
+    text = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    # Then inline code spans (single line).
+    text = re.sub(r"`[^`\n]*`", " ", text)
+    return text
+
+
+def _find_at_mentions(message: str) -> list[str]:
+    """Return every ``@<word>``-style token outside of backtick-wrapped code.
+
+    Args:
+        message: The commit-message text after extraction.
+
+    Returns:
+        A list of matched tokens in source order (duplicates preserved so
+        the caller can choose to dedupe). Each token starts with ``@`` and
+        is followed by one or more characters from
+        ``[A-Za-z0-9_/-]`` — covers ``@username``, ``@org/team``, and bare
+        decorator references like ``@qkernel``.
+    """
+    stripped = _strip_backtick_code(message)
+    return re.findall(r"@[A-Za-z0-9][A-Za-z0-9_/-]*", stripped)
+
+
+def _allow() -> None:
+    """Emit an empty hook response (no decision) and exit 0."""
+    print(json.dumps({}))
+    sys.exit(0)
+
+
+def _deny(mentions: list[str]) -> None:
+    """Emit a PreToolUse ``deny`` decision with an actionable reason.
+
+    Args:
+        mentions: The matched ``@<word>`` tokens (deduped before being
+            interpolated into the user-facing reason string).
+    """
+    unique = sorted(set(mentions))
+    reason = (
+        "Commit message contains bare @-mention(s): "
+        f"{', '.join(unique)}.\n\n"
+        "Project rule (CLAUDE.md '### No @-mentions'): never write @username, "
+        "@org/team, or bare Python decorators like @qkernel in commit messages, "
+        "PR / issue titles or bodies, or review comments — they trigger "
+        "unintended GitHub mention rendering / notifications.\n\n"
+        "Fix: rewrite the offending token in descriptive prose "
+        '(e.g. "the qkernel decorator" instead of @qkernel), or — only if the '
+        "code form is genuinely required — wrap it in backticks (`@qkernel`). "
+        "Then redo the commit."
+    )
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+def main() -> None:
+    """Hook entry point.
+
+    Reads JSON from stdin, decides allow / deny based on the commit message
+    body, and prints the resulting hook response to stdout. Any unexpected
+    exception falls open (allow) so the hook is never the cause of a
+    blocked legitimate commit.
+    """
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, OSError):
+        _allow()
+        return
+
+    if data.get("tool_name") != "Bash":
+        _allow()
+        return
+
+    command = data.get("tool_input", {}).get("command", "")
+    if not isinstance(command, str):
+        _allow()
+        return
+
+    message = _extract_commit_message(command)
+    if message is None:
+        _allow()
+        return
+
+    mentions = _find_at_mentions(message)
+    if not mentions:
+        _allow()
+        return
+
+    _deny(mentions)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -120,9 +120,11 @@ def _strip_backtick_code(text: str) -> str:
         text: The candidate commit-message text.
 
     Returns:
-        ``text`` with all backtick-wrapped code spans replaced by spaces so
-        ``@`` characters inside them are not flagged. Spaces preserve token
-        offsets in case future error reporting wants to point at a column.
+        ``text`` with all backtick-wrapped code spans replaced by a single
+        space each, so ``@`` characters inside them are not flagged. The
+        replacement is intentionally not length-preserving — the downstream
+        scanner only needs to know whether a bare ``@<word>`` exists, not
+        where it is in the original message.
     """
     # Fenced code blocks first (greedy across newlines, but non-greedy for
     # the closing fence to avoid swallowing the whole message).

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -55,6 +55,10 @@ def _extract_commit_message(command: str) -> str | None:
     3. ``-m '...'`` (plain single-quoted, NO escapes — POSIX single
        quotes are literal, including any backslashes inside).
 
+    The whitespace between the flag and the value is optional, so the
+    no-space attached forms ``-m"msg"`` / ``-m'msg'`` (which
+    ``git commit`` accepts) are also matched.
+
     Short-option groups that include ``m`` as the trailing flag are also
     recognized: ``-am``, ``-sm``, ``-asm`` etc. — common with
     ``git commit -am "msg"``. Because ``-m`` consumes the rest of the
@@ -88,11 +92,17 @@ def _extract_commit_message(command: str) -> str | None:
     for flag_match in re.finditer(r"(?:^|\s)-[a-zA-Z]*m\b", command):
         remainder = command[flag_match.end() :]
 
+        # ``\s*`` (not ``\s+``) lets us also match the no-space attached
+        # forms ``-m"msg"`` / ``-am'msg'`` / ``-am$(cat <<EOF...)``, which
+        # ``git commit`` accepts. The flag walker's trailing ``\b`` already
+        # ensures the position is right before a non-word character (``"``,
+        # ``'``, or ``$``), so ``\s*`` only allows the optional separator.
+        #
         # 1) HEREDOC inside a subshell. Surrounding quote (if any) before
         #    ``$(`` and after ``)`` must match. The closing ``\1`` must be
         #    on its own line; ``re.DOTALL`` lets ``.*?`` span newlines.
         heredoc_match = re.match(
-            r'\s+(["\']?)\$\(\s*cat\s+<<-?\s*[\'"]?(\w+)[\'"]?\s*\n'
+            r'\s*(["\']?)\$\(\s*cat\s+<<-?\s*[\'"]?(\w+)[\'"]?\s*\n'
             r"(.*?)\n\2\s*\)\1",
             remainder,
             re.DOTALL,
@@ -104,7 +114,7 @@ def _extract_commit_message(command: str) -> str | None:
         # 2) Plain double-quoted with shell-style escape handling
         #    (``\"``, ``\\``, etc.).
         plain_double = re.match(
-            r'\s+"((?:[^"\\]|\\.)*)"',
+            r'\s*"((?:[^"\\]|\\.)*)"',
             remainder,
             re.DOTALL,
         )
@@ -117,7 +127,7 @@ def _extract_commit_message(command: str) -> str | None:
         #    character. Backslashes inside (Windows paths, regex
         #    fragments) pass through unchanged.
         plain_single = re.match(
-            r"\s+'([^']*)'",
+            r"\s*'([^']*)'",
             remainder,
             re.DOTALL,
         )
@@ -189,22 +199,29 @@ def _allow() -> None:
 def _deny(mentions: list[str]) -> None:
     """Emit a PreToolUse ``deny`` decision with an actionable reason.
 
+    Every literal ``@…`` token in the reason text — including the
+    detected mentions and the placeholder names in the rule explanation
+    (``@username``, ``@org/team``, ``@qkernel``) — is wrapped in
+    backticks so the message is safe to paste into a GitHub-tracked
+    comment / PR thread without itself triggering mention notifications.
+
     Args:
         mentions: The matched ``@<word>`` tokens (deduped before being
             interpolated into the user-facing reason string).
     """
-    unique = sorted(set(mentions))
+    formatted_mentions = [f"`{mention}`" for mention in sorted(set(mentions))]
     reason = (
         "Commit message contains bare @-mention(s): "
-        f"{', '.join(unique)}.\n\n"
-        "Project rule (CLAUDE.md '### No @-mentions'): never write @username, "
-        "@org/team, or bare Python decorators like @qkernel in commit messages, "
-        "PR / issue titles or bodies, or review comments — they trigger "
-        "unintended GitHub mention rendering / notifications.\n\n"
+        f"{', '.join(formatted_mentions)}.\n\n"
+        "Project rule (CLAUDE.md '### No @-mentions'): never write "
+        "`@username`, `@org/team`, or bare Python decorators like "
+        "`@qkernel` in commit messages, PR / issue titles or bodies, "
+        "or review comments — they trigger unintended GitHub mention "
+        "rendering / notifications.\n\n"
         "Fix: rewrite the offending token in descriptive prose "
-        '(e.g. "the qkernel decorator" instead of @qkernel), or — only if the '
-        "code form is genuinely required — wrap it in backticks (`@qkernel`). "
-        "Then redo the commit."
+        '(e.g. "the qkernel decorator" instead of `@qkernel`), or — '
+        "only if the code form is genuinely required — wrap it in "
+        "backticks (`@qkernel`). Then redo the commit."
     )
     output = {
         "hookSpecificOutput": {

--- a/.claude/hooks/check_commit_message.py
+++ b/.claude/hooks/check_commit_message.py
@@ -13,10 +13,14 @@ from ``CLAUDE.md``. The script handles the commit-message forms most
 commonly produced by Claude Code:
 
 - ``git commit -m "single-line"`` / ``git commit -m 'single-line'``
+  (POSIX single quotes are literal — backslashes inside are *not*
+  interpreted as escapes, matching shell semantics)
 - ``git commit -m "$(cat <<'EOF' ... EOF)"`` (HEREDOC, quoted or unquoted
   delimiter, with or without surrounding quotes around the subshell)
 - Multiple ``-m`` flags (each contribution treated as its own paragraph,
   matching ``git commit``'s own concatenation behavior)
+- Combined short-option groups whose trailing flag is ``m`` — ``-am``,
+  ``-sm``, ``-asm``, etc. (commonly ``git commit -am "msg"``)
 
 Forms the script intentionally does **not** inspect — and which therefore
 fall open (allow) — include editor-based commits (no ``-m``), ``-F`` /
@@ -38,18 +42,26 @@ import sys
 def _extract_commit_message(command: str) -> str | None:
     """Return the proposed commit-message text from a ``git commit`` command.
 
-    Iterates every ``-m`` flag in the command (``git commit`` concatenates
-    multiple ``-m`` values into one message, joined by blank lines) and,
-    for each, tries the recognized argument forms in order:
+    Iterates every ``-m``-bearing short-option group in the command
+    (``git commit`` concatenates multiple ``-m`` values into one message,
+    joined by blank lines) and, for each, tries the recognized argument
+    forms in order:
 
     1. ``-m "$(cat <<EOF ... EOF)"`` / ``-m '$(cat <<EOF ... EOF)'`` /
        ``-m $(cat <<EOF ... EOF)`` — HEREDOC inside a subshell, with
        optional surrounding quotes; quoted (``<<'EOF'``) and unquoted
        (``<<EOF``) delimiter variants.
-    2. ``-m "..."`` (plain double-quoted, escapes allowed).
-    3. ``-m '...'`` (plain single-quoted, no shell escapes inside).
+    2. ``-m "..."`` (plain double-quoted, shell-style escapes allowed).
+    3. ``-m '...'`` (plain single-quoted, NO escapes — POSIX single
+       quotes are literal, including any backslashes inside).
 
-    All matched ``-m`` segments are joined by a blank line so the
+    Short-option groups that include ``m`` as the trailing flag are also
+    recognized: ``-am``, ``-sm``, ``-asm`` etc. — common with
+    ``git commit -am "msg"``. Because ``-m`` consumes the rest of the
+    short-option group as its value in standard getopt parsing, ``m`` is
+    only valid at the end of the group; ``[a-zA-Z]*m\\b`` captures that.
+
+    All matched message segments are joined by a blank line so the
     downstream scanner sees the full effective message, matching what
     ``git commit`` itself would record.
 
@@ -59,7 +71,7 @@ def _extract_commit_message(command: str) -> str | None:
 
     Returns:
         The concatenated message body, or ``None`` when the command is
-        not a ``git commit`` or no recognized ``-m`` argument could be
+        not a ``git commit`` or no recognized message argument could be
         located. ``None`` causes the caller to fall open (allow).
     """
     if not re.search(r"\bgit\s+commit\b", command):
@@ -67,10 +79,13 @@ def _extract_commit_message(command: str) -> str | None:
 
     messages: list[str] = []
 
-    # Walk every ``-m`` flag in order. ``\b`` keeps us from misfiring on
-    # ``--message-id`` style long flags. ``re.MULTILINE`` is unnecessary
-    # because ``-m`` is matched against the raw command string.
-    for flag_match in re.finditer(r"(?:^|\s)-m\b", command):
+    # Walk every short-option group whose trailing flag is ``m`` —
+    # matches a bare ``-m`` as well as ``-am`` / ``-sm`` / ``-asm`` /
+    # any combination of letters followed by ``m\b``. ``getopt`` requires
+    # ``m`` to be last because it takes a value, so this pattern is
+    # complete for the realistic Claude Code-produced shapes. Long flags
+    # like ``--message-id`` are not matched (they start with ``--``).
+    for flag_match in re.finditer(r"(?:^|\s)-[a-zA-Z]*m\b", command):
         remainder = command[flag_match.end() :]
 
         # 1) HEREDOC inside a subshell. Surrounding quote (if any) before
@@ -86,7 +101,8 @@ def _extract_commit_message(command: str) -> str | None:
             messages.append(heredoc_match.group(3))
             continue
 
-        # 2) Plain double-quoted with escape handling.
+        # 2) Plain double-quoted with shell-style escape handling
+        #    (``\"``, ``\\``, etc.).
         plain_double = re.match(
             r'\s+"((?:[^"\\]|\\.)*)"',
             remainder,
@@ -96,9 +112,12 @@ def _extract_commit_message(command: str) -> str | None:
             messages.append(plain_double.group(1))
             continue
 
-        # 3) Plain single-quoted (shell does not interpret escapes here).
+        # 3) Plain single-quoted: POSIX single quotes are LITERAL — no
+        #    escape interpretation, no embedded ``'``. Match any non-quote
+        #    character. Backslashes inside (Windows paths, regex
+        #    fragments) pass through unchanged.
         plain_single = re.match(
-            r"\s+'((?:[^'\\]|\\.)*)'",
+            r"\s+'([^']*)'",
             remainder,
             re.DOTALL,
         )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/check_commit_message.py",
+            "if": "Bash(git commit *)",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -39,11 +39,11 @@ Dependencies flow only downstream. The practical rules:
 
 ### B-bis. IR Abstraction Level
 
-Qamomile prefers to **keep the IR as abstract as possible and delegate concretization to the transpile target** (backend emit / runtime). The IR encodes *what the program means*; how a backend realizes it (per-qubit instruction encoding, native composite-gate equivalents, runtime loop / branch lowering) is the backend's job. Concretizing too early at the IR layer locks Qamomile into a single backend's view and bypasses the `GateEmitter` / `CompositeGateEmitter` / `emit_measure_vector` extension points.
+Qamomile prefers to **keep the IR as abstract as possible and delegate concretization to the transpile target** (backend emit / runtime). The IR encodes *what the program means*; how a backend realizes it (per-qubit instruction encoding, native composite-gate equivalents, runtime loop / branch lowering) is the backend's job. Concretizing too early at the IR layer locks Qamomile into a single backend's view and bypasses the emit-time extension surfaces — `GateEmitter` (per-gate emission), `CompositeGateEmitter` (native lowering of composite gates), and the emit pass itself when something needs structural customization.
 
 Existing examples of the principle in code:
 
-- **Vector measurement** is a single `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py#L410`) — not expanded into N per-qubit `MeasureOperation`s at IR level. Per-qubit lowering happens in `emit_measure_vector`.
+- **Vector measurement** is a single `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py#L410`) — not expanded into N per-qubit `MeasureOperation`s at IR level. How it turns into actual measurement instructions is left to emit time: backends with a native vector primitive can emit one operation, others can iterate per-qubit. The IR does not commit to per-qubit semantics.
 - **`MeasureQFixedOperation`** is HYBRID (quantum measurement + classical decode). It is split into `MeasureVectorOperation + DecodeQFixedOperation` only at `plan`'s pre-segmentation lowering — late enough that the IR keeps the highest abstraction that still admits a clean classical/quantum segmentation boundary, and each resulting half remains as abstract as possible (no per-qubit expansion).
 - **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation`; native lowering is opt-in via `CompositeGateEmitter`.
 - **Symbolic loop bounds** stay as `ForOperation`; `LoopAnalyzer` decides unroll-vs-runtime-loop at emit time.
@@ -52,7 +52,7 @@ Reviewer rules:
 
 - A new IR op or transpiler pass that pre-expands an abstract concept into per-element / per-qubit / per-step concretization at IR level — **without** a stated reason such as enabling segmentation or breaking a HYBRID kind into pure halves — is a **P1** design regression.
 - A new pass that performs concretization (per-qubit expansion, native-gate substitution, loop unrolling) at a stage **earlier than necessary** — when the same lowering could happen later (typically `plan` or `emit`) — is **P1**.
-- A new pass or op that bypasses `GateEmitter` / `CompositeGateEmitter` / `emit_measure_vector` (or analogous emit-support extension points) by hard-coding a backend-specific lowering inside the IR layer is **P1** (also a Section B violation).
+- A new pass or op that hard-codes backend-specific lowering inside the IR layer — instead of leaving it to emit time where `GateEmitter`, `CompositeGateEmitter`, or the emit pass itself can express the lowering — is **P1** (also a Section B violation).
 - Splitting a HYBRID op into pure-quantum + pure-classical halves at IR level **is** acceptable when needed for segmentation (`MeasureQFixed → MeasureVector + DecodeQFixed` is the canonical example). The check is whether each resulting half stays as abstract as possible.
 
 When ambiguous, prefer (a) a single abstract op over multiple low-level ones, and (b) lowering at the **latest stage** where the IR still cleanly expresses the abstraction.

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -37,6 +37,26 @@ Dependencies flow only downstream. The practical rules:
 - **Transpiler passes** are IR-centric: each pass primarily reads / writes IR and must not depend on Frontend **implementation details** (AST machinery, tracer internals, frontend-only helpers). Passes at the compile-entry / config boundary may legitimately accept or type-reference Frontend surface types such as `QKernel` and `DecompositionConfig` as configuration inputs — e.g., `SubstitutionPass` takes `QKernel` as a substitution target and imports it under `TYPE_CHECKING` + runtime-late import (see `qamomile/circuit/transpiler/passes/substitution.py:34,276`). That pattern is NOT a layer violation. Flag only passes that reach into Frontend behavior or non-boundary internals.
 - **Backend** depends on IR and Transpiler public APIs. Backend MUST NOT import from Frontend.
 
+### B-bis. IR Abstraction Level
+
+Qamomile prefers to **keep the IR as abstract as possible and delegate concretization to the transpile target** (backend emit / runtime). The IR encodes *what the program means*; how a backend realizes it (per-qubit instruction encoding, native composite-gate equivalents, runtime loop / branch lowering) is the backend's job. Concretizing too early at the IR layer locks Qamomile into a single backend's view and bypasses the `GateEmitter` / `CompositeGateEmitter` / `emit_measure_vector` extension points.
+
+Existing examples of the principle in code:
+
+- **Vector measurement** is a single `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py:410`) — not expanded into N per-qubit `MeasureOperation`s at IR level. Per-qubit lowering happens in `emit_measure_vector`.
+- **`MeasureQFixedOperation`** is HYBRID (quantum measurement + classical decode). It is split into `MeasureVectorOperation + DecodeQFixedOperation` only at `plan`'s pre-segmentation lowering — late enough that the IR keeps the highest abstraction that still admits a clean classical/quantum segmentation boundary, and each resulting half remains as abstract as possible (no per-qubit expansion).
+- **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation`; native lowering is opt-in via `CompositeGateEmitter`.
+- **Symbolic loop bounds** stay as `ForOperation`; `LoopAnalyzer` decides unroll-vs-runtime-loop at emit time.
+
+Reviewer rules:
+
+- A new IR op or transpiler pass that pre-expands an abstract concept into per-element / per-qubit / per-step concretization at IR level — **without** a stated reason such as enabling segmentation or breaking a HYBRID kind into pure halves — is a **P1** design regression.
+- A new pass that performs concretization (per-qubit expansion, native-gate substitution, loop unrolling) at a stage **earlier than necessary** — when the same lowering could happen later (typically `plan` or `emit`) — is **P1**.
+- A new pass or op that bypasses `GateEmitter` / `CompositeGateEmitter` / `emit_measure_vector` (or analogous emit-support extension points) by hard-coding a backend-specific lowering inside the IR layer is **P1** (also a Section B violation).
+- Splitting a HYBRID op into pure-quantum + pure-classical halves at IR level **is** acceptable when needed for segmentation (`MeasureQFixed → MeasureVector + DecodeQFixed` is the canonical example). The check is whether each resulting half stays as abstract as possible.
+
+When ambiguous, prefer (a) a single abstract op over multiple low-level ones, and (b) lowering at the **latest stage** where the IR still cleanly expresses the abstraction.
+
 ### C. @qkernel & Converter Pattern
 
 - Quantum building blocks exposed for composition by algorithm or optimization converters (QAOA / QRAO / FQAOA ansatz pieces, stdlib algorithms like QFT / QPE / IQFT, mixer / cost-Hamiltonian prep, etc.) MUST use `@qm.qkernel` (or `@qmc.qkernel`). `CompositeGate._decompose()` methods and emitter-side decomposition strategies are separate patterns (class method / strategy protocol) and are out of scope for this rule.

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -43,7 +43,7 @@ Qamomile prefers to **keep the IR as abstract as possible and delegate concretiz
 
 Existing examples of the principle in code:
 
-- **Vector measurement** is a single `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py:410`) — not expanded into N per-qubit `MeasureOperation`s at IR level. Per-qubit lowering happens in `emit_measure_vector`.
+- **Vector measurement** is a single `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py#L410`) — not expanded into N per-qubit `MeasureOperation`s at IR level. Per-qubit lowering happens in `emit_measure_vector`.
 - **`MeasureQFixedOperation`** is HYBRID (quantum measurement + classical decode). It is split into `MeasureVectorOperation + DecodeQFixedOperation` only at `plan`'s pre-segmentation lowering — late enough that the IR keeps the highest abstraction that still admits a clean classical/quantum segmentation boundary, and each resulting half remains as abstract as possible (no per-qubit expansion).
 - **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation`; native lowering is opt-in via `CompositeGateEmitter`.
 - **Symbolic loop bounds** stay as `ForOperation`; `LoopAnalyzer` decides unroll-vs-runtime-loop at emit time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ overlapping name with `ValueError` ([transpiler.py][overlap-check]):
   flow handled at emit time by backends with a supporting
   `MeasurementMode`.
 
-[overlap-check]: qamomile/circuit/transpiler/transpiler.py
+[overlap-check]: qamomile/circuit/transpiler/transpiler.py#L475-L487
 
 ## Docstring Convention (MANDATORY)
 
@@ -365,7 +365,10 @@ typing `@qkernel` directly in the prose. Inside fenced code blocks the
 decorator syntax is fine, since GitHub does not parse mentions there.
 
 - ✅ "Update the qkernel decorator so metadata survives `next_version`."
-- ❌ "Update @qkernel so metadata survives `next_version`."
+- ❌ "Update `@qkernel` so metadata survives `next_version`." (the
+  `@qkernel` is wrapped in code here only so this example itself doesn't
+  trigger a GitHub mention render; in real prose, never type the literal
+  `@qkernel` symbol — write "the qkernel decorator" instead)
 
 ### No unsolicited external links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,17 @@ Pre-expanding an abstract concept into per-element / per-qubit / per-step concre
 
 ### Core Pipeline Flow
 
+This is a high-level overview of the layers a `@qkernel` flows through.
+For the canonical, ordered pass sequence — including every transformation
+the pipeline runs and the `BlockKind` boundary each pass advances — see
+"Transpiler Pipeline Stages" below.
+
 ```
 @qkernel Python function
          ↓
     Frontend (AST transform → tracing → Block with operations)
          ↓
-    Transpiler Pipeline (to_block → inline → partial_eval → analyze → plan → emit)
+    Transpiler Pipeline (multi-pass IR rewriting; canonical sequence below)
          ↓
     Backend Execution (Qiskit, QuriParts, CUDA-Q, etc.)
 ```
@@ -202,8 +207,11 @@ depending on parameter-array elements (see #354 / 7198bfe9).
   compilation to fail. The same applies to any other compile-time
   structural decision such as `qmc.range(...)` bounds. Measurement-backed
   `if bit:` / `while bit:` (where `bit = qmc.measure(q)`) is unrelated —
-  that is runtime control flow handled at emit time by backends with a
-  supporting `MeasurementMode`.
+  that is runtime control flow handled at emit time by backends whose
+  emitters report support for the corresponding constructs
+  (`GateEmitter.supports_if_else()` / `supports_while_loop()`), with the
+  appropriate measurement handling on the same backend (`MeasurementMode`)
+  when mid-circuit measurement is required.
 
 [overlap-check]: qamomile/circuit/transpiler/transpiler.py#L475-L487
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,14 +141,16 @@ executable = transpiler.transpile(my_circuit, bindings={"theta": 0.5})
 
 `Transpiler.transpile()` runs the following passes in order. `BlockKind`
 advances as preconditions are met. Every pass other than
-`entrypoint_validate` is idempotent and exposed as a public method on
-`Transpiler` for step-by-step debugging; `entrypoint_validate` runs inline
-inside `transpile()` as a structural check (no public method today).
+`validate_entrypoint` is idempotent and exposed as a public method on
+`Transpiler` for step-by-step debugging; `validate_entrypoint`
+(implemented by `EntrypointValidationPass`, whose `.name` is
+`"validate_entrypoint"`) runs inline inside `transpile()` as a structural
+check (no public method today).
 
 ```
 QKernel
    │  to_block                    (trace Python AST → IR)
-   │  entrypoint_validate         (internal — require classical I/O on entrypoint kernels)
+   │  validate_entrypoint         (internal: EntrypointValidationPass — require classical I/O on entrypoint kernels)
    ▼
 Block [HIERARCHICAL]
    │  substitute                  (optional rule-based block / strategy replacement)
@@ -404,19 +406,21 @@ harmless and preserves the existing review thread.
 
 ### No `@`-mentions
 
-Never include `@username` or `@org/team` strings in **any** GitHub-tracked
-text — commit messages, PR titles / bodies, issue titles / bodies, **and
-PR / code review comments and replies posted to those threads** —
-because they trigger unintended GitHub notifications. The rule covers
-the entire scope listed at the top of this section; review-thread
-replies are not an exception, even when the reply is short or only
-quotes a previous reviewer comment. This rule applies to bare Python
-decorators in running prose too: refer to them descriptively (e.g.,
-"the qkernel decorator") instead of typing `@qkernel` directly in the
-prose. If you must show the literal decorator syntax, only do so inside
-a fenced code block or an inline code span — GitHub does not parse
-mentions in either. In normal prose, write "the qkernel decorator"
-instead.
+Never include **bare** `@username` or `@org/team` mention tokens in
+normal GitHub-tracked text — commit messages, PR titles / bodies, issue
+titles / bodies, **and PR / code review comments and replies posted to
+those threads** — because they trigger unintended GitHub notifications.
+The rule covers the entire scope listed at the top of this section;
+review-thread replies are not an exception, even when the reply is
+short or only quotes a previous reviewer comment. This rule applies to
+bare Python decorators in running prose too: refer to them
+descriptively (e.g., "the qkernel decorator") instead of typing
+`@qkernel` directly in prose. If you must show a literal `@…` string
+(decorator syntax, an actual user handle being discussed, etc.), do so
+**only** inside a fenced code block or an inline code span — GitHub
+does not parse mentions in either, so a code-wrapped `@qkernel` is fine
+and is the only permitted way to render the literal symbol. In normal
+prose, write "the qkernel decorator" instead.
 
 - ✅ "Update the qkernel decorator so metadata survives `next_version`."
 - ❌ "Update `@qkernel` so metadata survives `next_version`." (the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,18 @@ current branch. Address every finding it reports, then re-run
 **no remaining issues** — only then create the PR. A clean `/local-review`
 run is a precondition for PR creation, not a post-merge polish step.
 
+### Sync PR branches with `merge`, not `rebase` + force-push
+
+When a PR branch needs to incorporate the latest `main` (for example, when
+the documentation or code in this PR depends on a recent commit on `main`
+that has not yet propagated to the branch's parent), use a regular
+`git merge origin/main` on the PR branch, **not** `git rebase origin/main`
+followed by a force-push. Force-pushing rewrites the commit SHAs that
+reviewers and review bots may have already anchored their comments to,
+disturbs the chronological view of the PR, and creates extra noise for
+everyone re-reading the diff. A merge commit on a feature branch is
+harmless and preserves the existing review thread.
+
 ### No `@`-mentions
 
 Never include `@username` or `@org/team` strings in commit messages, PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,24 @@ current branch. Address every finding it reports, then re-run
 **no remaining issues** — only then create the PR. A clean `/local-review`
 run is a precondition for PR creation, not a post-merge polish step.
 
+### Reply to GitHub review threads when addressing feedback
+
+Whenever a PR review comment is addressed — whether by a code change, a
+documentation update, or a reasoned disagreement that leaves the line as
+is — post a reply directly in that comment's GitHub thread describing the
+resolution. A short, specific note is enough:
+
+- "Fixed in `<commit-sha>`: `<one-line summary of the change>`."
+- "Out of scope for this PR; tracked as a follow-up at `<reference>`."
+- "Disagreed because `<reason>` — left as is."
+
+Do **not** rely on the reviewer (or a review bot) to infer that a new
+commit resolves their comment by reading the diff alone. Every individual
+review comment should end up with at least one explicit reply explaining
+the resolution. This keeps the discussion self-contained, makes the
+conversation easy to audit later, and prevents the same concern from
+being re-raised in the next review pass.
+
 ### Sync PR branches with `merge`, not `rebase` + force-push
 
 When a PR branch needs to incorporate the latest `main` (for example, when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,4 +438,8 @@ supply one. Internal references to other issues / PRs in this repo
 (e.g., `#354`) are fine when factually relevant.
 
 - ✅ "Implements the Trotter circuit (see #337 for the design discussion)."
-- ❌ "Implements the Trotter circuit (see https://arxiv.org/abs/... )."
+- ❌ "Implements the Trotter circuit (see `<external-url>`)." (the URL is
+  shown as a `<external-url>` placeholder rather than a real address so
+  this example itself doesn't render as a clickable external link;
+  outside this kind of placeholder, never paste a literal external URL
+  in prose unless the user explicitly provided it)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,30 +171,39 @@ See [docs/en/tutorial/09_compilation_and_transpilation.py](docs/en/tutorial/09_c
 
 ### Binding vs. Parameter Contract
 
-`Transpiler.transpile(kernel, bindings=..., parameters=...)` enforces a
-**disjoint partition** of the kernel's arguments — the API rejects any
-overlapping name with `ValueError` ([transpiler.py][overlap-check]):
+**Project rule: `bindings` and `parameters` MUST be strictly disjoint** —
+a kernel argument name must never appear in both. This rule is a hard
+project-level constraint; treat it as inviolable when writing kernels,
+helpers, or higher-level wrappers around `transpile()`. The API also
+enforces it at the function boundary by raising `ValueError` immediately
+on any overlap ([transpiler.py][overlap-check]); historically the absence
+of this check caused silent miscompilation of control-flow predicates
+depending on parameter-array elements (see #354 / 7198bfe9).
 
-- **Each kernel argument must appear in exactly one of `bindings` or
-  `parameters`.** Specifying the same name in both is invalid; every argument
-  must be assigned to one of them (modulo arguments with Python defaults, or
-  `Qubit` / `Observable` inputs handled implicitly by the frontend).
-  - `bindings={...}` — values resolved at compile time, substituted into the
-    IR by `resolve_parameter_shapes` / `partial_eval`. The value is baked
-    into the emitted circuit.
-  - `parameters=[...]` — argument names that survive the pipeline as runtime
-    parameters in the emitted backend circuit.
-- **Arguments driving a classical-value `if` branch (one whose condition is
-  not a measurement-backed `Bit`) must be in `bindings` so
+- **Never specify the same name in both `bindings` and `parameters`.**
+  - `bindings={...}` — values resolved at compile time, substituted into
+    the IR by `resolve_parameter_shapes` / `partial_eval`. The value is
+    baked into the emitted circuit.
+  - `parameters=[...]` — argument names that survive the pipeline as
+    runtime parameters in the emitted backend circuit.
+- **Required classical arguments (those without Python defaults) must be
+  resolved exactly one way.** Bind them via `bindings`, list them in an
+  explicit `parameters=[...]`, or rely on `parameters=None` to let
+  `QKernel.build()` auto-detect them — auto-detect picks up classical
+  arguments that have neither a `bindings` value nor a Python default and
+  treats them as runtime parameters. Classical arguments with Python
+  defaults may be omitted from both `bindings` and `parameters`, in which
+  case the default is used.
+- **Arguments driving a classical-value `if` branch (one whose condition
+  is not a measurement-backed `Bit`) must be in `bindings` so
   `CompileTimeIfLoweringPass` can resolve the condition at compile time.**
-  Per the disjoint partition rule above, this means such arguments
-  cannot simultaneously be in `parameters` — leaving them in `parameters`
-  keeps the condition symbolic and the compile fails. The same rule
-  applies to any other compile-time structural decision such as
-  `qmc.range(...)` bounds. Measurement-backed `if bit:` / `while bit:`
-  (where `bit = qmc.measure(q)`) is unrelated — that is runtime control
-  flow handled at emit time by backends with a supporting
-  `MeasurementMode`.
+  Per the no-overlap rule above, such arguments therefore cannot
+  simultaneously appear in `parameters`; leaving them symbolic causes
+  compilation to fail. The same applies to any other compile-time
+  structural decision such as `qmc.range(...)` bounds. Measurement-backed
+  `if bit:` / `while bit:` (where `bit = qmc.measure(q)`) is unrelated —
+  that is runtime control flow handled at emit time by backends with a
+  supporting `MeasurementMode`.
 
 [overlap-check]: qamomile/circuit/transpiler/transpiler.py#L475-L487
 
@@ -371,16 +380,18 @@ harmless and preserves the existing review thread.
 
 Never include `@username` or `@org/team` strings in commit messages, PR
 titles / bodies, or issue titles / bodies — they trigger unintended GitHub
-notifications. This rule applies to bare Python decorators in running prose
-too: refer to them descriptively (e.g., "the qkernel decorator") instead of
-typing `@qkernel` directly in the prose. Inside fenced code blocks the
-decorator syntax is fine, since GitHub does not parse mentions there.
+notifications. This rule applies to bare Python decorators in running
+prose too: refer to them descriptively (e.g., "the qkernel decorator")
+instead of typing `@qkernel` directly in the prose. If you must show the
+literal decorator syntax, only do so inside a fenced code block or an
+inline code span — GitHub does not parse mentions in either. In normal
+prose, write "the qkernel decorator" instead.
 
 - ✅ "Update the qkernel decorator so metadata survives `next_version`."
 - ❌ "Update `@qkernel` so metadata survives `next_version`." (the
-  `@qkernel` is wrapped in code here only so this example itself doesn't
-  trigger a GitHub mention render; in real prose, never type the literal
-  `@qkernel` symbol — write "the qkernel decorator" instead)
+  `@qkernel` is wrapped in inline code here only so this example itself
+  doesn't render as a mention; outside a fenced code block or inline code
+  span, never type the literal `@qkernel` symbol in prose)
 
 ### No unsolicited external links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Dependency direction: `optimization → circuit ← backends`. No reverse depend
 
 How the codebase already follows this:
 
-- **Vector measurement** is a single `MeasureVectorOperation` ([qamomile/circuit/ir/operation/gate.py:410](qamomile/circuit/ir/operation/gate.py:410)) — never expanded into N per-qubit `MeasureOperation`s at IR level. Each backend's `emit_measure_vector` decides how to lower per-qubit.
+- **Vector measurement** is a single `MeasureVectorOperation` ([qamomile/circuit/ir/operation/gate.py#L410](qamomile/circuit/ir/operation/gate.py#L410)) — never expanded into N per-qubit `MeasureOperation`s at IR level. Each backend's `emit_measure_vector` decides how to lower per-qubit.
 - **`MeasureQFixedOperation`** lives at an even higher abstraction (HYBRID quantum measurement + classical decode). At `plan`'s pre-segmentation lowering, it is split into `MeasureVectorOperation + DecodeQFixedOperation` so segmentation can route the halves into the right (quantum / classical) segment — but **each half stays abstract**: `MeasureVectorOperation` still represents "measure this whole Vector" (not per-qubit), `DecodeQFixedOperation` is a clean classical op.
 - **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation` boxes; backends with a native `CompositeGateEmitter` emit a single high-level gate, others fall back to library decomposition. The IR is identical either way.
 - **Loops** (`qmc.range(...)`) stay as `ForOperation`s with symbolic bounds when possible; `LoopAnalyzer` decides unroll vs. runtime loop at emit time.
@@ -135,13 +135,15 @@ executable = transpiler.transpile(my_circuit, bindings={"theta": 0.5})
 ### Transpiler Pipeline Stages
 
 `Transpiler.transpile()` runs the following passes in order. `BlockKind`
-advances as preconditions are met; each pass is idempotent and exposed as a
-public method for step-by-step debugging.
+advances as preconditions are met. Every pass other than
+`entrypoint_validate` is idempotent and exposed as a public method on
+`Transpiler` for step-by-step debugging; `entrypoint_validate` runs inline
+inside `transpile()` as a structural check (no public method today).
 
 ```
 QKernel
    │  to_block                    (trace Python AST → IR)
-   │  entrypoint_validate         (require classical I/O on entrypoint kernels)
+   │  entrypoint_validate         (internal — require classical I/O on entrypoint kernels)
    ▼
 Block [HIERARCHICAL]
    │  substitute                  (optional rule-based block / strategy replacement)
@@ -170,25 +172,31 @@ See [docs/en/tutorial/09_compilation_and_transpilation.py](docs/en/tutorial/09_c
 ### Binding vs. Parameter Contract
 
 `Transpiler.transpile(kernel, bindings=..., parameters=...)` enforces a
-**disjoint partition** of the kernel's arguments:
+**disjoint partition** of the kernel's arguments — the API rejects any
+overlapping name with `ValueError` ([transpiler.py][overlap-check]):
 
 - **Each kernel argument must appear in exactly one of `bindings` or
   `parameters`.** Specifying the same name in both is invalid; every argument
   must be assigned to one of them (modulo arguments with Python defaults, or
   `Qubit` / `Observable` inputs handled implicitly by the frontend).
   - `bindings={...}` — values resolved at compile time, substituted into the
-    IR by `resolve_parameter_shapes` / `partial_eval`.
+    IR by `resolve_parameter_shapes` / `partial_eval`. The value is baked
+    into the emitted circuit.
   - `parameters=[...]` — argument names that survive the pipeline as runtime
     parameters in the emitted backend circuit.
 - **Arguments driving a classical-value `if` branch (one whose condition is
-  not a measurement-backed `Bit`) must always be in `bindings`.**
-  `CompileTimeIfLoweringPass` needs the value at compile time to lower the
-  branch; leaving it in `parameters` keeps the condition symbolic and the
-  compile fails. The same rule applies to any other compile-time structural
-  decision such as `qmc.range(...)` bounds. Measurement-backed `if bit:` /
-  `while bit:` (where `bit = qmc.measure(q)`) is unrelated to this rule —
-  that is runtime control flow handled at emit time by backends with a
-  supporting `MeasurementMode`.
+  not a measurement-backed `Bit`) must be in `bindings` so
+  `CompileTimeIfLoweringPass` can resolve the condition at compile time.**
+  Per the disjoint partition rule above, this means such arguments
+  cannot simultaneously be in `parameters` — leaving them in `parameters`
+  keeps the condition symbolic and the compile fails. The same rule
+  applies to any other compile-time structural decision such as
+  `qmc.range(...)` bounds. Measurement-backed `if bit:` / `while bit:`
+  (where `bit = qmc.measure(q)`) is unrelated — that is runtime control
+  flow handled at emit time by backends with a supporting
+  `MeasurementMode`.
+
+[overlap-check]: qamomile/circuit/transpiler/transpiler.py
 
 ## Docstring Convention (MANDATORY)
 
@@ -323,8 +331,21 @@ Translation rules (tone, spacing, terminology, soft line breaks, etc.) are defin
 ## Commits, Pull Requests, and Issues
 
 The rules below apply to any text Claude writes that lands in the project's
-permanent record — commit messages, PR titles / bodies, and issue titles /
-bodies. Consult this section **before** creating any commit, PR, or issue.
+permanent record or on GitHub — commit messages, PR titles / bodies, issue
+titles / bodies, PR review comments, code review replies, and inline source
+code comments. Consult this section **before** creating any commit, PR, or
+issue.
+
+### Use English
+
+All text that lands in the project's permanent record or on GitHub — commit
+messages, PR titles / bodies, issue titles / bodies, PR / code review
+comments and replies, and inline source code comments — MUST be written in
+**English**. English is the project's lingua franca so that contributors
+regardless of native-language background can read, search, and respond to
+the shared record. Japanese (or other languages) is appropriate only in
+private chat / Slack / live verbal discussion, never in checked-in text or
+GitHub-tracked artifacts.
 
 ### Run `/local-review` before opening a PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,11 @@ check (no public method today).
 ```
 QKernel
    │  to_block                    (trace Python AST → IR)
-   │  validate_entrypoint         (internal: EntrypointValidationPass — require classical I/O on entrypoint kernels)
+   │  validate_entrypoint         (internal: EntrypointValidationPass — requires classical I/O on entrypoint kernels)
    ▼
 Block [HIERARCHICAL]
    │  substitute                  (optional rule-based block / strategy replacement)
-   │  resolve_parameter_shapes    (concretise Vector shape dims from bindings)
+   │  resolve_parameter_shapes    (concretize Vector shape dims from bindings)
    │  inline                      (remove CallBlockOperations)
    ▼
 Block [AFFINE]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,25 @@ Qamomile is a quantum programming language built around a circuit-first compiler
 
 Dependency direction: `optimization → circuit ← backends`. No reverse dependencies.
 
+### IR Abstraction Principle
+
+**Keep the IR as abstract as possible; delegate concretization to the transpile target.** The IR should express *what the program means*, not *how a particular backend realizes it*. Per-qubit instruction encoding, native composite-gate equivalents, and runtime control-flow lowering are backend concerns — push them down to the backend's emit pass / `GateEmitter`.
+
+How the codebase already follows this:
+
+- **Vector measurement** is a single `MeasureVectorOperation` ([qamomile/circuit/ir/operation/gate.py:410](qamomile/circuit/ir/operation/gate.py:410)) — never expanded into N per-qubit `MeasureOperation`s at IR level. Each backend's `emit_measure_vector` decides how to lower per-qubit.
+- **`MeasureQFixedOperation`** lives at an even higher abstraction (HYBRID quantum measurement + classical decode). At `plan`'s pre-segmentation lowering, it is split into `MeasureVectorOperation + DecodeQFixedOperation` so segmentation can route the halves into the right (quantum / classical) segment — but **each half stays abstract**: `MeasureVectorOperation` still represents "measure this whole Vector" (not per-qubit), `DecodeQFixedOperation` is a clean classical op.
+- **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation` boxes; backends with a native `CompositeGateEmitter` emit a single high-level gate, others fall back to library decomposition. The IR is identical either way.
+- **Loops** (`qmc.range(...)`) stay as `ForOperation`s with symbolic bounds when possible; `LoopAnalyzer` decides unroll vs. runtime loop at emit time.
+
+When introducing a new IR op or pass:
+
+1. Prefer **a single abstract op** over expanding into multiple low-level ops at IR level.
+2. Push lowering as **late as possible** — `emit` for backend-specific concretization, `plan` only when segmentation forces a split (HYBRID → pure-quantum + pure-classical).
+3. When IR-level lowering IS needed, keep each resulting op as abstract as the next stage allows.
+
+Pre-expanding an abstract concept into per-element / per-qubit / per-step concretization at IR level — without a stated reason — is a design regression.
+
 ### Core Pipeline Flow
 
 ```
@@ -115,12 +134,61 @@ executable = transpiler.transpile(my_circuit, bindings={"theta": 0.5})
 
 ### Transpiler Pipeline Stages
 
-1. **to_block()**: `QKernel` → `Block`
-2. **inline()**: Inlines `CallBlockOperation` → affine `Block`
-3. **partial_eval()**: Constant folds and lowers compile-time control flow
-4. **analyze()**: Validates dependencies → analyzed `Block`
-5. **plan()**: Builds a `ProgramPlan`
-6. **emit()**: Backend-specific circuit generation → `ExecutableProgram`
+`Transpiler.transpile()` runs the following passes in order. `BlockKind`
+advances as preconditions are met; each pass is idempotent and exposed as a
+public method for step-by-step debugging.
+
+```
+QKernel
+   │  to_block                    (trace Python AST → IR)
+   │  entrypoint_validate         (require classical I/O on entrypoint kernels)
+   ▼
+Block [HIERARCHICAL]
+   │  substitute                  (optional rule-based block / strategy replacement)
+   │  resolve_parameter_shapes    (concretise Vector shape dims from bindings)
+   │  inline                      (remove CallBlockOperations)
+   ▼
+Block [AFFINE]
+   │  unroll_recursion            (iterated inline ↔ partial_eval for self-recursive kernels)
+   │  affine_validate             (enforce "each quantum value used at most once")
+   │  partial_eval                (constant fold + CompileTimeIfLoweringPass)
+   │  analyze                     (dependency graph + classical/quantum operand check)
+   ▼
+Block [ANALYZED]
+   │  classical_lowering          (rewrite measurement-derived classical ops to RuntimeClassicalExpr)
+   │  validate_symbolic_shapes    (reject unresolved Vector dims at ForOperation bounds)
+   │  plan                        (segment into C→Q→C; pre-segmentation lowering of MeasureQFixed etc.)
+   ▼
+ProgramPlan
+   │  emit                        (backend-specific codegen; LoopAnalyzer decides unroll vs runtime loop)
+   ▼
+ExecutableProgram[T]
+```
+
+See [docs/en/tutorial/09_compilation_and_transpilation.py](docs/en/tutorial/09_compilation_and_transpilation.py) for a step-by-step walk-through with IR dumps after each pass.
+
+### Binding vs. Parameter Contract
+
+`Transpiler.transpile(kernel, bindings=..., parameters=...)` enforces a
+**disjoint partition** of the kernel's arguments:
+
+- **Each kernel argument must appear in exactly one of `bindings` or
+  `parameters`.** Specifying the same name in both is invalid; every argument
+  must be assigned to one of them (modulo arguments with Python defaults, or
+  `Qubit` / `Observable` inputs handled implicitly by the frontend).
+  - `bindings={...}` — values resolved at compile time, substituted into the
+    IR by `resolve_parameter_shapes` / `partial_eval`.
+  - `parameters=[...]` — argument names that survive the pipeline as runtime
+    parameters in the emitted backend circuit.
+- **Arguments driving a classical-value `if` branch (one whose condition is
+  not a measurement-backed `Bit`) must always be in `bindings`.**
+  `CompileTimeIfLoweringPass` needs the value at compile time to lower the
+  branch; leaving it in `parameters` keeps the condition symbolic and the
+  compile fails. The same rule applies to any other compile-time structural
+  decision such as `qmc.range(...)` bounds. Measurement-backed `if bit:` /
+  `while bit:` (where `bit = qmc.measure(q)`) is unrelated to this rule —
+  that is runtime control flow handled at emit time by backends with a
+  supporting `MeasurementMode`.
 
 ## Docstring Convention (MANDATORY)
 
@@ -251,3 +319,40 @@ To translate English docs (`docs/en/`) into Japanese (`docs/ja/`), use the `/tra
 ```
 
 Translation rules (tone, spacing, terminology, soft line breaks, etc.) are defined in `.claude/skills/translate/SKILL.md`. Always use this skill when translating documentation.
+
+## Commits, Pull Requests, and Issues
+
+The rules below apply to any text Claude writes that lands in the project's
+permanent record — commit messages, PR titles / bodies, and issue titles /
+bodies. Consult this section **before** creating any commit, PR, or issue.
+
+### Run `/local-review` before opening a PR
+
+Before opening a pull request, run the `/local-review` skill against the
+current branch. Address every finding it reports, then re-run
+`/local-review`. Repeat the review-and-fix cycle until the skill reports
+**no remaining issues** — only then create the PR. A clean `/local-review`
+run is a precondition for PR creation, not a post-merge polish step.
+
+### No `@`-mentions
+
+Never include `@username` or `@org/team` strings in commit messages, PR
+titles / bodies, or issue titles / bodies — they trigger unintended GitHub
+notifications. This rule applies to bare Python decorators in running prose
+too: refer to them descriptively (e.g., "the qkernel decorator") instead of
+typing `@qkernel` directly in the prose. Inside fenced code blocks the
+decorator syntax is fine, since GitHub does not parse mentions there.
+
+- ✅ "Update the qkernel decorator so metadata survives `next_version`."
+- ❌ "Update @qkernel so metadata survives `next_version`."
+
+### No unsolicited external links
+
+Do not add external URLs (arXiv, blog posts, docs sites, vendor pages, etc.)
+to commits / PRs / issues unless the user has explicitly provided that URL
+in the current conversation. When in doubt, omit the link or ask the user
+to supply one. Internal references to other issues / PRs in this repo
+(e.g., `#354`) are fine when factually relevant.
+
+- ✅ "Implements the Trotter circuit (see #337 for the design discussion)."
+- ❌ "Implements the Trotter circuit (see https://arxiv.org/abs/... )."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,12 @@ current conversation. When in doubt, omit the link or ask the user to
 supply one. Internal references to other issues / PRs in this repo
 (e.g., `#354`) are fine when factually relevant.
 
+This rule targets **editorial** content — prose humans read. URLs that
+are functional metadata consumed by tooling rather than read by people
+(e.g., `$schema` references in JSON / YAML config files, dependency
+URLs in lockfiles, IDE / editor schema hints) are out of scope and may
+be added when the tool requires them.
+
 - ✅ "Implements the Trotter circuit (see #337 for the design discussion)."
 - ❌ "Implements the Trotter circuit (see `<external-url>`)." (the URL is
   shown as a `<external-url>` placeholder rather than a real address so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,14 +404,19 @@ harmless and preserves the existing review thread.
 
 ### No `@`-mentions
 
-Never include `@username` or `@org/team` strings in commit messages, PR
-titles / bodies, or issue titles / bodies — they trigger unintended GitHub
-notifications. This rule applies to bare Python decorators in running
-prose too: refer to them descriptively (e.g., "the qkernel decorator")
-instead of typing `@qkernel` directly in the prose. If you must show the
-literal decorator syntax, only do so inside a fenced code block or an
-inline code span — GitHub does not parse mentions in either. In normal
-prose, write "the qkernel decorator" instead.
+Never include `@username` or `@org/team` strings in **any** GitHub-tracked
+text — commit messages, PR titles / bodies, issue titles / bodies, **and
+PR / code review comments and replies posted to those threads** —
+because they trigger unintended GitHub notifications. The rule covers
+the entire scope listed at the top of this section; review-thread
+replies are not an exception, even when the reply is short or only
+quotes a previous reviewer comment. This rule applies to bare Python
+decorators in running prose too: refer to them descriptively (e.g.,
+"the qkernel decorator") instead of typing `@qkernel` directly in the
+prose. If you must show the literal decorator syntax, only do so inside
+a fenced code block or an inline code span — GitHub does not parse
+mentions in either. In normal prose, write "the qkernel decorator"
+instead.
 
 - ✅ "Update the qkernel decorator so metadata survives `next_version`."
 - ❌ "Update `@qkernel` so metadata survives `next_version`." (the
@@ -421,10 +426,11 @@ prose, write "the qkernel decorator" instead.
 
 ### No unsolicited external links
 
-Do not add external URLs (arXiv, blog posts, docs sites, vendor pages, etc.)
-to commits / PRs / issues unless the user has explicitly provided that URL
-in the current conversation. When in doubt, omit the link or ask the user
-to supply one. Internal references to other issues / PRs in this repo
+Do not add external URLs (arXiv, blog posts, docs sites, vendor pages,
+etc.) to commits, PRs, issues, **or PR / code review comments and
+replies** unless the user has explicitly provided that URL in the
+current conversation. When in doubt, omit the link or ask the user to
+supply one. Internal references to other issues / PRs in this repo
 (e.g., `#354`) are fine when factually relevant.
 
 - ✅ "Implements the Trotter circuit (see #337 for the design discussion)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Dependency direction: `optimization → circuit ← backends`. No reverse depend
 
 How the codebase already follows this:
 
-- **Vector measurement** is a single `MeasureVectorOperation` ([qamomile/circuit/ir/operation/gate.py#L410](qamomile/circuit/ir/operation/gate.py#L410)) — never expanded into N per-qubit `MeasureOperation`s at IR level. Each backend's `emit_measure_vector` decides how to lower per-qubit.
+- **Vector measurement** is a single `MeasureVectorOperation` ([qamomile/circuit/ir/operation/gate.py#L410](qamomile/circuit/ir/operation/gate.py#L410)) — never expanded into N per-qubit `MeasureOperation`s at IR level. How a vector measurement turns into actual measurement instructions is delegated entirely to emit time: a backend with a native vector-measurement primitive can emit it as one operation, while backends without one can iterate per-qubit. The IR does not commit to per-qubit semantics.
 - **`MeasureQFixedOperation`** lives at an even higher abstraction (HYBRID quantum measurement + classical decode). At `plan`'s pre-segmentation lowering, it is split into `MeasureVectorOperation + DecodeQFixedOperation` so segmentation can route the halves into the right (quantum / classical) segment — but **each half stays abstract**: `MeasureVectorOperation` still represents "measure this whole Vector" (not per-qubit), `DecodeQFixedOperation` is a clean classical op.
 - **Composite gates** (QFT / QPE / IQFT) stay as `CompositeGateOperation` boxes; backends with a native `CompositeGateEmitter` emit a single high-level gate, others fall back to library decomposition. The IR is identical either way.
 - **Loops** (`qmc.range(...)`) stay as `ForOperation`s with symbolic bounds when possible; `LoopAnalyzer` decides unroll vs. runtime loop at emit time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,7 @@ Pre-expanding an abstract concept into per-element / per-qubit / per-step concre
 
 ### Core Pipeline Flow
 
-This is a high-level overview of the layers a `@qkernel` flows through.
-For the canonical, ordered pass sequence — including every transformation
-the pipeline runs and the `BlockKind` boundary each pass advances — see
-"Transpiler Pipeline Stages" below.
+This is a high-level overview of the layers a `@qkernel` flows through. For the canonical, ordered pass sequence — including every transformation the pipeline runs and the `BlockKind` boundary each pass advances — see "Transpiler Pipeline Stages" below.
 
 ```
 @qkernel Python function
@@ -139,13 +136,7 @@ executable = transpiler.transpile(my_circuit, bindings={"theta": 0.5})
 
 ### Transpiler Pipeline Stages
 
-`Transpiler.transpile()` runs the following passes in order. `BlockKind`
-advances as preconditions are met. Every pass other than
-`validate_entrypoint` is idempotent and exposed as a public method on
-`Transpiler` for step-by-step debugging; `validate_entrypoint`
-(implemented by `EntrypointValidationPass`, whose `.name` is
-`"validate_entrypoint"`) runs inline inside `transpile()` as a structural
-check (no public method today).
+`Transpiler.transpile()` runs the following passes in order. `BlockKind` advances as preconditions are met. Every pass other than `validate_entrypoint` is idempotent and exposed as a public method on `Transpiler` for step-by-step debugging; `validate_entrypoint` (implemented by `EntrypointValidationPass`, whose `.name` is `"validate_entrypoint"`) runs inline inside `transpile()` as a structural check (no public method today).
 
 ```
 QKernel
@@ -178,42 +169,13 @@ See [docs/en/tutorial/09_compilation_and_transpilation.py](docs/en/tutorial/09_c
 
 ### Binding vs. Parameter Contract
 
-**Project rule: `bindings` and `parameters` MUST be strictly disjoint** —
-a kernel argument name must never appear in both. This rule is a hard
-project-level constraint; treat it as inviolable when writing kernels,
-helpers, or higher-level wrappers around `transpile()`. The API also
-enforces it at the function boundary by raising `ValueError` immediately
-on any overlap ([transpiler.py][overlap-check]); historically the absence
-of this check caused silent miscompilation of control-flow predicates
-depending on parameter-array elements (see #354 / 7198bfe9).
+**Project rule: `bindings` and `parameters` MUST be strictly disjoint** — a kernel argument name must never appear in both. This rule is a hard project-level constraint; treat it as inviolable when writing kernels, helpers, or higher-level wrappers around `transpile()`. The API also enforces it at the function boundary by raising `ValueError` immediately on any overlap ([transpiler.py][overlap-check]); historically the absence of this check caused silent miscompilation of control-flow predicates depending on parameter-array elements (see #354 / 7198bfe9).
 
 - **Never specify the same name in both `bindings` and `parameters`.**
-  - `bindings={...}` — values resolved at compile time, substituted into
-    the IR by `resolve_parameter_shapes` / `partial_eval`. The value is
-    baked into the emitted circuit.
-  - `parameters=[...]` — argument names that survive the pipeline as
-    runtime parameters in the emitted backend circuit.
-- **Required classical arguments (those without Python defaults) must be
-  resolved exactly one way.** Bind them via `bindings`, list them in an
-  explicit `parameters=[...]`, or rely on `parameters=None` to let
-  `QKernel.build()` auto-detect them — auto-detect picks up classical
-  arguments that have neither a `bindings` value nor a Python default and
-  treats them as runtime parameters. Classical arguments with Python
-  defaults may be omitted from both `bindings` and `parameters`, in which
-  case the default is used.
-- **Arguments driving a classical-value `if` branch (one whose condition
-  is not a measurement-backed `Bit`) must be in `bindings` so
-  `CompileTimeIfLoweringPass` can resolve the condition at compile time.**
-  Per the no-overlap rule above, such arguments therefore cannot
-  simultaneously appear in `parameters`; leaving them symbolic causes
-  compilation to fail. The same applies to any other compile-time
-  structural decision such as `qmc.range(...)` bounds. Measurement-backed
-  `if bit:` / `while bit:` (where `bit = qmc.measure(q)`) is unrelated —
-  that is runtime control flow handled at emit time by backends whose
-  emitters report support for the corresponding constructs
-  (`GateEmitter.supports_if_else()` / `supports_while_loop()`), with the
-  appropriate measurement handling on the same backend (`MeasurementMode`)
-  when mid-circuit measurement is required.
+  - `bindings={...}` — values resolved at compile time, substituted into the IR by `resolve_parameter_shapes` / `partial_eval`. The value is baked into the emitted circuit.
+  - `parameters=[...]` — argument names that survive the pipeline as runtime parameters in the emitted backend circuit.
+- **Required classical arguments (those without Python defaults) must be resolved exactly one way.** Bind them via `bindings`, list them in an explicit `parameters=[...]`, or rely on `parameters=None` to let `QKernel.build()` auto-detect them — auto-detect picks up classical arguments that have neither a `bindings` value nor a Python default and treats them as runtime parameters. Classical arguments with Python defaults may be omitted from both `bindings` and `parameters`, in which case the default is used.
+- **Arguments driving a classical-value `if` branch (one whose condition is not a measurement-backed `Bit`) must be in `bindings` so `CompileTimeIfLoweringPass` can resolve the condition at compile time.** Per the no-overlap rule above, such arguments therefore cannot simultaneously appear in `parameters`; leaving them symbolic causes compilation to fail. The same applies to any other compile-time structural decision such as `qmc.range(...)` bounds. Measurement-backed `if bit:` / `while bit:` (where `bit = qmc.measure(q)`) is unrelated — that is runtime control flow handled at emit time by backends whose emitters report support for the corresponding constructs (`GateEmitter.supports_if_else()` / `supports_while_loop()`), with the appropriate measurement handling on the same backend (`MeasurementMode`) when mid-circuit measurement is required.
 
 [overlap-check]: qamomile/circuit/transpiler/transpiler.py#L475-L487
 
@@ -349,103 +311,42 @@ Translation rules (tone, spacing, terminology, soft line breaks, etc.) are defin
 
 ## Commits, Pull Requests, and Issues
 
-The rules below apply to any text Claude writes that lands in the project's
-permanent record or on GitHub — commit messages, PR titles / bodies, issue
-titles / bodies, PR review comments, code review replies, and inline source
-code comments. Consult this section **before** creating any commit, PR, or
-issue.
+The rules below apply to any text Claude writes that lands in the project's permanent record or on GitHub — commit messages, PR titles / bodies, issue titles / bodies, PR review comments, code review replies, and inline source code comments. Consult this section **before** creating any commit, PR, or issue.
 
 ### Use English
 
-All text that lands in the project's permanent record or on GitHub — commit
-messages, PR titles / bodies, issue titles / bodies, PR / code review
-comments and replies, and inline source code comments — MUST be written in
-**English**. English is the project's lingua franca so that contributors
-regardless of native-language background can read, search, and respond to
-the shared record. Japanese (or other languages) is appropriate only in
-private chat / Slack / live verbal discussion, never in checked-in text or
-GitHub-tracked artifacts.
+All text that lands in the project's permanent record or on GitHub — commit messages, PR titles / bodies, issue titles / bodies, PR / code review comments and replies, and inline source code comments — MUST be written in **English**. English is the project's lingua franca so that contributors regardless of native-language background can read, search, and respond to the shared record. Japanese (or other languages) is appropriate only in private chat / Slack / live verbal discussion, never in checked-in text or GitHub-tracked artifacts.
 
 ### Run `/local-review` before opening a PR
 
-Before opening a pull request, run the `/local-review` skill against the
-current branch. Address every finding it reports, then re-run
-`/local-review`. Repeat the review-and-fix cycle until the skill reports
-**no remaining issues** — only then create the PR. A clean `/local-review`
-run is a precondition for PR creation, not a post-merge polish step.
+Before opening a pull request, run the `/local-review` skill against the current branch. Address every finding it reports, then re-run `/local-review`. Repeat the review-and-fix cycle until the skill reports **no remaining issues** — only then create the PR. A clean `/local-review` run is a precondition for PR creation, not a post-merge polish step.
 
 ### Reply to GitHub review threads when addressing feedback
 
-Whenever a PR review comment is addressed — whether by a code change, a
-documentation update, or a reasoned disagreement that leaves the line as
-is — post a reply directly in that comment's GitHub thread describing the
-resolution. A short, specific note is enough:
+Whenever a PR review comment is addressed — whether by a code change, a documentation update, or a reasoned disagreement that leaves the line as is — post a reply directly in that comment's GitHub thread describing the resolution. A short, specific note is enough:
 
 - "Fixed in `<commit-sha>`: `<one-line summary of the change>`."
 - "Out of scope for this PR; tracked as a follow-up at `<reference>`."
 - "Disagreed because `<reason>` — left as is."
 
-Do **not** rely on the reviewer (or a review bot) to infer that a new
-commit resolves their comment by reading the diff alone. Every individual
-review comment should end up with at least one explicit reply explaining
-the resolution. This keeps the discussion self-contained, makes the
-conversation easy to audit later, and prevents the same concern from
-being re-raised in the next review pass.
+Do **not** rely on the reviewer (or a review bot) to infer that a new commit resolves their comment by reading the diff alone. Every individual review comment should end up with at least one explicit reply explaining the resolution. This keeps the discussion self-contained, makes the conversation easy to audit later, and prevents the same concern from being re-raised in the next review pass.
 
 ### Sync PR branches with `merge`, not `rebase` + force-push
 
-When a PR branch needs to incorporate the latest `main` (for example, when
-the documentation or code in this PR depends on a recent commit on `main`
-that has not yet propagated to the branch's parent), use a regular
-`git merge origin/main` on the PR branch, **not** `git rebase origin/main`
-followed by a force-push. Force-pushing rewrites the commit SHAs that
-reviewers and review bots may have already anchored their comments to,
-disturbs the chronological view of the PR, and creates extra noise for
-everyone re-reading the diff. A merge commit on a feature branch is
-harmless and preserves the existing review thread.
+When a PR branch needs to incorporate the latest `main` (for example, when the documentation or code in this PR depends on a recent commit on `main` that has not yet propagated to the branch's parent), use a regular `git merge origin/main` on the PR branch, **not** `git rebase origin/main` followed by a force-push. Force-pushing rewrites the commit SHAs that reviewers and review bots may have already anchored their comments to, disturbs the chronological view of the PR, and creates extra noise for everyone re-reading the diff. A merge commit on a feature branch is harmless and preserves the existing review thread.
 
 ### No `@`-mentions
 
-Never include **bare** `@username` or `@org/team` mention tokens in
-normal GitHub-tracked text — commit messages, PR titles / bodies, issue
-titles / bodies, **and PR / code review comments and replies posted to
-those threads** — because they trigger unintended GitHub notifications.
-The rule covers the entire scope listed at the top of this section;
-review-thread replies are not an exception, even when the reply is
-short or only quotes a previous reviewer comment. This rule applies to
-bare Python decorators in running prose too: refer to them
-descriptively (e.g., "the qkernel decorator") instead of typing
-`@qkernel` directly in prose. If you must show a literal `@…` string
-(decorator syntax, an actual user handle being discussed, etc.), do so
-**only** inside a fenced code block or an inline code span — GitHub
-does not parse mentions in either, so a code-wrapped `@qkernel` is fine
-and is the only permitted way to render the literal symbol. In normal
-prose, write "the qkernel decorator" instead.
+Never include **bare** `@username` or `@org/team` mention tokens in normal GitHub-tracked text — commit messages, PR titles / bodies, issue titles / bodies, **and PR / code review comments and replies posted to those threads** — because they trigger unintended GitHub notifications. The rule covers the entire scope listed at the top of this section; review-thread replies are not an exception, even when the reply is short or only quotes a previous reviewer comment. This rule applies to bare Python decorators in running prose too: refer to them descriptively (e.g., "the qkernel decorator") instead of typing `@qkernel` directly in prose. If you must show a literal `@…` string (decorator syntax, an actual user handle being discussed, etc.), do so **only** inside a fenced code block or an inline code span — GitHub does not parse mentions in either, so a code-wrapped `@qkernel` is fine and is the only permitted way to render the literal symbol. In normal prose, write "the qkernel decorator" instead.
 
 - ✅ "Update the qkernel decorator so metadata survives `next_version`."
-- ❌ "Update `@qkernel` so metadata survives `next_version`." (the
-  `@qkernel` is wrapped in inline code here only so this example itself
-  doesn't render as a mention; outside a fenced code block or inline code
-  span, never type the literal `@qkernel` symbol in prose)
+- ❌ "Update `@qkernel` so metadata survives `next_version`." (the `@qkernel` is wrapped in inline code here only so this example itself doesn't render as a mention; outside a fenced code block or inline code span, never type the literal `@qkernel` symbol in prose)
 
 ### No unsolicited external links
 
-Do not add external URLs (arXiv, blog posts, docs sites, vendor pages,
-etc.) to commits, PRs, issues, **or PR / code review comments and
-replies** unless the user has explicitly provided that URL in the
-current conversation. When in doubt, omit the link or ask the user to
-supply one. Internal references to other issues / PRs in this repo
-(e.g., `#354`) are fine when factually relevant.
+Do not add external URLs (arXiv, blog posts, docs sites, vendor pages, etc.) to commits, PRs, issues, **or PR / code review comments and replies** unless the user has explicitly provided that URL in the current conversation. When in doubt, omit the link or ask the user to supply one. Internal references to other issues / PRs in this repo (e.g., `#354`) are fine when factually relevant.
 
-This rule targets **editorial** content — prose humans read. URLs that
-are functional metadata consumed by tooling rather than read by people
-(e.g., `$schema` references in JSON / YAML config files, dependency
-URLs in lockfiles, IDE / editor schema hints) are out of scope and may
-be added when the tool requires them.
+This rule targets **editorial** content — prose humans read. URLs that are functional metadata consumed by tooling rather than read by people (e.g., `$schema` references in JSON / YAML config files, dependency URLs in lockfiles, IDE / editor schema hints) are out of scope and may be added when the tool requires them.
 
 - ✅ "Implements the Trotter circuit (see #337 for the design discussion)."
-- ❌ "Implements the Trotter circuit (see `<external-url>`)." (the URL is
-  shown as a `<external-url>` placeholder rather than a real address so
-  this example itself doesn't render as a clickable external link;
-  outside this kind of placeholder, never paste a literal external URL
-  in prose unless the user explicitly provided it)
+- ❌ "Implements the Trotter circuit (see `<external-url>`)." (the URL is shown as a `<external-url>` placeholder rather than a real address so this example itself doesn't render as a clickable external link; outside this kind of placeholder, never paste a literal external URL in prose unless the user explicitly provided it)


### PR DESCRIPTION
## Summary

- Refresh **Transpiler Pipeline Stages** in CLAUDE.md to match the current `transpile()` implementation and tutorial 09 — adds `entrypoint_validate`, `substitute`, `resolve_parameter_shapes`, `unroll_recursion`, `affine_validate`, `classical_lowering`, `validate_symbolic_shapes` to the diagram and groups passes by `BlockKind` transitions.
- Add **Binding vs. Parameter Contract** — every kernel argument must be in exactly one of `bindings` / `parameters`; arguments driving a classical-value `if` (no measurement-backed `Bit`) must be in `bindings`. Mirrors the runtime rejection added in #354 / 7198bfe9.
- Add **IR Abstraction Principle** to CLAUDE.md, plus matching **B-bis. IR Abstraction Level** to `.claude/skills/local-review/SKILL.md`. Codifies "keep the IR as abstract as possible, delegate concretization to the transpile target", with `MeasureVectorOperation`, `MeasureQFixedOperation` split timing, `CompositeGateOperation`, and `ForOperation` as concrete examples. Adds reviewer rules for IR-level pre-expansion / too-early concretization / extension-point bypass.
- Add **Commits, Pull Requests, and Issues** section: run `/local-review` until clean before opening a PR; no `@`-mentions in commits / PRs / issues (refer to decorators descriptively); no unsolicited external links.

`AGENTS.md` is a symlink to `CLAUDE.md`, so both surfaces stay in sync automatically.

## Test plan

- [ ] Confirm CLAUDE.md renders correctly on GitHub (lists, code blocks, ASCII pipeline diagram).
- [ ] Spot-check the file:line reference for `MeasureVectorOperation` (`qamomile/circuit/ir/operation/gate.py:410`) on the rendered file.
- [ ] Confirm the pipeline diagram matches `Transpiler.transpile()` step-by-step.
- [ ] Confirm `AGENTS.md` symlink resolves to the updated content.