### PR TITLE
Fix nested-loop variable name collision in IR emit resolver

### DIFF
--- a/qamomile/circuit/transpiler/emit_context.py
+++ b/qamomile/circuit/transpiler/emit_context.py
@@ -173,21 +173,18 @@ class EmitContext(dict):
                 user-chosen names (e.g. nested ``for i``) get distinct
                 UUIDs and therefore never collide here.
             value: The bound iteration value (int / Hamiltonian item / etc.).
-            display_name: Optional name for debug printing. Also written
-                to the flat-dict view for legacy name-fallback readers
-                during the migration period; remove once all readers
-                use UUID lookup.
+            display_name: Reserved for future debug-only use. Currently
+                unused — loop variables are looked up exclusively by
+                UUID, so the display name is never written into the
+                bindings dict. Defaults to None.
 
         Note: this *adds* a binding to the existing context. Loop
         unrollers typically copy the parent context first so the binding
         is local to one iteration; this method does not copy.
         """
+        del display_name
         self._loop_vars[uuid] = value
         self[uuid] = value
-        if display_name:
-            # Migration shim: legacy readers still look up by name.
-            # Remove once Phase 3 of #7 lands and all readers use UUID.
-            self[display_name] = value
 
     def get_loop_var(self, uuid: str) -> Any:
         """Get a loop variable binding by Value UUID, or None if absent."""

--- a/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
@@ -117,21 +117,37 @@ def _bind_loop_var(
 
     Single source of truth for "how is a loop iteration variable bound
     into the emit context". Always writes UUID-keyed (the canonical
-    identity) and additionally writes name-keyed for legacy readers
-    during the Phase-3 migration. Once name-fallback resolution is
-    removed (Phase 3 of #7), the name-keyed write also goes away.
+    identity). Nested loops with identical display names (e.g. outer
+    and inner ``for i``) coexist safely because each ``ForOperation``
+    carries its own ``loop_var_value`` with a distinct UUID.
+
+    Args:
+        loop_bindings: The emit context to receive the binding.
+            ``EmitContext`` instances are written via ``push_loop_var``;
+            plain dicts get a UUID-keyed write.
+        op: The ``ForOperation`` whose iteration variable is being bound.
+            ``op.loop_var_value`` must not be None.
+        value: The bound iteration value (int / Hamiltonian item /
+            backend loop parameter / etc.).
+
+    Raises:
+        EmitError: If ``op.loop_var_value`` is None — the IR predates
+            the UUID-keyed binding migration. Such IR cannot be emitted
+            correctly because the loop variable has no stable identity.
     """
-    uuid = op.loop_var_value.uuid if op.loop_var_value is not None else None
+    if op.loop_var_value is None:
+        raise EmitError(
+            f"ForOperation '{op.loop_var or '<unnamed>'}' has no "
+            "loop_var_value; cannot bind the iteration variable. The IR "
+            "must be re-built with the current frontend.",
+            operation="ForOperation",
+        )
+    uuid = op.loop_var_value.uuid
     push_loop_var = getattr(loop_bindings, "push_loop_var", None)
-    if callable(push_loop_var) and uuid is not None:
+    if callable(push_loop_var):
         push_loop_var(uuid, value, display_name=op.loop_var or None)
     else:
-        # Legacy fallback: plain dict context, or IR built without
-        # loop_var_value (should not happen post-migration).
-        if uuid is not None:
-            loop_bindings[uuid] = value
-        if op.loop_var:
-            loop_bindings[op.loop_var] = value
+        loop_bindings[uuid] = value
 
 
 # ---------------------------------------------------------------------------
@@ -224,14 +240,22 @@ def emit_for_items(
             _push=push,
             _ctx=loop_bindings,
         ) -> None:
-            """Bind a key/value loop variable both UUID-keyed and (legacy) name-keyed."""
+            """Bind a for-items key/value variable.
+
+            For-items key variables and dim0-shape entries are read by
+            name from ``_index_into_array`` (the container lookup is
+            ``bindings.get(parent.name)``), so the name-keyed write
+            stays here even though scalar ``for`` loop variables no
+            longer write by name. UUID-keyed writes happen alongside
+            for canonical identity tracking.
+            """
             if callable(_push) and uuid is not None:
                 _push(uuid, v, display_name=display_name or None)
             else:
                 if uuid is not None:
                     _ctx[uuid] = v
-                if display_name:
-                    _ctx[display_name] = v
+            if display_name:
+                _ctx[display_name] = v
 
         # Bind key variables (tuple unpacking)
         if len(op.key_vars) > 1:

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -70,41 +70,43 @@ class ValueResolver:
             idx = None
             if idx_value.is_constant():
                 idx = int(idx_value.get_const())
