### PR TITLE
feat(observable): add Hamiltonian commutator helper

### DIFF
--- a/docs/en/algorithm/hamiltonian_simulation.ipynb
+++ b/docs/en/algorithm/hamiltonian_simulation.ipynb
@@ -37,10 +37,10 @@
    "id": "718e65e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.292198Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.291968Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.295436Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.294854Z"
+     "iopub.execute_input": "2026-05-21T05:45:51.805211Z",
+     "iopub.status.busy": "2026-05-21T05:45:51.805158Z",
+     "iopub.status.idle": "2026-05-21T05:45:51.808482Z",
+     "shell.execute_reply": "2026-05-21T05:45:51.808199Z"
     }
    },
    "outputs": [],
@@ -55,10 +55,10 @@
    "id": "b7e12a9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.297879Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.297641Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.757643Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.757240Z"
+     "iopub.execute_input": "2026-05-21T05:45:51.810950Z",
+     "iopub.status.busy": "2026-05-21T05:45:51.810892Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.156157Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.155218Z"
     }
    },
    "outputs": [],
@@ -103,10 +103,10 @@
    "id": "2dc956e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.758884Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.758795Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.760460Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.760239Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.159046Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.158827Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.162524Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.161243Z"
     }
    },
    "outputs": [],
@@ -118,6 +118,59 @@
     "Hz = 0.5 * omega * qm_o.Z(0)\n",
     "Hx = 0.5 * Omega * qm_o.X(0)\n",
     "Hs = [Hz, Hx]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fdd8b89",
+   "metadata": {},
+   "source": [
+    "### Verifying $[H_z, H_x] \\neq 0$\n",
+    "\n",
+    "Trotter approximations only matter because $H_z$ and $H_x$ do not commute.\n",
+    "`qamomile.observable.commutator(a, b)` computes the commutator\n",
+    "$[a, b] = a b - b a$ on Hamiltonians directly. Internally it iterates over\n",
+    "the Pauli-string pairs once and uses the qubit-parity rule — two Pauli\n",
+    "strings anticommute iff the number of qubits on which they carry different\n",
+    "non-identity Paulis is odd — to drop every commuting pair before any\n",
+    "product is built. This is cheaper than expanding `Hz * Hx - Hx * Hz` and\n",
+    "cancelling, and the result is a fully simplified `Hamiltonian` that we can\n",
+    "inspect or compare against an analytic value.\n",
+    "\n",
+    "For the Rabi Hamiltonian the textbook value is\n",
+    "\n",
+    "$$ [H_z, H_x] \\;=\\; \\tfrac{\\omega \\Omega}{4}\\,[Z, X] \\;=\\; i\\,\\tfrac{\\omega \\Omega}{2}\\, Y, $$\n",
+    "\n",
+    "which `commutator` reproduces exactly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eaf10ade",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-21T05:45:55.164964Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.164844Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.168812Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.168121Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hamiltonian((Y0,): 0.48j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "comm_zx = qm_o.commutator(Hz, Hx)\n",
+    "print(comm_zx)\n",
+    "\n",
+    "expected = 1j * 0.5 * omega * Omega * qm_o.Y(0)\n",
+    "assert comm_zx == expected"
    ]
   },
   {
@@ -134,14 +187,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "47be41ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.761463Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.761414Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.766336Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.765969Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.171541Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.171481Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.174728Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.174408Z"
     }
    },
    "outputs": [],
@@ -154,14 +207,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "43677da8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.767291Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.767235Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.769187Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.768889Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.175692Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.175633Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.177503Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.177246Z"
     },
     "lines_to_next_cell": 2
    },
@@ -212,14 +265,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "181971d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.770000Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.769952Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.772153Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.771748Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.178383Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.178337Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.180512Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.180296Z"
     }
    },
    "outputs": [],
@@ -235,14 +288,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9f59cdd8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.773057Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.773012Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.775022Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.774754Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.181308Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.181263Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.183305Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.182872Z"
     },
     "lines_to_next_cell": 2
    },
@@ -277,14 +330,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "19c09be1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.775849Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.775797Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.778041Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.777724Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.184049Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.184009Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.186210Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.185920Z"
     }
    },
    "outputs": [],
@@ -301,14 +354,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "b07266d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.778860Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.778819Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.781187Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.780837Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.187049Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.187008Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.189242Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.188887Z"
     },
     "lines_to_next_cell": 2
    },
@@ -390,14 +443,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "2955ad03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.782102Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.782063Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.785248Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.785040Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.192591Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.192517Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.198060Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.197288Z"
     }
    },
    "outputs": [],
@@ -424,14 +477,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "6dc094cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.786233Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.786197Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.788279Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.787905Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.200796Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.200643Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.207550Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.205578Z"
     },
     "lines_to_next_cell": 2
    },
@@ -477,14 +530,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "47c5b6f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.789115Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.789077Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.791064Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.790780Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.211068Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.210934Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.214889Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.214343Z"
     }
    },
    "outputs": [],
@@ -529,14 +582,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "a9827e1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.792061Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.792024Z",
-     "iopub.status.idle": "2026-05-08T02:55:11.988959Z",
-     "shell.execute_reply": "2026-05-08T02:55:11.987947Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.216110Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.216050Z",
+     "iopub.status.idle": "2026-05-21T05:45:55.431941Z",
+     "shell.execute_reply": "2026-05-21T05:45:55.431579Z"
     }
    },
    "outputs": [
@@ -546,7 +599,13 @@
      "text": [
       "S1 at N=8: fidelity error = 1.183e-03\n",
       "S2 at N=8: fidelity error = 1.059e-06\n",
-      "S4 at N=8: fidelity error = 1.468e-13\n",
+      "S4 at N=8: fidelity error = 1.468e-13\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "S6 at N=8: fidelity error = 0.000e+00\n"
      ]
     }
@@ -599,14 +658,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "008f39d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:11.990411Z",
-     "iopub.status.busy": "2026-05-08T02:55:11.990332Z",
-     "iopub.status.idle": "2026-05-08T02:55:13.108944Z",
-     "shell.execute_reply": "2026-05-08T02:55:13.108361Z"
+     "iopub.execute_input": "2026-05-21T05:45:55.434949Z",
+     "iopub.status.busy": "2026-05-21T05:45:55.434881Z",
+     "iopub.status.idle": "2026-05-21T05:45:56.682650Z",
+     "shell.execute_reply": "2026-05-21T05:45:56.679770Z"
     }
    },
    "outputs": [],
@@ -636,14 +695,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "48e97da9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:13.110510Z",
-     "iopub.status.busy": "2026-05-08T02:55:13.110408Z",
-     "iopub.status.idle": "2026-05-08T02:55:13.112188Z",
-     "shell.execute_reply": "2026-05-08T02:55:13.111794Z"
+     "iopub.execute_input": "2026-05-21T05:45:56.683779Z",
+     "iopub.status.busy": "2026-05-21T05:45:56.683708Z",
+     "iopub.status.idle": "2026-05-21T05:45:56.688811Z",
+     "shell.execute_reply": "2026-05-21T05:45:56.687059Z"
     }
    },
    "outputs": [],
