### PR TITLE
fix(quri_parts): support parameter arithmetic via linear-combination dicts

### DIFF
--- a/qamomile/circuit/transpiler/gate_emitter.py
+++ b/qamomile/circuit/transpiler/gate_emitter.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
+
+if TYPE_CHECKING:
+    from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind
 
 T = TypeVar("T")  # Backend circuit type
 
@@ -171,6 +174,16 @@ class GateEmitter(Protocol[T]):
             Backend-specific parameter object
         """
         ...
+
+    # ``combine_symbolic`` is an *optional* hook. Backends whose
+    # ``Parameter`` type already supports Python arithmetic (Qiskit
+    # ``ParameterExpression``, CUDA-Q parameters) need not implement it
+    # — ``evaluate_binop`` falls back to ``default_combine_symbolic``
+    # below via a ``getattr`` lookup. Backends whose ``Parameter`` does
+    # NOT support Python operators (e.g. QURI Parts' Rust-backed
+    # ``Parameter``) MUST define ``combine_symbolic`` on their emitter
+    # class and return a backend-native symbolic angle representation
+    # (e.g. a linear-combination dict).
 
     # Single-qubit gates (no parameters)
     @abstractmethod
@@ -439,3 +452,50 @@ class GateEmitter(Protocol[T]):
     def emit_while_end(self, circuit: T, context: Any) -> None:
         """End the while loop context."""
         raise NotImplementedError("Backend does not support native while loops")
+
+
+def default_combine_symbolic(
+    kind: "BinOpKind",
+    lhs: Any,
+    rhs: Any,
+) -> Any:
+    """Default ``combine_symbolic`` for backends with arithmetic-capable Parameters.
+
+    Performs Python operator dispatch on the operands. Used by
+    ``evaluate_binop`` whenever the active emitter does not define its
+    own ``combine_symbolic`` method — the typical case for Qiskit
+    (``ParameterExpression`` overloads ``__add__`` etc.) and CUDA-Q
+    parameters. Backends whose Parameter type lacks Python operators
+    (e.g. QURI Parts) define their own ``combine_symbolic`` on the
+    emitter class to return a backend-native symbolic representation
+    instead.
+
+    Args:
+        kind: The ``BinOpKind`` to apply.
+        lhs: Left operand (numeric or backend Parameter / expression).
+        rhs: Right operand (same shape).
+
+    Returns:
+        ``lhs OP rhs`` for the matching operator. ``0.0`` / ``0`` for
+        division-by-zero in the symbolic path so the caller can finish
+        emission without aborting on a numerically degenerate case.
+        ``None`` for unrecognised ``kind`` values, which the caller
+        treats as a no-op.
+    """
+    from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind
+
+    match kind:
+        case BinOpKind.ADD:
+            return lhs + rhs
+        case BinOpKind.SUB:
+            return lhs - rhs
+        case BinOpKind.MUL:
+            return lhs * rhs
+        case BinOpKind.DIV:
+            return lhs / rhs if rhs != 0 else 0.0
+        case BinOpKind.FLOORDIV:
+            return lhs // rhs if rhs != 0 else 0
+        case BinOpKind.POW:
+            return lhs**rhs
+        case _:
+            return None

--- a/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/cast_binop_emission.py
@@ -14,12 +14,12 @@ if TYPE_CHECKING:
 
 from qamomile.circuit.ir.operation.arithmetic_operations import (
     BinOp,
-    BinOpKind,
     CompOp,
     CondOp,
     NotOp,
 )
 from qamomile.circuit.ir.operation.cast import CastOperation
+from qamomile.circuit.transpiler.gate_emitter import default_combine_symbolic
 from qamomile.circuit.transpiler.passes.eval_utils import (
     FoldPolicy,
     fold_classical_op,
@@ -151,25 +151,26 @@ def evaluate_binop(
     if lhs is None or rhs is None:
         return
 
-    # Symbolic arithmetic over backend Parameter objects. Concrete-only
-    # operands have already been handled by ``fold_classical_op`` above,
-    # so we land here only when at least one operand is a backend
-    # Parameter; ``0``-valued defaults guard against div-by-zero on the
-    # symbolic side without losing the symbolic result for the common case.
-    result = None
-    match op.kind:
-        case BinOpKind.ADD:
-            result = lhs + rhs
-        case BinOpKind.SUB:
-            result = lhs - rhs
-        case BinOpKind.MUL:
-            result = lhs * rhs
-        case BinOpKind.DIV:
-            result = lhs / rhs if rhs != 0 else 0.0
-        case BinOpKind.FLOORDIV:
-            result = lhs // rhs if rhs != 0 else 0
-        case BinOpKind.POW:
-            result = lhs**rhs
+    # Symbolic arithmetic. Concrete-only operands have already been
+    # handled by ``fold_classical_op`` above, so we land here only when
+    # at least one operand is a backend Parameter (or a previously
+    # combined symbolic value). The actual operator dispatch is delegated
+    # to the backend emitter's ``combine_symbolic`` if it provides one,
+    # so that backends whose Parameter type lacks Python operator
+    # overloads (e.g. QURI Parts' Rust-backed Parameter, which raises
+    # ``TypeError`` for ``param * float``) can substitute a backend-native
+    # representation such as a linear-combination dict. Backends with
+    # arithmetic-capable Parameters (Qiskit ``ParameterExpression``,
+    # CUDA-Q parameters) need not implement the hook — we fall back to
+    # ``default_combine_symbolic`` which performs the original Python
+    # operator dispatch.
+    if op.kind is None:
+        return
+    combine = getattr(emit_pass._emitter, "combine_symbolic", None)
+    if callable(combine):
+        result = combine(op.kind, lhs, rhs)
+    else:
+        result = default_combine_symbolic(op.kind, lhs, rhs)
 
     if result is not None and op.results:
         _set_emit_value(bindings, op.results[0].uuid, result)

--- a/qamomile/quri_parts/emitter.py
+++ b/qamomile/quri_parts/emitter.py
@@ -13,6 +13,7 @@ import math
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind
 from qamomile.circuit.transpiler.decompositions import (  # noqa: F401 -- recipe data
     CH_DECOMPOSITION,
     CP_DECOMPOSITION,
@@ -22,11 +23,85 @@ from qamomile.circuit.transpiler.decompositions import (  # noqa: F401 -- recipe
 )
 from qamomile.circuit.transpiler.gate_emitter import MeasurementMode
 
+from .exceptions import QamomileQuriPartsTranspileError
+
 if TYPE_CHECKING:
     from quri_parts.circuit import (
         LinearMappedUnboundParametricQuantumCircuit,
         Parameter,
     )
+
+
+def _to_linear_form(angle: Any) -> dict[Any, float]:
+    """Normalize an angle operand to QURI Parts linear-combination form.
+
+    Three input shapes occur in the symbolic emit path:
+
+    - ``int`` / ``float``: a concrete numeric offset; lifted to
+      ``{CONST: float(angle)}``.
+    - QURI Parts ``Parameter``: a single parameter atom; lifted to
+      ``{angle: 1.0}``.
+    - ``dict``: an existing linear form (typically the result of an
+      earlier ``combine_symbolic`` call stored in ``EmitContext._values``);
+      returned as a fresh ``dict`` so callers can mutate the result
+      without aliasing the stored intermediate.
+
+    Args:
+        angle: The operand to normalize.
+
+    Returns:
+        A fresh ``dict`` mapping QURI Parts ``Parameter`` (including
+        ``CONST``) to ``float`` coefficients.
+    """
+    if isinstance(angle, (int, float)):
+        from quri_parts.circuit import CONST
+
+        return {CONST: float(angle)}
+    if isinstance(angle, dict):
+        return dict(angle)
+    return {angle: 1.0}
+
+
+def _is_pure_const(form: dict[Any, float]) -> bool:
+    """Return True when ``form`` has no parameter atoms (CONST-only or empty).
+
+    Used by ``combine_symbolic`` to detect linear-only multiplication and
+    division: ``param * scalar`` is allowed, ``param * param`` is not.
+    """
+    from quri_parts.circuit import CONST
+
+    return all(k is CONST for k in form)
+
+
+def _add_forms(
+    lhs: dict[Any, float],
+    rhs: dict[Any, float],
+) -> dict[Any, float]:
+    """Coefficient-wise add two linear forms into a fresh dict."""
+    out = dict(lhs)
+    for k, v in rhs.items():
+        out[k] = out.get(k, 0.0) + v
+    return out
+
+
+def _scale_form(form: dict[Any, float], scalar: float) -> dict[Any, float]:
+    """Multiply every coefficient of ``form`` by ``scalar`` into a fresh dict."""
+    return {k: v * scalar for k, v in form.items()}
+
+
+def _sub_forms(
+    lhs: dict[Any, float],
+    rhs: dict[Any, float],
+) -> dict[Any, float]:
+    """Subtract ``rhs`` from ``lhs`` coefficient-wise into a fresh dict."""
+    return _add_forms(lhs, _scale_form(rhs, -1.0))
+
+
+def _const_value(form: dict[Any, float]) -> float:
+    """Extract the CONST coefficient from a CONST-only linear form."""
+    from quri_parts.circuit import CONST
+
+    return form.get(CONST, 0.0)
 
 
 class QuriPartsGateEmitter:
@@ -79,13 +154,110 @@ class QuriPartsGateEmitter:
     def _make_angle_dict(self, angle: float | Any) -> "dict[Parameter, float] | float":
         """Convert angle to QURI Parts format.
 
