### PR TITLE
Add per-language GitHub Pages redirects to Read the Docs

### DIFF
--- a/docs/github_page/en/index.html
+++ b/docs/github_page/en/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">
+  <title>Qamomile Documentation</title>
+  <link rel="canonical" href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">
+</head>
+<body>
+  <p>Redirecting to <a href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/en/">Qamomile English documentation on Read the Docs</a>.</p>
+</body>
+</html>

--- a/docs/github_page/ja/index.html
+++ b/docs/github_page/ja/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=https://jij-inc-qamomile.readthedocs-hosted.com/latest/ja/">
+  <title>Qamomile ドキュメント</title>
+  <link rel="canonical" href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/ja/">
+</head>
+<body>
+  <p>Redirecting to <a href="https://jij-inc-qamomile.readthedocs-hosted.com/latest/ja/">Qamomile 日本語ドキュメント (Read the Docs)</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/github_page/en/index.html` and `docs/github_page/ja/index.html` so that `/en/` and `/ja/` paths on GitHub Pages also redirect to the corresponding Read the Docs pages.

## Test plan
- [ ] Open `docs/github_page/en/index.html` in a browser and confirm it redirects to the RTD English docs.
- [ ] Open `docs/github_page/ja/index.html` in a browser and confirm it redirects to the RTD Japanese docs.