### PR TITLE
Fix ControlledU index-spec emit for Vector[Qubit]-input inner kernels

### DIFF
--- a/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
@@ -617,7 +617,40 @@ def blockvalue_to_gate(
     num_qubits: int,
     bindings: dict[str, Any],
 ) -> Any:
-    """Convert a Block to a backend gate."""
+    """Convert a Block to a backend gate.
+
+    Pre-populates ``local_qubit_map`` with one entry per quantum input in
+    declaration order, then runs the allocator over the block's body.
+    For ``Vector[Qubit]`` inputs (``ArrayValue`` with a quantum element
+    type) the entry expands into per-element ``QubitAddress(uuid, i)``
+    keys — the inner block has no ``QInitOperation`` for inputs, so
+    without these the allocator's element-resolution assertion fires for
+    every ``qs[i]`` reference in the body.
+
+    Args:
+        emit_pass (StandardEmitPass): The emit pass driving the
+            conversion. Used for its ``_allocator``, ``_emitter``,
+            ``_resolver``, and ``_emit_operations``.
+        block_value (Any): The inner block to convert. Expected to expose
+            ``operations`` and ``input_values``; anything else returns
+            ``None`` (the caller falls back to gate-by-gate
+            decomposition).
+        num_qubits (int): Total physical qubits the resulting gate will
+            occupy in the parent circuit. Used as the fallback length
+            for a single ``Vector[Qubit]`` input whose shape is symbolic
+            and unresolvable from ``bindings``, and as the sub-circuit
+            width when the block has no qubit-producing operations.
+        bindings (dict[str, Any]): Parameter bindings forwarded to the
+            allocator and ``_emit_operations``. Also consulted when
+            resolving ``Vector[Qubit]`` input shapes.
+
+    Returns:
+        Any: A backend gate object produced by
+            ``emit_pass._emitter.circuit_to_gate``, or ``None`` when the
+            conversion is unable to proceed (missing ``operations``,
+            allocator / emitter exception, etc.) so the caller can fall
+            back to gate-by-gate emission.
+    """
     if not hasattr(block_value, "operations"):
         return None
 