-        If angle is a float, return it directly.
-        If angle is a Parameter, return {parameter: 1.0}.
+        Three shapes are accepted:
+
+        - ``int``/``float``: returned as ``float`` for the non-parametric
+          gate API (``add_RX_gate`` etc.).
+        - ``dict``: a linear-combination form already produced by
+          ``combine_symbolic`` (e.g. ``{gamma: 0.5, CONST: 0.1}``). Passed
+          through unchanged — QURI Parts'
+          ``LinearMappedUnboundParametricQuantumCircuit.add_Parametric*``
+          API consumes this form natively.
+        - QURI Parts ``Parameter``: a single parameter atom (no BinOp came
+          through), wrapped as ``{angle: 1.0}``.
+
+        Args:
+            angle: The angle value to convert.
+
+        Returns:
+            ``float`` for concrete angles, otherwise a
+            ``dict[Parameter, float]`` linear combination.
         """
         if isinstance(angle, (int, float)):
             return float(angle)
-        # Assume it's a QURI Parts Parameter
+        if isinstance(angle, dict):
+            return angle
         return {angle: 1.0}
+
+    def combine_symbolic(
+        self,
+        kind: BinOpKind,
+        lhs: Any,
+        rhs: Any,
+    ) -> "dict[Parameter, float]":
+        """Combine two angle operands as a QURI Parts linear-combination dict.
+
+        QURI Parts' ``Parameter`` is Rust-backed and exposes no Python
+        arithmetic operators (``param * float`` raises ``TypeError``).
+        The only supported representation for parametric angles is the
+        linear-combination dict consumed by
+        ``LinearMappedUnboundParametricQuantumCircuit.add_Parametric*``,
+        which fundamentally cannot express non-linear combinations
+        (parameter × parameter, parameter ** n, etc.). This override
+        produces such a dict for every linear case and raises a clear
+        ``QamomileQuriPartsTranspileError`` for non-linear cases instead
+        of letting the underlying ``TypeError`` bubble up.
+
+        Args:
+            kind: The ``BinOpKind`` from the IR.
+            lhs: Left operand (numeric, QURI Parts ``Parameter``, or an
+                existing linear-combination ``dict``).
+            rhs: Right operand (same shapes).
+
+        Returns:
+            A fresh ``dict[Parameter, float]`` representing the linear
+            combination of the operands.
+
+        Raises:
+            QamomileQuriPartsTranspileError: When the operation cannot be
+                expressed as a linear combination (e.g.
+                ``param * param``, ``param / param``, ``param ** n``,
+                ``param // n``, division by zero in the symbolic path).
+        """
+        lf_lhs = _to_linear_form(lhs)
+        lf_rhs = _to_linear_form(rhs)
+
+        match kind:
+            case BinOpKind.ADD:
+                return _add_forms(lf_lhs, lf_rhs)
+            case BinOpKind.SUB:
+                return _sub_forms(lf_lhs, lf_rhs)
+            case BinOpKind.MUL:
+                if _is_pure_const(lf_rhs):
+                    return _scale_form(lf_lhs, _const_value(lf_rhs))
+                if _is_pure_const(lf_lhs):
+                    return _scale_form(lf_rhs, _const_value(lf_lhs))
+                raise QamomileQuriPartsTranspileError(
+                    "QURI Parts backend supports only linear combinations of "
+                    "parameters; parameter * parameter is non-linear and "
+                    "cannot be expressed as a LinearMappedUnboundParametric "
+                    "angle. Bind one side to a concrete value first."
+                )
+            case BinOpKind.DIV:
+                if not _is_pure_const(lf_rhs):
+                    raise QamomileQuriPartsTranspileError(
+                        "QURI Parts backend supports only linear combinations "
+                        "of parameters; division by a parameter is non-linear "
+                        "and cannot be expressed as a LinearMappedUnboundParametric "
+                        "angle. Bind the divisor to a concrete value first."
+                    )
+                divisor = _const_value(lf_rhs)
+                if divisor == 0:
+                    raise QamomileQuriPartsTranspileError(
+                        "QURI Parts backend: division by zero in symbolic angle."
+                    )
+                return _scale_form(lf_lhs, 1.0 / divisor)
+            case BinOpKind.POW | BinOpKind.FLOORDIV:
+                raise QamomileQuriPartsTranspileError(
+                    f"QURI Parts backend supports only linear combinations of "
+                    f"parameters; '{kind.name}' is not supported on parametric "
+                    f"angles. Bind the parameter to a concrete value first."
+                )
+            case _:
+                raise QamomileQuriPartsTranspileError(
+                    f"QURI Parts backend: unsupported BinOpKind '{kind}' on "
+                    f"parametric angle."
+                )
 
     # Single-qubit gates (no parameters)
     def emit_h(

--- a/tests/transpiler/backends/test_quri_parts_frontend.py
+++ b/tests/transpiler/backends/test_quri_parts_frontend.py
@@ -2421,11 +2421,48 @@ class TestControlFlowQAOAPattern:
             g = cz_gates[len(even_pairs_list) + idx]
             assert g.control_indices == (start,) and g.target_indices == (start + 1,)
 
-    # NOTE: test_qaoa_single_layer_parametric is NOT ported because it uses
-    # `gamma * Jij` where gamma is a Parameter and Jij is a float — this
-    # triggers TypeError: unsupported operand type(s) for *: 'Parameter' and
-    # 'float' in QuriParts. This is a fundamental limitation of QURI Parts'
-    # Parameter type not supporting arithmetic with float operands.
+    def test_qaoa_single_layer_parametric(self):
+        """QAOA layer with parameters=["gamma","beta"] — bind and execute.
+
+        Verifies that ``gamma * Jij`` (Parameter × Float BinOp) survives
+        emission as a QURI Parts linear-combination dict and produces a
+        bindable parametric circuit.
+        """
+
+        @qmc.qkernel
+        def qaoa_layer(
+            n: qmc.UInt,
+            ising: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            gamma: qmc.Float,
+            beta: qmc.Float,
+        ) -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(n, "q")
+            for i in qmc.range(n):
+                q[i] = qmc.h(q[i])
+            for (i, j), Jij in qmc.items(ising):
+                q[i], q[j] = qmc.rzz(q[i], q[j], gamma * Jij)
+            for i in qmc.range(n):
+                q[i] = qmc.rx(q[i], beta)
+            return qmc.measure(q)
+
+        ising = {(0, 1): 1.0}
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            qaoa_layer,
+            bindings={"n": 2, "ising": ising},
+            parameters=["gamma", "beta"],
+        )
+        assert exe.has_parameters
+        # Bind and execute — exercises the linear-form dict emission path
+        executor = transpiler.executor()
+        job = exe.sample(
+            executor,
+            shots=100,
+            bindings={"gamma": 0.5, "beta": 0.3},
+        )
+        result = job.result()
+        assert result is not None
+        assert len(result.results) > 0
 
 
 # ============================================================================
@@ -3068,12 +3105,7 @@ class TestParametricGates:
     # -- BinOp parametric tests --
 
     def test_parametric_mul_binop(self):
-        """theta * c via items() loop, bind and verify numerical result.
-
-        Note: QURI Parts' Rust-backed Parameter does not support arithmetic
-        operators (*, +, -) with floats, so BinOp with unbound parameters
-        is not possible. We test with fully bound parameters instead.
-        """
+        """theta * c via items() loop, fully bound — verifies fold path."""
 
         @qmc.qkernel
         def circuit(
@@ -3094,11 +3126,7 @@ class TestParametricGates:
         assert np.isclose(rx_gates[0].params[0], 3.0, atol=1e-10)
 
     def test_parametric_add_binop(self):
-        """theta + o via items() loop, bind and verify numerical result.
-
-        Note: QURI Parts' Rust-backed Parameter does not support arithmetic
-        operators, so BinOp with unbound parameters is not possible.
-        """
+        """theta + o via items() loop, fully bound — verifies fold path."""
 
         @qmc.qkernel
         def circuit(
@@ -3119,11 +3147,7 @@ class TestParametricGates:
         assert np.isclose(rx_gates[0].params[0], 1.5, atol=1e-10)
 
     def test_parametric_sub_binop(self):
-        """theta - o via items() loop, bind and verify numerical result.
-
-        Note: QURI Parts' Rust-backed Parameter does not support arithmetic
-        operators, so BinOp with unbound parameters is not possible.
-        """
+        """theta - o via items() loop, fully bound — verifies fold path."""
 
         @qmc.qkernel
         def circuit(
@@ -3139,6 +3163,93 @@ class TestParametricGates:
             circuit, bindings={"theta": 1.0, "offset": {0: 0.5}}
         )
         gates = _get_gates(qc)
+        rx_gates = [g for g in gates if g.name == gate_names.RX]
+        assert len(rx_gates) == 1
+        assert np.isclose(rx_gates[0].params[0], 0.5, atol=1e-10)
+
+    # -- Symbolic (unbound parameter) BinOp tests --
+    #
+    # These exercise the new ``GateEmitter.combine_symbolic`` path: the
+    # parameter is left as a runtime parameter (``parameters=["theta"]``)
+    # so the BinOp is not constant-folded and the QURI Parts emitter must
+    # produce a linear-combination dict.
+
+    def test_symbolic_mul_binop_param_times_const(self):
+        """theta * c with theta unbound — produces ParametricRX with coeff."""
+
+        @qmc.qkernel
+        def circuit(
+            theta: qmc.Float,
+            coeff: qmc.Dict[qmc.UInt, qmc.Float],
+        ) -> qmc.Bit:
+            q = qmc.qubit("q")
+            for _, c in qmc.items(coeff):
+                q = qmc.rx(q, theta * c)
+            return qmc.measure(q)
+
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            circuit,
+            bindings={"coeff": {0: 2.0}},
+            parameters=["theta"],
+        )
+        qc = exe.compiled_quantum[0].circuit
+        # Parametric RX should be present (not folded)
+        assert qc.parameter_count == 1
+        # Bind theta=1.5 → angle = 3.0
+        gates = _get_gates(qc, parameter_bindings=[1.5])
+        rx_gates = [g for g in gates if g.name == gate_names.RX]
+        assert len(rx_gates) == 1
+        assert np.isclose(rx_gates[0].params[0], 3.0, atol=1e-10)
+
+    def test_symbolic_add_binop_param_plus_const(self):
+        """theta + o with theta unbound — linear form {theta: 1, CONST: o}."""
+
+        @qmc.qkernel
+        def circuit(
+            theta: qmc.Float,
+            offset: qmc.Dict[qmc.UInt, qmc.Float],
+        ) -> qmc.Bit:
+            q = qmc.qubit("q")
+            for _, o in qmc.items(offset):
+                q = qmc.rx(q, theta + o)
+            return qmc.measure(q)
+
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            circuit,
+            bindings={"offset": {0: 0.5}},
+            parameters=["theta"],
+        )
+        qc = exe.compiled_quantum[0].circuit
+        assert qc.parameter_count == 1
+        gates = _get_gates(qc, parameter_bindings=[1.0])
+        rx_gates = [g for g in gates if g.name == gate_names.RX]
+        assert len(rx_gates) == 1
+        assert np.isclose(rx_gates[0].params[0], 1.5, atol=1e-10)
+
+    def test_symbolic_sub_binop_param_minus_const(self):
+        """theta - o with theta unbound — verifies linear form sign."""
+
+        @qmc.qkernel
+        def circuit(
+            theta: qmc.Float,
+            offset: qmc.Dict[qmc.UInt, qmc.Float],
+        ) -> qmc.Bit:
+            q = qmc.qubit("q")
+            for _, o in qmc.items(offset):
+                q = qmc.rx(q, theta - o)
+            return qmc.measure(q)
+
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            circuit,
+            bindings={"offset": {0: 0.5}},
+            parameters=["theta"],
+        )
+        qc = exe.compiled_quantum[0].circuit
+        assert qc.parameter_count == 1
+        gates = _get_gates(qc, parameter_bindings=[1.0])
         rx_gates = [g for g in gates if g.name == gate_names.RX]
         assert len(rx_gates) == 1
         assert np.isclose(rx_gates[0].params[0], 0.5, atol=1e-10)

--- a/tests/transpiler/backends/test_quri_parts_symbolic.py
+++ b/tests/transpiler/backends/test_quri_parts_symbolic.py
@@ -1,0 +1,315 @@
+"""QURI Parts symbolic-angle (linear-combination dict) tests.
+
+Covers ``QuriPartsGateEmitter.combine_symbolic`` directly and the
+end-to-end emission path that produces ``ParametricRX``/``Parametric...``
+gates when a runtime parameter participates in a ``BinOp``.
+
+QURI Parts' Rust-backed ``Parameter`` does not support Python arithmetic,
+so the qamomile compiler routes parametric BinOps through
+``combine_symbolic`` to produce the linear-combination dicts that
+``LinearMappedUnboundParametricQuantumCircuit`` consumes natively.
+Non-linear combinations (``param * param``, ``param ** n``, etc.)
+fundamentally cannot be expressed in this form and must surface a clear
+``QamomileQuriPartsTranspileError`` rather than a low-level ``TypeError``.
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.quri_parts
+
+import qamomile.circuit as qmc  # noqa: E402
+
+pytest.importorskip("quri_parts")
+pytest.importorskip("quri_parts.qulacs")
+
+from quri_parts.circuit import CONST, gate_names  # noqa: E402
+
+from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind  # noqa: E402
+from qamomile.quri_parts import QuriPartsTranspiler  # noqa: E402
+from qamomile.quri_parts.emitter import QuriPartsGateEmitter  # noqa: E402
+from qamomile.quri_parts.exceptions import (  # noqa: E402
+    QamomileQuriPartsTranspileError,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for combine_symbolic
+# ---------------------------------------------------------------------------
+
+
+def _emitter_with_circuit():
+    """Build an emitter with an active circuit so create_parameter works."""
+    e = QuriPartsGateEmitter()
+    e.create_circuit(num_qubits=1, num_clbits=0)
+    return e
+
+
+class TestCombineSymbolicLinear:
+    """Linear-combination cases that combine_symbolic must handle."""
+
+    def test_param_times_const_lhs_const(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        result = e.combine_symbolic(BinOpKind.MUL, gamma, 2.5)
+        assert result == {gamma: 2.5}
+
+    def test_param_times_const_rhs_const(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        # Symmetric — scalar on the left
+        result = e.combine_symbolic(BinOpKind.MUL, 2.5, gamma)
+        assert result == {gamma: 2.5}
+
+    def test_param_plus_const(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        result = e.combine_symbolic(BinOpKind.ADD, gamma, 0.5)
+        assert result == {gamma: 1.0, CONST: 0.5}
+
+    def test_param_minus_const(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        result = e.combine_symbolic(BinOpKind.SUB, gamma, 0.5)
+        assert result == {gamma: 1.0, CONST: -0.5}
+
+    def test_const_minus_param(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        result = e.combine_symbolic(BinOpKind.SUB, 1.0, gamma)
+        assert result == {CONST: 1.0, gamma: -1.0}
+
+    def test_param_plus_param(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        beta = e.create_parameter("beta")
+        result = e.combine_symbolic(BinOpKind.ADD, gamma, beta)
+        assert result == {gamma: 1.0, beta: 1.0}
+
+    def test_param_div_const(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        result = e.combine_symbolic(BinOpKind.DIV, gamma, 2.0)
+        assert result == {gamma: 0.5}
+
+    def test_chained_form_dict_lhs(self):
+        """combine_symbolic re-applied to its own output handles dict inputs."""
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        # First: gamma * 2.0 → {gamma: 2.0}
+        first = e.combine_symbolic(BinOpKind.MUL, gamma, 2.0)
+        # Then: (gamma * 2.0) + 0.1 → {gamma: 2.0, CONST: 0.1}
+        second = e.combine_symbolic(BinOpKind.ADD, first, 0.1)
+        assert second == {gamma: 2.0, CONST: 0.1}
+
+    def test_to_linear_form_returns_fresh_dict(self):
+        """Mutation of result must not alias an upstream stored intermediate."""
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        first = e.combine_symbolic(BinOpKind.MUL, gamma, 2.0)
+        second = e.combine_symbolic(BinOpKind.ADD, first, 0.1)
+        # Mutating ``second`` must not change ``first``.
+        second.clear()
+        assert first == {gamma: 2.0}
+
+
+class TestCombineSymbolicNonLinear:
+    """Non-linear or unsupported cases must raise a clear error."""
+
+    def test_param_times_param_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        beta = e.create_parameter("beta")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="non-linear"):
+            e.combine_symbolic(BinOpKind.MUL, gamma, beta)
+
+    def test_const_div_param_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="division by"):
+            e.combine_symbolic(BinOpKind.DIV, 1.0, gamma)
+
+    def test_param_div_param_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        beta = e.create_parameter("beta")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="division by"):
+            e.combine_symbolic(BinOpKind.DIV, gamma, beta)
+
+    def test_param_div_zero_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="division by zero"):
+            e.combine_symbolic(BinOpKind.DIV, gamma, 0.0)
+
+    def test_pow_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="POW"):
+            e.combine_symbolic(BinOpKind.POW, gamma, 2)
+
+    def test_floordiv_raises(self):
+        e = _emitter_with_circuit()
+        gamma = e.create_parameter("gamma")
+        with pytest.raises(QamomileQuriPartsTranspileError, match="FLOORDIV"):
+            e.combine_symbolic(BinOpKind.FLOORDIV, gamma, 2)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: parametric circuits with BinOps
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolicEndToEnd:
+    """End-to-end transpile + bind + sample/estimate with symbolic angles.
+
+    Note: top-level ``rx(q, theta * 2.0)`` patterns (BinOp directly between
+    quantum gates without an enclosing for-items loop) are rejected by the
+    segmentation pass with ``MultipleQuantumSegmentsError`` on every backend
+    — this is a separate, pre-existing constraint of the NISQ segmentation
+    strategy, not a QURI-Parts-specific issue. The realistic and supported
+    pattern is BinOp-inside-loop, which the QAOA tests below exercise.
+    """
+
+    def test_rx_with_param_times_const_in_items_loop(self):
+        """Inside qmc.items, rx(q, theta * c) survives emission and binds."""
+
+        @qmc.qkernel
+        def circuit(
+            theta: qmc.Float,
+            coeffs: qmc.Dict[qmc.UInt, qmc.Float],
+        ) -> qmc.Bit:
+            q = qmc.qubit("q")
+            for _, c in qmc.items(coeffs):
+                q = qmc.rx(q, theta * c)
+            return qmc.measure(q)
+
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            circuit,
+            bindings={"coeffs": {0: 2.0, 1: -0.5}},
+            parameters=["theta"],
+        )
+        qc = exe.compiled_quantum[0].circuit
+        assert qc.parameter_count == 1
+        # Bind theta = 1.0 → angles = [2.0, -0.5]
+        bound = qc.bind_parameters([1.0])
+        gates = list(bound.gates)
+        rx_gates = [g for g in gates if g.name == gate_names.RX]
+        assert len(rx_gates) == 2
+        assert np.isclose(rx_gates[0].params[0], 2.0, atol=1e-10)
+        assert np.isclose(rx_gates[1].params[0], -0.5, atol=1e-10)
+
+    def test_qaoa_layer_sample_matches_qiskit(self):
+        """QAOA layer with symbolic gamma*Jij — sampling distribution sanity."""
+
+        @qmc.qkernel
+        def qaoa_layer(
+            n: qmc.UInt,
+            ising: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            gamma: qmc.Float,
+            beta: qmc.Float,
+        ) -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(n, "q")
+            for i in qmc.range(n):
+                q[i] = qmc.h(q[i])
+            for (i, j), Jij in qmc.items(ising):
+                q[i], q[j] = qmc.rzz(q[i], q[j], gamma * Jij)
+            for i in qmc.range(n):
+                q[i] = qmc.rx(q[i], beta)
+            return qmc.measure(q)
+
+        ising = {(0, 1): 1.0}
+        transpiler = QuriPartsTranspiler()
+        exe = transpiler.transpile(
+            qaoa_layer,
+            bindings={"n": 2, "ising": ising},
+            parameters=["gamma", "beta"],
+        )
+        executor = transpiler.executor()
+        job = exe.sample(
+            executor,
+            shots=2000,
+            bindings={"gamma": 0.5, "beta": 0.3},
+        )
+        result = job.result()
+        # Symmetric Ising with H+RX produces non-trivial distribution; just
+        # verify shots add up and all bitstrings are length-2.
+        total = sum(count for _, count in result.results)
+        assert total == 2000
+        for value, _ in result.results:
+            assert len(value) == 2
+
+    def test_qaoa_expval_matches_qiskit(self):
+        """QAOA expval through both QURI Parts and Qiskit must agree.
+
+        Cross-backend equivalence check per CLAUDE.md (sampling + expval
+        both required for algorithm/stdlib changes).
+        """
+        pytest.importorskip("qiskit")
+        import qamomile.observable as qm_o
+        from qamomile.qiskit import QiskitTranspiler
+
+        ising = {(0, 1): 1.0}
+
+        @qmc.qkernel
+        def qaoa_expval(
+            n: qmc.UInt,
+            ising: qmc.Dict[qmc.Tuple[qmc.UInt, qmc.UInt], qmc.Float],
+            obs: qmc.Observable,
+            gamma: qmc.Float,
+            beta: qmc.Float,
+        ) -> qmc.Float:
+            q = qmc.qubit_array(n, "q")
+            for i in qmc.range(n):
+                q[i] = qmc.h(q[i])
+            for (i, j), Jij in qmc.items(ising):
+                q[i], q[j] = qmc.rzz(q[i], q[j], gamma * Jij)
+            for i in qmc.range(n):
+                q[i] = qmc.rx(q[i], beta)
+            return qmc.expval(q, obs)
+
+        H = qm_o.Z(0) * qm_o.Z(1)
+
+        gamma_val, beta_val = 0.7, 0.4
+        bindings = {"n": 2, "ising": ising, "obs": H}
+
+        qp = QuriPartsTranspiler()
+        exe_qp = qp.transpile(
+            qaoa_expval, bindings=bindings, parameters=["gamma", "beta"]
+        )
+        val_qp = exe_qp.run(
+            qp.executor(),
+            bindings={"gamma": gamma_val, "beta": beta_val},
+        ).result()
+
+        qk = QiskitTranspiler()
+        exe_qk = qk.transpile(
+            qaoa_expval, bindings=bindings, parameters=["gamma", "beta"]
+        )
+        val_qk = exe_qk.run(
+            qk.executor(),
+            bindings={"gamma": gamma_val, "beta": beta_val},
+        ).result()
+
+        assert np.isclose(val_qp, val_qk, atol=1e-8)
+
+    def test_nonlinear_param_squared_raises_at_transpile(self):
+        """theta * theta inside an items loop surfaces our linear-only error."""
+
+        @qmc.qkernel
+        def circuit(
+            theta: qmc.Float,
+            coeffs: qmc.Dict[qmc.UInt, qmc.Float],
+        ) -> qmc.Bit:
+            q = qmc.qubit("q")
+            for _, _c in qmc.items(coeffs):
+                q = qmc.rx(q, theta * theta)
+            return qmc.measure(q)
+
+        transpiler = QuriPartsTranspiler()
+        with pytest.raises(QamomileQuriPartsTranspileError, match="non-linear"):
+            transpiler.transpile(
+                circuit,
+                bindings={"coeffs": {0: 1.0}},
+                parameters=["theta"],
+            )


### PR DESCRIPTION
## Summary

- Fix a fundamental QURI Parts limitation: `gamma * Jij` (Parameter × Float) and similar parametric BinOps could not be transpiled because QURI Parts' Rust-backed `Parameter` exposes no Python arithmetic operators (`p * 2.0`, `p + 1.0`, … all raise `TypeError`).
- Move the symbolic combine to a backend hook (`emitter.combine_symbolic`) with a `default_combine_symbolic` fallback that preserves the existing Qiskit/CUDA-Q behavior.
- Implement QURI Parts' override using the linear-combination dict (`{Parameter: coeff, CONST: offset}`) that `LinearMappedUnboundParametricQuantumCircuit` consumes natively. Non-linear cases (`param * param`, `param ** n`, …) raise `QamomileQuriPartsTranspileError` with a clear message instead of letting the underlying `TypeError` surface.

## Why

Before this change the canonical QAOA layer

```python
for (i, j), Jij in qmc.items(ising):
    q[i], q[j] = qmc.rzz(q[i], q[j], gamma * Jij)
```

failed at emit time on QURI Parts (`cast_binop_emission.py` did `result = lhs * rhs` directly on the backend Parameter). Tests papered over this by fully-binding `gamma` or by skipping outright — the QURI Parts version of `test_qaoa_single_layer_parametric` was [explicitly not ported](https://github.com/Jij-Inc/Qamomile/blob/main/tests/transpiler/backends/test_quri_parts_frontend.py#L2424) with a NOTE describing the limitation. The "Parameter type does not support arithmetic" report is now resolved at the right architectural seam.

## Design

- **`evaluate_binop` Phase 2** delegates to `getattr(emitter, "combine_symbolic", None)`. When the emitter defines the hook, its return value is stored in `EmitContext._values`. Otherwise we fall back to `default_combine_symbolic`, which is the original Python-operator dispatch (`lhs + rhs`, `lhs * rhs`, …). Qiskit and CUDA-Q emitters do not implement the hook → identical behavior to before.
- **QURI Parts emitter** maintains a `LinearForm = dict[Parameter, float]` (with `quri_parts.circuit.CONST` as the offset key). `_to_linear_form` normalizes float / Parameter / dict inputs; `_add_forms` / `_scale_form` / `_sub_forms` handle the linear ops; non-linear ops raise `QamomileQuriPartsTranspileError`. `_make_angle_dict` is extended to accept `dict` inputs and pass them through to `add_Parametric*_gate` unchanged. The existing `{k: v/2 for k, v in dict.items()}` pattern in `emit_crx`/`emit_cry`/`emit_crz`/`emit_cp` already works on the new form.
- **Single Parameter case** (no BinOp, e.g. `rx(q, theta)`) bypasses `combine_symbolic` entirely — `_make_angle_dict` already wraps it as `{theta: 1.0}`. No change to that path.

| Input (IR) | QURI Parts result | Qiskit/CUDA-Q result |
|---|---|---|
| `rx(q, gamma)` | `{gamma: 1.0}` (unchanged) | unchanged |
| `rzz(q, q, gamma * Jij)` | `{gamma: Jij}` | `ParameterExpression(gamma * Jij)` |
| `rx(q, gamma + offset)` | `{gamma: 1.0, CONST: offset}` | unchanged |
| `rx(q, gamma + phi)` | `{gamma: 1.0, phi: 1.0}` | unchanged |
| `rx(q, gamma * gamma)` | `QamomileQuriPartsTranspileError("non-linear ...")` | unchanged (squared expr) |
| `rx(q, gamma ** 2)` | `QamomileQuriPartsTranspileError` | unchanged |

## Tests

- Unskipped and ported `test_qaoa_single_layer_parametric` for QURI Parts.
- Added parametric (unbound `theta`) versions of the existing `test_parametric_mul/add/sub_binop` tests.
- New `tests/transpiler/backends/test_quri_parts_symbolic.py`:
  - `combine_symbolic` direct unit tests — linear cases (param×const, ±, /scalar, multi-param ADD, dict-input chaining, defensive copy).
  - Non-linear error tests — `param*param`, `_/param`, `param/0`, `POW`, `FLOORDIV`.
  - End-to-end: `rx(q, theta * c)` inside `qmc.items` binds correctly; QAOA layer sample passes; **QAOA expval cross-checked against Qiskit (`np.allclose` atol 1e-8)** per CLAUDE.md sampling-+-expval requirement; non-linear `theta * theta` surfaces our error at transpile time.

## Test plan

- [x] `pytest tests/transpiler/backends/test_quri_parts_*` — 584 passed
- [x] `pytest tests/transpiler/backends/test_qiskit_*` — 531 passed (no regression)
- [x] `pytest tests/transpiler/backends/test_cudaq_*` — 359 passed (no regression)
- [x] `pytest tests/circuit/algorithm/ tests/circuit/test_qft.py tests/circuit/test_qpe.py` — 473 passed
- [x] `pytest -m ""` (full unit suite, 7615 + 19 new) — all green
- [x] `ruff check qamomile/ tests/` — clean
- [x] `zuban check qamomile/` — baseline 27 → 28 (one new "Statement is unreachable" mirroring the established pattern in `eval_utils.py:194`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)