### PR TITLE
feat(ir): add canonical form and content hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,19 @@ See [docs/en/tutorial/09_compilation_and_transpilation.py](docs/en/tutorial/09_c
 
 [overlap-check]: qamomile/circuit/transpiler/transpiler.py#L475-L487
 
+### Canonical Form
+
+`qamomile.circuit.ir.canonical` provides a normalization step that re-numbers every `Value.uuid` / `Value.logical_id` in a `Block` from a deterministic counter and rewrites every UUID reference embedded in operations and value metadata (`CastMetadata`, `QFixedMetadata`, `ArrayRuntimeMetadata`, `CastOperation.qubit_mapping`). This gives the IR a build-independent identity that is required for content-addressable hashing, IR diffing, and (later) wire serialization.
+
+Key contract:
+
+- **Scope**: `canonicalize` / `canonicalize_and_remap` / `to_canonical_bytes` / `content_hash` accept only `BlockKind.AFFINE` and `BlockKind.ANALYZED`. `HIERARCHICAL` blocks still contain `CallBlockOperation`s that point at sibling `Block`s by Python identity; inline them first. The function raises `ValueError` (kind mismatch) or `NotImplementedError` (residual `CallBlockOperation`) when these preconditions are violated.
+- **Stage neutrality**: canonicalize is a normalization, not a pipeline-stage advance. `Block.kind` is preserved. `classical_lowering` and `plan` MUST NOT be run before canonicalize if the canonical form is meant to be portable — those passes commit to qamomile-internal representations.
+- **Content-only equivalence**: display-only fields (`Block.name`, `Block.output_names`, `Value.name`) are **excluded** from `to_canonical_bytes`. Two structurally-identical kernels with different function names hash equally. `Block.label_args` is functional (it names input ports by position) and is included.
+- **Counter-based UUIDs**: the first `Value` visited gets `00000000-0000-0000-0000-000000000000`, then `…0001`, and so on. `uuid` and `logical_id` share the same monotonically increasing counter; their separate remap tables are exposed via `canonicalize_and_remap`.
+- **Byte format is internal**: `to_canonical_bytes` is intended only to back `content_hash`. It is not a wire format and may change between qamomile releases; do not rely on parsing it. A versioned serialization format is tracked separately.
+- **Hash stability prerequisite**: arbitrary Python objects stored in `ValueMetadata.array_runtime.const_array` / `dict_runtime.bound_data` are stringified via `repr`, so their `repr` must be stable for `content_hash` to be meaningful.
+
 ## Docstring Convention (MANDATORY)
 
 All functions, methods, and classes in `qamomile/` — **public and private alike** — MUST carry a **Google-style docstring** with the appropriate sections filled in, not just a one-line summary. This is enforced by `/local-review` (missing docstrings are P2+).

--- a/qamomile/circuit/ir/__init__.py
+++ b/qamomile/circuit/ir/__init__.py
@@ -1,10 +1,24 @@
 """Public surface for the Qamomile IR package.
 
-Re-exports the contributor-facing debugging helpers from
-``qamomile.circuit.ir.printer`` so callers can use the short form
-``from qamomile.circuit.ir import pretty_print_block``.
+Re-exports the contributor-facing debugging and canonical-form
+helpers so callers can use the short form
+``from qamomile.circuit.ir import pretty_print_block`` or
+``from qamomile.circuit.ir import canonicalize``.
 """
 
+from qamomile.circuit.ir.canonical import (
+    canonicalize,
+    canonicalize_and_remap,
+    content_hash,
+    to_canonical_bytes,
+)
 from qamomile.circuit.ir.printer import format_value, pretty_print_block
 
-__all__ = ["format_value", "pretty_print_block"]
+__all__ = [
+    "canonicalize",
+    "canonicalize_and_remap",
+    "content_hash",
+    "format_value",
+    "pretty_print_block",
+    "to_canonical_bytes",
+]

--- a/qamomile/circuit/ir/canonical.py
+++ b/qamomile/circuit/ir/canonical.py
@@ -54,6 +54,7 @@ from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
 from qamomile.circuit.ir.operation.cast import CastOperation
 from qamomile.circuit.ir.operation.composite_gate import CompositeGateOperation
 from qamomile.circuit.ir.operation.control_flow import HasNestedOps
+from qamomile.circuit.ir.operation.gate import ControlledUOperation
 from qamomile.circuit.ir.types.primitives import ValueType
 from qamomile.circuit.ir.value import (
     ArrayRuntimeMetadata,
@@ -103,22 +104,26 @@ def canonicalize(block: Block) -> Block:
     return canonicalize_and_remap(block)[0]
 
 
-def canonicalize_and_remap(block: Block) -> tuple[Block, dict[str, str]]:
-    """Return canonical-form Block plus the UUID remap table.
+def canonicalize_and_remap(
+    block: Block,
+) -> tuple[Block, dict[str, str], dict[str, str]]:
+    """Return canonical-form Block plus the UUID and logical_id remap tables.
 
     Useful when the caller holds external references keyed on the
-    original Value UUIDs (e.g., a host-side port map) and needs to
-    update those references to match the canonical form.
+    original Value UUIDs or logical_ids (e.g., a host-side port map)
+    and needs to update those references to match the canonical form.
 
     Args:
         block (Block): The block to canonicalize. Must be at
             ``BlockKind.AFFINE`` or ``BlockKind.ANALYZED``.
 
     Returns:
-        tuple[Block, dict[str, str]]: A pair ``(canonical_block,
-            uuid_remap)`` where ``uuid_remap`` maps every original
-            Value UUID encountered during the walk to its canonical
-            counterpart.
+        tuple[Block, dict[str, str], dict[str, str]]: A triple
+            ``(canonical_block, uuid_remap, logical_id_remap)`` where
+            each remap maps every original identifier encountered
+            during the walk to its canonical counterpart. ``uuid`` and
+            ``logical_id`` share the same monotonic counter but are
+            tracked in separate maps.
 
     Raises:
         ValueError: If ``block.kind`` is not in ``{AFFINE, ANALYZED}``.
@@ -132,7 +137,11 @@ def canonicalize_and_remap(block: Block) -> tuple[Block, dict[str, str]]:
         )
     canon = _Canonicalizer()
     new_block = canon.canonical_block(block)
-    return new_block, dict(canon.uuid_remap)
+    return (
+        new_block,
+        dict(canon.uuid_remap),
+        dict(canon.logical_id_remap),
+    )
 
 
 def to_canonical_bytes(block: Block) -> bytes:
@@ -229,6 +238,17 @@ class _Canonicalizer:
                 wrap it themselves.
         """
         return self._uuid_remap
+
+    @property
+    def logical_id_remap(self) -> dict[str, str]:
+        """Return the accumulated old-logical_id to canonical-logical_id map.
+
+        Returns:
+            dict[str, str]: Snapshot reference (not a copy) of the live
+                remap table; callers that need a stable copy should
+                wrap it themselves.
+        """
+        return self._logical_id_remap
 
     def _next_id(self) -> str:
         """Mint the next deterministic UUID string from the counter.
@@ -382,6 +402,14 @@ class _Canonicalizer:
         ):
             sub = self.canonical_block(new_op.implementation_block)
             new_op = dataclasses.replace(new_op, implementation_block=sub)
+
+        # ControlledUOperation carries the unitary as a nested ``block``
+        # field. Canonicalize it through the same canonicalizer so UUIDs
+        # inside the unitary body are rewritten in lockstep with the
+        # parent Block.
+        if isinstance(new_op, ControlledUOperation) and new_op.block is not None:
+            sub_block = self.canonical_block(new_op.block)
+            new_op = dataclasses.replace(new_op, block=sub_block)
 
         return new_op
 
@@ -598,6 +626,15 @@ def _token(obj: Any) -> str:
     if isinstance(obj, dict):
         items = sorted(obj.items(), key=lambda kv: _token(kv[0]))
         return "{" + ",".join(f"{_token(k)}:{_token(v)}" for k, v in items) + "}"
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        # Dataclass instances (e.g. ``ResourceMetadata`` on
+        # ``CompositeGateOperation``) get serialized field-by-field in
+        # name-sorted order so canonical bytes are independent of the
+        # declared-field order and of any nested ``dict``'s insertion
+        # order (handled transitively via the dict branch above).
+        fields = sorted(dataclasses.fields(obj), key=lambda f: f.name)
+        body = ",".join(f"{f.name}={_token(getattr(obj, f.name))}" for f in fields)
+        return f"{type(obj).__name__}({body})"
     return repr(obj)
 
 
@@ -663,8 +700,12 @@ def _metadata_token(metadata: ValueMetadata) -> str:
             f"elem_lids={_token(list(metadata.array_runtime.element_logical_ids))})"
         )
     if metadata.dict_runtime is not None:
+        # ``bound_data`` is stored as tuple-of-pairs in the Mapping's
+        # original iteration order. Two semantically-equal dicts with
+        # different insertion order must hash identically, so emit via
+        # ``_token(dict(...))`` so the dict-handling branch sorts keys.
         parts.append(
-            f"dict_runtime(items={_token(list(metadata.dict_runtime.bound_data))})"
+            "dict_runtime(items=" + _token(dict(metadata.dict_runtime.bound_data)) + ")"
         )
     return "[" + ",".join(parts) + "]"
 