-            elif idx_value.uuid in bindings:
-                idx = self._resolve_numeric_index(bindings[idx_value.uuid])
-                if idx is None:
-                    bound_val = bindings[idx_value.uuid]
-                    return QubitResolutionResult(
-                        success=False,
-                        failure_reason=ResolutionFailureReason.INDEX_NOT_NUMERIC,
-                        failure_details=(
-                            f"Index '{idx_value.name}' (uuid: "
-                            f"{idx_value.uuid[:8]}...) resolved to non-numeric "
-                            f"type: {type(bound_val).__name__}"
-                        ),
-                    )
-            elif idx_value.parent_array is not None:
-                nested_result = self.resolve_classical_value(idx_value, bindings)
-                if nested_result is None:
-                    array_name = idx_value.parent_array.name
-                    return QubitResolutionResult(
-                        success=False,
-                        failure_reason=ResolutionFailureReason.NESTED_ARRAY_RESOLUTION_FAILED,
-                        failure_details=(
-                            f"Nested array access '{array_name}[...]' could not be resolved. "
-                            f"Array '{array_name}' may not be in bindings."
-                        ),
-                    )
-                idx = int(nested_result)
             else:
-                return QubitResolutionResult(
-                    success=False,
-                    failure_reason=ResolutionFailureReason.SYMBOLIC_INDEX_NOT_BOUND,
-                    failure_details=(
-                        f"Index variable '{idx_value.name}' (uuid: "
-                        f"{idx_value.uuid[:8]}...) is not bound."
-                    ),
-                )
+                raw = self.lookup_in_bindings(idx_value, bindings)
+                if raw is not None:
+                    idx = self._resolve_numeric_index(raw)
+                    if idx is None:
+                        return QubitResolutionResult(
+                            success=False,
+                            failure_reason=ResolutionFailureReason.INDEX_NOT_NUMERIC,
+                            failure_details=(
+                                f"Index '{idx_value.name}' (uuid: "
+                                f"{idx_value.uuid[:8]}...) resolved to "
+                                f"non-numeric type: {type(raw).__name__}"
+                            ),
+                        )
+            if idx is None:
+                if idx_value.parent_array is not None:
+                    nested_result = self.resolve_classical_value(idx_value, bindings)
+                    if nested_result is None:
+                        array_name = idx_value.parent_array.name
+                        return QubitResolutionResult(
+                            success=False,
+                            failure_reason=ResolutionFailureReason.NESTED_ARRAY_RESOLUTION_FAILED,
+                            failure_details=(
+                                f"Nested array access '{array_name}[...]' could not be resolved. "
+                                f"Array '{array_name}' may not be in bindings."
+                            ),
+                        )
+                    idx = int(nested_result)
+                else:
+                    return QubitResolutionResult(
+                        success=False,
+                        failure_reason=ResolutionFailureReason.SYMBOLIC_INDEX_NOT_BOUND,
+                        failure_details=(
+                            f"Index variable '{idx_value.name}' (uuid: "
+                            f"{idx_value.uuid[:8]}...) is not bound."
+                        ),
+                    )
 
             if idx is not None:
                 array_qubit_addr = QubitAddress(parent_uuid, idx)
@@ -368,12 +370,7 @@ class ValueResolver:
             if parent_name in self.parameters:
                 if value.element_indices and len(value.element_indices) > 0:
                     idx_value = value.element_indices[0]
-                    idx = None
-                    if idx_value.is_constant():
-                        idx = int(idx_value.get_const())
-                    elif idx_value.uuid in bindings:
-                        idx = self._resolve_numeric_index(bindings[idx_value.uuid])
-
+                    idx = self.resolve_int_value(idx_value, bindings)
                     if idx is not None:
                         return f"{parent_name}[{idx}]"
 

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -70,18 +70,6 @@ class ValueResolver:
             idx = None
             if idx_value.is_constant():
                 idx = int(idx_value.get_const())
-            elif idx_value.name and idx_value.name in bindings:
-                idx = self._resolve_numeric_index(bindings[idx_value.name])
-                if idx is None:
-                    bound_val = bindings[idx_value.name]
-                    return QubitResolutionResult(
-                        success=False,
-                        failure_reason=ResolutionFailureReason.INDEX_NOT_NUMERIC,
-                        failure_details=(
-                            f"Index '{idx_value.name}' resolved to non-numeric type: "
-                            f"{type(bound_val).__name__}"
-                        ),
-                    )
             elif idx_value.uuid in bindings:
                 idx = self._resolve_numeric_index(bindings[idx_value.uuid])
                 if idx is None:
@@ -90,8 +78,9 @@ class ValueResolver:
                         success=False,
                         failure_reason=ResolutionFailureReason.INDEX_NOT_NUMERIC,
                         failure_details=(
-                            f"Index (uuid: {idx_value.uuid[:8]}...) resolved to "
-                            f"non-numeric type: {type(bound_val).__name__}"
+                            f"Index '{idx_value.name}' (uuid: "
+                            f"{idx_value.uuid[:8]}...) resolved to non-numeric "
+                            f"type: {type(bound_val).__name__}"
                         ),
                     )
             elif idx_value.parent_array is not None:
@@ -112,8 +101,8 @@ class ValueResolver:
                     success=False,
                     failure_reason=ResolutionFailureReason.SYMBOLIC_INDEX_NOT_BOUND,
                     failure_details=(
-                        f"Index variable '{idx_value.name}' is not bound. "
-                        f"Neither name nor uuid found in bindings."
+                        f"Index variable '{idx_value.name}' (uuid: "
+                        f"{idx_value.uuid[:8]}...) is not bound."
                     ),
                 )
 
@@ -382,8 +371,6 @@ class ValueResolver:
                     idx = None
                     if idx_value.is_constant():
                         idx = int(idx_value.get_const())
-                    elif idx_value.name and idx_value.name in bindings:
-                        idx = self._resolve_numeric_index(bindings[idx_value.name])
                     elif idx_value.uuid in bindings:
                         idx = self._resolve_numeric_index(bindings[idx_value.uuid])
 

--- a/tests/transpiler/test_nested_loop_name_collision.py
+++ b/tests/transpiler/test_nested_loop_name_collision.py
@@ -1,0 +1,153 @@
+"""Regression tests for nested same-name loop variables.
+
+When an outer ``@qkernel`` and an inlined inner ``@qkernel`` both used
+a loop variable with the same display name (e.g. both ``for i in
+qm.range(...)``), the emit-time parameter resolver previously consulted
+``bindings[name]`` before ``bindings[uuid]``. Because the inner loop
+overwrote ``bindings["i"]`` with its own iteration value, expressions
+captured from the outer scope (such as ``arr[i]`` in the call site)
+were resolved against the *inner* loop's index — producing extra
+parameters keyed by inner-loop iterations and failing at qiskit
+``assign_parameters``.
+
+The fix removes the legacy name-keyed loop variable binding entirely:
+loop variables are bound by ``loop_var_value.uuid`` only, so different
+``ForOperation`` instances with identical display names never collide.
+"""
+
+import pytest
+
+pytest.importorskip("qiskit")
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.qiskit.transpiler import QiskitExecutor, QiskitTranspiler
+
+
+def _zz_hamiltonian(num_qubits: int) -> qm_o.Hamiltonian:
+    """Build a chain of nearest-neighbour ZZ terms on ``num_qubits``."""
+    H = qm_o.Hamiltonian()
+    for i in range(num_qubits - 1):
+        H.add_term(
+            (
+                qm_o.PauliOperator(qm_o.Pauli.Z, i),
+                qm_o.PauliOperator(qm_o.Pauli.Z, i + 1),
+            ),
+            1.0,
+        )
+    return H
+
+
+@qmc.qkernel
+def _inner_uses_same_name(
+    q: qmc.Vector[qmc.Qubit], beta: qmc.Float
+) -> qmc.Vector[qmc.Qubit]:
+    """Apply rx(beta) to every qubit. Inner loop variable is named ``i``."""
+    n = q.shape[0]
+    for i in qmc.range(n):
+        q[i] = qmc.rx(q[i], beta)
+    return q
+
+
+@qmc.qkernel
+def _outer_uses_same_name(
+    n: qmc.UInt,
+    p: qmc.UInt,
+    beta: qmc.Vector[qmc.Float],
+) -> qmc.Vector[qmc.Bit]:
+    """Outer loop also named ``i`` — must shadow the inner one cleanly."""
+    q = qmc.qubit_array(n, "q")
+    for i in qmc.range(p):
+        q = _inner_uses_same_name(q, beta[i])
+    return qmc.measure(q)
+
+
+@pytest.mark.parametrize("p", [1, 2, 3])
+def test_nested_same_name_loops_param_count(p: int):
+    """Number of emitted parameters tracks the outer loop only."""
+    n = 3
+    tr = QiskitTranspiler()
+    exe = tr.transpile(
+        _outer_uses_same_name,
+        bindings={"n": n, "p": p},
+        parameters=["beta"],
+    )
+
+    circuit = exe.compiled_quantum[0].circuit
+    assert circuit.num_parameters == p, (
+        f"Inner loop variable leaked into outer scope: expected {p} "
+        f"parameters but got {circuit.num_parameters}"
+    )
+
+    expected = {f"beta[{k}]" for k in range(p)}
+    assert {str(param) for param in circuit.parameters} == expected
+
+
+def test_nested_same_name_loops_sample_runs():
+    """End-to-end sample with bindings matching the outer loop length."""
+    n = 3
+    p = 2
+    tr = QiskitTranspiler()
+    exe = tr.transpile(
+        _outer_uses_same_name,
+        bindings={"n": n, "p": p},
+        parameters=["beta"],
+    )
+
+    executor = QiskitExecutor()
+    job = exe.sample(executor, bindings={"beta": [0.3, 0.7]}, shots=128)
+    sample = job.result()
+    assert sample.shots == 128
+    assert sum(c for _, c in sample.results) == 128
+
+
+@qmc.qkernel
+def _inner_pauli_evolve(
+    q: qmc.Vector[qmc.Qubit], H: qmc.Observable, gamma: qmc.Float
+) -> qmc.Vector[qmc.Qubit]:
+    return qmc.pauli_evolve(q, H, gamma)
+
+
+@qmc.qkernel
+def _qaoa_with_colliding_names(
+    H: qmc.Observable,
+    n: qmc.UInt,
+    p: qmc.UInt,
+    gamma: qmc.Vector[qmc.Float],
+    beta: qmc.Vector[qmc.Float],
+) -> qmc.Vector[qmc.Bit]:
+    """QAOA-style kernel with outer ``i`` shadowed by an inner ``i``."""
+    q = qmc.qubit_array(n, "q")
+    for i in qmc.range(p):
+        q = _inner_pauli_evolve(q, H, gamma[i])
+        q = _inner_uses_same_name(q, beta[i])
+    return qmc.measure(q)
+
+
+@pytest.mark.parametrize("p", [1, 2])
+def test_qaoa_pattern_with_colliding_names(p: int):
+    """The original bug repro: QAOA with mixer using a colliding ``i``."""
+    H = _zz_hamiltonian(num_qubits=3)
+    tr = QiskitTranspiler()
+    exe = tr.transpile(
+        _qaoa_with_colliding_names,
+        bindings={"H": H, "n": H.num_qubits, "p": p},
+        parameters=["gamma", "beta"],
+    )
+
+    circuit = exe.compiled_quantum[0].circuit
+    expected = {f"gamma[{k}]" for k in range(p)} | {f"beta[{k}]" for k in range(p)}
+    actual = {str(param) for param in circuit.parameters}
+    assert actual == expected, f"Unexpected parameter set: {actual}"
+
+    executor = QiskitExecutor()
+    gamma_values = [0.1 * (k + 1) for k in range(p)]
+    beta_values = [0.2 * (k + 1) for k in range(p)]
+    job = exe.sample(
+        executor,
+        bindings={"gamma": gamma_values, "beta": beta_values},
+        shots=64,
+    )
+    sample = job.result()
+    assert sample.shots == 64
+    assert sum(c for _, c in sample.results) == 64


