### PR TITLE
Make local-review run ruff and zuban checks every time

### DIFF
--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -185,7 +185,7 @@ git log $TARGET...HEAD --oneline
 
 ### Step 1.5: Run Mechanical Checks (MANDATORY)
 
-Before any human-style review, run the mechanical checks that GitHub CI and CLAUDE.md require. **These are non-negotiable — execute them on every invocation of this skill and surface every failure in the final report. Never skip them, never "trust the diff looks clean", never stop after a single check fails.** Skipping these is itself a regression of the skill.
+Before any human-style review, run the mechanical checks that GitHub CI enforces on every PR. (CLAUDE.md's "Build and Development Commands" documents the same tools at a narrower `qamomile/`-only scope; this skill follows CI's wider `qamomile/ tests/` scope so the user sees what CI will see.) **These are non-negotiable — execute them on every invocation of this skill and surface every failure in the final report. Never skip them, never "trust the diff looks clean", never stop after one check reports violations.** Skipping these is itself a regression of the skill.
 
 ```bash
 # Ruff lint + isort
@@ -205,13 +205,21 @@ Run **all three** even if earlier ones fail — each surfaces a different class 
 
 Severity mapping:
 
-- **ruff `check` violation** — severity follows the underlying rule. A real bug rule (`B006` mutable default, `F841` unused assignment masking a typo, `B008` mutable arg in function call) is **P0**. A correctness-adjacent rule (`E722` bare except, `B904` missing `from e`) is **P0/P1** depending on whether Section E is already violated. A pure style nit (`E501` line length, `I001` import order) is **P3**. A missing-docstring rule (`D100`–`D107`) is **P2+** (CLAUDE.md "Docstring Convention (MANDATORY)").
+- **ruff `check` violation** — severity follows the underlying rule. A real bug rule (`B006` mutable default, `F841` unused assignment masking a typo, `B008` mutable arg in function call) is **P0**. `E722` (bare `except`) and `B904` (missing `from e` on re-raise) are also **P0** directly — the Severity Levels rubric at the top of this document lists "bare `except` swallowing" and "missing exception chaining" as P0 without conditioning on other sections, and the mechanical mapping must match. A pure style nit (`E501` line length, `I001` import order) is **P3**. A missing-docstring rule (`D100`–`D107`) is **P2+** (CLAUDE.md "Docstring Convention (MANDATORY)").
 - **ruff `format` divergence** — **P3**. Mechanically fixable with `uv run ruff format qamomile/ tests/`; mention the one-liner in the recommendation.
 - **zuban type error** — **P2** by default. **P1+** if it reveals a behavioral bug, a contract mismatch with a public API, or a `None`-related foot-gun.
 
-If a check tool itself fails to *run* (missing dependency, broken config, `uv` not on PATH, etc.), **stop the skill and report it as a P0** rather than silently moving on — a non-runnable check is functionally equivalent to a disabled check.
+Distinguish "the check ran and reported violations" (handled by the severity mapping above) from "the check could not be run at all". If a specific check tool fails to invoke — e.g., `zuban` is missing, a config file is broken, the formatter binary errors before reading any files — **continue with the remaining checks** and report the unrunnable tool as its own **P0** finding. A non-runnable check is functionally equivalent to a disabled one and the user must be told, but stopping early would hide the other tools' output that may still be actionable. **Only hard-stop the skill when `uv` itself is unavailable** so that none of the three commands can run; in that case Step 1.5 as a whole is uninvokable and the skill cannot produce a valid review — report that single P0 and exit.
 
-These checks scope to the whole `qamomile/` + `tests/` tree (matching CI), not just the diff. Pre-existing violations outside the diff still count, since the user will eventually be blocked by CI on them; report them too, but annotate as "pre-existing on `<target>`" so the user can distinguish "introduced by this branch" from "already broken on the base branch".
+These checks scope to the whole `qamomile/` + `tests/` tree (matching CI), not just the diff. Pre-existing violations outside the diff still count, since the user will eventually be blocked by CI on them; report them too. **The "pre-existing on `<target>`" annotation is optional and only valid when you actually verified it on the target branch.** If you want to label findings that way, run the same Step 1.5 commands against `<target>` in a temporary worktree and diff the outputs:
+
+```bash
+git worktree add /tmp/qamomile-base "$TARGET"
+( cd /tmp/qamomile-base && uv run ruff check qamomile/ tests/; uv run ruff format --check qamomile/ tests/; uv run zuban qamomile/ )
+git worktree remove /tmp/qamomile-base
+```
+
+If you skip the baseline, report each violation without claiming whether it is pre-existing — an unverified annotation is more misleading than no annotation at all.
 
 ### Step 2: Read Changed Files
 

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -183,6 +183,36 @@ git diff $TARGET...HEAD --name-status
 git log $TARGET...HEAD --oneline
 ```
 