@@ -654,14 +713,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "6c45a9b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:13.113528Z",
-     "iopub.status.busy": "2026-05-08T02:55:13.113447Z",
-     "iopub.status.idle": "2026-05-08T02:55:13.116059Z",
-     "shell.execute_reply": "2026-05-08T02:55:13.115585Z"
+     "iopub.execute_input": "2026-05-21T05:45:56.690252Z",
+     "iopub.status.busy": "2026-05-21T05:45:56.690187Z",
+     "iopub.status.idle": "2026-05-21T05:45:56.692692Z",
+     "shell.execute_reply": "2026-05-21T05:45:56.692025Z"
     }
    },
    "outputs": [
@@ -692,14 +751,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "ee9c2438",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-08T02:55:13.117497Z",
-     "iopub.status.busy": "2026-05-08T02:55:13.117426Z",
-     "iopub.status.idle": "2026-05-08T02:55:13.265386Z",
-     "shell.execute_reply": "2026-05-08T02:55:13.264935Z"
+     "iopub.execute_input": "2026-05-21T05:45:56.693710Z",
+     "iopub.status.busy": "2026-05-21T05:45:56.693651Z",
+     "iopub.status.idle": "2026-05-21T05:45:57.024933Z",
+     "shell.execute_reply": "2026-05-21T05:45:57.024589Z"
     }
    },
    "outputs": [

--- a/docs/en/algorithm/hamiltonian_simulation.py
+++ b/docs/en/algorithm/hamiltonian_simulation.py
@@ -81,6 +81,32 @@ Hx = 0.5 * Omega * qm_o.X(0)
 Hs = [Hz, Hx]
 
 # %% [markdown]
+# ### Verifying $[H_z, H_x] \neq 0$
+#
+# Trotter approximations only matter because $H_z$ and $H_x$ do not commute.
+# `qamomile.observable.commutator(a, b)` computes the commutator
+# $[a, b] = a b - b a$ on Hamiltonians directly. Internally it iterates over
+# the Pauli-string pairs once and uses the qubit-parity rule — two Pauli
+# strings anticommute iff the number of qubits on which they carry different
+# non-identity Paulis is odd — to drop every commuting pair before any
+# product is built. This is cheaper than expanding `Hz * Hx - Hx * Hz` and
+# cancelling, and the result is a fully simplified `Hamiltonian` that we can
+# inspect or compare against an analytic value.
+#
+# For the Rabi Hamiltonian the textbook value is
+#
+# $$ [H_z, H_x] \;=\; \tfrac{\omega \Omega}{4}\,[Z, X] \;=\; i\,\tfrac{\omega \Omega}{2}\, Y, $$
+#
+# which `commutator` reproduces exactly:
+
+# %%
+comm_zx = qm_o.commutator(Hz, Hx)
+print(comm_zx)
+
+expected = 1j * 0.5 * omega * Omega * qm_o.Y(0)
+assert comm_zx == expected
+
+# %% [markdown]
 # ## Exact reference state
 #
 # A 2x2 matrix exponential gives the exact state $|\psi(T)\rangle = e^{-iHT}|0\rangle$,

--- a/docs/ja/algorithm/hamiltonian_simulation.ipynb
+++ b/docs/ja/algorithm/hamiltonian_simulation.ipynb
@@ -22,10 +22,10 @@
    "id": "231bd8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.345649Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.345494Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.350875Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.350284Z"
+     "iopub.execute_input": "2026-05-21T06:26:03.927055Z",
+     "iopub.status.busy": "2026-05-21T06:26:03.926996Z",
+     "iopub.status.idle": "2026-05-21T06:26:03.929347Z",
+     "shell.execute_reply": "2026-05-21T06:26:03.928759Z"
     }
    },
    "outputs": [],
@@ -40,10 +40,10 @@
    "id": "eb7ea809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.352836Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.352681Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.906814Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.906364Z"
+     "iopub.execute_input": "2026-05-21T06:26:03.930557Z",
+     "iopub.status.busy": "2026-05-21T06:26:03.930491Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.653906Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.653234Z"
     }
    },
    "outputs": [],
@@ -82,10 +82,10 @@
    "id": "9d822c1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.908058Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.907966Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.909664Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.909379Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.655294Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.655170Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.657054Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.656710Z"
     }
    },
    "outputs": [],
@@ -101,6 +101,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "584fc220",
+   "metadata": {},
+   "source": [
+    "### $[H_z, H_x] \\neq 0$ の確認\n",
+    "\n",
+    "Trotter近似が必要になるのは$H_z$と$H_x$が可換でないからです。`qamomile.observable.commutator(a, b)`はハミルトニアン同士の交換子$[a, b] = a b - b a$を直接計算します。内部では各Pauli列ペアを1度だけ走査し、qubitパリティの規則(2つのPauli列は、両方とも非恒等かつ異なるPauliが乗っているqubitの数が奇数のときにだけ反交換)に従って、可換なペアを積を作る前に落とします。`Hz * Hx - Hx * Hz`のように一旦展開してから打ち消す素朴な計算より軽く、結果として完全に簡約された`Hamiltonian`が返ってくるので、そのまま検査したり解析値と比較したりできます。\n",
+    "\n",
+    "Rabiハミルトニアンの場合、教科書的な値は\n",
+    "\n",
+    "$$ [H_z, H_x] \\;=\\; \\tfrac{\\omega \\Omega}{4}\\,[Z, X] \\;=\\; i\\,\\tfrac{\\omega \\Omega}{2}\\, Y $$\n",
+    "\n",
+    "であり、`commutator`はこれを厳密に再現します:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8f488011",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-21T06:26:04.657932Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.657882Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.659447Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.659183Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hamiltonian((Y0,): 0.48j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "comm_zx = qm_o.commutator(Hz, Hx)\n",
+    "print(comm_zx)\n",
+    "\n",
+    "expected = 1j * 0.5 * omega * Omega * qm_o.Y(0)\n",
+    "assert comm_zx == expected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6a5d0682",
    "metadata": {},
    "source": [
@@ -111,14 +156,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "cb838c2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.910544Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.910495Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.912561Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.912248Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.660336Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.660290Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.667744Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.667383Z"
     }
    },
    "outputs": [],
@@ -131,14 +176,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "a5c7a846",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.913373Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.913319Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.915141Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.914873Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.668582Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.668536Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.670636Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.670131Z"
     },
     "lines_to_next_cell": 2
    },
@@ -184,14 +229,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0d1832df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.915933Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.915888Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.917949Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.917674Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.671777Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.671705Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.674062Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.673700Z"
     }
    },
    "outputs": [],
@@ -207,14 +252,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "410b44d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.918655Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.918616Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.920441Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.920170Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.674892Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.674848Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.676882Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.676616Z"
     },
     "lines_to_next_cell": 2
    },