@@ -626,21 +659,20 @@ def blockvalue_to_gate(
         local_clbit_map: ClbitMap = {}
 
         if hasattr(block_value, "input_values"):
-            qubit_idx = 0
-            for input_val in block_value.input_values:
-                if hasattr(input_val, "type") and input_val.type.is_quantum():
-                    local_qubit_map[QubitAddress(input_val.uuid)] = qubit_idx
-                    qubit_idx += 1
+            _populate_input_qubit_map(
+                emit_pass,
+                block_value.input_values,
+                num_qubits,
+                bindings,
+                local_qubit_map,
+            )
 
         local_qubit_map, local_clbit_map = emit_pass._allocator.allocate(
-            block_value.operations
+            block_value.operations,
+            bindings,
+            initial_qubit_map=local_qubit_map,
+            initial_clbit_map=local_clbit_map,
         )
-
-        # Remap to ensure input qubits come first
-        if hasattr(block_value, "input_values"):
-            for i, input_val in enumerate(block_value.input_values):
-                if hasattr(input_val, "type") and input_val.type.is_quantum():
-                    local_qubit_map[QubitAddress(input_val.uuid)] = i
 
         qubit_count = (
             max(local_qubit_map.values()) + 1 if local_qubit_map else num_qubits
@@ -666,3 +698,129 @@ def blockvalue_to_gate(
             exc_info=True,
         )
         return None
+
+
+def _populate_input_qubit_map(
+    emit_pass: "StandardEmitPass",
+    input_values: list[Any],
+    num_qubits: int,
+    bindings: dict[str, Any],
+    qubit_map: QubitMap,
+) -> None:
+    """Pre-populate ``qubit_map`` with the inner block's quantum inputs.
+
+    Scalar ``Qubit`` inputs consume one physical index each;
+    ``Vector[Qubit]`` inputs (``ArrayValue`` with a quantum element type)
+    consume ``length`` consecutive indices, one per element, keyed as
+    ``QubitAddress(uuid, i)``. The base ``QubitAddress(uuid)`` is also
+    registered for the vector so any downstream lookup that addresses
+    the array as a whole resolves to its first element.
+
+    Args:
+        emit_pass (StandardEmitPass): Provides the value resolver used
+            to resolve symbolic ``Vector[Qubit]`` shapes against
+            ``bindings``.
+        input_values (list[Any]): The inner block's ``input_values``.
+            Non-quantum inputs (``Float``, ``UInt``, ...) are skipped.
+        num_qubits (int): Total qubit count the resulting gate will
+            occupy. Used as the fallback length for a single
+            ``Vector[Qubit]`` input whose shape Value is not present in
+            ``bindings``.
+        bindings (dict[str, Any]): Parameter bindings consulted when
+            resolving a vector's symbolic shape.
+        qubit_map (QubitMap): Mapping mutated in place. Each registered
+            entry maps a ``QubitAddress`` (scalar or array element) to a
+            consecutive physical index starting at 0.
+
+    Raises:
+        EmitError: If a ``Vector[Qubit]`` input's length cannot be
+            resolved and cannot be inferred from ``num_qubits`` (multiple
+            unresolvable vector inputs, or vector length exceeds the
+            remaining qubit budget).
+    """
+    from qamomile.circuit.ir.value import ArrayValue
+
+    quantum_inputs = [
+        iv for iv in input_values if hasattr(iv, "type") and iv.type.is_quantum()
+    ]
+
+    scalar_count = sum(1 for iv in quantum_inputs if not isinstance(iv, ArrayValue))
+    vector_inputs = [iv for iv in quantum_inputs if isinstance(iv, ArrayValue)]
+
+    resolved_lengths: dict[str, int] = {}
+    unresolved: list[ArrayValue] = []
+    for iv in vector_inputs:
+        length = _resolve_vector_input_length(emit_pass, iv, bindings)
+        if length is None:
+            unresolved.append(iv)
+        else:
+            resolved_lengths[iv.uuid] = length
+
+    # Fall back to ``num_qubits`` for the single unresolved Vector[Qubit]
+    # input. The caller's ``num_qubits`` is the total qubit count of the
+    # emitted gate, so subtracting scalars and any resolved vector
+    # lengths leaves exactly the remaining vector's length.
+    if len(unresolved) == 1:
+        inferred = num_qubits - scalar_count - sum(resolved_lengths.values())
+        if inferred < 0:
+            raise EmitError(
+                f"Vector[Qubit] input {unresolved[0].name!r} has an unresolved "
+                f"length and the remaining qubit budget "
+                f"({num_qubits - scalar_count - sum(resolved_lengths.values())}) "
+                f"is negative; bind the vector's shape before transpilation.",
+                operation="ControlledUOperation",
+            )
+        resolved_lengths[unresolved[0].uuid] = inferred
+    elif len(unresolved) > 1:
+        raise EmitError(
+            f"Cannot resolve Vector[Qubit] input shapes for inner block "
+            f"({[iv.name for iv in unresolved]!r}); only one symbolic "
+            f"length can be inferred from the gate's qubit count. Bind "
+            f"the remaining shapes before transpilation.",
+            operation="ControlledUOperation",
+        )
+
+    qubit_idx = 0
+    for input_val in quantum_inputs:
+        if isinstance(input_val, ArrayValue):
+            length = resolved_lengths[input_val.uuid]
+            for i in range(length):
+                qubit_map[QubitAddress(input_val.uuid, i)] = qubit_idx + i
+            base_addr = QubitAddress(input_val.uuid)
+            if base_addr not in qubit_map and length > 0:
+                qubit_map[base_addr] = qubit_idx
+            qubit_idx += length
+        else:
+            qubit_map[QubitAddress(input_val.uuid)] = qubit_idx
+            qubit_idx += 1
+
+
+def _resolve_vector_input_length(
+    emit_pass: "StandardEmitPass",
+    input_val: Any,
+    bindings: dict[str, Any],
+) -> int | None:
+    """Resolve a ``Vector[Qubit]`` input's length from its shape Value.
+
+    Args:
+        emit_pass (StandardEmitPass): Provides ``_resolver`` for shape
+            resolution.
+        input_val (Any): An ``ArrayValue`` representing a ``Vector[Qubit]``
+            input. The first element of ``input_val.shape`` is the
+            length Value (constant or symbolic).
+        bindings (dict[str, Any]): Bindings consulted when the shape
+            Value is symbolic.
+
+    Returns:
+        int | None: The resolved length, or ``None`` when ``input_val.shape``
+            is empty (no dimension Value at all) or when the first
+            dimension is symbolic and not present in ``bindings``. The
+            caller treats both cases as "unresolved" and falls back to
+            inferring the length from the surrounding qubit budget.
+    """
+    if not input_val.shape:
+        return None
+    size_val = input_val.shape[0]
+    if size_val.is_constant():
+        return int(size_val.get_const())
+    return emit_pass._resolver.resolve_int_value(size_val, bindings)

--- a/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
@@ -733,9 +733,13 @@ def _populate_input_qubit_map(
             consecutive physical index starting at 0.
 
     Raises:
-        EmitError: Three failure modes are surfaced loudly rather than
+        EmitError: Four failure modes are surfaced loudly rather than
             silently mis-mapping qubits:
 
+            * A resolved ``Vector[Qubit]`` length (from a constant shape
+              or a binding) is negative. ``range(length)`` would be
+              empty and ``qubit_idx += length`` would step the cursor
+              backwards, producing overlapping physical assignments.
             * Multiple unresolvable ``Vector[Qubit]`` inputs (only one
               symbolic length can be inferred from the remaining
               ``num_qubits`` budget).
@@ -762,6 +766,13 @@ def _populate_input_qubit_map(
         length = _resolve_vector_input_length(emit_pass, iv, bindings)
         if length is None:
             unresolved.append(iv)
+        elif length < 0:
+            raise EmitError(
+                f"Vector[Qubit] input {iv.name!r} resolved to a negative "
+                f"length ({length}); shapes must be non-negative. Check "
+                f"the binding for {iv.shape[0].name!r}.",
+                operation="ControlledUOperation",
+            )
         else:
             resolved_lengths[iv.uuid] = length
 

--- a/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/controlled_emission.py
@@ -733,10 +733,19 @@ def _populate_input_qubit_map(
             consecutive physical index starting at 0.
 
     Raises:
-        EmitError: If a ``Vector[Qubit]`` input's length cannot be
-            resolved and cannot be inferred from ``num_qubits`` (multiple
-            unresolvable vector inputs, or vector length exceeds the
-            remaining qubit budget).
+        EmitError: Three failure modes are surfaced loudly rather than
+            silently mis-mapping qubits:
+
+            * Multiple unresolvable ``Vector[Qubit]`` inputs (only one
+              symbolic length can be inferred from the remaining
+              ``num_qubits`` budget).
+            * A single unresolvable ``Vector[Qubit]`` whose inferred
+              length ``num_qubits - scalar_count - sum(resolved)`` is
+              negative.
+            * Total quantum-input footprint
+              ``scalar_count + sum(resolved_vector_lengths)`` exceeds
+              ``num_qubits`` (i.e., a resolved or bound vector shape
+              overflows the gate's declared qubit width).
     """
     from qamomile.circuit.ir.value import ArrayValue
 
@@ -765,9 +774,8 @@ def _populate_input_qubit_map(
         if inferred < 0:
             raise EmitError(
                 f"Vector[Qubit] input {unresolved[0].name!r} has an unresolved "
-                f"length and the remaining qubit budget "
-                f"({num_qubits - scalar_count - sum(resolved_lengths.values())}) "
-                f"is negative; bind the vector's shape before transpilation.",
+                f"length and the remaining qubit budget ({inferred}) is "
+                f"negative; bind the vector's shape before transpilation.",
                 operation="ControlledUOperation",
             )
         resolved_lengths[unresolved[0].uuid] = inferred
@@ -777,6 +785,23 @@ def _populate_input_qubit_map(
             f"({[iv.name for iv in unresolved]!r}); only one symbolic "
             f"length can be inferred from the gate's qubit count. Bind "
             f"the remaining shapes before transpilation.",
+            operation="ControlledUOperation",
+        )
+
+    # Sanity-check the total budget. The inferred-length branch above
+    # cannot overflow (its length is computed to fit exactly), but a
+    # vector whose length was resolved from a binding or a constant
+    # shape can legitimately be larger than the gate's qubit width if
+    # the caller misconfigured things. Reject upfront rather than
+    # silently writing physical indices past ``num_qubits - 1``.
+    total = scalar_count + sum(resolved_lengths.values())
+    if total > num_qubits:
+        raise EmitError(
+            f"Inner block's quantum inputs require {total} physical "
+            f"qubits (scalars={scalar_count}, vector lengths="
+            f"{sorted(resolved_lengths.values())}) but the controlled "
+            f"gate only provides {num_qubits}. Check the bound vector "
+            f"shapes against the gate's expected target count.",
             operation="ControlledUOperation",
         )
 

--- a/qamomile/circuit/transpiler/passes/emit_support/resource_allocator.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/resource_allocator.py
@@ -67,21 +67,44 @@ class ResourceAllocator:
         self,
         operations: list[Operation],
         bindings: dict[str, Any] | None = None,
+        initial_qubit_map: QubitMap | None = None,
+        initial_clbit_map: ClbitMap | None = None,
     ) -> tuple[QubitMap, ClbitMap]:
         """Allocate qubit and clbit indices for all operations.
 
         Args:
-            operations: List of operations to allocate resources for
-            bindings: Optional variable bindings for resolving dynamic sizes
+            operations (list[Operation]): Operations to allocate resources
+                for.
+            bindings (dict[str, Any] | None): Optional variable bindings
+                for resolving dynamic sizes. Defaults to None (treated as
+                an empty mapping).
+            initial_qubit_map (QubitMap | None): Optional pre-populated
+                qubit address mapping. Used by callers that need to seed
+                the allocator with bindings established outside the
+                operation list — for instance, the inner-block emitter
+                in ``blockvalue_to_gate`` pre-allocates ``Vector[Qubit]``
+                input elements (the inner block has no ``QInitOperation``
+                for inputs, so per-element entries must be supplied here
+                or the assertion in ``_allocate_gate`` fires). The map is
+                copied; allocation continues from
+                ``max(values) + 1`` so new ``QInitOperation`` allocations
+                inside ``operations`` do not collide. Defaults to None
+                (treated as empty).
+            initial_clbit_map (ClbitMap | None): Optional pre-populated
+                clbit address mapping. Same semantics as
+                ``initial_qubit_map`` but for classical bits. Defaults to
+                None.
 
         Returns:
-            Tuple of (qubit_map, clbit_map) where each maps
-            QubitAddress to physical index
+            tuple[QubitMap, ClbitMap]: ``(qubit_map, clbit_map)`` where
+                each maps ``QubitAddress`` to a physical index. If an
+                initial map was supplied, its entries are preserved
+                verbatim in the returned map.
         """
-        qubit_map: QubitMap = {}
-        clbit_map: ClbitMap = {}
-        self._next_qubit_index = 0
-        self._next_clbit_index = 0
+        qubit_map: QubitMap = dict(initial_qubit_map) if initial_qubit_map else {}
+        clbit_map: ClbitMap = dict(initial_clbit_map) if initial_clbit_map else {}
+        self._next_qubit_index = max(qubit_map.values(), default=-1) + 1
+        self._next_clbit_index = max(clbit_map.values(), default=-1) + 1
         self._allocate_recursive(operations, qubit_map, clbit_map, bindings or {})
         return qubit_map, clbit_map
 

--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -63,33 +63,131 @@ def _build_block_qubit_map(
     that SSA result versions inherit the same physical target as their
     operands.
 
-    This allows resolving which physical target an inner gate's operand
-    refers to, even across multiple SSA versions.
-    """
-    qubit_map: dict[str, int] = {}
+    Scalar ``Qubit`` inputs map one UUID -> one physical target;
+    ``Vector[Qubit]`` inputs (``ArrayValue`` carrying a quantum element
+    type) consume one physical index per element. The element UUIDs
+    themselves are unknown at seed time — they are created during the
+    inner kernel's tracing — so the body walk below also resolves any
+    operand whose ``parent_array`` matches a registered vector and
+    seeds ``qubit_map`` with the per-element UUID lazily.
 
-    # Seed from block inputs.
+    Args:
+        block_value (Any): Inner block whose ``input_values`` and
+            ``operations`` are walked. Missing attributes are treated as
+            an empty seed source.
+        target_indices (list[int]): Physical target indices the inner
+            block's quantum inputs map onto, in declaration order. Each
+            scalar input consumes one index; each ``Vector[Qubit]``
+            input consumes ``length`` consecutive indices, where
+            ``length`` is taken from the vector's per-element references
+            in the body (the maximum element_index + 1 actually used).
+
+    Returns:
+        dict[str, int]: Mapping from operand UUID (per-element or
+            scalar) to physical target index. Empty when ``block_value``
+            has no quantum inputs.
+    """
+    from qamomile.circuit.ir.value import ArrayValue
+
+    qubit_map: dict[str, int] = {}
+    # ``Vector[Qubit]`` input UUID -> ``(start_index_in_target_indices,
+    # length)`` so the body walk below can map each per-element operand
+    # back to its physical target.
+    vector_inputs: dict[str, tuple[int, int]] = {}
+
     if hasattr(block_value, "input_values"):
         qubit_idx = 0
-        for iv in block_value.input_values:
-            if hasattr(iv, "type") and iv.type.is_quantum():
+        quantum_inputs = [
+            iv
+            for iv in block_value.input_values
+            if hasattr(iv, "type") and iv.type.is_quantum()
+        ]
+        # Determine each Vector[Qubit] input's length from
+        # ``target_indices`` (one of the vectors may absorb the
+        # remainder; for now require a single Vector input or none, to
+        # match the IndexSpecControlledU caller contract).
+        scalar_count = sum(1 for iv in quantum_inputs if not isinstance(iv, ArrayValue))
+        for iv in quantum_inputs:
+            if isinstance(iv, ArrayValue):
+                length = len(target_indices) - scalar_count
+                if length < 0:
+                    length = 0
+                vector_inputs[iv.uuid] = (qubit_idx, length)
+                # Seed each element UUID once we walk the body; for now
+                # also store the base UUID for any downstream lookup
+                # that addresses the array as a whole.
+                if qubit_idx < len(target_indices) and length > 0:
+                    qubit_map[iv.uuid] = target_indices[qubit_idx]
+                qubit_idx += length
+            else:
                 if qubit_idx < len(target_indices):
                     qubit_map[iv.uuid] = target_indices[qubit_idx]
                 qubit_idx += 1
 
-    # Propagate through operations: result inherits operand's target.
+    # Walk all operations once to:
+    #   (a) seed each per-element operand UUID of a Vector[Qubit] input,
+    #   (b) propagate SSA so result versions inherit operand targets.
     if hasattr(block_value, "operations"):
         for op in block_value.operations:
             if isinstance(op, GateOperation):
+                for operand in op.qubit_operands:
+                    _seed_vector_element_uuid(
+                        operand, vector_inputs, target_indices, qubit_map
+                    )
                 for i, result in enumerate(op.results):
                     if hasattr(result, "type") and result.type.is_quantum():
-                        # Find the corresponding operand's physical target.
-                        if i < len(op.operands):
-                            operand = op.operands[i]
-                            if hasattr(operand, "uuid") and operand.uuid in qubit_map:
+                        if i < len(op.qubit_operands):
+                            operand = op.qubit_operands[i]
+                            if operand.uuid in qubit_map:
                                 qubit_map[result.uuid] = qubit_map[operand.uuid]
 
     return qubit_map
+
+
+def _seed_vector_element_uuid(
+    operand: Any,
+    vector_inputs: dict[str, tuple[int, int]],
+    target_indices: list[int],
+    qubit_map: dict[str, int],
+) -> None:
+    """Seed ``qubit_map`` with a Vector[Qubit] element operand's UUID.
+
+    Resolves an ``operand`` that addresses an element of a ``Vector[Qubit]``
+    input (i.e., ``operand.parent_array`` matches a registered vector
+    and ``operand.element_indices[0]`` is a constant) to its physical
+    target via ``vector_inputs`` and stores it under ``operand.uuid``.
+    Non-element operands and elements with non-constant indices are
+    ignored — they either belong to a scalar input (already seeded) or
+    fall outside the controlled helper's current resolution capability.
+
+    Args:
+        operand (Any): A gate operand to seed.
+        vector_inputs (dict[str, tuple[int, int]]): Map from
+            ``Vector[Qubit]`` input UUID to ``(start_offset, length)``
+            in ``target_indices``.
+        target_indices (list[int]): The physical target index list the
+            inner block's quantum inputs map onto.
+        qubit_map (dict[str, int]): UUID-to-physical-target map; mutated
+            in place when the operand is a recognized Vector[Qubit]
+            element.
+    """
+    parent = getattr(operand, "parent_array", None)
+    if parent is None:
+        return
+    if parent.uuid not in vector_inputs:
+        return
+    indices = tuple(getattr(operand, "element_indices", ()))
+    if not indices:
+        return
+    idx_val = indices[0]
+    if not idx_val.is_constant():
+        return
+    elem_idx = int(idx_val.get_const())
+    start, length = vector_inputs[parent.uuid]
+    if elem_idx < 0 or elem_idx >= length:
+        return
+    physical = target_indices[start + elem_idx]
+    qubit_map.setdefault(operand.uuid, physical)
 
 
 def _resolve_gate_targets(
@@ -102,6 +200,20 @@ def _resolve_gate_targets(
     For each quantum operand of the gate, looks up the corresponding
     physical target via ``qubit_map``.  Falls back to ``fallback_targets``
     if no mapping is found.
+
+    Args:
+        op (GateOperation): The gate operation whose operand targets are
+            being resolved.
+        qubit_map (dict[str, int]): UUID-to-physical-target map seeded
+            by ``_build_block_qubit_map``.
+        fallback_targets (list[int]): Default physical targets used when
+            no operand resolves through ``qubit_map``.
+
+    Returns:
+        list[int]: Per-operand physical target indices in
+            ``op.qubit_operands`` order, or ``fallback_targets`` when no
+            operand resolved through the map (matches prior behavior so
+            unrelated controlled callers keep working).
     """
     resolved: list[int] = []
     for operand in op.operands:

--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -255,12 +255,11 @@ def _resolve_gate_targets(
             unrelated controlled callers keep working).
     """
     resolved: list[int] = []
-    for operand in op.operands:
-        if hasattr(operand, "type") and operand.type.is_quantum():
-            if operand.uuid in qubit_map:
-                resolved.append(qubit_map[operand.uuid])
-            elif fallback_targets:
-                resolved.append(fallback_targets[0])
+    for operand in op.qubit_operands:
+        if operand.uuid in qubit_map:
+            resolved.append(qubit_map[operand.uuid])
+        elif fallback_targets:
+            resolved.append(fallback_targets[0])
     return resolved if resolved else fallback_targets
 
 

--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -64,12 +64,18 @@ def _build_block_qubit_map(
     operands.
 
     Scalar ``Qubit`` inputs map one UUID -> one physical target;
-    ``Vector[Qubit]`` inputs (``ArrayValue`` carrying a quantum element
-    type) consume one physical index per element. The element UUIDs
-    themselves are unknown at seed time — they are created during the
-    inner kernel's tracing — so the body walk below also resolves any
-    operand whose ``parent_array`` matches a registered vector and
-    seeds ``qubit_map`` with the per-element UUID lazily.
+    a single ``Vector[Qubit]`` input (``ArrayValue`` carrying a quantum
+    element type) absorbs the remaining target indices, one per
+    element. Multiple ``Vector[Qubit]`` inputs cannot be resolved here
+    because the helper has no shape information to allocate them
+    individually — the only consumer today is ``IndexSpecControlledU``,
+    whose caller contract is "exactly one Vector[Qubit] operand". The
+    function therefore enforces "at most one ``Vector[Qubit]`` input"
+    and raises ``EmitError`` otherwise. The element UUIDs themselves
+    are unknown at seed time — they are created during the inner
+    kernel's tracing — so the body walk below also resolves any operand
+    whose ``parent_array`` matches the registered vector and seeds
+    ``qubit_map`` with the per-element UUID lazily.
 
     Args:
         block_value (Any): Inner block whose ``input_values`` and
@@ -77,15 +83,19 @@ def _build_block_qubit_map(
             an empty seed source.
         target_indices (list[int]): Physical target indices the inner
             block's quantum inputs map onto, in declaration order. Each
-            scalar input consumes one index; each ``Vector[Qubit]``
-            input consumes ``length`` consecutive indices, where
-            ``length`` is taken from the vector's per-element references
-            in the body (the maximum element_index + 1 actually used).
+            scalar input consumes one index; the single ``Vector[Qubit]``
+            input (if any) consumes the remaining
+            ``len(target_indices) - scalar_count`` indices.
 
     Returns:
         dict[str, int]: Mapping from operand UUID (per-element or
             scalar) to physical target index. Empty when ``block_value``
             has no quantum inputs.
+
+    Raises:
+        EmitError: If the inner block declares more than one
+            ``Vector[Qubit]`` input, or if the scalar inputs alone
+            already exceed ``len(target_indices)``.
     """
     from qamomile.circuit.ir.value import ArrayValue
 
@@ -102,19 +112,31 @@ def _build_block_qubit_map(
             for iv in block_value.input_values
             if hasattr(iv, "type") and iv.type.is_quantum()
         ]
-        # Determine each Vector[Qubit] input's length from
-        # ``target_indices`` (one of the vectors may absorb the
-        # remainder; for now require a single Vector input or none, to
-        # match the IndexSpecControlledU caller contract).
+        vector_count = sum(1 for iv in quantum_inputs if isinstance(iv, ArrayValue))
+        if vector_count > 1:
+            raise EmitError(
+                f"CUDA-Q controlled helper supports at most one "
+                f"Vector[Qubit] input in the inner block, got "
+                f"{vector_count}. Wrap the helper so it takes individual "
+                f"Qubit arguments, or split the work across multiple "
+                f"controlled gates.",
+                operation="ControlledUOperation",
+            )
         scalar_count = sum(1 for iv in quantum_inputs if not isinstance(iv, ArrayValue))
+        if scalar_count > len(target_indices):
+            raise EmitError(
+                f"CUDA-Q controlled helper inner block has {scalar_count} "
+                f"scalar Qubit inputs but only {len(target_indices)} "
+                f"target indices are available.",
+                operation="ControlledUOperation",
+            )
         for iv in quantum_inputs:
             if isinstance(iv, ArrayValue):
+                # Single-vector enforced above, so this vector takes
+                # the entire remaining target budget.
                 length = len(target_indices) - scalar_count
-                if length < 0:
-                    length = 0
                 vector_inputs[iv.uuid] = (qubit_idx, length)
-                # Seed each element UUID once we walk the body; for now
-                # also store the base UUID for any downstream lookup
+                # Also store the base UUID for any downstream lookup
                 # that addresses the array as a whole.
                 if qubit_idx < len(target_indices) and length > 0:
                     qubit_map[iv.uuid] = target_indices[qubit_idx]
@@ -170,6 +192,16 @@ def _seed_vector_element_uuid(
         qubit_map (dict[str, int]): UUID-to-physical-target map; mutated
             in place when the operand is a recognized Vector[Qubit]
             element.
+
+    Raises:
+        EmitError: If the resolved physical slot ``start + elem_idx``
+            falls outside ``target_indices``. ``_build_block_qubit_map``
+            already constrains ``start + length`` to fit, so this only
+            triggers on a corrupted ``vector_inputs`` table or an
+            unexpected mismatch between ``target_indices`` and the
+            inner block's declared inputs — both internal-invariant
+            violations rather than user-facing miscompiles, but
+            surfacing them loudly beats a silent ``IndexError``.
     """
     parent = getattr(operand, "parent_array", None)
     if parent is None:
@@ -186,8 +218,15 @@ def _seed_vector_element_uuid(
     start, length = vector_inputs[parent.uuid]
     if elem_idx < 0 or elem_idx >= length:
         return
-    physical = target_indices[start + elem_idx]
-    qubit_map.setdefault(operand.uuid, physical)
+    slot = start + elem_idx
+    if slot < 0 or slot >= len(target_indices):
+        raise EmitError(
+            f"CUDA-Q controlled helper: Vector[Qubit] element index "
+            f"{elem_idx} resolves to physical slot {slot}, outside the "
+            f"available target range [0, {len(target_indices)}).",
+            operation="ControlledUOperation",
+        )
+    qubit_map.setdefault(operand.uuid, target_indices[slot])
 
 
 def _resolve_gate_targets(

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -2118,3 +2118,209 @@ class TestControlledBuiltinCrossSDKExpval:
             f"SDK={transpiler_factory.__name__}, seed={seed}, theta={theta}: "
             f"builtin={val_b}, wrapper={val_w}"
         )
+
+
+# =============================================================================
+# Cross-SDK execution: user @qkernel with Vector[Qubit] input + index-spec
+# =============================================================================
+#
+# Regression for the bug where ``controlled(inner_kernel, ...)(qs,
+# target_indices=[...])`` tripped an allocator assertion when
+# ``inner_kernel`` took a ``Vector[Qubit]`` argument: the inner block has
+# no QInitOperation for its inputs, so the per-element ``QubitAddress``
+# keys for ``qs[i]`` references in the body were never registered before
+# ``ResourceAllocator._allocate_gate`` ran.  These tests cover the
+# Vector[Qubit]-input + index-spec combination across every supported
+# SDK (transpile + sample + expval), with randomized parameters.
+
+
+@qmc.qkernel
+def _shift_first_three(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Cyclic shift ``(q0, q1, q2) -> (q2, q0, q1)`` via two SWAPs.
+
+    Used as the inner kernel for the ``Vector[Qubit]``-input regression
+    test.  The deterministic permutation makes it easy to verify the
+    final basis state by hand: when the outer control is ``|1>`` the
+    three target qubits are permuted, and when it is ``|0>`` they are
+    untouched.
+    """
+    qs[0], qs[1] = qmc.swap(qs[0], qs[1])
+    qs[1], qs[2] = qmc.swap(qs[1], qs[2])
+    return qs
+
+
+@qmc.qkernel
+def _rotate_first_two(
+    qs: qmc.Vector[qmc.Qubit],
+    theta: qmc.Float,
+) -> qmc.Vector[qmc.Qubit]:
+    """Apply ``RY(theta)`` to both ``qs[0]`` and ``qs[1]``.
+
+    Used to exercise the case where a ``Vector[Qubit]``-input inner
+    kernel also carries a classical parameter that must be threaded
+    through to the controlled gate's emit path.
+    """
+    qs[0] = qmc.ry(qs[0], theta)
+    qs[1] = qmc.ry(qs[1], theta)
+    return qs
+
+
+@pytest.mark.parametrize("transpiler_factory", _BUILTIN_BACKENDS)
+class TestControlledIndexSpecVectorInnerKernel:
+    """Vector[Qubit]-input inner kernels under target_indices/controlled_indices.
+
+    Regression coverage for the ``IndexSpecControlledU`` emit path when
+    the inner ``@qmc.qkernel``'s only quantum input is a
+    ``Vector[Qubit]``.  Each test transpiles on every supported SDK and
+    runs both the sampling and expectation-value paths so the two
+    backend primitives are independently regressed.
+
+    The sampling tests are deterministic basis-state checks and need no
+    randomization; the expval test rides a random rotation angle so it
+    carries its own seed parametrization at method scope.
+    """
+
+    def test_target_indices_sampling(self, transpiler_factory):
+        """Controlled cyclic shift gates a deterministic basis state when ctrl=|1>.
+
+        Initial state |1110>: q[3] is the outer control (ON), q[0..2]
+        are the targets carrying |1,1,1>.  The inner ``_shift_first_three``
+        permutes (q0,q1,q2) -> (q2,q0,q1); on |1,1,1> this is a no-op,
+        so the final measurement should be |1110> with probability 1.
+        """
+
+        @qmc.qkernel
+        def kernel() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(4, "qs")
+            qs[0] = qmc.x(qs[0])
+            qs[1] = qmc.x(qs[1])
+            qs[2] = qmc.x(qs[2])
+            qs[3] = qmc.x(qs[3])
+            cg = qmc.controlled(_shift_first_three, num_controls=1)
+            qs = cg(qs, target_indices=[0, 1, 2])
+            return qmc.measure(qs)
+
+        t = transpiler_factory()
+        try:
+            exe = t.transpile(kernel)
+        except EmitError as e:
+            pytest.skip(
+                f"{t.__class__.__name__} does not support this controlled-U: {e}"
+            )
+
+        result = exe.sample(t.executor(), shots=128).result()
+        total = sum(count for _value, count in result.results)
+        assert total > 0, f"no shots returned on SDK={transpiler_factory.__name__}"
+        # ``Vector[Bit]`` sampling yields ``((b0, b1, ...), count)``
+        # tuples in element order (q[0] first).  Every shot must be
+        # the deterministic outcome ``(1, 1, 1, 1)``.
+        for value, count in result.results:
+            assert tuple(value) == (1, 1, 1, 1), (
+                f"expected all shots to measure (1, 1, 1, 1), got value={value} "
+                f"count={count} on SDK={transpiler_factory.__name__}"
+            )
+
+    def test_controlled_indices_sampling(self, transpiler_factory):
+        """controlled_indices=[3] is equivalent to target_indices=[0,1,2].
+
+        With the outer control OFF (|0> on q[3]) and the three target
+        qubits prepared in |1,1,1>, the gate is the identity and the
+        measurement deterministically yields ``(1, 1, 1, 0)`` (q[0..2]
+        on, q[3] off).
+        """
+
+        @qmc.qkernel
+        def kernel() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(4, "qs")
+            qs[0] = qmc.x(qs[0])
+            qs[1] = qmc.x(qs[1])
+            qs[2] = qmc.x(qs[2])
+            cg = qmc.controlled(_shift_first_three, num_controls=1)
+            qs = cg(qs, controlled_indices=[3])
+            return qmc.measure(qs)
+
+        t = transpiler_factory()
+        try:
+            exe = t.transpile(kernel)
+        except EmitError as e:
+            pytest.skip(
+                f"{t.__class__.__name__} does not support this controlled-U: {e}"
+            )
+
+        result = exe.sample(t.executor(), shots=128).result()
+        total = sum(count for _value, count in result.results)
+        assert total > 0, f"no shots returned on SDK={transpiler_factory.__name__}"
+        for value, count in result.results:
+            assert tuple(value) == (1, 1, 1, 0), (
+                f"expected all shots to measure (1, 1, 1, 0), got value={value} "
+                f"count={count} on SDK={transpiler_factory.__name__}"
+            )
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 42])
+    def test_expval_matches_wrapper_form(self, transpiler_factory, seed):
+        """Vector[Qubit]-input form must agree with the individual-Qubit-arg form.
+
+        Builds two equivalent circuits: one passes ``qs`` to the
+        ``Vector[Qubit]``-input inner kernel via index-spec, the other
+        uses individual ``Qubit`` arguments (the documented workaround
+        in the bug report).  Both must produce the same expectation
+        value for ``Σ_i Z_i`` over a randomized rotation parameter.
+        """
+        import qamomile.observable as qm_o
+
+        rng = np.random.default_rng(seed)
+        theta = float(rng.uniform(-math.pi, math.pi))
+
+        # Vector[Qubit]-input form (the bug path).
+        @qmc.qkernel
+        def kernel_vector(obs: qmc.Observable) -> qmc.Float:
+            qs = qmc.qubit_array(3, "qs")
+            qs[0] = qmc.h(qs[0])  # Put outer control in superposition.
+            qs[1] = qmc.x(qs[1])  # Make inner state non-trivial.
+            cg = qmc.controlled(_rotate_first_two, num_controls=1)
+            qs = cg(qs, controlled_indices=[0], theta=theta)
+            return qmc.expval((qs[0], qs[1], qs[2]), obs)
+
+        # Equivalent individual-Qubit-arg form (the documented workaround).
+        @qmc.qkernel
+        def _rotate_first_two_scalar(
+            q0: qmc.Qubit,
+            q1: qmc.Qubit,
+            theta: qmc.Float,
+        ) -> tuple[qmc.Qubit, qmc.Qubit]:
+            q0 = qmc.ry(q0, theta)
+            q1 = qmc.ry(q1, theta)
+            return q0, q1
+
+        @qmc.qkernel
+        def kernel_scalar(obs: qmc.Observable) -> qmc.Float:
+            q0 = qmc.qubit(name="q0")
+            q1 = qmc.qubit(name="q1")
+            q2 = qmc.qubit(name="q2")
+            q0 = qmc.h(q0)
+            q1 = qmc.x(q1)
+            cg = qmc.controlled(_rotate_first_two_scalar, num_controls=1)
+            q0, q1, q2 = cg(q0, q1, q2, theta=theta)
+            return qmc.expval((q0, q1, q2), obs)
+
+        H = qm_o.Hamiltonian.zero(num_qubits=3)
+        for i in range(3):
+            H += qm_o.Z(i)
+
+        t = transpiler_factory()
+        try:
+            exe_v = t.transpile(kernel_vector, bindings={"obs": H})
+            exe_s = t.transpile(kernel_scalar, bindings={"obs": H})
+        except EmitError as e:
+            pytest.skip(
+                f"{t.__class__.__name__} does not support this controlled-U: {e}"
+            )
+
+        val_v = exe_v.run(t.executor()).result()
+        val_s = exe_s.run(t.executor()).result()
+
+        assert np.isclose(val_v, val_s, atol=1e-6), (
+            f"vector-input/scalar-arg expval mismatch on "
+            f"SDK={transpiler_factory.__name__}, seed={seed}, theta={theta}: "
+            f"vector={val_v}, scalar={val_s}"
+        )

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -2136,7 +2136,11 @@ class TestControlledBuiltinCrossSDKExpval:
 
 @qmc.qkernel
 def _shift_first_three(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
-    """Cyclic shift ``(q0, q1, q2) -> (q2, q0, q1)`` via two SWAPs.
+    """Cyclic shift ``(q0, q1, q2) -> (q1, q2, q0)`` via two SWAPs.
+
+    Tracing the two swaps starting from ``(a, b, c)``: ``swap(q0, q1)``
+    gives ``(b, a, c)``, then ``swap(q1, q2)`` gives ``(b, c, a)`` — i.e.,
+    the new ``q_i`` holds the original ``q_{(i+1) mod 3}``.
 
     Used as the inner kernel for the ``Vector[Qubit]``-input regression
     test.  The deterministic permutation makes it easy to verify the

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -2183,10 +2183,11 @@ class TestControlledIndexSpecVectorInnerKernel:
     def test_target_indices_sampling(self, transpiler_factory):
         """Controlled cyclic shift gates a deterministic basis state when ctrl=|1>.
 
-        Initial state |1110>: q[3] is the outer control (ON), q[0..2]
-        are the targets carrying |1,1,1>.  The inner ``_shift_first_three``
-        permutes (q0,q1,q2) -> (q2,q0,q1); on |1,1,1> this is a no-op,
-        so the final measurement should be |1110> with probability 1.
+        Initial state is |1111> after X on every qubit: q[3] is the
+        outer control (ON), q[0..2] are the targets carrying |1,1,1>.
+        The inner ``_shift_first_three`` permutes (q0,q1,q2) ->
+        (q1,q2,q0); on |1,1,1> this is a no-op, so the final
+        measurement deterministically yields ``(1, 1, 1, 1)``.
         """
 
         @qmc.qkernel


### PR DESCRIPTION
## Summary

- `qmc.controlled(inner_kernel, num_controls=...)(qs, target_indices=[...])` (and the `controlled_indices=[...]` form) raised an internal allocator assertion whenever `inner_kernel` took a `Vector[Qubit]` argument. The inner block has no `QInitOperation` for its inputs, so the per-element `QubitAddress(uuid, i)` keys for `qs[i]` references in the body were never registered before `ResourceAllocator._allocate_gate` ran.
- Fix at the emit boundary: `blockvalue_to_gate` now pre-populates `local_qubit_map` with per-element entries for `Vector[Qubit]` inputs (length resolved from `bindings` or, when symbolic, inferred from the caller's `num_qubits`) and forwards it via a new `initial_qubit_map` parameter on `ResourceAllocator.allocate`. The dead post-allocate input remap is removed.
- CUDA-Q goes through `_emit_controlled_fallback` rather than `blockvalue_to_gate`, so its `_build_block_qubit_map` got the analogous expansion: a body walk seeds each per-element operand UUID lazily because element UUIDs are created during inner-kernel tracing and unknown at seed time.
- Multiple unresolvable `Vector[Qubit]` inputs raise a clear `EmitError` rather than silently mis-mapping.

## Test plan

- [x] Cross-backend regression test added in `tests/circuit/test_controlled.py` (`TestControlledIndexSpecVectorInnerKernel`): Qiskit / QuriParts / CUDA-Q × sampling + expval paths, including a `Vector[Qubit]` inner kernel with a runtime rotation parameter.
- [x] Original reproducer (`swap_first_three` with `target_indices=[0, 1, 2]` and `controlled_indices=[3]`) now transpiles and produces the expected circuit.
- [x] `uv run pytest tests/circuit/test_controlled.py` — 1233 passed, 27 skipped.
- [x] `uv run pytest tests/circuit/` — 5416 passed, 27 skipped.
- [x] `uv run ruff check qamomile/ tests/` — clean.
- [x] `uv run ruff format --check qamomile/ tests/` — clean.
- [x] `uv run zuban check qamomile/` — no new type errors vs `main` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)