+### Step 1.5: Run Mechanical Checks (MANDATORY)
+
+Before any human-style review, run the mechanical checks that GitHub CI and CLAUDE.md require. **These are non-negotiable — execute them on every invocation of this skill and surface every failure in the final report. Never skip them, never "trust the diff looks clean", never stop after a single check fails.** Skipping these is itself a regression of the skill.
+
+```bash
+# Ruff lint + isort
+# (CI: .github/workflows/ruff.yml — "Lint with ruff (Linter & isort)")
+uv run ruff check qamomile/ tests/
+
+# Ruff formatter check
+# (CI: .github/workflows/ruff.yml — "Check formatting with ruff (Formatter)")
+uv run ruff format --check qamomile/ tests/
+
+# Type checking
+# (CLAUDE.md "Build and Development Commands")
+uv run zuban qamomile/
+```
+
+Run **all three** even if earlier ones fail — each surfaces a different class of regression and the reviewer / user needs the full picture in one pass. Do not paraphrase the output; quote each failing line (file:line + message) verbatim in the report so the user can jump to it.
+
+Severity mapping:
+
+- **ruff `check` violation** — severity follows the underlying rule. A real bug rule (`B006` mutable default, `F841` unused assignment masking a typo, `B008` mutable arg in function call) is **P0**. A correctness-adjacent rule (`E722` bare except, `B904` missing `from e`) is **P0/P1** depending on whether Section E is already violated. A pure style nit (`E501` line length, `I001` import order) is **P3**. A missing-docstring rule (`D100`–`D107`) is **P2+** (CLAUDE.md "Docstring Convention (MANDATORY)").
+- **ruff `format` divergence** — **P3**. Mechanically fixable with `uv run ruff format qamomile/ tests/`; mention the one-liner in the recommendation.
+- **zuban type error** — **P2** by default. **P1+** if it reveals a behavioral bug, a contract mismatch with a public API, or a `None`-related foot-gun.
+
+If a check tool itself fails to *run* (missing dependency, broken config, `uv` not on PATH, etc.), **stop the skill and report it as a P0** rather than silently moving on — a non-runnable check is functionally equivalent to a disabled check.
+
+These checks scope to the whole `qamomile/` + `tests/` tree (matching CI), not just the diff. Pre-existing violations outside the diff still count, since the user will eventually be blocked by CI on them; report them too, but annotate as "pre-existing on `<target>`" so the user can distinguish "introduced by this branch" from "already broken on the base branch".
+
 ### Step 2: Read Changed Files
 
 Read every new or modified file in full. Understand each file's role in the architecture.
@@ -224,5 +254,12 @@ Common root-cause patterns to watch for: **dead code** (multiple nits on code ne
 ### Step 6: Report
 
 For each finding, give: severity (using the **Severity Levels** rubric at the top of this document), `file:line`, code snippet, the violated section, a short explanation, a concrete recommendation with corrected code, and — for consolidated findings — a `Root cause of:` line listing subsumed surface issues. End with a severity-grouped summary table.
+
+**Mechanical-check section (MANDATORY)**: the report MUST contain a top-of-report block titled `## Mechanical checks` that lists the three Step 1.5 commands and, for each, one of:
+
+- ✅ `passed` (with the exit code and a one-line confirmation), or
+- ❌ `failed` (with the verbatim failing lines, and each failure also surfaced as a numbered finding below per the severity mapping in Step 1.5).
+
+Never omit this section, even when all three pass — a clean run is itself the evidence the user needs to satisfy CLAUDE.md's "Run `/local-review` before opening a PR" rule. If you do omit it, the skill output is not a valid local-review run.
 
 If Step 5.5 did not stabilize, append: "Note: some findings may have deeper interdependencies warranting further investigation."


### PR DESCRIPTION
## Summary
- Add a mandatory Step 1.5 ("Run Mechanical Checks") to the local-review skill that always runs `uv run ruff check qamomile/ tests/`, `uv run ruff format --check qamomile/ tests/`, and `uv run zuban qamomile/`, mirroring the Ruff GitHub workflow and CLAUDE.md's "Build and Development Commands".
- Specify how each failure maps to severity (real-bug ruff rules -> P0, style nits -> P3, missing-docstring rules -> P2+, ruff format divergence -> P3, zuban type errors -> P2/P1+) and require a top-of-report `## Mechanical checks` block in Step 6 so the result is always visible.
- pytest is intentionally out of scope; the skill never invokes the test suite.

## Test plan
- [x] Run `/local-review` on a branch with an intentional ruff lint violation and confirm it is reported as a finding under the mapped severity.
- [x] Run `/local-review` on a branch with `ruff format` divergence and confirm a P3 finding plus the `uv run ruff format qamomile/ tests/` recommendation.
- [x] Run `/local-review` on a branch with a clean tree and confirm the `## Mechanical checks` report block still appears with three passes.