### PR TITLE
fix(controlled-u): expand control Vector on Symbolic → Concrete promotion

### DIFF
--- a/qamomile/circuit/transpiler/passes/constant_fold.py
+++ b/qamomile/circuit/transpiler/passes/constant_fold.py
@@ -478,18 +478,37 @@ class ConstantFoldingPass(Pass[Block, Block]):
                 if new_nc is not result_op.num_controls:
                     if isinstance(new_nc, int):
                         # Promote to ConcreteControlledU.
+                        #
+                        # ``SymbolicControlledU`` carries the controls as a
+                        # single ``Vector[Qubit]`` operand (``operands[0]``)
+                        # plus individual target / param operands.  The
+                        # promoted ``ConcreteControlledU`` expects the
+                        # operand layout ``[ctrl_0, ..., ctrl_{nc-1}, tgt_0,
+                        # ..., params...]`` with one ``Value`` per control
+                        # qubit.  Expand both operands and results so the
+                        # layout matches the concrete subclass; without
+                        # this step ``control_operands`` aliases the first
+                        # target into the control slice and the emit path
+                        # produces a partial-arity controlled gate.
+                        current_operands = (
+                            new_operands if changed else list(result_op.operands)
+                        )
+                        current_results = list(result_op.results)
+                        new_operands, new_results = (
+                            self._expand_symbolic_controlled_operands(
+                                current_operands, current_results, new_nc
+                            )
+                        )
+                        changed = True
                         power = extra_kwargs.get("power", result_op.power)
                         result_op = ConcreteControlledU(
-                            operands=new_operands
-                            if changed
-                            else list(result_op.operands),
-                            results=list(result_op.results),
+                            operands=new_operands,
+                            results=new_results,
                             num_controls=new_nc,
                             power=power,
                             block=result_op.block,
                         )
                         extra_kwargs = {}  # Already applied
-                        changed = True
                     else:
                         extra_kwargs["num_controls"] = new_nc
                         changed = True
@@ -599,6 +618,95 @@ class ConstantFoldingPass(Pass[Block, Block]):
                 f"ControlledU power must be strictly positive, got {value}."
             )
         return value
