### PR TITLE
Add __neg__ operator to qamomile.circuit.Float handle

### DIFF
--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -257,10 +257,12 @@ class Float(ArithmeticMixin, Handle):
 
         Lets users write the natural ``-x`` inside a ``@qkernel`` instead
         of the awkward ``0 - x`` idiom (GitHub issue #329). The negation
-        is lowered to the existing ``SUB`` IR op as ``0.0 - self``, so it
-        carries no new IR node and every backend that already supports
-        subtraction emits it unchanged. When ``self`` is a compile-time
-        constant the result is folded eagerly by ``_emit_binop``.
+        is lowered to the existing ``MUL`` IR op as ``self * -1.0`` —
+        multiplication by ``-1`` is the direct expression of unary minus
+        — so it carries no new IR node and every backend that already
+        supports multiplication emits it unchanged. When ``self`` is a
+        compile-time constant the result is folded eagerly by
+        ``_emit_binop``.
 
         Returns:
             Float: A new Float handle holding the negated value.
@@ -272,9 +274,9 @@ class Float(ArithmeticMixin, Handle):
             ...     q = qmc.qubit("q")
             ...     return qmc.rz(q, -theta)
         """
-        zero = self._make_float(0.0)
+        neg_one = self._make_float(-1.0)
         result = self._make_result()
-        _emit_binop(zero.value, self.value, result, BinOpKind.SUB)
+        _emit_binop(self.value, neg_one.value, result, BinOpKind.MUL)
         return result
 
     def __mul__(self, other: "int | float | Float") -> "Float":

--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -252,6 +252,31 @@ class Float(ArithmeticMixin, Handle):
         _emit_binop(other.value, self.value, result, BinOpKind.SUB)
         return result
 
+    def __neg__(self) -> "Float":
+        """Negate this Float handle, returning the unary-minus result.
+
+        Lets users write the natural ``-x`` inside a ``@qkernel`` instead
+        of the awkward ``0 - x`` idiom (GitHub issue #329). The negation
+        is lowered to the existing ``SUB`` IR op as ``0.0 - self``, so it
+        carries no new IR node and every backend that already supports
+        subtraction emits it unchanged. When ``self`` is a compile-time
+        constant the result is folded eagerly by ``_emit_binop``.
+
+        Returns:
+            Float: A new Float handle holding the negated value.
+
+        Example:
+            >>> import qamomile.circuit as qmc
+            >>> @qmc.qkernel
+            ... def circuit(theta: qmc.Float) -> qmc.Qubit:
+            ...     q = qmc.qubit("q")
+            ...     return qmc.rz(q, -theta)
+        """
+        zero = self._make_float(0.0)
+        result = self._make_result()
+        _emit_binop(zero.value, self.value, result, BinOpKind.SUB)
+        return result
+
     def __mul__(self, other: "int | float | Float") -> "Float":
         other = self._coerce(other)
         result = self._make_result()

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -2,10 +2,10 @@
 
 ``Float.__neg__`` lets users write the natural ``-x`` inside a ``@qkernel``
 instead of the awkward ``0 - x`` idiom (GitHub issue #329). Negation is
-lowered to the existing ``SUB`` IR op as ``0.0 - self``, so it adds no new
-IR node and rides on every backend's existing subtraction support. When
+lowered to the existing ``MUL`` IR op as ``self * -1.0``, so it adds no new
+IR node and rides on every backend's existing multiplication support. When
 the operand is a compile-time-bound Float, ``partial_eval`` folds the
-``SUB`` into the literal negated constant baked into the emitted circuit.
+``MUL`` into the literal negated constant baked into the emitted circuit.
 
 These tests exercise three layers of evidence:
 
@@ -213,8 +213,8 @@ class TestNegConstantFold:
     def test_bound_neg_folds_to_constant_param(self, theta):
         """``-theta`` with ``theta`` bound emits a single ``rz`` with param ``-theta``.
 
-        When both operands of the underlying ``SUB`` are constants
-        (``0.0`` and the bound ``theta``), ``partial_eval`` folds the op,
+        When both operands of the underlying ``MUL`` are constants
+        (``-1.0`` and the bound ``theta``), ``partial_eval`` folds the op,
         so the emitted Qiskit circuit carries the literal ``-theta`` as
         the rotation parameter rather than a symbolic expression.
         """

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -1,0 +1,235 @@
+"""Tests for the unary-minus operator on the ``qamomile.circuit.Float`` handle.
+
+``Float.__neg__`` lets users write the natural ``-x`` inside a ``@qkernel``
+instead of the awkward ``0 - x`` idiom (GitHub issue #329). Negation is
+lowered to the existing ``SUB`` IR op as ``0.0 - self``, so it adds no new
+IR node and rides on every backend's existing subtraction support. When
+the operand is a compile-time-bound Float, ``partial_eval`` folds the
+``SUB`` into the literal negated constant baked into the emitted circuit.
+
+These tests exercise three layers of evidence:
+
+1. **Build / transpile**: a kernel using ``-theta`` compiles on each backend.
+2. **Execute**: both ``sample`` and ``run`` (expval) paths produce results
+   matching an analytic baseline. Per CLAUDE.md, sampling and expval go
+   through different backend primitives and must both pass.
+3. **Equivalence**: ``-theta`` is numerically identical to ``0.0 - theta``.
+
+Note on scope: arithmetic on a *runtime* parameter feeding a gate angle
+(e.g. ``rx(q, -theta)`` with ``theta`` left symbolic) is a pre-existing
+unsupported path — plain ``theta - 0.5`` collapses to ``Rx(0)`` the same
+way. ``__neg__`` is consistent with that existing behaviour, so these
+tests bind ``theta`` at compile time, which is the supported path.
+
+Cross-backend coverage spans Qiskit, QuriParts (Qulacs), and CUDA-Q with
+``skipif`` guards so a missing SDK skips rather than errors.
+
+Note: Do NOT use ``from __future__ import annotations`` in this file.
+The @qkernel AST transformer relies on resolved type annotations.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+
+# ---------------------------------------------------------------------------
+# Backend matrix
+# ---------------------------------------------------------------------------
+
+_HAS_QISKIT = True
+try:  # pragma: no cover - presence check, not behaviour
+    from qamomile.qiskit import QiskitTranspiler
+except ImportError:  # pragma: no cover - covered when qiskit is absent
+    _HAS_QISKIT = False
+    QiskitTranspiler = None  # type: ignore[assignment]
+
+_HAS_QURI_PARTS = True
+try:  # pragma: no cover - presence check, not behaviour
+    import quri_parts.qulacs  # noqa: F401
+
+    from qamomile.quri_parts import QuriPartsTranspiler
+except ImportError:  # pragma: no cover - covered when quri_parts is absent
+    _HAS_QURI_PARTS = False
+    QuriPartsTranspiler = None  # type: ignore[assignment]
+
+_HAS_CUDAQ = True
+try:  # pragma: no cover - presence check, not behaviour
+    import cudaq  # noqa: F401
+
+    from qamomile.cudaq import CudaqTranspiler
+except ImportError:  # pragma: no cover - covered when cudaq is absent
+    _HAS_CUDAQ = False
+    CudaqTranspiler = None  # type: ignore[assignment]
+
+BACKENDS = [
+    pytest.param(
+        QiskitTranspiler,
+        id="qiskit",
+        marks=pytest.mark.skipif(not _HAS_QISKIT, reason="qiskit not installed"),
+    ),
+    pytest.param(
+        QuriPartsTranspiler,
+        id="quri_parts",
+        marks=pytest.mark.skipif(
+            not _HAS_QURI_PARTS, reason="quri_parts/qulacs not installed"
+        ),
+    ),
+    pytest.param(
+        CudaqTranspiler,
+        id="cudaq",
+        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+    ),
+]
+
+# Boundary angles exercised alongside random ones drawn per-test by the RNG.
+_BOUNDARY_ANGLES = [0.0, math.pi, 2.0 * math.pi, -0.7]
+
+
+def test_float_handle_exposes_neg():
+    """``qamomile.circuit.Float`` implements ``__neg__`` (issue #329 fix)."""
+    assert hasattr(qmc.Float, "__neg__")
+
+
+class TestNegCancelsRotation:
+    """``ry(theta)`` followed by ``ry(-theta)`` is the identity."""
+
+    @pytest.mark.parametrize("transpiler_factory", BACKENDS)
+    @pytest.mark.parametrize("seed", [0, 1, 42])
+    def test_cancellation_expval(self, transpiler_factory, seed):
+        """``RY(theta)`` then ``RY(-theta)`` returns the register to |0>, so <Z> == 1.
+
+        If ``__neg__`` were wrong (e.g. a no-op leaving ``+theta``), the
+        circuit would be ``RY(2*theta)`` and <Z> would equal
+        ``cos(2*theta)`` instead of 1, so this pins down the negation.
+        Boundary angles (0, pi, 2*pi) are checked alongside random ones.
+        """
+        rng = np.random.default_rng(seed)
+        angles = _BOUNDARY_ANGLES + rng.uniform(-2 * math.pi, 2 * math.pi, 3).tolist()
+
+        @qmc.qkernel
+        def cancel(theta: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit_array(1, name="q")
+            q = qmc.ry(q, theta)
+            q = qmc.ry(q, -theta)
+            return qmc.expval(q, obs)
+
+        H = qm_o.Hamiltonian.zero(num_qubits=1) + qm_o.Z(0)
+        t = transpiler_factory()
+        for theta in angles:
+            exe = t.transpile(cancel, bindings={"theta": theta, "obs": H})
+            out = exe.run(t.executor()).result()
+            assert np.isclose(out, 1.0, atol=1e-6), (
+                f"[{transpiler_factory.__name__}, seed={seed}, theta={theta}] "
+                f"expected <Z>=1.0 after RY(theta)+RY(-theta), got {out}"
+            )
+
+    @pytest.mark.parametrize("transpiler_factory", BACKENDS)
+    @pytest.mark.parametrize("seed", [0, 7])
+    def test_cancellation_sampling(self, transpiler_factory, seed):
+        """Sampling the cancelling circuit yields outcome 0 on every shot.
+
+        Exercises the sampler primitive (distinct from the estimator path
+        covered above). Since ``RY(theta)+RY(-theta)`` restores |0>, the
+        circuit has no quantum randomness and every shot must be 0.
+        """
+        rng = np.random.default_rng(seed)
+        theta = float(rng.uniform(-2 * math.pi, 2 * math.pi))
+
+        @qmc.qkernel
+        def cancel_sample(theta: qmc.Float) -> qmc.Bit:
+            q = qmc.qubit("q")
+            q = qmc.ry(q, theta)
+            q = qmc.ry(q, -theta)
+            return qmc.measure(q)
+
+        t = transpiler_factory()
+        exe = t.transpile(cancel_sample, bindings={"theta": theta})
+        result = exe.sample(t.executor(), shots=256).result()
+        total = sum(count for _val, count in result.results)
+        assert total == 256
+        for value, count in result.results:
+            assert value == 0, (
+                f"[{transpiler_factory.__name__}, seed={seed}, theta={theta}] "
+                f"expected only outcome 0, got {value} ({count} times)"
+            )
+
+
+class TestNegMatchesZeroMinusX:
+    """``-theta`` is numerically identical to the old ``0.0 - theta`` idiom."""
+
+    @pytest.mark.parametrize("transpiler_factory", BACKENDS)
+    @pytest.mark.parametrize("seed", [0, 1, 2, 42])
+    def test_neg_equals_zero_minus_x_and_analytic(self, transpiler_factory, seed):
+        """``rx(q, -theta)`` matches ``rx(q, 0.0 - theta)`` and the analytic <Y>.
+
+        For ``RX(a)|0>`` the expectation ``<Y> = -sin(a)``; with
+        ``a = -theta`` this is ``sin(theta)``. The sign of the rotation
+        is observable through the ``Y`` observable (a ``Z``-only check
+        would be sign-blind), so this confirms ``__neg__`` truly negates
+        rather than merely leaving the angle unchanged.
+        """
+        rng = np.random.default_rng(seed)
+        angles = _BOUNDARY_ANGLES + rng.uniform(-2 * math.pi, 2 * math.pi, 3).tolist()
+
+        @qmc.qkernel
+        def neg_kernel(theta: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit_array(1, name="q")
+            q = qmc.rx(q, -theta)
+            return qmc.expval(q, obs)
+
+        @qmc.qkernel
+        def sub_kernel(theta: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit_array(1, name="q")
+            q = qmc.rx(q, 0.0 - theta)
+            return qmc.expval(q, obs)
+
+        H = qm_o.Hamiltonian.zero(num_qubits=1) + qm_o.Y(0)
+        t = transpiler_factory()
+        for theta in angles:
+            exe_neg = t.transpile(neg_kernel, bindings={"theta": theta, "obs": H})
+            exe_sub = t.transpile(sub_kernel, bindings={"theta": theta, "obs": H})
+            out_neg = exe_neg.run(t.executor()).result()
+            out_sub = exe_sub.run(t.executor()).result()
+            expected = math.sin(theta)
+            assert np.isclose(out_neg, expected, atol=1e-6), (
+                f"[{transpiler_factory.__name__}, seed={seed}, theta={theta}] "
+                f"-theta gave <Y>={out_neg}, expected {expected}"
+            )
+            assert np.isclose(out_neg, out_sub, atol=1e-8), (
+                f"[{transpiler_factory.__name__}, seed={seed}, theta={theta}] "
+                f"-theta ({out_neg}) differs from 0.0-theta ({out_sub})"
+            )
+
+
+class TestNegConstantFold:
+    """A negated compile-time-bound Float is folded into the emitted circuit."""
+
+    @pytest.mark.skipif(not _HAS_QISKIT, reason="qiskit not installed")
+    @pytest.mark.parametrize("theta", [0.0, 0.5, math.pi, -1.3])
+    def test_bound_neg_folds_to_constant_param(self, theta):
+        """``-theta`` with ``theta`` bound emits a single ``rz`` with param ``-theta``.
+
+        When both operands of the underlying ``SUB`` are constants
+        (``0.0`` and the bound ``theta``), ``partial_eval`` folds the op,
+        so the emitted Qiskit circuit carries the literal ``-theta`` as
+        the rotation parameter rather than a symbolic expression.
+        """
+
+        @qmc.qkernel
+        def circuit(theta: qmc.Float) -> qmc.Bit:
+            q = qmc.qubit("q")
+            q = qmc.rz(q, -theta)
+            return qmc.measure(q)
+
+        exe = QiskitTranspiler().transpile(circuit, bindings={"theta": theta})
+        rz_params = [
+            instr.operation.params[0]
+            for instr in exe.quantum_circuit.data
+            if instr.operation.name == "rz"
+        ]
+        assert len(rz_params) == 1
+        assert abs(float(rz_params[0]) - (-theta)) < 1e-10


### PR DESCRIPTION
Implement Float.__neg__ so users can write the natural -x inside a
qkernel instead of the 0 - x idiom (GitHub issue #329). Negation is
lowered to the existing SUB IR op as 0.0 - self, so it adds no new IR
node and rides on every backend's existing subtraction support; when
the operand is compile-time-bound, partial_eval folds it to the literal
negated constant.

Add cross-backend tests covering the sampling and expectation-value
paths with randomized seeds and boundary angles, verifying that -theta
cancels +theta, matches the analytic <Y>, equals the 0.0 - theta idiom,
and folds correctly for bound parameters.

Sibling handle audit: UInt is left unchanged since unsigned negation has
no valid unsigned result, and no signed integer handle type exists yet.

https://claude.ai/code/session_01F4tDu5QXLG2uuipTRdEKCn