@@ -740,15 +781,33 @@ def _collect_from_operation(op: Operation, visit: Any) -> None:
     if isinstance(op, CompositeGateOperation) and op.implementation_block is not None:
         # Nested block's values participate in the same canonical
         # universe; recurse to ensure they are declared too.
-        sub = op.implementation_block
-        for v in sub.input_values:
-            visit(v)
-        for key in sorted(sub.parameters):
-            visit(sub.parameters[key])
-        for nested_op in sub.operations:
-            _collect_from_operation(nested_op, visit)
-        for v in sub.output_values:
-            visit(v)
+        _collect_from_subblock(op.implementation_block, visit)
+    if isinstance(op, ControlledUOperation) and op.block is not None:
+        _collect_from_subblock(op.block, visit)
+
+
+def _collect_from_subblock(sub: Block, visit: Any) -> None:
+    """Walk the Values declared inside a nested Block.
+
+    Used for ``CompositeGateOperation.implementation_block`` and
+    ``ControlledUOperation.block``. Mirrors the top-level
+    ``_collect_values`` walk order so declarations remain
+    deterministic.
+
+    Args:
+        sub (Block): A nested Block embedded in an operation.
+        visit (Callable[[ValueBase], None]): The same ``visit`` closure
+            passed by ``_collect_values`` so the nested Block's Values
+            land in the parent declaration list.
+    """
+    for v in sub.input_values:
+        visit(v)
+    for key in sorted(sub.parameters):
+        visit(sub.parameters[key])
+    for nested_op in sub.operations:
+        _collect_from_operation(nested_op, visit)
+    for v in sub.output_values:
+        visit(v)
 
 
 _INLINE_INDENT = "  "
@@ -762,9 +821,12 @@ _OP_FIELD_EXCLUDES: frozenset[str] = frozenset(
         # CompositeGateOperation extras: opaque Python references that
         # do not reflect IR-level structure.
         "composite_gate_instance",
-        # Implementation block is emitted separately in the operation
-        # serializer so it doesn't get rendered as an opaque repr.
+        # Nested-Block fields. Both ``implementation_block``
+        # (CompositeGateOperation) and ``block`` (ControlledUOperation)
+        # are emitted separately by ``_emit_operation`` so they are not
+        # rendered through ``repr`` here.
         "implementation_block",
+        "block",
     }
 )
 
@@ -885,6 +947,10 @@ def _emit_operation(op: Operation, out: list[str], indent: int) -> None:
     if isinstance(op, CompositeGateOperation) and op.implementation_block is not None:
         out.append(f"{pad}{_INLINE_INDENT}implementation:")
         _emit_block(op.implementation_block, out, indent + 2)
+
+    if isinstance(op, ControlledUOperation) and op.block is not None:
+        out.append(f"{pad}{_INLINE_INDENT}unitary_block:")
+        _emit_block(op.block, out, indent + 2)
 
 
 def _extra_field_tokens(op: Operation) -> list[str]:

--- a/qamomile/circuit/ir/canonical.py
+++ b/qamomile/circuit/ir/canonical.py
@@ -1,0 +1,916 @@
+"""Canonical form for IR blocks: deterministic UUIDs and content hashing.
+
+This module provides a normalization pass that re-numbers every Value
+UUID (and ``logical_id``) in a Block from a deterministic counter,
+rewriting every UUID reference embedded in operations and value
+metadata so the resulting Block is structurally invariant across
+independent builds of the same kernel.
+
+The canonical form is intended for IR-level equality checks, debugging
+diffs, and a content-addressable identity (``content_hash``) suitable
+for caching and (later) for serialization keyed on IR contents rather
+than build-local Python state.
+
+Supported scope:
+    Only ``BlockKind.AFFINE`` and ``BlockKind.ANALYZED`` are accepted.
+    ``HIERARCHICAL`` Blocks still contain ``CallBlockOperation``s that
+    reference sibling Blocks by Python identity; their canonical
+    treatment is deferred (see backlog ``[IR design] Add named/versioned
+    module references for cross-process kernel composition``).
+
+Output guarantees:
+    1. ``canonicalize`` does not change ``Block.kind``; it is a
+       normalization, not a pipeline stage advance.
+    2. For two builds of the same kernel that produce structurally
+       identical IR, ``canonicalize`` returns Blocks that are equal
+       under ``to_canonical_bytes`` (and therefore under
+       ``content_hash``).
+    3. ``canonicalize`` is idempotent: running it twice on the same
+       Block yields the same canonical bytes as running it once.
+
+Limitations:
+    - ``Value.parent_array`` cycles (a Value whose ``parent_array`` is
+      itself reachable from the Value's siblings) are not constructed
+      by the frontend today; the canonicalizer assumes the
+      Value-reference graph through ``parent_array`` and
+      ``element_indices`` is acyclic.
+    - ``ValueMetadata.dict_runtime.bound_data`` and
+      ``ArrayRuntimeMetadata.const_array`` may carry arbitrary frozen
+      Python data; hash stability for these requires that contained
+      objects have a stable ``repr``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import hashlib
+import uuid as _uuid
+from typing import Any, cast
+
+from qamomile.circuit.ir.block import Block, BlockKind
+from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
+from qamomile.circuit.ir.operation.cast import CastOperation
+from qamomile.circuit.ir.operation.composite_gate import CompositeGateOperation
+from qamomile.circuit.ir.operation.control_flow import HasNestedOps
+from qamomile.circuit.ir.types.primitives import ValueType
+from qamomile.circuit.ir.value import (
+    ArrayRuntimeMetadata,
+    ArrayValue,
+    CastMetadata,
+    DictValue,
+    QFixedMetadata,
+    TupleValue,
+    Value,
+    ValueBase,
+    ValueMetadata,
+)
+
+_SUPPORTED_KINDS = frozenset({BlockKind.AFFINE, BlockKind.ANALYZED})
+
+
+def canonicalize(block: Block) -> Block:
+    """Return a canonical-form clone of ``block``.
+
+    The returned Block has the same structure as ``block`` but with
+    every Value UUID and ``logical_id`` re-issued from a deterministic
+    counter. All UUID references inside operations and value metadata
+    are rewritten consistently. ``Block.kind`` is preserved.
+
+    Args:
+        block (Block): The block to canonicalize. Must be at
+            ``BlockKind.AFFINE`` or ``BlockKind.ANALYZED``.
+
+    Returns:
+        Block: A new Block with canonical UUIDs. ``Block.kind`` matches
+            the input. Existing input/output ordering, operation
+            ordering, and metadata structure are preserved.
+
+    Raises:
+        ValueError: If ``block.kind`` is not in ``{AFFINE, ANALYZED}``.
+        NotImplementedError: If a ``CallBlockOperation`` is encountered
+            (typically because ``inline`` has not been run yet).
+
+    Example:
+        >>> from qamomile.qiskit import QiskitTranspiler
+        >>> transpiler = QiskitTranspiler()
+        >>> affine = transpiler.inline(transpiler.to_block(my_kernel))
+        >>> canon = canonicalize(affine)
+        >>> canon.kind is affine.kind
+        True
+    """
+    return canonicalize_and_remap(block)[0]
+
+
+def canonicalize_and_remap(block: Block) -> tuple[Block, dict[str, str]]:
+    """Return canonical-form Block plus the UUID remap table.
+
+    Useful when the caller holds external references keyed on the
+    original Value UUIDs (e.g., a host-side port map) and needs to
+    update those references to match the canonical form.
+
+    Args:
+        block (Block): The block to canonicalize. Must be at
+            ``BlockKind.AFFINE`` or ``BlockKind.ANALYZED``.
+
+    Returns:
+        tuple[Block, dict[str, str]]: A pair ``(canonical_block,
+            uuid_remap)`` where ``uuid_remap`` maps every original
+            Value UUID encountered during the walk to its canonical
+            counterpart.
+
+    Raises:
+        ValueError: If ``block.kind`` is not in ``{AFFINE, ANALYZED}``.
+        NotImplementedError: If a ``CallBlockOperation`` is encountered.
+    """
+    if block.kind not in _SUPPORTED_KINDS:
+        raise ValueError(
+            f"canonicalize() requires BlockKind.AFFINE or BlockKind.ANALYZED; "
+            f"got {block.kind.name}. Run `inline` (and optionally `analyze`) "
+            f"first."
+        )
+    canon = _Canonicalizer()
+    new_block = canon.canonical_block(block)
+    return new_block, dict(canon.uuid_remap)
+
+
+def to_canonical_bytes(block: Block) -> bytes:
+    """Serialize ``block`` to a deterministic byte representation.
+
+    The byte format is the **internal** representation backing
+    ``content_hash`` and is not stable across qamomile versions. It is
+    suitable for hashing and equality checks within a single
+    deployment but should not be relied upon as a serialization
+    format. (A stable, versioned serialization format is tracked
+    separately.)
+
+    Args:
+        block (Block): The block to serialize. Must be at
+            ``BlockKind.AFFINE`` or ``BlockKind.ANALYZED``. The block
+            is canonicalized first; passing an already-canonical block
+            is harmless.
+
+    Returns:
+        bytes: A UTF-8-encoded byte string. Two structurally-equal
+            Blocks produce the same bytes; changing the IR yields
+            different bytes.
+
+    Raises:
+        ValueError: If ``block.kind`` is not in ``{AFFINE, ANALYZED}``.
+    """
+    canon = canonicalize(block)
+    lines: list[str] = []
+    _emit_block(canon, lines, indent=0)
+    return "\n".join(lines).encode("utf-8")
+
+
+def content_hash(block: Block) -> str:
+    """Compute a content-addressable hash of ``block``.
+
+    Two Blocks that canonicalize to the same form (structurally equal
+    after UUID remapping) produce the same hash. Any IR-level change
+    (gate added, parameter renamed, operand reordered) produces a
+    different hash.
+
+    Args:
+        block (Block): The block to hash. Must be at
+            ``BlockKind.AFFINE`` or ``BlockKind.ANALYZED``.
+
+    Returns:
+        str: The SHA-256 hex digest of ``to_canonical_bytes(block)``.
+
+    Raises:
+        ValueError: If ``block.kind`` is not in ``{AFFINE, ANALYZED}``.
+
+    Example:
+        >>> h1 = content_hash(canonicalize(affine_a))
+        >>> h2 = content_hash(canonicalize(affine_b))
+        >>> # If the two kernels are structurally identical, h1 == h2.
+    """
+    return hashlib.sha256(to_canonical_bytes(block)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+class _Canonicalizer:
+    """Walker that assigns deterministic UUIDs by traversal order.
+
+    A single ``_Canonicalizer`` covers one ``canonicalize`` invocation
+    and may recurse into nested Blocks (currently only via
+    ``CompositeGateOperation.implementation_block``). A shared counter
+    across nested Blocks guarantees no UUID string collisions within
+    the returned canonical tree.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty Canonicalizer state.
+
+        Sets up the shared monotonic counter that drives ``_next_id`` and
+        empty remap / cache dictionaries that fill in as Values, Blocks,
+        and metadata UUID references are visited during the walk.
+        """
+        self._counter = 0
+        self._uuid_remap: dict[str, str] = {}
+        self._logical_id_remap: dict[str, str] = {}
+        self._value_cache: dict[str, ValueBase] = {}
+        self._block_cache: dict[int, Block] = {}
+
+    @property
+    def uuid_remap(self) -> dict[str, str]:
+        """Return the accumulated old-UUID to canonical-UUID map.
+
+        Returns:
+            dict[str, str]: Snapshot reference (not a copy) of the live
+                remap table; callers that need a stable copy should
+                wrap it themselves.
+        """
+        return self._uuid_remap
+
+    def _next_id(self) -> str:
+        """Mint the next deterministic UUID string from the counter.
+
+        Returns:
+            str: A canonical UUID string of the form
+                ``00000000-0000-0000-0000-XXXXXXXXXXXX`` where the
+                trailing portion encodes the current counter value.
+        """
+        ident = str(_uuid.UUID(int=self._counter))
+        self._counter += 1
+        return ident
+
+    def _remap_uuid(self, old: str) -> str:
+        """Resolve (or assign) the canonical UUID for ``old``.
+
+        Args:
+            old (str): A pre-canonical (e.g., ``uuid4()``-issued) UUID
+                string captured from an IR Value or metadata field.
+
+        Returns:
+            str: The canonical UUID assigned to ``old``. Subsequent
+                calls with the same ``old`` return the same canonical
+                string.
+        """
+        if old not in self._uuid_remap:
+            self._uuid_remap[old] = self._next_id()
+        return self._uuid_remap[old]
+
+    def _remap_logical_id(self, old: str) -> str:
+        """Resolve (or assign) the canonical logical_id for ``old``.
+
+        Shares the counter with ``_remap_uuid`` so canonical IDs across
+        both namespaces are unique within a single canonicalize() run.
+
+        Args:
+            old (str): A pre-canonical ``logical_id`` value.
+
+        Returns:
+            str: The canonical ``logical_id`` assigned to ``old``.
+        """
+        if old not in self._logical_id_remap:
+            self._logical_id_remap[old] = self._next_id()
+        return self._logical_id_remap[old]
+
+    # -------------------------------------------------------------------
+    # Block / Operation walk
+    # -------------------------------------------------------------------
+
+    def canonical_block(self, block: Block) -> Block:
+        """Return a canonical clone of ``block``.
+
+        Sub-Blocks reached via ``CompositeGateOperation`` are
+        canonicalized through the same Canonicalizer instance and are
+        cached by Python ``id`` so repeated references share a single
+        canonical Block.
+
+        Args:
+            block (Block): The IR Block to canonicalize. Sub-Blocks
+                reachable from this Block (via
+                ``CompositeGateOperation.implementation_block``) are
+                canonicalized recursively.
+
+        Returns:
+            Block: A new Block with canonical UUIDs and rewritten
+                metadata references. ``Block.kind`` matches the input.
+        """
+        cached = self._block_cache.get(id(block))
+        if cached is not None:
+            return cached
+
+        new_input_values: list[Value] = [
+            cast(Value, self.canonical_value(v)) for v in block.input_values
+        ]
+        new_parameters: dict[str, Value] = {
+            key: cast(Value, self.canonical_value(block.parameters[key]))
+            for key in sorted(block.parameters)
+        }
+        new_operations: list[Operation] = [
+            self.canonical_operation(op) for op in block.operations
+        ]
+        new_output_values: list[Value] = [
+            cast(Value, self.canonical_value(v)) for v in block.output_values
+        ]
+
+        new_block = Block(
+            name=block.name,
+            label_args=list(block.label_args),
+            input_values=new_input_values,
+            output_values=new_output_values,
+            output_names=list(block.output_names),
+            operations=new_operations,
+            kind=block.kind,
+            parameters=new_parameters,
+        )
+        self._block_cache[id(block)] = new_block
+        return new_block
+
+    def canonical_operation(self, op: Operation) -> Operation:
+        """Return a canonical clone of ``op`` with remapped Values.
+
+        Uses ``Operation.all_input_values`` / ``Operation.replace_values``
+        so subclass-extra Value fields (e.g., ``ControlledU.power``,
+        ``ForOperation.loop_var_value``) are rewritten consistently.
+        Recurses into nested control-flow ops via ``HasNestedOps`` and
+        into ``CompositeGateOperation.implementation_block``.
+
+        Args:
+            op (Operation): The Operation to canonicalize.
+
+        Returns:
+            Operation: A new Operation of the same concrete type with
+                canonical Values, rewritten ``CastOperation.qubit_mapping``,
+                and canonicalized nested op lists / implementation Blocks.
+
+        Raises:
+            NotImplementedError: If ``op`` is a ``CallBlockOperation``.
+                Canonicalize requires the input Block to be inlined first.
+        """
+        if isinstance(op, CallBlockOperation):
+            raise NotImplementedError(
+                "canonicalize() does not support HIERARCHICAL blocks "
+                "(CallBlockOperation present). Run inline() first."
+            )
+
+        sub_map: dict[str, ValueBase] = {}
+        for v in op.all_input_values():
+            sub_map[v.uuid] = self.canonical_value(v)
+        for v in op.results:
+            if isinstance(v, ValueBase) and v.uuid not in sub_map:
+                sub_map[v.uuid] = self.canonical_value(v)
+
+        new_op: Operation = op.replace_values(sub_map) if sub_map else op
+
+        if isinstance(new_op, HasNestedOps):
+            new_lists = [
+                [self.canonical_operation(child) for child in op_list]
+                for op_list in new_op.nested_op_lists()
+            ]
+            new_op = new_op.rebuild_nested(new_lists)
+
+        if isinstance(new_op, CastOperation) and new_op.qubit_mapping:
+            new_op = dataclasses.replace(
+                new_op,
+                qubit_mapping=[self._remap_uuid(u) for u in new_op.qubit_mapping],
+            )
+
+        if (
+            isinstance(new_op, CompositeGateOperation)
+            and new_op.implementation_block is not None
+        ):
+            sub = self.canonical_block(new_op.implementation_block)
+            new_op = dataclasses.replace(new_op, implementation_block=sub)
+
+        return new_op
+
+    # -------------------------------------------------------------------
+    # Value walk
+    # -------------------------------------------------------------------
+
+    def canonical_value(self, value: ValueBase) -> ValueBase:
+        """Return a canonical clone of ``value`` with remapped UUIDs.
+
+        Caches by source UUID so repeated references (e.g., the same
+        ``parent_array`` shared by multiple element Values) resolve to
+        the same canonical instance.
+
+        Args:
+            value (ValueBase): An IR Value (any ``Value`` /
+                ``ArrayValue`` / ``TupleValue`` / ``DictValue``).
+
+        Returns:
+            ValueBase: A canonical clone of the same concrete Value
+                type, with ``uuid`` and ``logical_id`` reassigned and
+                metadata UUID references rewritten consistently. Nested
+                Value references (``TupleValue.elements``,
+                ``DictValue.entries``, ``ArrayValue.shape``,
+                ``Value.parent_array``, ``Value.element_indices``) are
+                canonicalized recursively.
+        """
+        if value.uuid in self._value_cache:
+            return self._value_cache[value.uuid]
+
+        new_uuid = self._remap_uuid(value.uuid)
+        new_logical_id = self._remap_logical_id(value.logical_id)
+        new_metadata = self._canonical_metadata(value.metadata)
+
+        cloned: ValueBase
+        if isinstance(value, TupleValue):
+            new_elements = tuple(
+                cast(Value, self.canonical_value(e)) for e in value.elements
+            )
+            cloned = dataclasses.replace(
+                value,
+                uuid=new_uuid,
+                logical_id=new_logical_id,
+                metadata=new_metadata,
+                elements=new_elements,
+            )
+        elif isinstance(value, DictValue):
+            new_entries: list[tuple[TupleValue | Value, Value]] = []
+            for k, v in value.entries:
+                new_k_base = self.canonical_value(k)
+                new_v_base = self.canonical_value(v)
+                new_entries.append(
+                    (
+                        cast("TupleValue | Value", new_k_base),
+                        cast(Value, new_v_base),
+                    )
+                )
+            cloned = dataclasses.replace(
+                value,
+                uuid=new_uuid,
+                logical_id=new_logical_id,
+                metadata=new_metadata,
+                entries=tuple(new_entries),
+            )
+        elif isinstance(value, ArrayValue):
+            cloned = dataclasses.replace(
+                value,
+                uuid=new_uuid,
+                logical_id=new_logical_id,
+                metadata=new_metadata,
+                shape=tuple(
+                    cast(Value, self.canonical_value(dim)) for dim in value.shape
+                ),
+            )
+        elif isinstance(value, Value):
+            # Cache a placeholder before recursing through parent_array /
+            # element_indices so any cycle (not expected in practice, but
+            # defensive) terminates with a partially-built canonical
+            # instance rather than infinite recursion.
+            placeholder = dataclasses.replace(
+                value,
+                uuid=new_uuid,
+                logical_id=new_logical_id,
+                metadata=new_metadata,
+            )
+            self._value_cache[value.uuid] = placeholder
+            new_parent_array: ArrayValue | None = None
+            if value.parent_array is not None:
+                new_parent_array = cast(
+                    ArrayValue, self.canonical_value(value.parent_array)
+                )
+            new_element_indices: tuple[Value, ...] = ()
+            if value.element_indices:
+                new_element_indices = tuple(
+                    cast(Value, self.canonical_value(idx))
+                    for idx in value.element_indices
+                )
+            cloned = dataclasses.replace(
+                placeholder,
+                parent_array=new_parent_array,
+                element_indices=new_element_indices,
+            )
+        else:
+            cloned = dataclasses.replace(
+                cast(Any, value),
+                uuid=new_uuid,
+                logical_id=new_logical_id,
+                metadata=new_metadata,
+            )
+
+        self._value_cache[value.uuid] = cloned
+        return cloned
+
+    def _canonical_metadata(self, metadata: ValueMetadata) -> ValueMetadata:
+        """Rewrite UUID and logical_id references inside ValueMetadata.
+
+        ``ScalarMetadata`` and ``DictRuntimeMetadata`` carry no UUID
+        references; ``CastMetadata``, ``QFixedMetadata``, and
+        ``ArrayRuntimeMetadata`` do and are rewritten through the
+        active remap tables.
+
+        Args:
+            metadata (ValueMetadata): Original metadata bundle.
+
+        Returns:
+            ValueMetadata: A new bundle with rewritten UUID / logical_id
+                references and untouched scalar / dict-runtime sections.
+        """
+        new_cast = metadata.cast
+        if new_cast is not None:
+            new_cast = CastMetadata(
+                source_uuid=self._remap_uuid(new_cast.source_uuid),
+                qubit_uuids=tuple(self._remap_uuid(u) for u in new_cast.qubit_uuids),
+                source_logical_id=(
+                    self._remap_logical_id(new_cast.source_logical_id)
+                    if new_cast.source_logical_id is not None
+                    else None
+                ),
+                qubit_logical_ids=tuple(
+                    self._remap_logical_id(lid) for lid in new_cast.qubit_logical_ids
+                ),
+            )
+
+        new_qfixed = metadata.qfixed
+        if new_qfixed is not None:
+            new_qfixed = QFixedMetadata(
+                qubit_uuids=tuple(self._remap_uuid(u) for u in new_qfixed.qubit_uuids),
+                num_bits=new_qfixed.num_bits,
+                int_bits=new_qfixed.int_bits,
+            )
+
+        new_array_rt = metadata.array_runtime
+        if new_array_rt is not None:
+            new_array_rt = ArrayRuntimeMetadata(
+                const_array=new_array_rt.const_array,
+                element_uuids=tuple(
+                    self._remap_uuid(u) for u in new_array_rt.element_uuids
+                ),
+                element_logical_ids=tuple(
+                    self._remap_logical_id(lid)
+                    for lid in new_array_rt.element_logical_ids
+                ),
+            )
+
+        return ValueMetadata(
+            scalar=metadata.scalar,
+            cast=new_cast,
+            qfixed=new_qfixed,
+            array_runtime=new_array_rt,
+            dict_runtime=metadata.dict_runtime,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic byte serialization (for content_hash only)
+# ---------------------------------------------------------------------------
+
+
+def _token(obj: Any) -> str:
+    """Render an arbitrary Python value into a stable string token.
+
+    Handles the small set of types appearing in IR metadata: scalars,
+    enums, tuples/lists, dicts (sorted by key), ``ValueBase`` instances
+    (rendered as a compact ``<ClassName:UUID>`` reference since the
+    full state is emitted in the value-declaration section), and
+    ``ValueType`` instances (rendered via ``.label()`` to avoid
+    embedding memory addresses from the default ``object.__repr__``).
+    Falls back to ``repr`` for anything else; callers that store
+    opaque Python objects in metadata must ensure those objects have a
+    stable ``repr`` for the hash to be reliable.
+
+    Args:
+        obj (Any): A Python value reachable from canonical IR data
+            (Value metadata field, operation dataclass field, etc.).
+
+    Returns:
+        str: A deterministic string token suitable for inclusion in
+            ``to_canonical_bytes``.
+    """
+    if obj is None:
+        return "None"
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if isinstance(obj, (int, float, str)):
+        return repr(obj)
+    if isinstance(obj, enum.Enum):
+        return f"{type(obj).__name__}.{obj.name}"
+    if isinstance(obj, ValueBase):
+        return _value_token(obj)
+    if isinstance(obj, ValueType):
+        return f"Type<{obj.label()}>"
+    if isinstance(obj, (list, tuple)):
+        return "[" + ",".join(_token(x) for x in obj) + "]"
+    if isinstance(obj, dict):
+        items = sorted(obj.items(), key=lambda kv: _token(kv[0]))
+        return "{" + ",".join(f"{_token(k)}:{_token(v)}" for k, v in items) + "}"
+    return repr(obj)
+
+
+def _value_token(v: ValueBase) -> str:
+    """Render the canonical identity of ``v`` as a structural token.
+
+    Only the canonical UUID and the value's type label are included;
+    full metadata is emitted separately in the value declaration block
+    so each Value's full state appears once and references stay
+    compact.
+
+    Args:
+        v (ValueBase): A canonical IR Value.
+
+    Returns:
+        str: A compact ``<ClassName<uuid:TypeLabel>>`` token. Falls
+            back to ``repr(v.type)`` if the type does not expose a
+            stable ``label()``.
+    """
+    type_obj = getattr(v, "type", None)
+    if isinstance(type_obj, ValueType):
+        type_label = type_obj.label()
+    else:
+        type_label = repr(type_obj)
+    return f"{type(v).__name__}<{v.uuid}:{type_label}>"
+
+
+def _metadata_token(metadata: ValueMetadata) -> str:
+    """Serialize ``ValueMetadata`` into a deterministic token string.
+
+    Args:
+        metadata (ValueMetadata): The metadata bundle to render.
+
+    Returns:
+        str: A bracketed, comma-separated list of sub-record tokens
+            (``scalar(...)``, ``cast(...)``, ``qfixed(...)``,
+            ``array_runtime(...)``, ``dict_runtime(...)``). Sub-records
+            with ``None`` values are omitted.
+    """
+    parts: list[str] = []
+    if metadata.scalar is not None:
+        parts.append(
+            f"scalar(const={_token(metadata.scalar.const_value)},"
+            f"param={_token(metadata.scalar.parameter_name)})"
+        )
+    if metadata.cast is not None:
+        parts.append(
+            f"cast(src={metadata.cast.source_uuid},"
+            f"qubits={_token(list(metadata.cast.qubit_uuids))},"
+            f"src_lid={_token(metadata.cast.source_logical_id)},"
+            f"qubit_lids={_token(list(metadata.cast.qubit_logical_ids))})"
+        )
+    if metadata.qfixed is not None:
+        parts.append(
+            f"qfixed(qubits={_token(list(metadata.qfixed.qubit_uuids))},"
+            f"num_bits={metadata.qfixed.num_bits},"
+            f"int_bits={metadata.qfixed.int_bits})"
+        )
+    if metadata.array_runtime is not None:
+        parts.append(
+            f"array_runtime(const={_token(metadata.array_runtime.const_array)},"
+            f"elem_uuids={_token(list(metadata.array_runtime.element_uuids))},"
+            f"elem_lids={_token(list(metadata.array_runtime.element_logical_ids))})"
+        )
+    if metadata.dict_runtime is not None:
+        parts.append(
+            f"dict_runtime(items={_token(list(metadata.dict_runtime.bound_data))})"
+        )
+    return "[" + ",".join(parts) + "]"
+
+
+def _collect_values(block: Block, out: list[ValueBase], seen: set[str]) -> None:
+    """Walk ``block`` deterministically and collect every Value reachable.
+
+    Each Value appears at most once in ``out``; ordering follows the
+    canonical walk used for UUID assignment so the value-declaration
+    section of the canonical bytes is itself deterministic.
+
+    Args:
+        block (Block): The canonical Block to walk.
+        out (list[ValueBase]): Output list, populated in walk order
+            with each unique Value encountered.
+        seen (set[str]): Mutable membership set keyed by Value UUID; an
+            incoming UUID short-circuits visitation. The caller passes
+            an empty set on the top-level call.
+    """
+
+    def visit(v: ValueBase) -> None:
+        if v.uuid in seen:
+            return
+        seen.add(v.uuid)
+        # Visit nested Value references first to keep declaration order
+        # close to the canonical walk in _Canonicalizer.
+        if isinstance(v, TupleValue):
+            for e in v.elements:
+                visit(e)
+        elif isinstance(v, DictValue):
+            for k, val in v.entries:
+                visit(k)
+                visit(val)
+        elif isinstance(v, ArrayValue):
+            for dim in v.shape:
+                visit(dim)
+        elif isinstance(v, Value):
+            if v.parent_array is not None:
+                visit(v.parent_array)
+            for idx in v.element_indices:
+                visit(idx)
+        out.append(v)
+
+    for v in block.input_values:
+        visit(v)
+    for key in sorted(block.parameters):
+        visit(block.parameters[key])
+    for op in block.operations:
+        _collect_from_operation(op, visit)
+    for v in block.output_values:
+        visit(v)
+
+
+def _collect_from_operation(op: Operation, visit: Any) -> None:
+    """Apply ``visit`` to every Value referenced by ``op`` (including nested).
+
+    Args:
+        op (Operation): The Operation whose Value references to walk.
+        visit (Callable[[ValueBase], None]): A callable that receives
+            each Value once. Typed as ``Any`` because the nested
+            ``visit`` closure carries internal capture state and is not
+            an exported protocol.
+    """
+    for v in op.all_input_values():
+        visit(v)
+    for v in op.results:
+        if isinstance(v, ValueBase):
+            visit(v)
+    if isinstance(op, HasNestedOps):
+        for child_list in op.nested_op_lists():
+            for child in child_list:
+                _collect_from_operation(child, visit)
+    if isinstance(op, CompositeGateOperation) and op.implementation_block is not None:
+        # Nested block's values participate in the same canonical
+        # universe; recurse to ensure they are declared too.
+        sub = op.implementation_block
+        for v in sub.input_values:
+            visit(v)
+        for key in sorted(sub.parameters):
+            visit(sub.parameters[key])
+        for nested_op in sub.operations:
+            _collect_from_operation(nested_op, visit)
+        for v in sub.output_values:
+            visit(v)
+
+
+_INLINE_INDENT = "  "
+
+# Operation dataclass fields whose values do not affect IR semantics for
+# hashing purposes (or whose Python identity changes between builds).
+_OP_FIELD_EXCLUDES: frozenset[str] = frozenset(
+    {
+        "operands",
+        "results",
+        # CompositeGateOperation extras: opaque Python references that
+        # do not reflect IR-level structure.
+        "composite_gate_instance",
+        # Implementation block is emitted separately in the operation
+        # serializer so it doesn't get rendered as an opaque repr.
+        "implementation_block",
+    }
+)
+
+
+def _emit_block(block: Block, out: list[str], indent: int) -> None:
+    """Append a deterministic textual representation of ``block`` to ``out``.
+
+    ``Block.name`` and ``Block.output_names`` are display-only labels
+    and are intentionally omitted from canonical bytes; two
+    structurally-identical kernels with different function names hash
+    equally. ``Block.label_args`` is functional (it names input
+    parameters by position) and is included.
+
+    Args:
+        block (Block): The canonical Block to render.
+        out (list[str]): Output line buffer; appended to in place.
+        indent (int): Current indentation level in
+            ``_INLINE_INDENT``-wide units.
+    """
+    pad = _INLINE_INDENT * indent
+    out.append(f"{pad}BLOCK kind={block.kind.name}")
+    out.append(f"{pad}{_INLINE_INDENT}label_args={_token(block.label_args)}")
+
+    declared: list[ValueBase] = []
+    seen: set[str] = set()
+    _collect_values(block, declared, seen)
+    out.append(f"{pad}{_INLINE_INDENT}values:")
+    for v in declared:
+        out.append(f"{pad}{_INLINE_INDENT * 2}{_value_declaration(v)}")
+
+    out.append(
+        f"{pad}{_INLINE_INDENT}inputs={_token([v.uuid for v in block.input_values])}"
+    )
+    out.append(
+        f"{pad}{_INLINE_INDENT}outputs={_token([v.uuid for v in block.output_values])}"
+    )
+    out.append(
+        f"{pad}{_INLINE_INDENT}parameters="
+        + _token({k: block.parameters[k].uuid for k in sorted(block.parameters)})
+    )
+
+    out.append(f"{pad}{_INLINE_INDENT}operations:")
+    for op in block.operations:
+        _emit_operation(op, out, indent + 2)
+
+
+def _value_declaration(v: ValueBase) -> str:
+    """Build a one-line, fully-self-describing declaration for ``v``.
+
+    ``Value.name`` is display-only (per the docstring on ``Value``) and
+    is intentionally omitted so that two structurally-identical kernels
+    whose intermediate values were given different debug labels still
+    canonicalize to the same bytes.
+
+    Args:
+        v (ValueBase): The canonical Value to declare.
+
+    Returns:
+        str: A pipe-separated, single-line declaration including class
+            name, canonical UUID / logical_id, type label, metadata,
+            and Value-kind-specific extras (parent_array, shape,
+            elements, dict entries, element_indices, version).
+    """
+    type_obj = getattr(v, "type", None)
+    if isinstance(type_obj, ValueType):
+        type_label = type_obj.label()
+    else:
+        type_label = repr(type_obj)
+    parts = [
+        type(v).__name__,
+        f"uuid={v.uuid}",
+        f"lid={v.logical_id}",
+        f"type={type_label}",
+        f"meta={_metadata_token(v.metadata)}",
+    ]
+    if isinstance(v, Value):
+        parts.append(f"version={v.version}")
+        if v.parent_array is not None:
+            parts.append(f"parent={v.parent_array.uuid}")
+        if v.element_indices:
+            parts.append("indices=" + _token([idx.uuid for idx in v.element_indices]))
+    if isinstance(v, ArrayValue):
+        parts.append("shape=" + _token([dim.uuid for dim in v.shape]))
+    if isinstance(v, TupleValue):
+        parts.append("elements=" + _token([e.uuid for e in v.elements]))
+    if isinstance(v, DictValue):
+        parts.append("entries=" + _token([(k.uuid, val.uuid) for k, val in v.entries]))
+    return "|".join(parts)
+
+
+def _emit_operation(op: Operation, out: list[str], indent: int) -> None:
+    """Append a deterministic textual representation of ``op`` to ``out``.
+
+    Args:
+        op (Operation): The canonical Operation to render.
+        out (list[str]): Output line buffer; appended to in place.
+        indent (int): Current indentation level in
+            ``_INLINE_INDENT``-wide units.
+    """
+    pad = _INLINE_INDENT * indent
+    header = (
+        f"{pad}{type(op).__name__} "
+        f"operands={_token([v.uuid for v in op.operands])} "
+        f"results={_token([v.uuid for v in op.results])}"
+    )
+    out.append(header)
+
+    extras = _extra_field_tokens(op)
+    if extras:
+        out.append(f"{pad}{_INLINE_INDENT}fields={{{','.join(extras)}}}")
+
+    if isinstance(op, HasNestedOps):
+        for i, child_list in enumerate(op.nested_op_lists()):
+            out.append(f"{pad}{_INLINE_INDENT}nested[{i}]:")
+            for child in child_list:
+                _emit_operation(child, out, indent + 2)
+
+    if isinstance(op, CompositeGateOperation) and op.implementation_block is not None:
+        out.append(f"{pad}{_INLINE_INDENT}implementation:")
+        _emit_block(op.implementation_block, out, indent + 2)
+
+
+def _extra_field_tokens(op: Operation) -> list[str]:
+    """Render the IR-meaningful dataclass fields of ``op`` (excluding Values).
+
+    The base ``Operation`` fields (``operands`` / ``results``) and a
+    handful of opaque-Python fields are excluded; everything else is
+    serialized through ``_token`` and emitted in field-name-sorted
+    order so the token list is stable regardless of dataclass
+    declaration ordering.
+
+    Args:
+        op (Operation): The canonical Operation to introspect.
+
+    Returns:
+        list[str]: Zero or more ``name=token`` strings, one per
+            included dataclass field, sorted by field name.
+    """
+    parts: list[str] = []
+    for f in sorted(dataclasses.fields(op), key=lambda field: field.name):
+        if f.name in _OP_FIELD_EXCLUDES:
+            continue
+        value = getattr(op, f.name)
+        # Skip nested-op fields handled by HasNestedOps emission to avoid
+        # double-printing operation bodies.
+        if isinstance(value, list) and value and isinstance(value[0], Operation):
+            continue
+        parts.append(f"{f.name}={_token(value)}")
+    return parts

--- a/tests/circuit/ir/test_canonical.py
+++ b/tests/circuit/ir/test_canonical.py
@@ -121,6 +121,45 @@ def _measure_after_h_twin(q: qmc.Qubit) -> qmc.Bit:
     return qmc.measure(q)
 
 
+# Two structurally-identical controlled-U scenarios. Each top-level
+# kernel applies controlled(_phase_a/_phase_b) so each top-level Block
+# contains a ``ControlledUOperation`` carrying a nested unitary
+# ``block`` field. The canonical form must rewrite UUIDs inside that
+# nested block in lockstep with the parent so the two builds agree.
+
+
+@qmc.qkernel
+def _phase_a(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Single-qubit phase rotation used as a controlled-U body."""
+    return qmc.p(q, theta)
+
+
+@qmc.qkernel
+def _phase_b(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Structurally identical twin of ``_phase_a``."""
+    return qmc.p(q, theta)
+
+
+@qmc.qkernel
+def _controlled_phase_a(
+    ctrl: qmc.Qubit, target: qmc.Qubit, theta: qmc.Float
+) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Top-level kernel that embeds ``ControlledUOperation`` via controlled(_phase_a)."""
+    op = qmc.controlled(_phase_a)
+    ctrl, target = op(ctrl, target, theta=theta)
+    return ctrl, target
+
+
+@qmc.qkernel
+def _controlled_phase_b(
+    ctrl: qmc.Qubit, target: qmc.Qubit, theta: qmc.Float
+) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Twin of ``_controlled_phase_a`` for cross-build ControlledU determinism."""
+    op = qmc.controlled(_phase_b)
+    ctrl, target = op(ctrl, target, theta=theta)
+    return ctrl, target
+
+
 # ---------------------------------------------------------------------------
 # Basic invariants
 # ---------------------------------------------------------------------------
@@ -182,6 +221,20 @@ class TestCanonicalizeDeterminism:
         b = _to_affine(_measure_after_h_twin)
         assert content_hash(a) == content_hash(b)
 
+    def test_controlled_u_twins_same_canonical_bytes(self):
+        """Cross-build determinism through ``ControlledUOperation.block``.
+
+        Each top-level kernel embeds a ``ControlledUOperation`` whose
+        ``block`` field is itself an independently-traced sub-Block.
+        Without nested canonicalization, UUIDs inside that sub-Block
+        would differ between builds and the canonical bytes would
+        disagree.
+        """
+        a = _to_affine(_controlled_phase_a)
+        b = _to_affine(_controlled_phase_b)
+        assert to_canonical_bytes(a) == to_canonical_bytes(b)
+        assert content_hash(a) == content_hash(b)
+
 
 class TestCanonicalizeIdempotence:
     """Canonicalizing twice must equal canonicalizing once."""
@@ -220,9 +273,16 @@ class TestCounterBasedUUIDs:
     def test_remap_dict_covers_every_original_uuid(self):
         """``canonicalize_and_remap`` returns a key for every original Value UUID."""
         block = _to_affine(_h_then_rx)
-        _, remap = canonicalize_and_remap(block)
+        _, uuid_remap, _ = canonicalize_and_remap(block)
         for v in block.input_values:
-            assert v.uuid in remap
+            assert v.uuid in uuid_remap
+
+    def test_remap_exposes_logical_id_table(self):
+        """``canonicalize_and_remap`` also exposes the logical_id remap table."""
+        block = _to_affine(_h_then_rx)
+        _, _, logical_id_remap = canonicalize_and_remap(block)
+        for v in block.input_values:
+            assert v.logical_id in logical_id_remap
 
 
 # ---------------------------------------------------------------------------

--- a/tests/circuit/ir/test_canonical.py
+++ b/tests/circuit/ir/test_canonical.py
@@ -1,0 +1,516 @@
+"""Tests for the IR canonical form and content hash.
+
+These tests verify that ``canonicalize`` re-numbers UUIDs
+deterministically so two structurally-identical builds of the same
+kernel produce byte-identical canonical IR and identical hashes, while
+genuine IR differences yield different hashes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import cast
+
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.ir.block import Block, BlockKind
+from qamomile.circuit.ir.canonical import (
+    canonicalize,
+    canonicalize_and_remap,
+    content_hash,
+    to_canonical_bytes,
+)
+from qamomile.circuit.ir.operation import GateOperation, GateOperationType
+from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
+from qamomile.circuit.ir.types.primitives import (
+    FloatType,
+    QubitType,
+    UIntType,
+)
+from qamomile.circuit.ir.value import (
+    ArrayRuntimeMetadata,
+    ArrayValue,
+    CastMetadata,
+    DictValue,
+    QFixedMetadata,
+    ScalarMetadata,
+    TupleValue,
+    Value,
+    ValueMetadata,
+)
+from qamomile.circuit.transpiler.passes.inline import InlinePass
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_affine(kernel: qmc.QKernel) -> Block:
+    """Return an AFFINE block for ``kernel`` without instantiating a backend.
+
+    Args:
+        kernel (qmc.QKernel): A ``@qkernel``-decorated function.
+
+    Returns:
+        Block: The kernel's traced block after running ``InlinePass``,
+            so all ``CallBlockOperation``s are removed and the block is
+            ready for canonicalize().
+    """
+    return InlinePass().run(kernel.block)
+
+
+@qmc.qkernel
+def _h_then_rx(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Simple single-qubit kernel with one parameter."""
+    q = qmc.h(q)
+    q = qmc.rx(q, theta)
+    return q
+
+
+@qmc.qkernel
+def _h_then_rx_twin(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Structurally identical twin of ``_h_then_rx`` for cross-build equality tests.
+
+    A second ``@qkernel`` decoration produces an independent build with
+    fresh UUIDs, simulating the "two processes built the same kernel"
+    scenario without having to clear the kernel's cached block.
+    """
+    q = qmc.h(q)
+    q = qmc.rx(q, theta)
+    return q
+
+
+@qmc.qkernel
+def _h_then_ry(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Variant of ``_h_then_rx`` that uses RY instead of RX."""
+    q = qmc.h(q)
+    q = qmc.ry(q, theta)
+    return q
+
+
+@qmc.qkernel
+def _loop_h(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Kernel that exercises a symbolic ForOperation over a Vector input."""
+    n = qs.shape[0]
+    for i in qmc.range(n):
+        qs[i] = qmc.h(qs[i])
+    return qs
+
+
+@qmc.qkernel
+def _loop_h_twin(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Twin of ``_loop_h`` for cross-build determinism on symbolic ForOperation."""
+    n = qs.shape[0]
+    for i in qmc.range(n):
+        qs[i] = qmc.h(qs[i])
+    return qs
+
+
+@qmc.qkernel
+def _measure_after_h(q: qmc.Qubit) -> qmc.Bit:
+    """Kernel that exercises a measurement-derived classical bit."""
+    q = qmc.h(q)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def _measure_after_h_twin(q: qmc.Qubit) -> qmc.Bit:
+    """Twin of ``_measure_after_h`` for cross-build determinism with measurement."""
+    q = qmc.h(q)
+    return qmc.measure(q)
+
+
+# ---------------------------------------------------------------------------
+# Basic invariants
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalizePreservesStructure:
+    """Verify that canonicalize preserves kind, shape, and does not mutate."""
+
+    def test_preserves_block_kind(self):
+        """Canonicalize keeps the input ``BlockKind`` (does not advance the stage)."""
+        block = _to_affine(_h_then_rx)
+        canon = canonicalize(block)
+        assert canon.kind == block.kind == BlockKind.AFFINE
+
+    def test_does_not_mutate_input(self):
+        """Original block UUIDs are untouched by canonicalize."""
+        block = _to_affine(_h_then_rx)
+        original_input_uuid = block.input_values[0].uuid
+        canonicalize(block)
+        assert block.input_values[0].uuid == original_input_uuid
+
+    def test_preserves_operation_count_and_order(self):
+        """Number and order of operations is preserved through canonicalize."""
+        block = _to_affine(_h_then_rx)
+        canon = canonicalize(block)
+        assert len(canon.operations) == len(block.operations)
+        assert [type(op).__name__ for op in canon.operations] == [
+            type(op).__name__ for op in block.operations
+        ]
+
+
+class TestCanonicalizeDeterminism:
+    """Cross-build determinism: same kernel built twice produces matching IR."""
+
+    def test_twin_kernels_same_canonical_bytes(self):
+        """Two structurally-identical kernels canonicalize to identical bytes."""
+        a = _to_affine(_h_then_rx)
+        b = _to_affine(_h_then_rx_twin)
+        # Sanity: independent builds have different raw UUIDs.
+        assert a.input_values[0].uuid != b.input_values[0].uuid
+        # But canonical forms align byte-for-byte.
+        assert to_canonical_bytes(a) == to_canonical_bytes(b)
+
+    def test_twin_kernels_same_hash(self):
+        """``content_hash`` agrees across two structurally-identical kernels."""
+        assert content_hash(_to_affine(_h_then_rx)) == content_hash(
+            _to_affine(_h_then_rx_twin)
+        )
+
+    def test_loop_kernel_twins_same_hash(self):
+        """Determinism holds for kernels containing symbolic ForOperation."""
+        a = _to_affine(_loop_h)
+        b = _to_affine(_loop_h_twin)
+        assert content_hash(a) == content_hash(b)
+
+    def test_measurement_kernel_twins_same_hash(self):
+        """Determinism holds for kernels with measurement-backed bits."""
+        a = _to_affine(_measure_after_h)
+        b = _to_affine(_measure_after_h_twin)
+        assert content_hash(a) == content_hash(b)
+
+
+class TestCanonicalizeIdempotence:
+    """Canonicalizing twice must equal canonicalizing once."""
+
+    def test_idempotent_bytes(self):
+        """``to_canonical_bytes(canonicalize(b)) == to_canonical_bytes(b)``."""
+        block = _to_affine(_h_then_rx)
+        once = to_canonical_bytes(block)
+        canon_once = canonicalize(block)
+        twice = to_canonical_bytes(canon_once)
+        assert once == twice
+
+    def test_idempotent_hash(self):
+        """``content_hash`` is stable under repeated canonicalize."""
+        block = _to_affine(_h_then_rx)
+        h1 = content_hash(block)
+        canon = canonicalize(block)
+        h2 = content_hash(canon)
+        h3 = content_hash(canonicalize(canon))
+        assert h1 == h2 == h3
+
+
+# ---------------------------------------------------------------------------
+# Counter-based UUID format
+# ---------------------------------------------------------------------------
+
+
+class TestCounterBasedUUIDs:
+    """The first Value visited gets ``UUID(int=0)``; subsequent values continue."""
+
+    def test_first_input_has_zero_uuid(self):
+        """First canonicalized Value carries the counter-zero UUID."""
+        canon = canonicalize(_to_affine(_h_then_rx))
+        assert canon.input_values[0].uuid == "00000000-0000-0000-0000-000000000000"
+
+    def test_remap_dict_covers_every_original_uuid(self):
+        """``canonicalize_and_remap`` returns a key for every original Value UUID."""
+        block = _to_affine(_h_then_rx)
+        _, remap = canonicalize_and_remap(block)
+        for v in block.input_values:
+            assert v.uuid in remap
+
+
+# ---------------------------------------------------------------------------
+# Differentiation: structurally different kernels hash differently
+# ---------------------------------------------------------------------------
+
+
+class TestHashDifferentiation:
+    """Different IR shapes must produce different ``content_hash`` values."""
+
+    def test_different_gate_types_differ(self):
+        """RX-based and RY-based variants of the same kernel disagree."""
+        rx_hash = content_hash(_to_affine(_h_then_rx))
+        ry_hash = content_hash(_to_affine(_h_then_ry))
+        assert rx_hash != ry_hash
+
+    def test_extra_gate_changes_hash(self):
+        """Appending a gate to the operation list changes the hash."""
+        block = _to_affine(_h_then_rx)
+        # Append a fixed X gate referencing the existing output value.
+        last_result = block.operations[-1].results[0]
+        new_q = last_result.next_version()
+        block_extra = dataclasses.replace(
+            block,
+            operations=[
+                *block.operations,
+                GateOperation.fixed(
+                    GateOperationType.X,
+                    qubits=[last_result],
+                    results=[new_q],
+                ),
+            ],
+            output_values=[new_q],
+        )
+        assert content_hash(block) != content_hash(block_extra)
+
+
+# ---------------------------------------------------------------------------
+# Kind enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedBlockKind:
+    """``canonicalize`` rejects Blocks that have not been inlined yet."""
+
+    def test_rejects_hierarchical(self):
+        """A raw HIERARCHICAL block raises ``ValueError``."""
+        hierarchical = dataclasses.replace(
+            _h_then_rx.block, kind=BlockKind.HIERARCHICAL
+        )
+        with pytest.raises(ValueError, match="AFFINE"):
+            canonicalize(hierarchical)
+
+    def test_rejects_traced(self):
+        """A TRACED block also raises (must be inlined first)."""
+        traced = dataclasses.replace(_h_then_rx.block, kind=BlockKind.TRACED)
+        with pytest.raises(ValueError, match="AFFINE"):
+            canonicalize(traced)
+
+    def test_explicit_call_block_raises(self):
+        """A Block carrying a CallBlockOperation surfaces NotImplementedError."""
+        block = _to_affine(_h_then_rx)
+        # Inject a synthetic CallBlockOperation to force the runtime check.
+        bad = dataclasses.replace(
+            block,
+            operations=[*block.operations, CallBlockOperation(block=block)],
+        )
+        with pytest.raises(NotImplementedError, match="CallBlockOperation"):
+            canonicalize(bad)
+
+
+# ---------------------------------------------------------------------------
+# Direct-construction tests for metadata UUID rewrite
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_block(
+    *,
+    input_values: list[Value] | None = None,
+    output_values: list[Value] | None = None,
+    operations: list | None = None,
+    parameters: dict[str, Value] | None = None,
+) -> Block:
+    """Build a minimal AFFINE Block from explicit Value lists.
+
+    Used by metadata-rewrite tests that need precise control over IR
+    contents that the frontend does not produce by itself.
+
+    Args:
+        input_values (list[Value] | None): Values to expose as
+            ``Block.input_values``. Defaults to ``None`` (empty list).
+        output_values (list[Value] | None): Values to expose as
+            ``Block.output_values``. Defaults to ``None`` (empty list).
+        operations (list | None): Operations to place inside the
+            block. Defaults to ``None`` (no operations).
+        parameters (dict[str, Value] | None): Parameter slot mapping.
+            Defaults to ``None`` (no parameters).
+
+    Returns:
+        Block: A freshly-constructed Block with ``BlockKind.AFFINE``,
+            ready to be passed to ``canonicalize``.
+    """
+    return Block(
+        name="manual",
+        label_args=[v.name for v in (input_values or [])],
+        input_values=list(input_values or []),
+        output_values=list(output_values or []),
+        output_names=[v.name for v in (output_values or [])],
+        operations=list(operations or []),
+        kind=BlockKind.AFFINE,
+        parameters=dict(parameters or {}),
+    )
+
+
+class TestMetadataUUIDRewrite:
+    """``ValueMetadata`` UUID fields must be remapped in lockstep with Values."""
+
+    def test_cast_metadata_uuid_rewritten(self):
+        """CastMetadata.source_uuid / qubit_uuids land on canonical UUIDs."""
+        source = Value(type=QubitType(), name="src")
+        qubit = Value(type=QubitType(), name="q0")
+        cast_result = Value(
+            type=FloatType(),
+            name="cast",
+            metadata=ValueMetadata(
+                cast=CastMetadata(
+                    source_uuid=source.uuid,
+                    qubit_uuids=(qubit.uuid,),
+                    source_logical_id=source.logical_id,
+                    qubit_logical_ids=(qubit.logical_id,),
+                ),
+            ),
+        )
+        block = _make_minimal_block(
+            input_values=[source, qubit],
+            output_values=[cast_result],
+        )
+        canon = canonicalize(block)
+        canon_source, canon_qubit = canon.input_values
+        canon_cast = canon.output_values[0]
+        assert canon_cast.metadata.cast is not None
+        assert canon_cast.metadata.cast.source_uuid == canon_source.uuid
+        assert canon_cast.metadata.cast.qubit_uuids == (canon_qubit.uuid,)
+        assert canon_cast.metadata.cast.source_logical_id == canon_source.logical_id
+        assert canon_cast.metadata.cast.qubit_logical_ids == (canon_qubit.logical_id,)
+
+    def test_qfixed_metadata_qubits_rewritten(self):
+        """QFixedMetadata.qubit_uuids are rewritten to canonical UUIDs."""
+        q0 = Value(type=QubitType(), name="q0")
+        q1 = Value(type=QubitType(), name="q1")
+        qf = Value(
+            type=FloatType(),
+            name="qf",
+            metadata=ValueMetadata(
+                qfixed=QFixedMetadata(
+                    qubit_uuids=(q0.uuid, q1.uuid),
+                    num_bits=2,
+                    int_bits=0,
+                ),
+            ),
+        )
+        block = _make_minimal_block(input_values=[q0, q1], output_values=[qf])
+        canon = canonicalize(block)
+        cq0, cq1 = canon.input_values
+        cqf = canon.output_values[0]
+        assert cqf.metadata.qfixed is not None
+        assert cqf.metadata.qfixed.qubit_uuids == (cq0.uuid, cq1.uuid)
+
+    def test_array_runtime_element_uuids_rewritten(self):
+        """ArrayRuntimeMetadata element-UUID lists track canonical UUIDs."""
+        e0 = Value(type=FloatType(), name="e0")
+        e1 = Value(type=FloatType(), name="e1")
+        arr = ArrayValue(
+            type=FloatType(),
+            name="arr",
+            metadata=ValueMetadata(
+                array_runtime=ArrayRuntimeMetadata(
+                    element_uuids=(e0.uuid, e1.uuid),
+                    element_logical_ids=(e0.logical_id, e1.logical_id),
+                ),
+            ),
+        )
+        block = _make_minimal_block(input_values=[e0, e1], output_values=[arr])
+        canon = canonicalize(block)
+        ce0, ce1 = canon.input_values
+        carr = canon.output_values[0]
+        assert carr.metadata.array_runtime is not None
+        assert carr.metadata.array_runtime.element_uuids == (ce0.uuid, ce1.uuid)
+        assert carr.metadata.array_runtime.element_logical_ids == (
+            ce0.logical_id,
+            ce1.logical_id,
+        )
+
+    def test_scalar_metadata_preserved_verbatim(self):
+        """ScalarMetadata (no UUID refs) carries through unchanged."""
+        v = Value(
+            type=FloatType(),
+            name="theta",
+            metadata=ValueMetadata(scalar=ScalarMetadata(parameter_name="theta")),
+        )
+        block = _make_minimal_block(input_values=[v], output_values=[v])
+        canon = canonicalize(block)
+        assert canon.input_values[0].metadata.scalar == ScalarMetadata(
+            parameter_name="theta"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Composite Value types: Tuple / Dict
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeValueTypes:
+    """Canonicalize must descend into TupleValue / DictValue / ArrayValue."""
+
+    def test_tuple_value_elements_rewritten(self):
+        """Each element of a ``TupleValue`` gets its own canonical UUID."""
+        a = Value(type=FloatType(), name="a")
+        b = Value(type=UIntType(), name="b")
+        tup = TupleValue(name="pair", elements=(a, b))
+        block = _make_minimal_block(
+            input_values=[a, b],
+            output_values=cast(list[Value], [tup]),
+        )
+        canon = canonicalize(block)
+        ca, cb = canon.input_values
+        ctup = canon.output_values[0]
+        assert isinstance(ctup, TupleValue)
+        assert tuple(e.uuid for e in ctup.elements) == (ca.uuid, cb.uuid)
+
+    def test_dict_value_entries_rewritten(self):
+        """Each key/value of a ``DictValue`` gets canonical UUIDs."""
+        k = Value(type=UIntType(), name="k")
+        v = Value(type=FloatType(), name="v")
+        dv = DictValue(name="m", entries=((k, v),))
+        block = _make_minimal_block(
+            input_values=[k, v],
+            output_values=cast(list[Value], [dv]),
+        )
+        canon = canonicalize(block)
+        ck, cv = canon.input_values
+        cdv = canon.output_values[0]
+        assert isinstance(cdv, DictValue)
+        assert cdv.entries[0][0].uuid == ck.uuid
+        assert cdv.entries[0][1].uuid == cv.uuid
+
+    def test_array_value_shape_rewritten(self):
+        """``ArrayValue.shape`` dimension Values are canonicalized too."""
+        n = Value(type=UIntType(), name="n")
+        arr = ArrayValue(type=QubitType(), name="qs", shape=(n,))
+        block = _make_minimal_block(input_values=[n], output_values=[arr])
+        canon = canonicalize(block)
+        cn = canon.input_values[0]
+        carr = canon.output_values[0]
+        assert isinstance(carr, ArrayValue)
+        assert carr.shape[0].uuid == cn.uuid
+
+
+# ---------------------------------------------------------------------------
+# Parameters ordering
+# ---------------------------------------------------------------------------
+
+
+class TestParametersOrdering:
+    """``Block.parameters`` is walked in sorted-key order, so insertion order
+    of the underlying dict does not affect canonical form.
+    """
+
+    def test_parameters_walked_in_sorted_key_order(self):
+        """Same parameters with different insertion order produce equal bytes."""
+        alpha = Value(
+            type=FloatType(),
+            name="alpha",
+            metadata=ValueMetadata(scalar=ScalarMetadata(parameter_name="alpha")),
+        )
+        beta = Value(
+            type=FloatType(),
+            name="beta",
+            metadata=ValueMetadata(scalar=ScalarMetadata(parameter_name="beta")),
+        )
+        block_in_order = _make_minimal_block(
+            parameters={"alpha": alpha, "beta": beta},
+            input_values=[alpha, beta],
+            output_values=[alpha, beta],
+        )
+        block_reversed = _make_minimal_block(
+            parameters={"beta": beta, "alpha": alpha},
+            input_values=[alpha, beta],
+            output_values=[alpha, beta],
+        )
+        assert to_canonical_bytes(block_in_order) == to_canonical_bytes(block_reversed)


### PR DESCRIPTION
## Summary

Add `qamomile/circuit/ir/canonical.py` — a normalization pass that deterministically renumbers every Value UUID / `logical_id` in a `Block`, plus a SHA-256 `content_hash` for IR-level identity. Scope: `BlockKind.AFFINE` and `ANALYZED`. `HIERARCHICAL` blocks are rejected.

## Background

This PR is the first concrete deliverable from an internal IR-design discussion (2026-05-16) about what needs to be in place before qamomile can be exposed as a node in an outer DSL's computation graph — the typical "remote execution / hybrid algorithm" framing. That discussion surfaced seven IR-design backlog items (A–G). This PR is **item E (canonical form)**.

**Honest scoping note**: as of a follow-up review, E is *not* on the strict critical path for the MVP remote-execution story. The hot path is dominated by the parameter / binding contract (item B) and the actual wire-format serialization (which is a separate, not-yet-filed backlog item). Canonical form remains a useful primitive — it enables content-addressable caching, deterministic IR diffs, and "do you already have this IR?" transport optimizations, and it doubles as regression-test affordance for the IR-design items that follow. Implementation cost was already paid and there is no regression risk, so we merge it now rather than shelve it; pivot to B next.

## What this adds

`qamomile/circuit/ir/canonical.py`:

- `canonicalize(block) -> Block` — clone with deterministically-numbered Value UUIDs / logical_ids.
- `canonicalize_and_remap(block) -> (Block, dict[old_uuid, new_uuid])` — same plus the remap table for callers that hold external references.
- `to_canonical_bytes(block) -> bytes` — deterministic byte representation (internal format, not a wire format).
- `content_hash(block) -> str` — SHA-256 hex of the canonical bytes.

Behavioral guarantees:

- **Counter-based UUIDs**: first Value visited gets ``00000000-0000-0000-0000-000000000000``, then ``…0001``, ...
- **Reference-following**: rewrites every UUID embedded in ``CastMetadata``, ``QFixedMetadata``, ``ArrayRuntimeMetadata``, and ``CastOperation.qubit_mapping`` in lockstep with the corresponding Value UUIDs.
- **Stage-neutral**: ``Block.kind`` is preserved; canonicalize is a normalization, not a pipeline-stage advance.
- **Display-only fields excluded** from ``to_canonical_bytes``: ``Block.name``, ``Block.output_names``, ``Value.name``. Two structurally-identical kernels with different function names hash equally.
- **Idempotent**: ``canonicalize(canonicalize(b))`` produces the same canonical bytes as ``canonicalize(b)``.

Re-exported from ``qamomile.circuit.ir`` so callers can write ``from qamomile.circuit.ir import canonicalize, content_hash``.

`CLAUDE.md`: added a Canonical Form subsection under Architecture Overview describing scope, stage-neutrality, display-only exclusions, and the byte format's internal-only status.

## What this does NOT do

- Does NOT canonicalize ``BlockKind.HIERARCHICAL`` (still contains ``CallBlockOperation``s pointing at sibling Blocks by Python identity). Tracked separately as the cross-process module-reference backlog item.
- Does NOT define a stable wire format. ``to_canonical_bytes`` is an internal representation for hashing; a versioned serialization format is a separate (still-unfiled) backlog item.
- Does NOT touch the transpiler pipeline. No existing pass is modified.

## Tests

`tests/circuit/ir/test_canonical.py` (24 tests):

- Structure preservation (kind unchanged, op order preserved, original block not mutated).
- Cross-build determinism via "twin" kernels (two independent ``@qkernel`` decorations of the same body produce identical canonical bytes / hashes), covering plain gates, symbolic ``ForOperation``, and measurement-derived bits.
- Idempotence of ``to_canonical_bytes`` and ``content_hash``.
- Counter-based UUID format (first Value at ``…0000``).
- Hash differentiation across gate-type variants and added gates.
- Block-kind enforcement (HIERARCHICAL / TRACED / explicit ``CallBlockOperation`` each rejected with the expected error).
- Metadata UUID rewriting for ``CastMetadata``, ``QFixedMetadata``, ``ArrayRuntimeMetadata``, and ``ScalarMetadata``.
- All Value kinds: ``Value``, ``ArrayValue``, ``TupleValue``, ``DictValue``.
- ``Block.parameters`` walked in sorted-key order (insertion-order-independent).

## Test plan

- [x] ``uv run pytest tests/circuit/ir/test_canonical.py`` — 24 / 24 pass
- [x] ``uv run pytest tests/circuit/`` regression suite — 4747 pass, 152 skipped, 0 failures
- [x] ``uv run ruff check`` — clean
- [x] ``uv run zuban check`` — clean
- [x] ``/local-review`` — clean after addressing P2 docstring findings