+
+    def _expand_symbolic_controlled_operands(
+        self,
+        operands: list[Any],
+        results: list[Any],
+        num_controls: int,
+    ) -> tuple[list[Any], list[Any]]:
+        """Expand a ``SymbolicControlledU`` operand/result layout into the
+        ``ConcreteControlledU`` per-qubit layout.
+
+        ``SymbolicControlledU`` carries the controls as one
+        ``Vector[Qubit]`` operand at index 0; the matching result is a
+        new-version ``ArrayValue`` at result index 0.  The promoted
+        ``ConcreteControlledU`` expects ``num_controls`` individual qubit
+        ``Value`` operands (and matching results) followed by the target
+        and parameter slots.  This helper builds those per-qubit
+        ``Value``\\ s, anchoring them to the original ``ArrayValue``\\ s
+        via ``parent_array`` so the emit-time qubit resolver finds the
+        physical qubit through the existing slice / array-element path.
+
+        Args:
+            operands (list[Any]): Operand list with ``operands[0]`` set to
+                the control ``ArrayValue``; the remaining entries are the
+                target qubits and classical parameters in their original
+                order.
+            results (list[Any]): Result list whose first entry is the
+                next-version control ``ArrayValue``; the remaining entries
+                are the target output qubits in their original order.
+            num_controls (int): Concrete (folded) number of control
+                qubits.  The control vector's length is assumed to match.
+
+        Returns:
+            tuple[list[Any], list[Any]]: A pair ``(new_operands,
+            new_results)`` carrying the expanded per-qubit layout.
+
+        Raises:
+            ValidationError: If the operand or result layout does not
+                match the ``SymbolicControlledU`` contract (missing
+                control ``ArrayValue`` at index 0).
+        """
+        from qamomile.circuit.ir.types.primitives import QubitType, UIntType
+        from qamomile.circuit.ir.value import ArrayValue
+
+        if not operands or not isinstance(operands[0], ArrayValue):
+            raise ValidationError(
+                "SymbolicControlledU expected an ArrayValue at operands[0] "
+                "(the control Vector), but the layout did not match.  This "
+                "is a compiler bug; the SymbolicControlledU contract was "
+                "violated upstream of ConstantFoldingPass."
+            )
+        if not results or not isinstance(results[0], ArrayValue):
+            raise ValidationError(
+                "SymbolicControlledU expected an ArrayValue at results[0] "
+                "(the next-version control Vector), but the layout did "
+                "not match.  This is a compiler bug; the "
+                "SymbolicControlledU contract was violated upstream of "
+                "ConstantFoldingPass."
+            )
+
+        ctrl_vector_in = operands[0]
+        ctrl_vector_out = results[0]
+        tail_operands = list(operands[1:])
+        tail_results = list(results[1:])
+
+        ctrl_operands: list[Any] = []
+        ctrl_results: list[Any] = []
+        for i in range(num_controls):
+            idx_value = Value(
+                type=UIntType(),
+                name=f"const_{i}",
+            ).with_const(i)
+            ctrl_operands.append(
+                Value(
+                    type=QubitType(),
+                    name=f"{ctrl_vector_in.name}[{i}]",
+                    parent_array=ctrl_vector_in,
+                    element_indices=(idx_value,),
+                )
+            )
+            ctrl_results.append(
+                Value(
+                    type=QubitType(),
+                    name=f"{ctrl_vector_out.name}[{i}]",
+                    parent_array=ctrl_vector_out,
+                    element_indices=(idx_value,),
+                )
+            )
+
+        return ctrl_operands + tail_operands, ctrl_results + tail_results
 
     def _fold_value_list(
         self,

--- a/qamomile/circuit/transpiler/passes/constant_fold.py
+++ b/qamomile/circuit/transpiler/passes/constant_fold.py
@@ -656,7 +656,9 @@ class ConstantFoldingPass(Pass[Block, Block]):
         Raises:
             ValidationError: If the operand or result layout does not
                 match the ``SymbolicControlledU`` contract (missing
-                control ``ArrayValue`` at index 0).
+                control ``ArrayValue`` at index 0), or if the control
+                ``Vector``'s length resolves to a concrete value that
+                disagrees with *num_controls*.
         """
         from qamomile.circuit.ir.types.primitives import QubitType, UIntType
         from qamomile.circuit.ir.value import ArrayValue
@@ -679,6 +681,28 @@ class ConstantFoldingPass(Pass[Block, Block]):
 
         ctrl_vector_in = operands[0]
         ctrl_vector_out = results[0]
+
+        # Verify the control Vector's length matches num_controls when both
+        # are resolvable to concrete integers.  Without this check, a
+        # mismatch silently uses the first num_controls elements of an
+        # over-sized Vector (rest of the Vector is dropped from the circuit)
+        # or, for an under-sized Vector, triggers a downstream allocator
+        # AssertionError whose surface message ("QInit was not allocated"
+        # — see ``_allocate_qubit_list``) hides the real cause.
+        if ctrl_vector_in.shape:
+            shape_const = ctrl_vector_in.shape[0].get_const()
+            if shape_const is not None:
+                vector_len = int(shape_const)
+                if vector_len != num_controls:
+                    raise ValidationError(
+                        f"SymbolicControlledU: control Vector "
+                        f"'{ctrl_vector_in.name}' has length {vector_len}, "
+                        f"but num_controls resolves to {num_controls}.  The "
+                        f"Vector passed as the first argument to a "
+                        f"symbolic-num_controls controlled gate must hold "
+                        f"exactly num_controls qubits."
+                    )
+
         tail_operands = list(operands[1:])
         tail_results = list(results[1:])
 

--- a/qamomile/circuit/transpiler/passes/emit_support/resource_allocator.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/resource_allocator.py
@@ -511,7 +511,7 @@ class ResourceAllocator:
 
         for i, result in enumerate(results):
             result_addr = QubitAddress(result.uuid)
-            if result_addr not in qubit_map and i < len(all_qubits):
+            if i < len(all_qubits):
                 operand = all_qubits[i]
                 chain_addr = self._resolve_root_qubit_address(operand)
                 if chain_addr is not None:
@@ -519,8 +519,23 @@ class ResourceAllocator:
                 else:
                     qubit_addr, _ = resolve_qubit_key(operand)
                 if qubit_addr is not None and qubit_addr in qubit_map:
-                    qubit_map[result_addr] = qubit_map[qubit_addr]
-                elif qubit_addr is not None:
+                    physical = qubit_map[qubit_addr]
+                    if result_addr not in qubit_map:
+                        qubit_map[result_addr] = physical
+                    # If the result is itself an array element, also
+                    # register the (parent_array.uuid, idx) key so that
+                    # downstream operations referencing the result's
+                    # parent ``ArrayValue`` (e.g. ``MeasureVectorOperation``
+                    # on a controlled-U's next-version control vector)
+                    # can resolve each element through the same path
+                    # used for QInit-allocated arrays.
+                    result_chain_addr = self._resolve_root_qubit_address(result)
+                    if (
+                        result_chain_addr is not None
+                        and result_chain_addr not in qubit_map
+                    ):
+                        qubit_map[result_chain_addr] = physical
+                elif qubit_addr is not None and result_addr not in qubit_map:
                     raise AssertionError(
                         f"Missing qubit address '{str(qubit_addr)}' in qubit_map when "
                         f"allocating result '{result.uuid}'. "

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -1873,21 +1873,6 @@ class TestControlledBuiltinSymbolicNumControls:
     upstream of this PR.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "Latent ``SymbolicControlledU`` → ``ConcreteControlledU`` "
-            "promotion bug: the control ``Vector`` operand is not "
-            "expanded to individual qubits, so ``operands[:num_controls]`` "
-            "picks up a target Value rather than each control "
-            "individually.  Previously the controlled gate was silently "
-            "dropped at emit-time; now ``emit_controlled_u`` raises "
-            "``EmitError`` (or Qiskit raises ``CircuitError`` downstream) "
-            "instead of producing a silent miscompile.  This xfail "
-            "marker will turn into an xpass once the promotion bug is "
-            "fixed in ``ConstantFoldingPass``."
-        ),
-        strict=True,
-    )
     def test_symbolic_num_controls_runs_end_to_end(self, qiskit_transpiler):
         @qmc.qkernel
         def circuit(n: qmc.UInt) -> qmc.Bit:

--- a/tests/transpiler/test_constant_fold_controlled_u.py
+++ b/tests/transpiler/test_constant_fold_controlled_u.py
@@ -216,6 +216,42 @@ class TestConstantFoldControlledUFields:
             assert ctrl_out.parent_array is not None
             assert ctrl_out.element_indices[0].get_const() == i
 
+    @pytest.mark.parametrize(
+        ("vector_len", "num_controls"),
+        [
+            (2, 4),  # oversized num_controls (would OOB without check)
+            (4, 2),  # undersized num_controls (would silently drop qubits)
+        ],
+    )
+    def test_symbolic_promotion_rejects_vector_length_mismatch(
+        self, vector_len, num_controls
+    ):
+        """Length mismatch between control Vector and num_controls must
+        raise ValidationError during the symbolic→concrete promotion.
+
+        Without the check, the oversized case fails later with a
+        misleading ``QInit not allocated`` AssertionError from the
+        allocator, and the undersized case silently uses only the first
+        ``num_controls`` qubits of the Vector — both are confusing
+        failure modes that the explicit check turns into a single
+        clear error.
+        """
+        from qamomile.circuit.transpiler.errors import ValidationError
+
+        @qm.qkernel
+        def kernel(m: qm.UInt, n: qm.UInt) -> qm.Vector[qm.Bit]:
+            ctrls = qm.qubit_array(m, "ctrls")
+            tgt = qm.qubit("tgt")
+            cg = qm.controlled(_zgate, num_controls=n)
+            ctrls, tgt = cg(ctrls, tgt)  # type: ignore
+            return qm.measure(ctrls)
+
+        from qamomile.qiskit import QiskitTranspiler
+
+        transpiler = QiskitTranspiler()
+        with pytest.raises(ValidationError, match="control Vector"):
+            transpiler.transpile(kernel, bindings={"m": vector_len, "n": num_controls})
+
 
 # -- Integration tests: full transpilation -----------------------------------
 

--- a/tests/transpiler/test_constant_fold_controlled_u.py
+++ b/tests/transpiler/test_constant_fold_controlled_u.py
@@ -154,6 +154,70 @@ class TestConstantFoldControlledUFields:
                 f"Expected controlled_indices[{i}] const={expected}, got {const_val}"
             )
 
+    @pytest.mark.parametrize("n_value", [1, 2, 3])
+    def test_symbolic_promotion_expands_control_vector_operands(self, n_value):
+        """SymbolicControlledU -> ConcreteControlledU promotion must expand
+        the control Vector operand into ``num_controls`` per-qubit Values.
+
+        Without this expansion the promoted ``ConcreteControlledU`` keeps a
+        ``[ctrl_vector, tgt, ...]`` operand layout, so
+        ``control_operands = operands[:nc]`` accidentally aliases the
+        target into the control slice and the emit path produces a
+        partial-arity controlled gate (Qiskit raises ``CircuitError``).
+        """
+        from qamomile.circuit.ir.operation.gate import ConcreteControlledU
+        from qamomile.circuit.ir.value import ArrayValue
+
+        @qm.qkernel
+        def kernel(n: qm.UInt) -> qm.Vector[qm.Bit]:
+            ctrls = qm.qubit_array(n, "ctrls")
+            tgt = qm.qubit("tgt")
+            cg = qm.controlled(_zgate, num_controls=n)
+            ctrls, tgt = cg(ctrls, tgt)  # type: ignore
+            return qm.measure(ctrls)
+
+        from qamomile.qiskit import QiskitTranspiler
+
+        transpiler = QiskitTranspiler()
+        block = transpiler.to_block(kernel, bindings={"n": n_value})
+        inlined = transpiler.inline(transpiler.substitute(block))
+        validated = transpiler.affine_validate(inlined)
+        folded = transpiler.constant_fold(validated, bindings={"n": n_value})
+
+        cu = self._find_controlled_u(folded.operations)
+        assert cu is not None, "ControlledUOperation not found after folding"
+        assert isinstance(cu, ConcreteControlledU), (
+            f"Expected promotion to ConcreteControlledU, "
+            f"got {type(cu).__name__}"
+        )
+        assert cu.num_controls == n_value
+        # Per-qubit control operands: each ``operands[i]`` for i<nc is a
+        # scalar Qubit Value whose ``parent_array`` references the original
+        # control Vector.
+        controls = cu.control_operands
+        assert len(controls) == n_value
+        for i, ctrl in enumerate(controls):
+            assert ctrl.parent_array is not None, (
+                f"control_operands[{i}] should carry parent_array; got "
+                f"a non-element Value instead"
+            )
+            assert not isinstance(ctrl, ArrayValue), (
+                f"control_operands[{i}] should be a scalar Qubit Value, "
+                f"not the bare control Vector"
+            )
+            assert ctrl.element_indices, (
+                f"control_operands[{i}] should have element_indices "
+                f"populated"
+            )
+            assert ctrl.element_indices[0].get_const() == i
+        # Per-qubit control results carry the matching parent_array — the
+        # next-version control Vector — so downstream MeasureVectorOperation
+        # on that Vector resolves each element.
+        ctrl_results = cu.results[: cu.num_controls]
+        for i, ctrl_out in enumerate(ctrl_results):
+            assert ctrl_out.parent_array is not None
+            assert ctrl_out.element_indices[0].get_const() == i
+
 
 # -- Integration tests: full transpilation -----------------------------------
 
@@ -193,22 +257,9 @@ class TestControlledUTranspileIntegration:
         result = transpiler.transpile(kernel)
         assert result is not None
 
-    @pytest.mark.xfail(
-        reason=(
-            "Latent ``SymbolicControlledU`` → ``ConcreteControlledU`` "
-            "promotion bug: a symbolic ``num_controls`` resolved through "
-            "bindings produces an inconsistent operand layout (the "
-            "control ``Vector`` is not expanded to individual control "
-            "qubits).  Previously the controlled gate was silently "
-            "dropped at emit-time; now ``emit_controlled_u`` raises "
-            "``EmitError`` (or Qiskit raises ``CircuitError`` downstream) "
-            "instead of producing a silent miscompile.  Becomes xpass "
-            "once the promotion bug is fixed."
-        ),
-        strict=True,
-    )
-    def test_case_c_symbolic_non_index(self):
-        """Case C: num_controls=n (non-index), bindings={'n':2}."""
+    @pytest.mark.parametrize("n_value", [1, 2, 3])
+    def test_case_c_symbolic_non_index(self, n_value):
+        """Case C: num_controls=n (non-index), parametrized over n_value."""
 
         @qm.qkernel
         def kernel(n: qm.UInt) -> qm.Vector[qm.Bit]:
@@ -221,7 +272,7 @@ class TestControlledUTranspileIntegration:
         from qamomile.qiskit import QiskitTranspiler
 
         transpiler = QiskitTranspiler()
-        result = transpiler.transpile(kernel, bindings={"n": 2})
+        result = transpiler.transpile(kernel, bindings={"n": n_value})
         assert result is not None
 
     def test_case_d_concrete_nc_symbolic_index(self):
@@ -275,8 +326,6 @@ class TestControlledUTranspileIntegration:
 
 # -- Power field strict-int-cast unit tests ----------------------------------
 
-
-import pytest  # noqa: E402
 
 from qamomile.circuit.transpiler.passes.constant_fold import (  # noqa: E402
     ConstantFoldingPass,

--- a/tests/transpiler/test_constant_fold_controlled_u.py
+++ b/tests/transpiler/test_constant_fold_controlled_u.py
@@ -187,8 +187,7 @@ class TestConstantFoldControlledUFields:
         cu = self._find_controlled_u(folded.operations)
         assert cu is not None, "ControlledUOperation not found after folding"
         assert isinstance(cu, ConcreteControlledU), (
-            f"Expected promotion to ConcreteControlledU, "
-            f"got {type(cu).__name__}"
+            f"Expected promotion to ConcreteControlledU, got {type(cu).__name__}"
         )
         assert cu.num_controls == n_value
         # Per-qubit control operands: each ``operands[i]`` for i<nc is a
@@ -206,8 +205,7 @@ class TestConstantFoldControlledUFields:
                 f"not the bare control Vector"
             )
             assert ctrl.element_indices, (
-                f"control_operands[{i}] should have element_indices "
-                f"populated"
+                f"control_operands[{i}] should have element_indices populated"
             )
             assert ctrl.element_indices[0].get_const() == i
         # Per-qubit control results carry the matching parent_array — the


### PR DESCRIPTION
## Summary

- Fix the latent `SymbolicControlledU` → `ConcreteControlledU` promotion bug surfaced by PR #357: when `ConstantFoldingPass` folded `num_controls` to a concrete `int`, the promoted op kept the symbolic vector operand layout `[ctrl_vector, tgt, ...]` instead of the per-qubit layout `[ctrl_0, ..., ctrl_{nc-1}, tgt, ...]`, so `control_operands = operands[:nc]` aliased target / param slots into the control slice and emit produced a partial-arity controlled gate (Qiskit raised `CircuitError` downstream; pre-#357 it was silently dropped).
- Expand operands and results into `num_controls` per-qubit `Value` instances anchored to the input / next-version control `ArrayValue` via `parent_array`, so the existing array-element resolution path picks each control up from the qubit_map keys allocated by `QInitOperation`.
- Drop the `pytest.mark.xfail(strict=True)` markers on the two regression cases that pinned the broken behaviour, and add an IR-structure regression test parametrized over `n ∈ {1, 2, 3}`.

## Implementation notes

- `ConstantFoldingPass._expand_symbolic_controlled_operands` is the new helper; the promotion branch calls it before constructing the `ConcreteControlledU`. The helper validates that `operands[0]` and `results[0]` are `ArrayValue`s (raises `ValidationError` otherwise) and builds element Values with constant `UIntType` indices.
- `ResourceAllocator._allocate_qubit_list` now also registers `_resolve_root_qubit_address(result)` when it returns non-None, so a downstream `MeasureVectorOperation` on the next-version control vector resolves each element through the same `(array_uuid, idx)` keys used for QInit-allocated arrays. The extra registration is a no-op when operand and result share the same root (the `CompositeGateOperation` case).
- The promotion concretizes per-qubit at the IR layer rather than deferring to emit time. This completes an existing concretization path (`SymbolicControlledU → ConcreteControlledU` already commits to per-qubit semantics by class design) rather than introducing a new pre-expansion, so the IR Abstraction Principle is preserved.

## Test plan

- [x] `uv run pytest tests/transpiler/test_constant_fold_controlled_u.py` — 23 passed (4 new parametrized cases for `n ∈ {1, 2, 3}`).
- [x] `uv run pytest tests/circuit/test_controlled.py` — 1164 passed, 96 skipped.
- [x] `uv run pytest tests/` — 7570 passed, 430 skipped, 250 deselected.
- [x] `uv run ruff check qamomile/ tests/` — clean.
- [x] `uv run zuban check` on the touched files — no new errors (the 3 pre-existing `_substitute_slice_op_result` return-type warnings remain unchanged).