### PR TITLE
Add GitHub Pages redirect to Read the Docs

### DIFF
--- a/docs/github_page/index.html
+++ b/docs/github_page/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">
+  <title>Qamomile Documentation</title>
+  <link rel="canonical" href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">
+</head>
+<body>
+  <p>Redirecting to <a href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">Qamomile documentation on Read the Docs</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/github_page/index.html` that redirects to the Read the Docs English documentation.

## Test plan
- [ ] Open `docs/github_page/index.html` in a browser and confirm it redirects to RTD.