### PR DESCRIPTION
## Summary

- 同じ display name のループ変数(典型: 外側/内側ともに `for i in qm.range(...)`)を持つ `@qkernel` をネスト呼び出しすると、emit 段で外側スコープから渡された `arr[i]` が**内側ループの値で解決され**、余分なパラメータが生成されて qiskit `assign_parameters` で `TypeError` を出すバグの修正。
- 原因は `value_resolver.py` の 2 箇所が `bindings[idx_value.name]` を `bindings[idx_value.uuid]` より先に引いていたこと。インライン後の内側ループが `bindings["i"]` を上書きするため、外側 Value の解決に内側のイテレーション値が漏れていた。
- ループ変数のバインドを **UUID 一本**に統一(`ForOperation` ごとに別 UUID なので名前衝突しても識別が壊れない)。`for_items` の key var だけは `_index_into_array` の container ルックアップが name 経由なので、name-keyed 書込を残してある。

## Changes

- `value_resolver.py`: `resolve_qubit_index_detailed` と `get_parameter_key` から name-keyed loop var ルックアップを削除。
- `emit_context.py`: `EmitContext.push_loop_var` の `display_name` シム書込を撤去。引数は将来のデバッグ用予約として残置。
- `control_flow_emission.py`:
  - `_bind_loop_var`(scalar `for`)を UUID-only に簡素化。`loop_var_value=None` の旧 IR には `EmitError` で明示的に落とす。
  - `_bind`(`for_items`)は name-keyed 書込を保持(container ルックアップが name 経由のため)。docstring に「なぜ残るか」を明記。

## Test plan

- [x] `tests/transpiler/test_nested_loop_name_collision.py` を新規追加(外側/内側ともに `i` を使うネスト qkernel + 元の QAOA 再現パターン、6 ケース全 green)
- [x] `uv run pytest tests/` — 6401 passed, 28 skipped(回帰なし)
- [x] `uv run ruff check qamomile/` — clean
- [x] `uv run zuban check qamomile/` — 37 errors すべて pre-existing、変更ファイルには発生せず
- [x] 元の再現スクリプト(`qrao_qaoa.py` 相当)が完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)