@@ -248,14 +293,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "4b680def",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.921350Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.921294Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.923383Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.923086Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.677709Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.677670Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.680023Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.679607Z"
     }
    },
    "outputs": [],
@@ -272,14 +317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "86e0ee99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.924254Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.924215Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.926247Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.925883Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.681018Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.680974Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.682940Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.682685Z"
     },
     "lines_to_next_cell": 2
    },
@@ -340,14 +385,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "b5b9cf42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.927059Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.927020Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.930243Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.930008Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.683867Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.683829Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.687049Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.686511Z"
     }
    },
    "outputs": [],
@@ -374,14 +419,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "401f1d66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.931040Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.931004Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.933006Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.932733Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.688011Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.687948Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.690059Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.689819Z"
     },
     "lines_to_next_cell": 2
    },
@@ -422,14 +467,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "39381526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.933839Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.933796Z",
-     "iopub.status.idle": "2026-04-28T12:08:35.935566Z",
-     "shell.execute_reply": "2026-04-28T12:08:35.935321Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.691014Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.690976Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.692812Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.692525Z"
     }
    },
    "outputs": [],
@@ -466,14 +511,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "fab40fc1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:35.936527Z",
-     "iopub.status.busy": "2026-04-28T12:08:35.936475Z",
-     "iopub.status.idle": "2026-04-28T12:08:36.115852Z",
-     "shell.execute_reply": "2026-04-28T12:08:36.115301Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.693598Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.693557Z",
+     "iopub.status.idle": "2026-05-21T06:26:04.924241Z",
+     "shell.execute_reply": "2026-05-21T06:26:04.923873Z"
     }
    },
    "outputs": [
@@ -483,7 +528,13 @@
      "text": [
       "S1 at N=8: fidelity error = 1.183e-03\n",
       "S2 at N=8: fidelity error = 1.059e-06\n",
-      "S4 at N=8: fidelity error = 1.468e-13\n",
+      "S4 at N=8: fidelity error = 1.468e-13\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "S6 at N=8: fidelity error = 0.000e+00\n"
      ]
     }
@@ -531,14 +582,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "505634ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:36.117156Z",
-     "iopub.status.busy": "2026-04-28T12:08:36.117105Z",
-     "iopub.status.idle": "2026-04-28T12:08:37.147320Z",
-     "shell.execute_reply": "2026-04-28T12:08:37.146759Z"
+     "iopub.execute_input": "2026-05-21T06:26:04.925551Z",
+     "iopub.status.busy": "2026-05-21T06:26:04.925501Z",
+     "iopub.status.idle": "2026-05-21T06:26:06.113167Z",
+     "shell.execute_reply": "2026-05-21T06:26:06.112285Z"
     }
    },
    "outputs": [],
@@ -568,14 +619,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "c2ededd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:37.148983Z",
-     "iopub.status.busy": "2026-04-28T12:08:37.148882Z",
-     "iopub.status.idle": "2026-04-28T12:08:37.150564Z",
-     "shell.execute_reply": "2026-04-28T12:08:37.150217Z"
+     "iopub.execute_input": "2026-05-21T06:26:06.114822Z",
+     "iopub.status.busy": "2026-05-21T06:26:06.114727Z",
+     "iopub.status.idle": "2026-05-21T06:26:06.116631Z",
+     "shell.execute_reply": "2026-05-21T06:26:06.116121Z"
     }
    },
    "outputs": [],
