### PR TITLE
Enforce affine type rule for Vector broadcast gates

### DIFF
--- a/qamomile/circuit/frontend/operation/qubit_gates.py
+++ b/qamomile/circuit/frontend/operation/qubit_gates.py
@@ -67,27 +67,39 @@ def _broadcast_single_qubit_gate(
     transpiler passes, resource estimation, and visualization continue to
     work without any broadcast-specific handling.
 
+    The input ``Vector[Qubit]`` handle is consumed (affine type
+    enforcement) — the caller must capture the returned new handle, just
+    as the scalar single-qubit gate path does. Dropping the return value
+    will trip ``QubitConsumedError`` on the next use of the original
+    handle.
+
     Args:
-        qubits: The `Vector[Qubit]` to apply the gate to. Must have all
-            previously-borrowed elements returned; otherwise the loop body's
-            element borrow will fail. The handle itself is not consumed —
-            the same instance is returned with element borrows released.
-        gate_type: The `GateOperationType` to apply to each element. Must
-            correspond to a non-parametric single-qubit gate
-            (e.g. `H`, `X`, `Y`, `Z`, `S`, `T`, `SDG`, `TDG`).
+        qubits (Vector[Qubit]): The `Vector[Qubit]` to apply the gate to.
+            Must have all previously-borrowed elements returned; otherwise
+            the loop body's element borrow will fail. This handle is
+            consumed by the call.
+        gate_type (GateOperationType): The `GateOperationType` to apply to
+            each element. Must correspond to a non-parametric single-qubit
+            gate (e.g. `H`, `X`, `Y`, `Z`, `S`, `T`, `SDG`, `TDG`).
 
     Returns:
-        The same `Vector[Qubit]` handle that was passed in, after the
-        broadcast loop has been emitted into the active tracer.
+        Vector[Qubit]: A fresh `Vector[Qubit]` handle wrapping the same
+            underlying array value, with the broadcast loop emitted into
+            the active tracer.
 
     Raises:
         UnreturnedBorrowError: If any element of `qubits` is still borrowed
             when broadcasting begins.
+        QubitConsumedError: If the input handle has already been consumed
+            (e.g. a previous broadcast result was dropped).
     """
     # Local import to avoid a frontend.operation circular import chain.
     from qamomile.circuit.frontend.operation.control_flow import for_loop
 
-    qubits.validate_all_returned()
+    # Consume the input handle up-front, mirroring `_measure_vector_qubit`
+    # and `pauli_evolve`. `ArrayBase.consume` runs `validate_all_returned`
+    # internally, so we drop the redundant explicit call.
+    qubits = qubits.consume(operation_name=gate_type.name)
     n = qubits.shape[0]
     # ``var_name`` is display-only — the IR uses UUIDs for identity. Use ``i``
     # so the visualization matches a hand-written ``for i in qmc.range(n)``.
@@ -108,22 +120,31 @@ def _broadcast_rotation_gate(
     per-qubit angle arrays remain a per-element-loop concern (e.g.
     `rx_layer`).
 
+    The input ``Vector[Qubit]`` handle is consumed (affine type
+    enforcement) — the caller must capture the returned new handle.
+
     Args:
-        qubits: The `Vector[Qubit]` to apply the rotation to.
-        angle: The rotation angle in radians, shared across all qubits in
-            the broadcast. Accepts a Python `float` or a `Float` handle.
-        gate_type: The rotation gate kind (`RX`, `RY`, `RZ`, or `P`).
+        qubits (Vector[Qubit]): The `Vector[Qubit]` to apply the rotation
+            to. This handle is consumed by the call.
+        angle (float | Float): The rotation angle in radians, shared
+            across all qubits in the broadcast. Accepts a Python `float`
+            or a `Float` handle.
+        gate_type (GateOperationType): The rotation gate kind (`RX`, `RY`,
+            `RZ`, or `P`).
 
     Returns:
-        The same `Vector[Qubit]` handle that was passed in.
+        Vector[Qubit]: A fresh `Vector[Qubit]` handle wrapping the same
+            underlying array value, with the broadcast loop emitted.
 
     Raises:
         UnreturnedBorrowError: If any element of `qubits` is still borrowed
             when broadcasting begins.
+        QubitConsumedError: If the input handle has already been consumed
+            (e.g. a previous broadcast result was dropped).
     """
     from qamomile.circuit.frontend.operation.control_flow import for_loop
 
-    qubits.validate_all_returned()
+    qubits = qubits.consume(operation_name=gate_type.name)
     n = qubits.shape[0]
     with for_loop(0, n, var_name="i") as i:
         qubits[i] = _apply_rotation_gate(qubits[i], angle, gate_type)
@@ -442,21 +463,29 @@ def _broadcast_phase_gate(qubits: Vector[Qubit], theta: float | Float) -> Vector
     Lowers to a `ForOperation` so that downstream passes see the same IR
     they would for an explicit hand-written loop.
 
+    The input ``Vector[Qubit]`` handle is consumed (affine type
+    enforcement) — the caller must capture the returned new handle.
+
     Args:
-        qubits: The `Vector[Qubit]` to apply the phase gate to.
-        theta: Phase angle in radians, shared across all qubits.
+        qubits (Vector[Qubit]): The `Vector[Qubit]` to apply the phase
+            gate to. This handle is consumed by the call.
+        theta (float | Float): Phase angle in radians, shared across all
+            qubits.
 
     Returns:
-        The same `Vector[Qubit]` handle, with the broadcast loop emitted
-        into the active tracer.
+        Vector[Qubit]: A fresh `Vector[Qubit]` handle wrapping the same
+            underlying array value, with the broadcast loop emitted into
+            the active tracer.
 
     Raises:
         UnreturnedBorrowError: If any element of `qubits` is still borrowed
             when broadcasting begins.
+        QubitConsumedError: If the input handle has already been consumed
+            (e.g. a previous broadcast result was dropped).
     """
     from qamomile.circuit.frontend.operation.control_flow import for_loop
 
-    qubits.validate_all_returned()
+    qubits = qubits.consume(operation_name="P")
     n = qubits.shape[0]
     with for_loop(0, n, var_name="i") as i:
         qubits[i] = _apply_phase_gate(qubits[i], theta)

--- a/tests/circuit/test_gate_broadcast.py
+++ b/tests/circuit/test_gate_broadcast.py
@@ -654,8 +654,11 @@ class TestBroadcastConsumesVectorHandle:
         """The canonical ``qs = qmc.gate(qs)`` pattern remains valid for every gate.
 
         Sanity check that the new consume contract does not regress the
-        common reassign idiom — every gate type chains through a single
-        kernel and the resulting block is non-empty.
+        common reassign idiom: every gate type chains through a single
+        kernel, lowers to one ``ForOperation`` per call in source order,
+        and each loop body contains exactly one ``GateOperation`` of the
+        matching gate kind (no spurious or reordered ops introduced by
+        the consume-at-start refactor).
         """
 
         @qmc.qkernel
@@ -677,6 +680,33 @@ class TestBroadcastConsumesVectorHandle:
 
         assert _good.block is not None
         fors = [op for op in _good.block.operations if isinstance(op, ForOperation)]
-        # 12 broadcast gate calls → 12 ForOperations (one per gate); measure
-        # lowers to a single MeasureVectorOperation, not a ForOperation.
-        assert len(fors) == 12
+        # 12 broadcast gate calls → 12 ForOperations in source order
+        # (one per gate); ``measure`` lowers to a single
+        # ``MeasureVectorOperation``, not a ``ForOperation``.
+        expected_gate_types = [
+            GateOperationType.H,
+            GateOperationType.X,
+            GateOperationType.Y,
+            GateOperationType.Z,
+            GateOperationType.S,
+            GateOperationType.SDG,
+            GateOperationType.T,
+            GateOperationType.TDG,
+            GateOperationType.RX,
+            GateOperationType.RY,
+            GateOperationType.RZ,
+            GateOperationType.P,
+        ]
+        assert len(fors) == len(expected_gate_types)
+        for for_op, expected in zip(fors, expected_gate_types):
+            gate_ops = [
+                op for op in for_op.operations if isinstance(op, GateOperation)
+            ]
+            assert len(gate_ops) == 1, (
+                f"Expected one gate inside the {expected.name} broadcast loop, "
+                f"got {len(gate_ops)}"
+            )
+            assert gate_ops[0].gate_type is expected, (
+                f"Expected {expected.name} inside its broadcast loop, "
+                f"got {gate_ops[0].gate_type.name}"
+            )

--- a/tests/circuit/test_gate_broadcast.py
+++ b/tests/circuit/test_gate_broadcast.py
@@ -19,6 +19,7 @@ import pytest
 import qamomile.circuit as qmc
 from qamomile.circuit.ir.operation.control_flow import ForOperation
 from qamomile.circuit.ir.operation.gate import GateOperation, GateOperationType
+from qamomile.circuit.transpiler.errors import QubitConsumedError
 
 # ---------------------------------------------------------------------------
 # IR-shape assertions (no backend required)
@@ -572,3 +573,110 @@ class TestBroadcastInputValidation:
         """Calling ``rx`` with a non-Qubit target raises TypeError."""
         with pytest.raises(TypeError, match="Expected Qubit or Vector"):
             qmc.rx("not a qubit", 0.5)  # type: ignore[arg-type]
+
+
+class TestBroadcastConsumesVectorHandle:
+    """Broadcast over ``Vector[Qubit]`` consumes the Vector handle.
+
+    Single-qubit gates already consume their input ``Qubit`` handle, so
+    ``qmc.h(q)`` without re-assignment makes ``q`` unusable on the next
+    call. The Vector broadcast path must give the same guarantee: writing
+    ``qmc.h(qs)`` and dropping the return value must mark ``qs`` consumed,
+    so any subsequent use of ``qs`` raises ``QubitConsumedError`` rather
+    than silently emitting another loop. Without this contract, the affine
+    type rule (every quantum handle used at most once) is enforced for
+    scalars but quietly bypassed for Vectors.
+
+    Note: ``@qmc.qkernel`` decoration is lazy — tracing only runs on
+    ``.block`` access. Tests therefore force ``.block`` inside
+    ``pytest.raises`` so the consume violation actually surfaces.
+    """
+
+    @pytest.mark.parametrize(
+        "gate",
+        [qmc.h, qmc.x, qmc.y, qmc.z, qmc.s, qmc.sdg, qmc.t, qmc.tdg],
+        ids=["h", "x", "y", "z", "s", "sdg", "t", "tdg"],
+    )
+    def test_non_parametric_broadcast_consumes_when_return_dropped(self, gate):
+        """Dropping the broadcast return value makes the next use of the Vector raise.
+
+        Builds a kernel that calls a non-parametric gate broadcast without
+        re-assigning the result, then tries to ``measure`` the same Vector.
+        The measurement must trip ``QubitConsumedError`` at tracing time.
+        """
+
+        @qmc.qkernel
+        def _bad() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(3, "qs")
+            gate(qs)  # return value intentionally dropped
+            return qmc.measure(qs)
+
+        with pytest.raises(QubitConsumedError):
+            _bad.block  # force tracing
+
+    @pytest.mark.parametrize(
+        "gate",
+        [qmc.rx, qmc.ry, qmc.rz, qmc.p],
+        ids=["rx", "ry", "rz", "p"],
+    )
+    def test_parametric_broadcast_consumes_when_return_dropped(self, gate):
+        """Same contract as the non-parametric case, for rotation/phase gates."""
+
+        @qmc.qkernel
+        def _bad() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(3, "qs")
+            gate(qs, 0.5)  # return value intentionally dropped
+            return qmc.measure(qs)
+
+        with pytest.raises(QubitConsumedError):
+            _bad.block
+
+    def test_broadcast_then_broadcast_without_reassign_raises(self):
+        """Two consecutive broadcasts both dropping the return raise on the second.
+
+        Ensures the failure point is the second broadcast call itself, not
+        a downstream measure — so users get the diagnostic at the line
+        where the affine rule was violated, even when no measurement
+        follows.
+        """
+
+        @qmc.qkernel
+        def _bad() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(3, "qs")
+            qmc.h(qs)  # qs consumed
+            qmc.x(qs)  # raises: qs already consumed
+            return qmc.measure(qs)
+
+        with pytest.raises(QubitConsumedError):
+            _bad.block
+
+    def test_broadcast_reassign_pattern_compiles_cleanly(self):
+        """The canonical ``qs = qmc.gate(qs)`` pattern remains valid for every gate.
+
+        Sanity check that the new consume contract does not regress the
+        common reassign idiom — every gate type chains through a single
+        kernel and the resulting block is non-empty.
+        """
+
+        @qmc.qkernel
+        def _good() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(3, "qs")
+            qs = qmc.h(qs)
+            qs = qmc.x(qs)
+            qs = qmc.y(qs)
+            qs = qmc.z(qs)
+            qs = qmc.s(qs)
+            qs = qmc.sdg(qs)
+            qs = qmc.t(qs)
+            qs = qmc.tdg(qs)
+            qs = qmc.rx(qs, 0.3)
+            qs = qmc.ry(qs, 0.4)
+            qs = qmc.rz(qs, 0.5)
+            qs = qmc.p(qs, 0.6)
+            return qmc.measure(qs)
+
+        assert _good.block is not None
+        fors = [op for op in _good.block.operations if isinstance(op, ForOperation)]
+        # 12 broadcast gate calls → 12 ForOperations (one per gate); measure
+        # lowers to a single MeasureVectorOperation, not a ForOperation.
+        assert len(fors) == 12

--- a/tests/circuit/test_gate_broadcast.py
+++ b/tests/circuit/test_gate_broadcast.py
@@ -699,9 +699,7 @@ class TestBroadcastConsumesVectorHandle:
         ]
         assert len(fors) == len(expected_gate_types)
         for for_op, expected in zip(fors, expected_gate_types):
-            gate_ops = [
-                op for op in for_op.operations if isinstance(op, GateOperation)
-            ]
+            gate_ops = [op for op in for_op.operations if isinstance(op, GateOperation)]
             assert len(gate_ops) == 1, (
                 f"Expected one gate inside the {expected.name} broadcast loop, "
                 f"got {len(gate_ops)}"


### PR DESCRIPTION
## Summary

- Fixes an affine-type-rule asymmetry: `qmc.h(qs)` on a `Vector[Qubit]` previously left the Vector handle reusable when the return value was dropped, while the scalar `qmc.h(q)` correctly raised `QubitConsumedError`. The Vector broadcast path now consumes its input handle up-front, mirroring `_measure_vector_qubit` and `pauli_evolve`.
- Three frontend helpers updated in `qamomile/circuit/frontend/operation/qubit_gates.py`: `_broadcast_single_qubit_gate`, `_broadcast_rotation_gate`, `_broadcast_phase_gate`. `ArrayBase.consume` runs `validate_all_returned` internally, so the previous explicit pre-check is now redundant and removed.
- Emitted IR is unchanged: `consume()` returns a new handle wrapping the same `ArrayValue`, so the `ForOperation` and child gate ops are identical. Existing broadcast sampling / expval / loop-equivalence tests continue to pass without modification.
- Docstrings now describe the consume contract and list `QubitConsumedError` in `Raises`, with types spelled out in `Args` / `Returns` per the project's Google-style mandate.

## Test plan

- [x] New `TestBroadcastConsumesVectorHandle` (14 cases) parametrizes over all 12 broadcast gates (`h`, `x`, `y`, `z`, `s`, `sdg`, `t`, `tdg`, `rx`, `ry`, `rz`, `p`), asserts `QubitConsumedError` on return-drop, and confirms the canonical `qs = qmc.h(qs)` idiom still compiles cleanly with the expected `ForOperation` count.
- [x] TDD verified: the new tests fail on the previous implementation (13 fail / 1 pass) and pass on the fix (14 pass).
- [x] Full `tests/circuit/` suite: 4601 passed / 0 failed.
- [x] `ruff check` and `zuban check` on the changed files are clean.