@@ -586,14 +637,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "bc3cfd4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:37.151701Z",
-     "iopub.status.busy": "2026-04-28T12:08:37.151656Z",
-     "iopub.status.idle": "2026-04-28T12:08:37.154193Z",
-     "shell.execute_reply": "2026-04-28T12:08:37.153724Z"
+     "iopub.execute_input": "2026-05-21T06:26:06.117995Z",
+     "iopub.status.busy": "2026-05-21T06:26:06.117858Z",
+     "iopub.status.idle": "2026-05-21T06:26:06.120411Z",
+     "shell.execute_reply": "2026-05-21T06:26:06.119881Z"
     }
    },
    "outputs": [
@@ -624,14 +675,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "7b93e28c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T12:08:37.155552Z",
-     "iopub.status.busy": "2026-04-28T12:08:37.155489Z",
-     "iopub.status.idle": "2026-04-28T12:08:37.291427Z",
-     "shell.execute_reply": "2026-04-28T12:08:37.290821Z"
+     "iopub.execute_input": "2026-05-21T06:26:06.121975Z",
+     "iopub.status.busy": "2026-05-21T06:26:06.121883Z",
+     "iopub.status.idle": "2026-05-21T06:26:06.269898Z",
+     "shell.execute_reply": "2026-05-21T06:26:06.269406Z"
     }
    },
    "outputs": [

--- a/docs/ja/algorithm/hamiltonian_simulation.py
+++ b/docs/ja/algorithm/hamiltonian_simulation.py
@@ -60,6 +60,24 @@ Hx = 0.5 * Omega * qm_o.X(0)
 Hs = [Hz, Hx]
 
 # %% [markdown]
+# ### $[H_z, H_x] \neq 0$ の確認
+#
+# Trotter近似が必要になるのは$H_z$と$H_x$が可換でないからです。`qamomile.observable.commutator(a, b)`はハミルトニアン同士の交換子$[a, b] = a b - b a$を直接計算します。内部では各Pauli列ペアを1度だけ走査し、qubitパリティの規則(2つのPauli列は、両方とも非恒等かつ異なるPauliが乗っているqubitの数が奇数のときにだけ反交換)に従って、可換なペアを積を作る前に落とします。`Hz * Hx - Hx * Hz`のように一旦展開してから打ち消す素朴な計算より軽く、結果として完全に簡約された`Hamiltonian`が返ってくるので、そのまま検査したり解析値と比較したりできます。
+#
+# Rabiハミルトニアンの場合、教科書的な値は
+#
+# $$ [H_z, H_x] \;=\; \tfrac{\omega \Omega}{4}\,[Z, X] \;=\; i\,\tfrac{\omega \Omega}{2}\, Y $$
+#
+# であり、`commutator`はこれを厳密に再現します:
+
+# %%
+comm_zx = qm_o.commutator(Hz, Hx)
+print(comm_zx)
+
+expected = 1j * 0.5 * omega * Omega * qm_o.Y(0)
+assert comm_zx == expected
+
+# %% [markdown]
 # ## 厳密な参照状態
 #
 # 2x2行列の指数関数で厳密な状態$|\psi(T)\rangle = e^{-iHT}|0\rangle$が得られます。各Trotter近似は**フィデリティ誤差**$1 - |\langle\psi_\text{exact}|\psi_\text{trotter}\rangle|$によってこの状態と比較します。

--- a/qamomile/observable/__init__.py
+++ b/qamomile/observable/__init__.py
@@ -1,4 +1,4 @@
-from .hamiltonian import Hamiltonian, Pauli, PauliOperator, X, Y, Z
+from .hamiltonian import Hamiltonian, Pauli, PauliOperator, X, Y, Z, commutator
 
 __all__ = [
     "Hamiltonian",
@@ -7,4 +7,5 @@ __all__ = [
     "X",
     "Y",
     "Z",
+    "commutator",
 ]

--- a/qamomile/observable/hamiltonian.py
+++ b/qamomile/observable/hamiltonian.py
@@ -646,3 +646,97 @@ def simplify_pauliop_terms(
             pauli_list.append(_pauli_list[0])
 
     return tuple(pauli_list), phase
+
+
+def _pauli_strings_anticommute(
+    term1: tuple[PauliOperator, ...],
+    term2: tuple[PauliOperator, ...],
+) -> bool:
+    """Decide whether two Pauli strings anticommute.
+
+    Two Pauli strings ``P`` and ``Q`` anticommute iff the number of
+    qubits on which both act with different non-identity Pauli
+    operators is odd. On every other qubit ``P`` and ``Q`` commute
+    trivially (one is identity, or the two Paulis are equal), so the
+    overall sign of ``PQ`` versus ``QP`` is ``(-1)`` raised to that
+    count.
+
+    Args:
+        term1 (tuple[PauliOperator, ...]): The first Pauli string,
+            expressed as a tuple of single-qubit Pauli operators with
+            at most one operator per qubit (the canonical form
+            produced by `simplify_pauliop_terms`).
+        term2 (tuple[PauliOperator, ...]): The second Pauli string,
+            in the same canonical form as `term1`.
+
+    Returns:
+        bool: True if the two strings anticommute (``PQ = -QP``),
+            False if they commute (``PQ = QP``).
+
+    Example:
+        >>> X0 = PauliOperator(Pauli.X, 0)
+        >>> Y0 = PauliOperator(Pauli.Y, 0)
+        >>> Z1 = PauliOperator(Pauli.Z, 1)
+        >>> _pauli_strings_anticommute((X0,), (Y0,))
+        True
+        >>> _pauli_strings_anticommute((X0,), (Z1,))
+        False
+    """
+    map1 = {op.index: op.pauli for op in term1 if op.pauli != Pauli.I}
+    map2 = {op.index: op.pauli for op in term2 if op.pauli != Pauli.I}
+
+    anticommute_count = 0
+    for qubit in map1.keys() & map2.keys():
+        if map1[qubit] != map2[qubit]:
+            anticommute_count += 1
+
+    return anticommute_count % 2 == 1
+
+
+def commutator(a: Hamiltonian, b: Hamiltonian) -> Hamiltonian:
+    """Compute the commutator ``[A, B] = A B - B A`` of two Hamiltonians.
+
+    Iterates over the Pauli-string terms of `a` and `b` once and uses
+    the fact that two Pauli strings either commute (``[P, Q] = 0``) or
+    anticommute (``[P, Q] = 2 P Q``). Commuting pairs are skipped
+    entirely, so for sparse or nearly-commuting Hamiltonians this is
+    cheaper than expanding ``a * b - b * a`` and then cancelling.
+    The asymptotic cost is still O(|a| * |b|) Pauli-string pairs in
+    the worst case where every pair anticommutes.
+
+    The constant parts of `a` and `b` commute with every Pauli string
+    and with each other, so they contribute nothing to the commutator
+    and are ignored.
+
+    Args:
+        a (Hamiltonian): The left operand of the commutator.
+        b (Hamiltonian): The right operand of the commutator.
+
+    Returns:
+        Hamiltonian: A new Hamiltonian equal to ``a * b - b * a``.
+            Its `num_qubits` is the maximum of `a.num_qubits` and
+            `b.num_qubits` so the qubit register is preserved even
+            when the commutator collapses to zero on a subset of
+            qubits.
+
+    Example:
+        >>> from qamomile.observable.hamiltonian import X, Y, commutator
+        >>> commutator(X(0), Y(0))
+        Hamiltonian((Z0,): 2j)
+        >>> commutator(X(0), X(1))
+        Hamiltonian()
+    """
+    result = Hamiltonian(num_qubits=max(a.num_qubits, b.num_qubits))
+
+    for term_a, coeff_a in a.terms.items():
+        for term_b, coeff_b in b.terms.items():
+            if not _pauli_strings_anticommute(term_a, term_b):
+                continue
+            product, phase = simplify_pauliop_terms(term_a + term_b)
+            scaled = 2.0 * phase * coeff_a * coeff_b
+            if product:
+                result.add_term(product, scaled)
+            else:
+                result.constant += scaled
+
+    return result

--- a/qamomile/observable/hamiltonian.py
+++ b/qamomile/observable/hamiltonian.py
@@ -219,16 +219,43 @@ class Hamiltonian:
 
         operators, phase = simplify_pauliop_terms(operators)
         if operators:
-            # Sort the operators to ensure consistent representation
-            operators = tuple(
-                sorted(operators, key=lambda x: x.index * 10 + x.pauli.value)
-            )
-            if operators in self._terms:
-                self._terms[operators] += phase * coeff
-            else:
-                self._terms[operators] = phase * coeff
+            self._add_simplified_term(operators, phase * coeff)
         else:
             self.constant += phase * coeff
+
+    def _add_simplified_term(
+        self,
+        operators: tuple[PauliOperator, ...],
+        coeff: float | complex,
+    ) -> None:
+        """Add a pre-simplified Pauli term, skipping a second simplification pass.
+
+        Fast path for callers that have already run
+        ``simplify_pauliop_terms`` and know ``operators`` is a canonical
+        non-empty Pauli string — at most one operator per qubit, no
+        identities. The helper only sorts the operators into the
+        canonical (index, pauli) order and updates ``_terms``; it does
+        NOT re-run ``simplify_pauliop_terms`` or fold any phase, so the
+        caller is responsible for passing the fully resolved coefficient.
+
+        Args:
+            operators (tuple[PauliOperator, ...]): A pre-simplified,
+                non-empty Pauli string. Empty tuples must be routed by
+                the caller to ``self.constant`` directly.
+            coeff (float | complex): The fully resolved coefficient to
+                add. Summed with any existing coefficient for the same
+                canonicalized term.
+
+        Returns:
+            None: This method mutates ``self._terms`` in place.
+        """
+        sorted_ops = tuple(
+            sorted(operators, key=lambda x: x.index * 10 + x.pauli.value)
+        )
+        if sorted_ops in self._terms:
+            self._terms[sorted_ops] += coeff
+        else:
+            self._terms[sorted_ops] = coeff
 
     @property
     def num_qubits(self) -> int:
@@ -735,7 +762,9 @@ def commutator(a: Hamiltonian, b: Hamiltonian) -> Hamiltonian:
             product, phase = simplify_pauliop_terms(term_a + term_b)
             scaled = 2.0 * phase * coeff_a * coeff_b
             if product:
-                result.add_term(product, scaled)
+                # ``product`` is already simplified, so route around
+                # the second simplify pass inside ``add_term``.
+                result._add_simplified_term(product, scaled)
             else:
                 result.constant += scaled
 

--- a/qamomile/observable/hamiltonian.py
+++ b/qamomile/observable/hamiltonian.py
@@ -234,9 +234,10 @@ class Hamiltonian:
         ``simplify_pauliop_terms`` and know ``operators`` is a canonical
         non-empty Pauli string — at most one operator per qubit, no
         identities. The helper only sorts the operators into the
-        canonical (index, pauli) order and updates ``_terms``; it does
-        NOT re-run ``simplify_pauliop_terms`` or fold any phase, so the
-        caller is responsible for passing the fully resolved coefficient.
+        canonical ``(index, pauli.value)`` order and updates ``_terms``;
+        it does NOT re-run ``simplify_pauliop_terms`` or fold any phase,
+        so the caller is responsible for passing the fully resolved
+        coefficient.
 
         Args:
             operators (tuple[PauliOperator, ...]): A pre-simplified,
@@ -249,9 +250,7 @@ class Hamiltonian:
         Returns:
             None: This method mutates ``self._terms`` in place.
         """
-        sorted_ops = tuple(
-            sorted(operators, key=lambda x: x.index * 10 + x.pauli.value)
-        )
+        sorted_ops = tuple(sorted(operators, key=lambda x: (x.index, x.pauli.value)))
         if sorted_ops in self._terms:
             self._terms[sorted_ops] += coeff
         else:
@@ -698,13 +697,28 @@ def _pauli_strings_anticommute(
     overall sign of ``PQ`` versus ``QP`` is ``(-1)`` raised to that
     count.
 
+    Both inputs MUST be sorted by qubit index, free of ``Pauli.I``
+    entries, and carry at most one Pauli per qubit. Term tuples stored
+    on ``Hamiltonian._terms`` satisfy this contract because
+    ``Hamiltonian.add_term`` runs ``simplify_pauliop_terms`` *and then*
+    sorts by ``(index, pauli.value)`` before insertion. Note that
+    ``simplify_pauliop_terms`` by itself does NOT sort its returned
+    tuple — it preserves the insertion order of its internal per-qubit
+    dict — so external callers reusing this helper on the raw output of
+    ``simplify_pauliop_terms`` must sort the tuple themselves.
+
+    Under the canonical invariant the parity check is a single linear
+    merge over the two tuples — no per-call dict / set allocation is
+    needed, which matters because this helper is the inner-loop filter
+    of ``commutator``. Passing a non-canonical string (unsorted, or with
+    explicit ``Pauli.I`` entries) is undefined behavior.
+
     Args:
-        term1 (tuple[PauliOperator, ...]): The first Pauli string,
-            expressed as a tuple of single-qubit Pauli operators with
-            at most one operator per qubit (the canonical form
-            produced by `simplify_pauliop_terms`).
-        term2 (tuple[PauliOperator, ...]): The second Pauli string,
-            in the same canonical form as `term1`.
+        term1 (tuple[PauliOperator, ...]): The first canonical Pauli
+            string (one non-identity operator per qubit, sorted by
+            ``index``).
+        term2 (tuple[PauliOperator, ...]): The second canonical Pauli
+            string, in the same canonical form as ``term1``.
 
     Returns:
         bool: True if the two strings anticommute (``PQ = -QP``),
@@ -719,13 +733,23 @@ def _pauli_strings_anticommute(
         >>> _pauli_strings_anticommute((X0,), (Z1,))
         False
     """
-    map1 = {op.index: op.pauli for op in term1 if op.pauli != Pauli.I}
-    map2 = {op.index: op.pauli for op in term2 if op.pauli != Pauli.I}
-
+    i, j = 0, 0
+    n1, n2 = len(term1), len(term2)
     anticommute_count = 0
-    for qubit in map1.keys() & map2.keys():
-        if map1[qubit] != map2[qubit]:
-            anticommute_count += 1
+    while i < n1 and j < n2:
+        op1 = term1[i]
+        op2 = term2[j]
+        if op1.index < op2.index:
+            i += 1
+        elif op1.index > op2.index:
+            j += 1
+        else:
+            # Same qubit; canonical form rules out identities, so two
+            # distinct Paulis anticommute on this qubit.
+            if op1.pauli != op2.pauli:
+                anticommute_count += 1
+            i += 1
+            j += 1
 
     return anticommute_count % 2 == 1
 

--- a/qamomile/observable/hamiltonian.py
+++ b/qamomile/observable/hamiltonian.py
@@ -469,8 +469,13 @@ class Hamiltonian:
                 h.add_term(term, coeff)
             h.constant += other.constant
 
-            if h.num_qubits < self.num_qubits:
-                h._num_qubits = self.num_qubits
+            # Preserve the qubit register from BOTH operands.  The previous
+            # logic only kept ``self.num_qubits``, so e.g.
+            # ``Hamiltonian.identity(1, num_qubits=2) + Hamiltonian.identity(1, num_qubits=5)``
+            # silently lost the right-hand register.
+            declared = max(self.num_qubits, other.num_qubits)
+            if h.num_qubits < declared:
+                h._num_qubits = declared
 
             return h
         elif isinstance(other, (int, float, complex)):
@@ -518,8 +523,13 @@ class Hamiltonian:
 
             h.constant += self.constant * other.constant
 
-            if h.num_qubits < self.num_qubits:
-                h._num_qubits = self.num_qubits
+            # Preserve the qubit register from BOTH operands.  The previous
+            # logic only kept ``self.num_qubits``, so e.g.
+            # ``Hamiltonian.identity(1, num_qubits=2) * Hamiltonian.identity(1, num_qubits=5)``
+            # silently lost the right-hand register.
+            declared = max(self.num_qubits, other.num_qubits)
+            if h.num_qubits < declared:
+                h._num_qubits = declared
 
             return h
         else:

--- a/tests/observable/test_commutator.py
+++ b/tests/observable/test_commutator.py
@@ -1,0 +1,244 @@
+"""Tests for ``qamomile.observable.hamiltonian.commutator``.
+
+Verifies known Pauli-algebra identities, antisymmetry, the zero
+commutator for terms that share no anticommuting qubits, and
+equivalence with the naive ``a * b - b * a`` expansion over random
+multi-term Hamiltonians.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+
+from qamomile.observable.hamiltonian import (
+    Hamiltonian,
+    Pauli,
+    PauliOperator,
+    X,
+    Y,
+    Z,
+    _pauli_strings_anticommute,
+    commutator,
+)
+
+
+def _naive_commutator(a: Hamiltonian, b: Hamiltonian) -> Hamiltonian:
+    """Reference implementation: compute ``a * b - b * a`` directly.
+
+    Args:
+        a (Hamiltonian): The left operand of the commutator.
+        b (Hamiltonian): The right operand of the commutator.
+
+    Returns:
+        Hamiltonian: The naively expanded commutator, used as the
+            ground truth that ``commutator(a, b)`` is checked against.
+    """
+    return a * b - b * a
+
+
+def _hamiltonians_close(a: Hamiltonian, b: Hamiltonian, *, atol: float = 1e-10) -> bool:
+    """Compare two Hamiltonians up to a numerical tolerance on coefficients.
+
+    Args:
+        a (Hamiltonian): The left-hand Hamiltonian to compare.
+        b (Hamiltonian): The right-hand Hamiltonian to compare.
+        atol (float): Absolute tolerance forwarded to ``np.isclose``
+            for both the constant term and every Pauli-string
+            coefficient. Defaults to 1e-10.
+
+    Returns:
+        bool: True when the constant terms and all term coefficients
+            (over the union of both ``terms`` dicts) agree within
+            ``atol``; False otherwise.
+    """
+    if not np.isclose(a.constant, b.constant, atol=atol):
+        return False
+    keys = set(a.terms) | set(b.terms)
+    for key in keys:
+        ca = a.terms.get(key, 0.0)
+        cb = b.terms.get(key, 0.0)
+        if not np.isclose(ca, cb, atol=atol):
+            return False
+    return True
+
+
+def _random_hamiltonian(
+    rng: np.random.Generator,
+    num_qubits: int,
+    num_terms: int,
+    *,
+    include_constant: bool = True,
+) -> Hamiltonian:
+    """Build a random Hamiltonian for property-based equivalence tests.
+
+    Each term draws an independent Pauli from {X, Y, Z, I} per qubit
+    (identities are dropped) and a complex Gaussian coefficient.
+
+    Args:
+        rng (np.random.Generator): Seeded RNG used for every random
+            choice so the helper stays deterministic per test.
+        num_qubits (int): Number of qubits the Hamiltonian acts on.
+            Sets both the per-term Pauli string length and the
+            ``Hamiltonian._num_qubits`` floor.
+        num_terms (int): Number of Pauli-string terms to add. Terms
+            that collapse to identity (all-I draws) are still passed
+            through ``add_term`` and routed to ``constant``.
+        include_constant (bool): When True, also assigns a random
+            complex constant to the Hamiltonian. Defaults to True.
+
+    Returns:
+        Hamiltonian: A random Hamiltonian instance suitable for
+            comparing ``commutator(a, b)`` against the naive
+            ``a * b - b * a`` expansion.
+    """
+    h = Hamiltonian(num_qubits=num_qubits)
+    paulis = (Pauli.X, Pauli.Y, Pauli.Z, Pauli.I)
+    for _ in range(num_terms):
+        ops = []
+        for q in range(num_qubits):
+            p = paulis[rng.integers(0, 4)]
+            if p != Pauli.I:
+                ops.append(PauliOperator(p, q))
+        coeff = complex(rng.normal(), rng.normal())
+        h.add_term(tuple(ops), coeff)
+    if include_constant:
+        h.constant = complex(rng.normal(), rng.normal())
+    return h
+
+
+class TestPauliAlgebraIdentities:
+    """Single-qubit Pauli commutators must match the textbook values."""
+
+    def test_xy_gives_2iz(self):
+        """[X, Y] = 2i Z."""
+        assert commutator(X(0), Y(0)) == 2j * Z(0)
+
+    def test_yz_gives_2ix(self):
+        """[Y, Z] = 2i X."""
+        assert commutator(Y(0), Z(0)) == 2j * X(0)
+
+    def test_zx_gives_2iy(self):
+        """[Z, X] = 2i Y."""
+        assert commutator(Z(0), X(0)) == 2j * Y(0)
+
+    def test_self_commutator_is_zero(self):
+        """[P, P] = 0 for any Pauli P."""
+        for factory in (X, Y, Z):
+            result = commutator(factory(0), factory(0))
+            assert len(result) == 0
+            assert result.constant == 0.0
+
+
+class TestCommutingTermsVanish:
+    """Terms whose Pauli strings commute must contribute nothing."""
+
+    def test_disjoint_qubits_commute(self):
+        """Operators on disjoint qubits commute, so [X0, X1] = 0."""
+        result = commutator(X(0), X(1))
+        assert len(result) == 0
+        assert result.constant == 0.0
+
+    def test_same_pauli_different_qubits(self):
+        """[Z0 Z1, Z1 Z2] = 0 because every shared qubit carries the same Pauli."""
+        a = Z(0) * Z(1)
+        b = Z(1) * Z(2)
+        result = commutator(a, b)
+        assert len(result) == 0
+        assert result.constant == 0.0
+
+    def test_two_anticommuting_qubits_commute(self):
+        """X0 X1 and Y0 Y1 anticommute twice, so they commute overall."""
+        a = X(0) * X(1)
+        b = Y(0) * Y(1)
+        assert not _pauli_strings_anticommute(
+            tuple(next(iter(a.terms))),
+            tuple(next(iter(b.terms))),
+        )
+        result = commutator(a, b)
+        assert len(result) == 0
+        assert result.constant == 0.0
+
+
+class TestAlgebraicProperties:
+    """Bilinearity and antisymmetry hold for the commutator."""
+
+    def test_antisymmetry(self):
+        """[A, B] = -[B, A]."""
+        rng = np.random.default_rng(0)
+        a = _random_hamiltonian(rng, num_qubits=3, num_terms=4)
+        b = _random_hamiltonian(rng, num_qubits=3, num_terms=4)
+        ab = commutator(a, b)
+        ba = commutator(b, a)
+        assert _hamiltonians_close(ab, -1.0 * ba)
+
+    def test_constant_part_drops_out(self):
+        """Adding a constant to either operand leaves the commutator unchanged."""
+        a = X(0) + 1.5 * Y(1)
+        b = Z(0) * X(1) + 0.5
+        without_const = commutator(a, b - 0.5)
+        with_const = commutator(a, b)
+        assert _hamiltonians_close(without_const, with_const)
+
+    def test_linearity_in_first_argument(self):
+        """[αA + βC, B] = α[A, B] + β[C, B]."""
+        rng = np.random.default_rng(1)
+        a = _random_hamiltonian(rng, num_qubits=2, num_terms=3, include_constant=False)
+        c = _random_hamiltonian(rng, num_qubits=2, num_terms=3, include_constant=False)
+        b = _random_hamiltonian(rng, num_qubits=2, num_terms=3, include_constant=False)
+        alpha, beta = 0.7 + 0.2j, -1.3
+        lhs = commutator(alpha * a + beta * c, b)
+        rhs = alpha * commutator(a, b) + beta * commutator(c, b)
+        assert _hamiltonians_close(lhs, rhs)
+
+
+class TestEquivalenceWithNaive:
+    """The optimized commutator must agree with ``a * b - b * a``."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 42, 1337])
+    @pytest.mark.parametrize("num_qubits", [1, 2, 3, 4])
+    def test_random_hamiltonians_match_naive(self, seed: int, num_qubits: int):
+        """commutator(a, b) == a * b - b * a for randomized inputs."""
+        rng = np.random.default_rng(seed)
+        a = _random_hamiltonian(rng, num_qubits=num_qubits, num_terms=5)
+        b = _random_hamiltonian(rng, num_qubits=num_qubits, num_terms=5)
+        assert _hamiltonians_close(commutator(a, b), _naive_commutator(a, b))
+
+    def test_matches_naive_for_known_anticommuting_pair(self):
+        """[XY, YX] worked example matches naive expansion exactly."""
+        a = X(0) * Y(1)
+        b = Y(0) * X(1)
+        assert _hamiltonians_close(commutator(a, b), _naive_commutator(a, b))
+
+
+class TestNumQubitsPropagation:
+    """The result must preserve the qubit register from its operands."""
+
+    def test_max_of_two_operands(self):
+        """num_qubits should not shrink even if the commutator is sparse."""
+        a = X(0) + X(4)
+        b = Y(0) + Y(4)
+        result = commutator(a, b)
+        assert result.num_qubits >= max(a.num_qubits, b.num_qubits)
+
+
+class TestPauliAnticommuteHelper:
+    """Direct coverage for the qubit-parity anticommutation predicate."""
+
+    @pytest.mark.parametrize(
+        "p1,p2,expected",
+        list(
+            itertools.chain.from_iterable(
+                [
+                    [(Pauli.X, Pauli.Y, True), (Pauli.X, Pauli.Z, True)],
+                    [(Pauli.Y, Pauli.Z, True), (Pauli.X, Pauli.X, False)],
+                    [(Pauli.X, Pauli.I, False), (Pauli.I, Pauli.Y, False)],
+                ]
+            )
+        ),
+    )
+    def test_single_qubit_table(self, p1: Pauli, p2: Pauli, expected: bool):
+        """Single-qubit Pauli pairs follow the standard anticommutation table."""
+        t1 = (PauliOperator(p1, 0),)
+        t2 = (PauliOperator(p2, 0),)
+        assert _pauli_strings_anticommute(t1, t2) is expected

--- a/tests/observable/test_commutator.py
+++ b/tests/observable/test_commutator.py
@@ -6,8 +6,6 @@ equivalence with the naive ``a * b - b * a`` expansion over random
 multi-term Hamiltonians.
 """
 
-import itertools
-
 import numpy as np
 import pytest
 
@@ -88,9 +86,10 @@ def _random_hamiltonian(
             ``Hamiltonian._num_qubits`` floor.
         num_terms (int): Number of Pauli-string terms to add. Terms
             that collapse to identity (all-I draws) are still passed
-            through ``add_term`` and routed to ``constant``.
-        include_constant (bool): When True, also assigns a random
-            complex constant to the Hamiltonian. Defaults to True.
+            through ``add_term`` and accumulate into ``constant``.
+        include_constant (bool): When True, also adds a random complex
+            constant to the Hamiltonian on top of any identity-collapsed
+            contributions from the per-term loop. Defaults to True.
 
     Returns:
         Hamiltonian: A random Hamiltonian instance suitable for
@@ -108,7 +107,11 @@ def _random_hamiltonian(
         coeff = complex(rng.normal(), rng.normal())
         h.add_term(tuple(ops), coeff)
     if include_constant:
-        h.constant = complex(rng.normal(), rng.normal())
+        # ``+=`` so any identity-collapsed contributions accumulated by
+        # ``add_term`` in the loop above survive alongside the random
+        # constant we add here.  Using ``=`` would silently overwrite
+        # them and reduce coverage of identity-collapsed paths.
+        h.constant += complex(rng.normal(), rng.normal())
     return h
 
 
@@ -228,19 +231,24 @@ class TestNumQubitsPropagation:
 
 
 class TestPauliAnticommuteHelper:
-    """Direct coverage for the qubit-parity anticommutation predicate."""
+    """Direct coverage for the qubit-parity anticommutation predicate.
+
+    Inputs follow the canonical-form contract of
+    ``_pauli_strings_anticommute`` (no ``Pauli.I`` entries; passing
+    explicit identities is undefined behavior and intentionally not
+    covered here).
+    """
 
     @pytest.mark.parametrize(
         "p1,p2,expected",
-        list(
-            itertools.chain.from_iterable(
-                [
-                    [(Pauli.X, Pauli.Y, True), (Pauli.X, Pauli.Z, True)],
-                    [(Pauli.Y, Pauli.Z, True), (Pauli.X, Pauli.X, False)],
-                    [(Pauli.X, Pauli.I, False), (Pauli.I, Pauli.Y, False)],
-                ]
-            )
-        ),
+        [
+            (Pauli.X, Pauli.Y, True),
+            (Pauli.X, Pauli.Z, True),
+            (Pauli.Y, Pauli.Z, True),
+            (Pauli.X, Pauli.X, False),
+            (Pauli.Y, Pauli.Y, False),
+            (Pauli.Z, Pauli.Z, False),
+        ],
     )
     def test_single_qubit_table(self, p1: Pauli, p2: Pauli, expected: bool):
         """Single-qubit Pauli pairs follow the standard anticommutation table."""

--- a/tests/observable/test_commutator.py
+++ b/tests/observable/test_commutator.py
@@ -38,27 +38,32 @@ def _naive_commutator(a: Hamiltonian, b: Hamiltonian) -> Hamiltonian:
 
 
 def _hamiltonians_close(a: Hamiltonian, b: Hamiltonian, *, atol: float = 1e-10) -> bool:
-    """Compare two Hamiltonians up to a numerical tolerance on coefficients.
+    """Compare two Hamiltonians up to an absolute tolerance on coefficients.
+
+    Pins ``np.isclose``'s ``rtol`` to ``0.0`` so the comparison is purely
+    absolute — without this, the default ``rtol=1e-5`` would silently
+    relax the threshold for large-magnitude coefficients and weaken the
+    equivalence check in ``test_random_hamiltonians_match_naive``.
 
     Args:
         a (Hamiltonian): The left-hand Hamiltonian to compare.
         b (Hamiltonian): The right-hand Hamiltonian to compare.
         atol (float): Absolute tolerance forwarded to ``np.isclose``
-            for both the constant term and every Pauli-string
-            coefficient. Defaults to 1e-10.
+            (with ``rtol=0.0``) for both the constant term and every
+            Pauli-string coefficient. Defaults to 1e-10.
 
     Returns:
         bool: True when the constant terms and all term coefficients
             (over the union of both ``terms`` dicts) agree within
             ``atol``; False otherwise.
     """
-    if not np.isclose(a.constant, b.constant, atol=atol):
+    if not np.isclose(a.constant, b.constant, atol=atol, rtol=0.0):
         return False
     keys = set(a.terms) | set(b.terms)
     for key in keys:
         ca = a.terms.get(key, 0.0)
         cb = b.terms.get(key, 0.0)
-        if not np.isclose(ca, cb, atol=atol):
+        if not np.isclose(ca, cb, atol=atol, rtol=0.0):
             return False
     return True
 

--- a/tests/observable/test_hamiltonian_modernization.py
+++ b/tests/observable/test_hamiltonian_modernization.py
@@ -378,6 +378,68 @@ class TestBackwardCompatibility:
         for ops, coeff in h6:
             assert coeff == -1.0
 
+
+class TestArithmeticNumQubitsPropagation:
+    """``__add__`` / ``__mul__`` / ``__sub__`` must preserve max(num_qubits).
+
+    Regression coverage for a bug where the binary operators inherited
+    ``num_qubits`` only from the left operand, so the right operand's
+    qubit register was silently dropped. For example,
+    ``Hamiltonian.identity(1, num_qubits=2) * Hamiltonian.identity(1, num_qubits=5)``
+    used to return ``num_qubits == 2``.
+    """
+
+    def test_add_takes_max_of_both_operands(self):
+        """``X(0) + Z(4)`` reports num_qubits == 5, not just 1."""
+        h = X(0) + Z(4)
+        assert h.num_qubits == 5
+
+    def test_add_respects_larger_right_declared_num_qubits(self):
+        """A declared register on the right operand survives addition."""
+        a = X(0)
+        b = Hamiltonian(num_qubits=7)
+        b.add_term((PauliOperator(Pauli.Z, 2),), 1.0)
+        assert (a + b).num_qubits == 7
+
+    def test_add_of_two_identity_hamiltonians_keeps_both_registers(self):
+        """Identity-only operands have no terms, so only the declared registers carry the info."""
+        a = Hamiltonian.identity(1.0, num_qubits=2)
+        b = Hamiltonian.identity(1.0, num_qubits=5)
+        assert (a + b).num_qubits == 5
+        assert (b + a).num_qubits == 5
+
+    def test_sub_takes_max_of_both_operands(self):
+        """Subtraction lowers through __add__ + scalar mul, so the same invariant must hold."""
+        a = Hamiltonian.identity(1.0, num_qubits=2)
+        b = Hamiltonian.identity(1.0, num_qubits=5)
+        assert (a - b).num_qubits == 5
+        assert (b - a).num_qubits == 5
+
+    def test_mul_takes_max_of_both_operands(self):
+        """Identity-only operands of different widths must keep the larger register after *."""
+        a = Hamiltonian.identity(1.0, num_qubits=2)
+        b = Hamiltonian.identity(1.0, num_qubits=5)
+        assert (a * b).num_qubits == 5
+        assert (b * a).num_qubits == 5
+
+    def test_mul_with_terms_respects_larger_right_declared_num_qubits(self):
+        """Even when the product yields terms, the declared register from the right operand is kept."""
+        a = X(0)
+        b = Hamiltonian(num_qubits=6)
+        b.add_term((PauliOperator(Pauli.Z, 1),), 1.0)
+        product = a * b
+        # The product term is X0 Z1 which only requires 2 qubits, but the
+        # declared register from ``b`` should be preserved at 6.
+        assert product.num_qubits == 6
+
+    def test_terms_driven_num_qubits_still_works(self):
+        """When neither operand declares num_qubits, the larger Pauli index still wins."""
+        h = X(0) + Z(4)
+        assert h.num_qubits == 5
+        product = X(0) * Z(4)
+        # X0 and Z4 act on disjoint qubits, so the product is the joint string X0 Z4.
+        assert product.num_qubits == 5
+
     def test_terms_property(self):
         """Test that terms property still works."""
         h = X(0) + Y(1)


### PR DESCRIPTION
## Summary

- Add `commutator(a, b)` to `qamomile.observable.hamiltonian` so users can take Pauli-Hamiltonian commutators directly instead of writing `a * b - b * a`.
- Use a qubit-parity rule to skip commuting Pauli-string pairs before any product is built — same asymptotic O(|a|*|b|) cost, lower per-pair work for the sparse / nearly-commuting Hamiltonians typical of optimization and Trotterization.
- Re-export `commutator` from `qamomile.observable.__init__` and extend the Hamiltonian Simulation tutorial (en/ja) with a section that shows `[H_z, H_x] = i * omega * Omega / 2 * Y` as the textbook motivation for Trotter splitting.
- **Bug fix in existing API (behavioral change)**: `Hamiltonian.__add__`, `__mul__`, and (transitively) `__sub__` for Hamiltonian-Hamiltonian operands now preserve `max(self.num_qubits, other.num_qubits)`. Previously the binary operators inherited only the left operand's declared register, silently dropping the right operand's qubit width — e.g. `Hamiltonian.identity(1, num_qubits=2) * Hamiltonian.identity(1, num_qubits=5)` returned `num_qubits == 2` instead of `5`. This aligns the binary operators with `commutator`'s own register handling and removes the need for the ``H = Z(0) + 0.0 * Z(1)  # pad to 2-qubit width`` workaround pattern (seen e.g. in `docs/en/algorithm/mottonen_amplitude_encoding.py:487`). Scalar arithmetic and all other signatures are unchanged. Regression coverage added in `tests/observable/test_hamiltonian_modernization.py::TestArithmeticNumQubitsPropagation`.

## Test plan

- [x] `uv run pytest tests/observable/` (83 passed: 38 commutator tests + 7 new TestArithmeticNumQubitsPropagation tests + existing modernization tests)
- [x] `uv run pytest` (7608 passed across the full unit-test suite — no regressions from the Hamiltonian arithmetic change)
- [x] `uv run pytest -m docs -k hamiltonian_simulation` (en + ja tutorial notebooks execute end-to-end with the new commutator section; tag whitelist still passes)
- [x] `uv run ruff check qamomile/observable/ tests/observable/`
- [x] `uv run ruff format --check qamomile/observable/ tests/observable/`
- [x] `uv run zuban check qamomile/observable/`
- [x] `/local-review` reports zero P0-P3 findings on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)