### PR TITLE
fix(qkernel): preserve shape-dependent stdlib gates across nested calls

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,144 @@
+# Known Limitations
+
+This file collects known limitations that survive (or were introduced
+by) the call-time specialization fix for issue #392. Each entry
+documents what the limitation is, when it bites, why the simpler
+fix was deferred, and the future fix path.
+
+## Re-trace cost is uncached
+
+Every nested call site that resolves new compile-time information
+about the callee triggers a fresh re-trace of the callee body via
+`_build_specialized` in `qamomile/circuit/frontend/qkernel.py`.
+There is no per-signature cache; deeply nested or repeatedly-called
+sub-kernels with identical arguments are re-traced from scratch on
+every call site.
+
+**When it bites**: tracing overhead grows linearly with the number
+of nested call sites that trigger specialization. For most
+applications this is invisible; for code that builds the same
+sub-kernel many times inside a parent tracing pass (e.g., a Python
+loop in the outer kernel body that calls a helper with
+`qmc.qubit_array(n)` each iteration) the overhead becomes visible.
+
+**Workaround**: build the callee once with `helper.build(...)`,
+then operate on the resulting `Block` directly instead of relying
+on the call-time path. Or wait for a follow-up cache.
+
+**Future fix**: per-signature cache keyed by the immutable
+`(parameters, bindings, qubit_sizes)` triple, with a stable hash
+for arbitrary `bindings` values. The stability problem (numpy
+arrays, dicts of arbitrary types) mirrors Qamomile's
+content-addressable hashing convention, so the cache key derivation
+can follow the same `repr()`-based canonicalization that
+`canonical.py` uses.
+
+## Self-recursive shape-dependent stdlib loses gates in recursive layers
+
+When a qkernel calls itself during its own specialized re-trace,
+the inner self-call observes `self._specializing == True` and falls
+back to the cached symbolic `self.block`. The transpiler's
+`inline ↔ partial_eval` loop then unrolls the recursion the same
+way as before this fix. The cached block has shape-dependent stdlib
+ops (qft / iqft / qpe) no-op'd because the recursion-passed
+register is symbolic in the cached trace, so the recursive layers
+do not emit the gate.
+
+**When it bites**: a self-recursive qkernel that applies
+`qmc.qft` / `qmc.iqft` / `qmc.qpe` to a passed-in register and
+recurses. The outer specialized layer keeps the gate, but the
+recursive layers lose it. The fully-unrolled IR ends up with the
+gate applied exactly once regardless of recursion depth, instead
+of once per recursion layer.
+
+**In practice**: this is virtually never written. Standard quantum
+algorithms apply QFT once on a register or in an explicit loop,
+not in a self-recursive shape-shrinking pattern. The Cooley-Tukey
+recursive FFT decomposition has no direct quantum analogue because
+the standard QFT decomposition emits its `O(n²)` gates iteratively.
+The limitation is pinned by
+`test_self_recursive_with_shape_dependent_stdlib_limitation` in
+`tests/circuit/test_qft.py`; if a future change relaxes the
+re-entry guard, that test will need to be updated to the expected
+per-depth count.
+
+**Future fix**: codex's short-term recommendation is *signature
+canonicalization* — replace the boolean `_specializing` flag with
+a set of currently-being-specialized `(parameters, bindings,
+qubit_sizes)` signatures, where each signature is resolved using
+only pure-const expressions already on each `Value`
+(literals, parameters with const bindings, simple `BinOp` / unary
+expressions over const operands). Same signature blocks (true
+infinite loop), different signature re-specializes. Add a maximum
+specialization-depth guard to bound pathological recursion. The
+long-term answer is deferred-shape composite IR (see the qft / iqft
+standalone no-op entry below), which makes this whole class of
+re-trace bug disappear.
+
+## `Matrix[Qubit]` / `Tensor[Qubit]` callee parameters skip specialization
+
+Higher-rank quantum-array parameters are not modeled in the
+`qubit_sizes` bucket. The specialization extractor leaves them out
+of all three buckets and continues, matching how `Dict` / `Tuple` /
+non-parameterizable runtime classicals are handled. The cached
+symbolic block is used for that argument position, with inline-time
+substitution wiring the caller's actual register through.
+
+**When it bites**: a callee that applies shape-dependent stdlib
+(`qmc.qft` / `qmc.iqft` / `qmc.qpe`) directly to a
+`Matrix[Qubit]` / `Tensor[Qubit]` parameter continues to silently
+no-op on those qubits — the same as the pre-#392 baseline for that
+specific case.
+
+**Why this trade-off was chosen**: raising `NotImplementedError`
+for every nested call carrying a higher-rank quantum argument
+would forbid composing any kernel that simply *takes* such an
+argument, including helpers that never touch shape-dependent
+stdlib on it. The silent-no-op trade-off is consistent with how
+`Dict` / `Tuple` / unbound runtime classicals are already handled
+in this PR.
+
+**Future fix**: extend `_extract_calltime_specialization` to
+record multi-dimensional shapes in a new bucket (a
+`qubit_shapes: dict[str, tuple[int, ...]]`), and extend
+`create_dummy_input` to accept multi-rank concrete shapes. Both
+are small mechanical changes; the only reason they are not in this
+PR is scope. Alternatively, the deferred-shape composite IR (next
+entry) makes this entry moot.
+
+## `qmc.qft` / `qmc.iqft` standalone no-op fallback is preserved
+
+The stdlib helpers `qft` / `iqft` (and indirectly `qpe` through the
+same `get_size` contract) silently return the input register
+unchanged when `get_size(qubits)` raises `ValueError`. The factory
+docstring documents this as the fallback for the outer composition
+layer to re-trace once the shape is resolved.
+
+**When it bites**: a kernel containing shape-dependent stdlib that
+is built directly via `my_kernel.build()` without bindings, or
+visualized via `my_kernel.draw()` without arguments, shows an
+empty / partial circuit body for the gate that no-op'd. The
+nested-call path is covered by this PR; the standalone trace path
+is not.
+
+**Why we did not raise instead**: the no-op fallback is also
+reached during `QKernel.block` lazy build, which traces the kernel
+body with all parameters symbolic before any binding is applied.
+Raising at that point would break every kernel that uses
+shape-dependent stdlib on a parameter-driven register, including
+the ones the nested-call path now handles correctly. The
+standalone build path is a debug / inspection surface
+(`transpile()` itself rejects quantum-I/O entrypoints), so users
+who hit it see the documented no-op rather than a crash.
+
+**Future fix**: deferred-shape composite IR — change
+`qmc.qft` / `qmc.iqft` to always emit a `CompositeGateOperation`
+even when the input shape is symbolic, with `num_target_qubits`
+typed as `int | Value`. Lower it at `resolve_parameter_shapes`
+once bindings are applied. This is the codex-recommended
+medium-term refactor and obviates both the standalone no-op above
+and the recursive-layer limitation. The design surface is
+non-trivial: `CompositeGateOperation` itself, serialization,
+canonicalization, resource estimation, backend emitters, and the
+decomposition strategies under `qamomile/circuit/stdlib/` all
+need to handle the symbolic-shape case.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,162 +1,43 @@
 # Known Limitations
 
-This file collects known limitations that survive (or were introduced
-by) the call-time specialization fix for issue #392. Each entry
-documents what the limitation is, when it bites, why the simpler
-fix was deferred, and the future fix path.
+This file collects known limitations that survive (or were introduced by) the call-time specialization fix for issue #392. Each entry documents what the limitation is, when it bites, why the simpler fix was deferred, and the future fix path.
 
 ## Re-trace cost is uncached
 
-Every nested call site that resolves new compile-time information
-about the callee triggers a fresh re-trace of the callee body via
-`_build_specialized` in `qamomile/circuit/frontend/qkernel.py`.
-There is no per-signature cache; deeply nested or repeatedly-called
-sub-kernels with identical arguments are re-traced from scratch on
-every call site.
+Every nested call site that resolves new compile-time information about the callee triggers a fresh re-trace of the callee body via `_build_specialized` in `qamomile/circuit/frontend/qkernel.py`. There is no per-signature cache; deeply nested or repeatedly-called sub-kernels with identical arguments are re-traced from scratch on every call site.
 
-**When it bites**: tracing overhead grows linearly with the number
-of nested call sites that trigger specialization. For most
-applications this is invisible; for code that builds the same
-sub-kernel many times inside a parent tracing pass (e.g., a Python
-loop in the outer kernel body that calls a helper with
-`qmc.qubit_array(n)` each iteration) the overhead becomes visible.
+**When it bites**: tracing overhead grows linearly with the number of nested call sites that trigger specialization. For most applications this is invisible; for code that builds the same sub-kernel many times inside a parent tracing pass (e.g., a Python loop in the outer kernel body that calls a helper with `qmc.qubit_array(n)` each iteration) the overhead becomes visible.
 
-**Workaround**: build the callee once with `helper.build(...)`,
-then operate on the resulting `Block` directly instead of relying
-on the call-time path. Or wait for a follow-up cache.
+**Workaround**: build the callee once with `helper.build(...)`, then operate on the resulting `Block` directly instead of relying on the call-time path. Or wait for a follow-up cache.
 
-**Future fix**: per-signature cache keyed by the immutable
-`(parameters, bindings, qubit_sizes)` triple, with a stable hash
-for arbitrary `bindings` values. The stability problem (numpy
-arrays, dicts of arbitrary types) mirrors Qamomile's
-content-addressable hashing convention, so the cache key derivation
-can follow the same `repr()`-based canonicalization that
-`canonical.py` uses.
+**Future fix**: per-signature cache keyed by the immutable `(parameters, bindings, qubit_sizes)` triple, with a stable hash for arbitrary `bindings` values. The stability problem (numpy arrays, dicts of arbitrary types) mirrors Qamomile's content-addressable hashing convention, so the cache key derivation can follow the same `repr()`-based canonicalization that `canonical.py` uses.
 
 ## Self-recursive shape-dependent stdlib loses gates in recursive layers
 
-When a qkernel calls itself during its own specialized re-trace,
-the inner self-call observes `self._specializing == True` and falls
-back to the cached symbolic `self.block`. The transpiler's
-`inline ↔ partial_eval` loop then unrolls the recursion the same
-way as before this fix. The cached block has shape-dependent stdlib
-ops (qft / iqft / qpe) no-op'd because the recursion-passed
-register is symbolic in the cached trace, so the recursive layers
-do not emit the gate.
+When a qkernel calls itself during its own specialized re-trace, the inner self-call observes `self._specializing == True` and falls back to the cached symbolic `self.block`. The transpiler's `inline ↔ partial_eval` loop then unrolls the recursion the same way as before this fix. The cached block has shape-dependent stdlib ops (qft / iqft / qpe) no-op'd because the recursion-passed register is symbolic in the cached trace, so the recursive layers do not emit the gate.
 
-**When it bites**: a self-recursive qkernel that applies
-`qmc.qft` / `qmc.iqft` / `qmc.qpe` to a passed-in register and
-recurses. The outer specialized layer keeps the gate, but the
-recursive layers lose it. The fully-unrolled IR ends up with the
-gate applied exactly once regardless of recursion depth, instead
-of once per recursion layer.
+**When it bites**: a self-recursive qkernel that applies `qmc.qft` / `qmc.iqft` / `qmc.qpe` to a passed-in register and recurses. The outer specialized layer keeps the gate, but the recursive layers lose it. The fully-unrolled IR ends up with the gate applied exactly once regardless of recursion depth, instead of once per recursion layer.
 
-**In practice**: this is virtually never written. Standard quantum
-algorithms apply QFT once on a register or in an explicit loop,
-not in a self-recursive shape-shrinking pattern. The Cooley-Tukey
-recursive FFT decomposition has no direct quantum analogue because
-the standard QFT decomposition emits its `O(n²)` gates iteratively.
-The limitation is pinned by
-`test_self_recursive_with_shape_dependent_stdlib_limitation` in
-`tests/circuit/test_qft.py`; if a future change relaxes the
-re-entry guard, that test will need to be updated to the expected
-per-depth count.
+**In practice**: this is virtually never written. Standard quantum algorithms apply QFT once on a register or in an explicit loop, not in a self-recursive shape-shrinking pattern. The Cooley-Tukey recursive FFT decomposition has no direct quantum analogue because the standard QFT decomposition emits its `O(n²)` gates iteratively. The limitation is pinned by `test_self_recursive_with_shape_dependent_stdlib_limitation` in `tests/circuit/test_qft.py`; if a future change relaxes the re-entry guard, that test will need to be updated to the expected per-depth count.
 
-**Future fix**: codex's short-term recommendation is *signature
-canonicalization* — replace the boolean `_specializing` flag with
-a set of currently-being-specialized `(parameters, bindings,
-qubit_sizes)` signatures, where each signature is resolved using
-only pure-const expressions already on each `Value`
-(literals, parameters with const bindings, simple `BinOp` / unary
-expressions over const operands). Same signature blocks (true
-infinite loop), different signature re-specializes. Add a maximum
-specialization-depth guard to bound pathological recursion. The
-long-term answer is deferred-shape composite IR (see the qft / iqft
-standalone no-op entry below), which makes this whole class of
-re-trace bug disappear.
+**Future fix**: codex's short-term recommendation is *signature canonicalization* — replace the boolean `_specializing` flag with a set of currently-being-specialized `(parameters, bindings, qubit_sizes)` signatures, where each signature is resolved using only pure-const expressions already on each `Value` (literals, parameters with const bindings, simple `BinOp` / unary expressions over const operands). Same signature blocks (true infinite loop), different signature re-specializes. Add a maximum specialization-depth guard to bound pathological recursion. The long-term answer is deferred-shape composite IR (see the qft / iqft standalone no-op entry below), which makes this whole class of re-trace bug disappear.
 
 ## `Matrix[Qubit]` / `Tensor[Qubit]` callee parameters skip specialization
 
-Higher-rank quantum-array parameters are not modeled in the
-`qubit_sizes` bucket. The specialization extractor leaves them out
-of all three buckets and continues, matching how `Dict` / `Tuple` /
-non-parameterizable runtime classicals are handled. The cached
-symbolic block is used for that argument position, with inline-time
-substitution wiring the caller's actual register through.
+Higher-rank quantum-array parameters are not modeled in the `qubit_sizes` bucket. The specialization extractor leaves them out of all three buckets and continues, matching how `Dict` / `Tuple` / non-parameterizable runtime classicals are handled. The cached symbolic block is used for that argument position, with inline-time substitution wiring the caller's actual register through.
 
-**When it bites**: a callee that applies shape-dependent stdlib
-(`qmc.qft` / `qmc.iqft` / `qmc.qpe`) directly to a
-`Matrix[Qubit]` / `Tensor[Qubit]` parameter continues to silently
-no-op on those qubits — the same as the pre-#392 baseline for that
-specific case.
+**When it bites**: a callee that applies shape-dependent stdlib (`qmc.qft` / `qmc.iqft` / `qmc.qpe`) directly to a `Matrix[Qubit]` / `Tensor[Qubit]` parameter continues to silently no-op on those qubits — the same as the pre-#392 baseline for that specific case.
 
-**Why this trade-off was chosen**: raising `NotImplementedError`
-for every nested call carrying a higher-rank quantum argument
-would forbid composing any kernel that simply *takes* such an
-argument, including helpers that never touch shape-dependent
-stdlib on it. The silent-no-op trade-off is consistent with how
-`Dict` / `Tuple` / unbound runtime classicals are already handled
-in this PR.
+**Why this trade-off was chosen**: raising `NotImplementedError` for every nested call carrying a higher-rank quantum argument would forbid composing any kernel that simply *takes* such an argument, including helpers that never touch shape-dependent stdlib on it. The silent-no-op trade-off is consistent with how `Dict` / `Tuple` / unbound runtime classicals are already handled in this PR.
 
-**Future fix**: change `_extract_calltime_specialization`'s
-`qubit_sizes: dict[str, int]` to a `qubit_shapes:
-dict[str, tuple[int, ...]]` carrying the full shape, then route
-each entry through `_create_traced_block` with the full tuple
-instead of `(qubit_sizes[name],)`. `create_dummy_input` itself
-already accepts any-rank concrete shapes via its `shape=` kwarg
-and validates `len(shape) == ndim`, so the change is confined to
-the specialization data model and the one `_create_traced_block`
-call site. Alternatively, the deferred-shape composite IR (next
-entry) makes this entry moot.
+**Future fix**: change `_extract_calltime_specialization`'s `qubit_sizes: dict[str, int]` to a `qubit_shapes: dict[str, tuple[int, ...]]` carrying the full shape, then route each entry through `_create_traced_block` with the full tuple instead of `(qubit_sizes[name],)`. `create_dummy_input` itself already accepts any-rank concrete shapes via its `shape=` kwarg and validates `len(shape) == ndim`, so the change is confined to the specialization data model and the one `_create_traced_block` call site. Alternatively, the deferred-shape composite IR (next entry) makes this entry moot.
 
 ## `qmc.qft` / `qmc.iqft` standalone no-op fallback is preserved
 
-The stdlib helpers `qft` / `iqft` silently return the input
-register unchanged when `get_size(qubits)` raises `ValueError`.
-`qpe` has the same concrete-shape hazard but a slightly different
-failure shape: it routes through `_get_concrete_size` in
-`qamomile/circuit/stdlib/qpe.py`, which falls back to the symbolic
-`UInt`'s `init_value` (default `0`) rather than raising. The
-result is that a symbolic-counting-size QPE emits a 0-width
-`CompositeGateOperation(IQFT)` and a 0-width `Cast`-to-`QFixed`
-while the surrounding QPE structure (controlled-U loop, etc.) is
-still emitted — partial / incorrect rather than the clean no-op
-of `qft` / `iqft`. The factory docstrings document the
-``get_size``-based fallback for `qft` / `iqft` as the way the
-outer composition layer is expected to re-trace once the shape is
-resolved.
+The stdlib helpers `qft` / `iqft` silently return the input register unchanged when `get_size(qubits)` raises `ValueError`. `qpe` has the same concrete-shape hazard but a slightly different failure shape: it routes through `_get_concrete_size` in `qamomile/circuit/stdlib/qpe.py`, which falls back to the symbolic `UInt`'s `init_value` (default `0`) rather than raising. The result is that a symbolic-counting-size QPE emits a 0-width `CompositeGateOperation(IQFT)` and a 0-width `Cast`-to-`QFixed` while the surrounding QPE structure (controlled-U loop, etc.) is still emitted — partial / incorrect rather than the clean no-op of `qft` / `iqft`. The factory docstrings document the `get_size`-based fallback for `qft` / `iqft` as the way the outer composition layer is expected to re-trace once the shape is resolved.
 
-**When it bites**: a kernel containing shape-dependent stdlib that
-is built directly via `my_kernel.build()` without bindings, or
-visualized via `my_kernel.draw()` without arguments, shows an
-empty / partial circuit body for the gate that no-op'd. The
-nested-call path is covered by this PR; the standalone trace path
-is not.
+**When it bites**: a kernel containing shape-dependent stdlib that is built directly via `my_kernel.build()` without bindings, or visualized via `my_kernel.draw()` without arguments, shows an empty / partial circuit body for the gate that no-op'd. The nested-call path is covered by this PR; the standalone trace path is not.
 
-**Why we did not raise instead**: the no-op fallback is also
-reached during `QKernel.block` lazy build, which traces the kernel
-body with all parameters symbolic before any binding is applied.
-Raising at that point would break every kernel that uses
-shape-dependent stdlib on a parameter-driven register, including
-the ones the nested-call path now handles correctly. The
-standalone build path is a debug / inspection surface
-(`transpile()` itself rejects quantum-I/O entrypoints), so users
-who hit it see the documented no-op rather than a crash.
+**Why we did not raise instead**: the no-op fallback is also reached during `QKernel.block` lazy build, which traces the kernel body with all parameters symbolic before any binding is applied. Raising at that point would break every kernel that uses shape-dependent stdlib on a parameter-driven register, including the ones the nested-call path now handles correctly. The standalone build path is a debug / inspection surface (`transpile()` itself rejects quantum-I/O entrypoints), so users who hit it see the documented no-op rather than a crash.
 
-**Future fix**: deferred-shape composite IR — change
-`qmc.qft` / `qmc.iqft` to always emit a `CompositeGateOperation`
-even when the input shape is symbolic, with `num_target_qubits`
-typed as `int | Value`. Lower it at `resolve_parameter_shapes`
-once bindings are applied. `qpe` needs the parallel change in
-`_emit_iqft_and_cast_to_qfixed`: drop the `_get_concrete_size`
-fallback to `init_value`, emit the inner `CompositeGateOperation
-(IQFT)` and the `Cast`-to-`QFixed` with a symbolic size carried in
-metadata, and lower both at the same `resolve_parameter_shapes`
-stage. This is the codex-recommended medium-term refactor and
-obviates both the standalone no-op above and the recursive-layer
-limitation. The design surface is non-trivial:
-`CompositeGateOperation` itself, `CastOperation` (or
-`QFixedMetadata`), serialization, canonicalization, resource
-estimation, backend emitters, and the decomposition strategies
-under `qamomile/circuit/stdlib/` all need to handle the
-symbolic-shape case.
+**Future fix**: deferred-shape composite IR — change `qmc.qft` / `qmc.iqft` to always emit a `CompositeGateOperation` even when the input shape is symbolic, with `num_target_qubits` typed as `int | Value`. Lower it at `resolve_parameter_shapes` once bindings are applied. `qpe` needs the parallel change in `_emit_iqft_and_cast_to_qfixed`: drop the `_get_concrete_size` fallback to `init_value`, emit the inner `CompositeGateOperation(IQFT)` and the `Cast`-to-`QFixed` with a symbolic size carried in metadata, and lower both at the same `resolve_parameter_shapes` stage. This is the codex-recommended medium-term refactor and obviates both the standalone no-op above and the recursive-layer limitation. The design surface is non-trivial: `CompositeGateOperation` itself, `CastOperation` (or `QFixedMetadata`), serialization, canonicalization, resource estimation, backend emitters, and the decomposition strategies under `qamomile/circuit/stdlib/` all need to handle the symbolic-shape case.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -98,21 +98,33 @@ stdlib on it. The silent-no-op trade-off is consistent with how
 `Dict` / `Tuple` / unbound runtime classicals are already handled
 in this PR.
 
-**Future fix**: extend `_extract_calltime_specialization` to
-record multi-dimensional shapes in a new bucket (a
-`qubit_shapes: dict[str, tuple[int, ...]]`), and extend
-`create_dummy_input` to accept multi-rank concrete shapes. Both
-are small mechanical changes; the only reason they are not in this
-PR is scope. Alternatively, the deferred-shape composite IR (next
+**Future fix**: change `_extract_calltime_specialization`'s
+`qubit_sizes: dict[str, int]` to a `qubit_shapes:
+dict[str, tuple[int, ...]]` carrying the full shape, then route
+each entry through `_create_traced_block` with the full tuple
+instead of `(qubit_sizes[name],)`. `create_dummy_input` itself
+already accepts any-rank concrete shapes via its `shape=` kwarg
+and validates `len(shape) == ndim`, so the change is confined to
+the specialization data model and the one `_create_traced_block`
+call site. Alternatively, the deferred-shape composite IR (next
 entry) makes this entry moot.
 
 ## `qmc.qft` / `qmc.iqft` standalone no-op fallback is preserved
 
-The stdlib helpers `qft` / `iqft` (and indirectly `qpe` through the
-same `get_size` contract) silently return the input register
-unchanged when `get_size(qubits)` raises `ValueError`. The factory
-docstring documents this as the fallback for the outer composition
-layer to re-trace once the shape is resolved.
+The stdlib helpers `qft` / `iqft` silently return the input
+register unchanged when `get_size(qubits)` raises `ValueError`.
+`qpe` has the same concrete-shape hazard but a slightly different
+failure shape: it routes through `_get_concrete_size` in
+`qamomile/circuit/stdlib/qpe.py`, which falls back to the symbolic
+`UInt`'s `init_value` (default `0`) rather than raising. The
+result is that a symbolic-counting-size QPE emits a 0-width
+`CompositeGateOperation(IQFT)` and a 0-width `Cast`-to-`QFixed`
+while the surrounding QPE structure (controlled-U loop, etc.) is
+still emitted — partial / incorrect rather than the clean no-op
+of `qft` / `iqft`. The factory docstrings document the
+``get_size``-based fallback for `qft` / `iqft` as the way the
+outer composition layer is expected to re-trace once the shape is
+resolved.
 
 **When it bites**: a kernel containing shape-dependent stdlib that
 is built directly via `my_kernel.build()` without bindings, or
@@ -135,10 +147,16 @@ who hit it see the documented no-op rather than a crash.
 `qmc.qft` / `qmc.iqft` to always emit a `CompositeGateOperation`
 even when the input shape is symbolic, with `num_target_qubits`
 typed as `int | Value`. Lower it at `resolve_parameter_shapes`
-once bindings are applied. This is the codex-recommended
-medium-term refactor and obviates both the standalone no-op above
-and the recursive-layer limitation. The design surface is
-non-trivial: `CompositeGateOperation` itself, serialization,
-canonicalization, resource estimation, backend emitters, and the
-decomposition strategies under `qamomile/circuit/stdlib/` all
-need to handle the symbolic-shape case.
+once bindings are applied. `qpe` needs the parallel change in
+`_emit_iqft_and_cast_to_qfixed`: drop the `_get_concrete_size`
+fallback to `init_value`, emit the inner `CompositeGateOperation
+(IQFT)` and the `Cast`-to-`QFixed` with a symbolic size carried in
+metadata, and lower both at the same `resolve_parameter_shapes`
+stage. This is the codex-recommended medium-term refactor and
+obviates both the standalone no-op above and the recursive-layer
+limitation. The design surface is non-trivial:
+`CompositeGateOperation` itself, `CastOperation` (or
+`QFixedMetadata`), serialization, canonicalization, resource
+estimation, backend emitters, and the decomposition strategies
+under `qamomile/circuit/stdlib/` all need to handle the
+symbolic-shape case.

--- a/qamomile/circuit/frontend/func_to_block.py
+++ b/qamomile/circuit/frontend/func_to_block.py
@@ -301,17 +301,39 @@ def create_dummy_handle(
 
 
 def create_dummy_input(
-    param_type: typing.Any, name: str = "param", emit_init: bool = True
+    param_type: typing.Any,
+    name: str = "param",
+    emit_init: bool = True,
+    *,
+    shape: tuple[int, ...] | None = None,
 ) -> Handle:
     """Create a dummy input based on parameter type annotation.
 
     Args:
-        param_type: The type annotation for the parameter.
-        name: Name for the value.
-        emit_init: If True, emit QInitOperation for qubit arrays (default: True).
-                   Set to False when creating a nested Block's internal dummy inputs.
+        param_type (Any): The type annotation for the parameter.
+        name (str): Name for the value.
+        emit_init (bool): If True, emit QInitOperation for qubit arrays
+            (default: True). Set to False when creating a nested Block's
+            internal dummy inputs, or when the dummy will receive its
+            qubits from a caller's CallBlockOperation.
+        shape (tuple[int, ...] | None): Optional concrete shape for array
+            types. When provided, the dummy array's shape Values carry
+            compile-time constants instead of symbolic placeholders.
+            Used by call-time sub-kernel specialization so that
+            shape-dependent stdlib helpers (qft / iqft / qpe) resolve
+            ``get_size`` to a concrete integer and emit the correct gate
+            sequence. Ignored for non-array types. Default: None
+            (symbolic shape).
 
-    This creates input Handles for function parameters.
+    Returns:
+        Handle: A frontend Handle wrapping a dummy Value or ArrayValue
+            suitable for use as a function-parameter input during
+            tracing.
+
+    Raises:
+        TypeError: If ``param_type`` is not a supported parameter type,
+            or if a Tuple/array annotation is missing its element
+            type(s).
     """
     # Handle Tuple types (e.g., Tuple[UInt, UInt])
     if is_tuple_type(param_type):
@@ -379,12 +401,24 @@ def create_dummy_input(
         # Determine number of dimensions (Vector=1, Matrix=2, Tensor=3)
         ndim = _get_ndim(param_type)
 
-        # Create symbolic dimension Values
-        shape_values = tuple(
-            Value(type=UIntType(), name=f"{name}_dim{i}") for i in range(ndim)
-        )
+        if shape is not None:
+            if len(shape) != ndim:
+                raise TypeError(
+                    f"Concrete shape {shape!r} has {len(shape)} dimensions "
+                    f"but parameter '{name}' of type {param_type} expects "
+                    f"{ndim} dimension(s)."
+                )
+            shape_values = tuple(
+                Value(type=UIntType(), name=f"{name}_dim{i}").with_const(dim)
+                for i, dim in enumerate(shape)
+            )
+        else:
+            # Symbolic dimensions for the standalone trace path.
+            shape_values = tuple(
+                Value(type=UIntType(), name=f"{name}_dim{i}") for i in range(ndim)
+            )
 
-        # Create ArrayValue with symbolic shape
+        # Create ArrayValue with the resolved shape
         array_value = ArrayValue(
             type=element_ir_type,
             name=name,

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -34,7 +34,7 @@ from qamomile.circuit.frontend.handle import Observable, Qubit
 from qamomile.circuit.frontend.handle.array import ArrayBase, Vector
 from qamomile.circuit.frontend.handle.containers import Dict
 from qamomile.circuit.frontend.handle.primitives import Bit, Float, Handle, UInt
-from qamomile.circuit.frontend.handle.utils import get_size as _get_qubit_array_size
+from qamomile.circuit.frontend.handle.utils import get_size as _get_size
 from qamomile.circuit.frontend.tracer import Tracer, get_current_tracer, trace
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
@@ -1027,13 +1027,9 @@ class QKernel(Generic[P, R]):
 
         for name, param in self.signature.parameters.items():
             param_type = self.input_types.get(name, param.annotation)
-            handle = arguments[name]
-            assert isinstance(handle, Handle), (
-                f"Internal invariant violated: argument {name!r} should "
-                f"already be a Handle by the time "
-                f"_extract_calltime_specialization runs (upstream check "
-                f"at __call__)."
-            )
+            handle = arguments.get(name)
+            if not isinstance(handle, Handle):
+                return None
 
             # Scalar Qubit: no specialization-relevant info to extract;
             # ``_create_traced_block`` will fall through to the regular
@@ -1075,12 +1071,12 @@ class QKernel(Generic[P, R]):
             ):
                 if getattr(param_type, "__origin__", param_type) is not Vector:
                     continue
-                # ``_get_qubit_array_size`` is declared over ``Vector``;
-                # the two checks above narrow ``handle`` to a
-                # ``Vector[Qubit]``, but the type system cannot see
-                # that — cast for the call.
+                # ``_get_size`` is declared over ``Vector``; the two
+                # checks above narrow ``handle`` to a ``Vector[Qubit]``,
+                # but the type system cannot see that — cast for the
+                # call.
                 try:
-                    size = _get_qubit_array_size(cast(Vector[Qubit], handle))
+                    size = _get_size(cast(Vector[Qubit], handle))
                 except ValueError:
                     continue
                 qubit_sizes[name] = size

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -992,10 +992,15 @@ class QKernel(Generic[P, R]):
         shapes are known.
 
         Args:
-            arguments (dict[str, Any]): Pre-consume mapping from
+            arguments (dict[str, Any]): Pre-consumption mapping from
                 parameter name to the caller's frontend
                 :class:`Handle`, as produced by
                 ``signature.bind(...).arguments`` in :meth:`__call__`.
+                The handles are inspected here before the call site
+                consumes them, so the extractor can read
+                ``handle.value`` metadata (``get_const``,
+                ``get_const_array``, ``dict_runtime``) without
+                affecting the affine-type ledger.
 
         Returns:
             tuple[list[str], dict[str, Any], dict[str, int]] | None:
@@ -1008,30 +1013,26 @@ class QKernel(Generic[P, R]):
                 argument names to their resolved first-axis sizes.
                 Arguments that cannot enter any of the three buckets
                 (scalar ``Qubit``, scalar ``Observable``, unbound
-                ``Vector[Observable]``, unbound ``Dict`` parameters,
-                ``Tuple`` parameters, and non-parameterizable
-                classical types like ``Bit`` / ``bool`` /
-                ``Vector[Bit]`` / ``Vector[bool]`` without a
-                compile-time constant) are deliberately left out so
-                that :meth:`_create_traced_block` falls back to its
-                standard ``create_dummy_input`` path for those argument
-                positions; specialization of the rest of the call
-                proceeds normally and inline-time substitution
-                supplies the caller's actual Value. Returns ``None``
-                only when no specialization is beneficial — i.e. the
-                call adds no new compile-time information over the
-                cached symbolic block. In the ``None`` case
-                ``__call__`` falls back to ``self.block``.
-
-        Raises:
-            NotImplementedError: If ``arguments`` contains a quantum
-                array argument that is not a 1-D ``Vector[Qubit]``
-                (e.g., ``Matrix[Qubit]`` / ``Tensor[Qubit]``).
-                Higher-rank quantum-array specialization is not yet
-                implemented, and silently falling back to the cached
-                symbolic block would lose shape-dependent stdlib gates
-                applied inside the callee — surfacing the limitation
-                as an exception prevents that.
+                ``Vector[Observable]``, multi-dimensional qubit
+                arrays — ``Matrix[Qubit]`` / ``Tensor[Qubit]`` —
+                unbound ``Dict`` parameters, ``Tuple`` parameters,
+                and non-parameterizable classical types like
+                ``Bit`` / ``bool`` / ``Vector[Bit]`` / ``Vector[bool]``
+                without a compile-time constant) are deliberately
+                left out so that :meth:`_create_traced_block` handles
+                those argument positions via its standard path
+                (``_create_parameter_input`` for ``Observable``,
+                ``create_dummy_input`` fall-through for everything
+                else); specialization of the rest of the call proceeds
+                normally and inline-time substitution supplies the
+                caller's actual Value. Returns ``None`` in two cases:
+                (a) the extractor encounters an argument type that
+                does not match any of the modeled branches above (the
+                catch-all at the bottom of the loop), or (b) the
+                modeled branches contributed no useful information
+                (``bindings`` and ``qubit_sizes`` are both empty at
+                the end). In the ``None`` case ``__call__`` falls
+                back to ``self.block``.
         """
         parameters: list[str] = []
         bindings: dict[str, Any] = {}
@@ -1084,31 +1085,27 @@ class QKernel(Generic[P, R]):
             # case: we extract the first-axis size via ``get_size`` and
             # carry it in ``qubit_sizes`` so the callee re-traces with
             # a concrete shape. ``Matrix[Qubit]`` / ``Tensor[Qubit]``
-            # are higher-rank registers; we do not yet have the
-            # multi-dim shape extraction nor the ``create_dummy_input
-            # (shape=...)`` plumbing for them, so passing one through a
-            # nested call would mean shape-dependent stdlib stays
-            # silently no-op'd on those qubits. Surface that as an
-            # explicit ``NotImplementedError`` rather than letting the
-            # call silently produce a wrong-unitary circuit.
+            # are higher-rank registers; we do not yet extract their
+            # multi-dim shape nor have the ``create_dummy_input
+            # (shape=...)`` plumbing for them, so we treat them like
+            # ``Dict`` / ``Tuple`` — leave the argument out of all
+            # three buckets and ``continue``. ``_create_traced_block``
+            # falls through to ``create_dummy_input`` for that
+            # position (matching the cached block), and the rest of
+            # the call still benefits from specialization. The
+            # trade-off: if the callee applies shape-dependent stdlib
+            # to the higher-rank register, that op continues to
+            # silently no-op — same as the pre-#392 baseline for
+            # that specific case. Raising here instead would forbid
+            # any nested call that takes a ``Matrix[Qubit]`` /
+            # ``Tensor[Qubit]``, even kernels that never touch
+            # shape-dependent stdlib on it.
             if (
                 is_array_type(param_type)
                 and _get_array_element_type(param_type) is Qubit
             ):
                 if getattr(param_type, "__origin__", param_type) is not Vector:
-                    raise NotImplementedError(
-                        f"Nested @qkernel call of '{self.name}' received "
-                        f"argument {name!r} of type {param_type!r}. "
-                        f"Call-time specialization currently supports only "
-                        f"``Vector[Qubit]`` for quantum-array inputs; "
-                        f"``Matrix[Qubit]`` / ``Tensor[Qubit]`` are not "
-                        f"yet supported and would silently lose "
-                        f"shape-dependent stdlib gates (qft, iqft, qpe) "
-                        f"applied inside the callee. Reshape the call "
-                        f"site so the callee receives a 1-D "
-                        f"``Vector[Qubit]`` view, or file an issue if "
-                        f"you need higher-rank specialization."
-                    )
+                    continue
                 # ``_get_size`` is declared over ``Vector``; the two
                 # checks above narrow ``handle`` to a ``Vector[Qubit]``,
                 # but the type system cannot see that — cast for the

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1007,21 +1007,30 @@ class QKernel(Generic[P, R]):
                 values, and ``qubit_sizes`` maps ``Vector[Qubit]``
                 argument names to their resolved first-axis sizes.
                 Scalar ``Qubit``, scalar ``Observable``, unbound
-                ``Vector[Observable]``, multi-dimensional qubit arrays
-                (``Matrix[Qubit]`` / ``Tensor[Qubit]``), unbound
-                ``Dict`` parameters, and ``Tuple`` parameters are
-                deliberately left out of all three buckets so that
-                :meth:`_create_traced_block` falls back to its standard
-                ``create_dummy_input`` handling for those argument
-                positions while still specializing the rest of the
-                call. Returns ``None`` only when no specialization is
-                beneficial (the call adds no new compile-time
-                information over the cached symbolic block) or when an
-                argument has a non-parameterizable classical type
+                ``Vector[Observable]``, unbound ``Dict`` parameters,
+                and ``Tuple`` parameters are deliberately left out of
+                all three buckets so that :meth:`_create_traced_block`
+                falls back to its standard ``create_dummy_input``
+                handling for those argument positions while still
+                specializing the rest of the call. Returns ``None``
+                only when no specialization is beneficial (the call
+                adds no new compile-time information over the cached
+                symbolic block) or when an argument has a
+                non-parameterizable classical type
                 (``Bit`` / ``bool`` / ``Vector[Bit]`` / ``Vector[bool]``)
                 with no compile-time constant — that combination has
                 nowhere to live in the specialization triple. In the
                 ``None`` case ``__call__`` falls back to ``self.block``.
+
+        Raises:
+            NotImplementedError: If ``arguments`` contains a quantum
+                array argument that is not a 1-D ``Vector[Qubit]``
+                (e.g., ``Matrix[Qubit]`` / ``Tensor[Qubit]``).
+                Higher-rank quantum-array specialization is not yet
+                implemented, and silently falling back to the cached
+                symbolic block would lose shape-dependent stdlib gates
+                applied inside the callee — surfacing the limitation
+                as an exception prevents that.
         """
         parameters: list[str] = []
         bindings: dict[str, Any] = {}
@@ -1070,19 +1079,35 @@ class QKernel(Generic[P, R]):
                     bindings[name] = const_array
                 continue
 
-            # Quantum array: only ``Vector[Qubit]`` is currently safe to
-            # specialize — ``Matrix[Qubit]`` / ``Tensor[Qubit]`` callees
-            # need multi-dim shape info that we do not yet extract, and
-            # passing a 1-element shape tuple would fail the
-            # ``create_dummy_input`` dimensionality check. For higher-
-            # rank quantum arrays, leave that argument's shape symbolic
-            # — specialization on other arguments may still proceed.
+            # Quantum array. ``Vector[Qubit]`` is the fully supported
+            # case: we extract the first-axis size via ``get_size`` and
+            # carry it in ``qubit_sizes`` so the callee re-traces with
+            # a concrete shape. ``Matrix[Qubit]`` / ``Tensor[Qubit]``
+            # are higher-rank registers; we do not yet have the
+            # multi-dim shape extraction nor the ``create_dummy_input
+            # (shape=...)`` plumbing for them, so passing one through a
+            # nested call would mean shape-dependent stdlib stays
+            # silently no-op'd on those qubits. Surface that as an
+            # explicit ``NotImplementedError`` rather than letting the
+            # call silently produce a wrong-unitary circuit.
             if (
                 is_array_type(param_type)
                 and _get_array_element_type(param_type) is Qubit
             ):
                 if getattr(param_type, "__origin__", param_type) is not Vector:
-                    continue
+                    raise NotImplementedError(
+                        f"Nested @qkernel call of '{self.name}' received "
+                        f"argument {name!r} of type {param_type!r}. "
+                        f"Call-time specialization currently supports only "
+                        f"``Vector[Qubit]`` for quantum-array inputs; "
+                        f"``Matrix[Qubit]`` / ``Tensor[Qubit]`` are not "
+                        f"yet supported and would silently lose "
+                        f"shape-dependent stdlib gates (qft, iqft, qpe) "
+                        f"applied inside the callee. Reshape the call "
+                        f"site so the callee receives a 1-D "
+                        f"``Vector[Qubit]`` view, or file an issue if "
+                        f"you need higher-rank specialization."
+                    )
                 # ``_get_size`` is declared over ``Vector``; the two
                 # checks above narrow ``handle`` to a ``Vector[Qubit]``,
                 # but the type system cannot see that — cast for the

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1007,19 +1007,21 @@ class QKernel(Generic[P, R]):
                 values, and ``qubit_sizes`` maps ``Vector[Qubit]``
                 argument names to their resolved first-axis sizes.
                 Scalar ``Qubit``, scalar ``Observable``, unbound
-                ``Vector[Observable]``, and multi-dimensional qubit
-                arrays (``Matrix[Qubit]`` / ``Tensor[Qubit]``) are
+                ``Vector[Observable]``, multi-dimensional qubit arrays
+                (``Matrix[Qubit]`` / ``Tensor[Qubit]``), unbound
+                ``Dict`` parameters, and ``Tuple`` parameters are
                 deliberately left out of all three buckets so that
                 :meth:`_create_traced_block` falls back to its standard
-                handling for those argument positions while still
-                specializing the rest of the call. Returns ``None``
-                when no specialization is beneficial (the call adds no
-                new compile-time information over the cached symbolic
-                block) or when an argument cannot be safely handled
-                (``Tuple``, a non-parameterizable classical type that
-                also has no compile-time constant, an unbound ``Dict``
-                parameter, etc.). In the ``None`` case ``__call__``
-                falls back to ``self.block``.
+                ``create_dummy_input`` handling for those argument
+                positions while still specializing the rest of the
+                call. Returns ``None`` only when no specialization is
+                beneficial (the call adds no new compile-time
+                information over the cached symbolic block) or when an
+                argument has a non-parameterizable classical type
+                (``Bit`` / ``bool`` / ``Vector[Bit]`` / ``Vector[bool]``)
+                with no compile-time constant — that combination has
+                nowhere to live in the specialization triple. In the
+                ``None`` case ``__call__`` falls back to ``self.block``.
         """
         parameters: list[str] = []
         bindings: dict[str, Any] = {}
@@ -1028,8 +1030,18 @@ class QKernel(Generic[P, R]):
         for name, param in self.signature.parameters.items():
             param_type = self.input_types.get(name, param.annotation)
             handle = arguments.get(name)
-            if not isinstance(handle, Handle):
-                return None
+            # ``QKernel.__call__`` rejects non-``Handle`` arguments before
+            # this method is reached, so an offending ``handle`` here is
+            # a programmer error in the upstream call site, not a
+            # normal specialization-abort condition. Use ``assert``
+            # (Section L of CLAUDE.md: ``assert`` for internal
+            # invariants).
+            assert isinstance(handle, Handle), (
+                f"Internal invariant violated: argument {name!r} should "
+                f"already be a Handle by the time "
+                f"_extract_calltime_specialization runs (upstream check "
+                f"at __call__)."
+            )
 
             # Scalar Qubit: no specialization-relevant info to extract;
             # ``_create_traced_block`` will fall through to the regular
@@ -1082,11 +1094,15 @@ class QKernel(Generic[P, R]):
                 qubit_sizes[name] = size
                 continue
 
-            # Classical scalar. Prefer the compile-time constant. Fall
-            # back to keeping it as a runtime parameter only when the
-            # type is parameterizable (``_validate_parameters`` rejects
-            # ``Bit`` / ``bool``); otherwise abort so the cached
-            # symbolic block path is used.
+            # Classical scalar. Bind the compile-time constant when
+            # available. If not, the only way to keep the value live
+            # through the specialized trace is as a runtime parameter
+            # via the ``parameters`` list — but ``_validate_parameters``
+            # only admits ``UInt`` / ``Float`` / ``int`` / ``float`` and
+            # their arrays. ``Bit`` / ``bool`` without a constant has
+            # nowhere to go (``bindings`` needs a value, ``parameters``
+            # would be rejected downstream), so we abort and let the
+            # cached symbolic ``self.block`` handle the call.
             if param_type in (int, UInt, float, Float, bool, Bit):
                 const_value = handle.value.get_const()
                 if const_value is not None:
@@ -1097,9 +1113,11 @@ class QKernel(Generic[P, R]):
                     return None
                 continue
 
-            # Classical array. Same pattern as scalars: bind when a
-            # constant array is known, otherwise either pass through as
-            # a runtime parameter (when parameterizable) or abort.
+            # Classical array. Same dead-end logic as scalars: bind the
+            # const array when available, otherwise list as a runtime
+            # parameter when parameterizable. ``Vector[Bit]`` /
+            # ``Vector[bool]`` without a const has neither option and
+            # aborts.
             if is_array_type(param_type):
                 const_array = handle.value.get_const_array()
                 if const_array is not None:
@@ -1115,15 +1133,30 @@ class QKernel(Generic[P, R]):
             # ``_create_bound_input``), so it can't distinguish the two.
             # Use the presence of ``dict_runtime`` metadata instead — it
             # is set if and only if the caller bound a concrete dict
-            # value, even if that dict is empty.
+            # value, even if that dict is empty. When no metadata is
+            # present, ``continue`` without entering any bucket so
+            # ``_create_traced_block``'s fall-through ``create_dummy_input``
+            # path produces a symbolic Dict dummy (the same shape the
+            # cached ``self.block`` would carry). Specialization on
+            # other arguments still proceeds — only this Dict stays
+            # symbolic.
             if is_dict_type(param_type):
                 if handle.value.metadata.dict_runtime is None:
-                    return None
+                    continue
                 bindings[name] = handle.value.get_bound_data()
                 continue
 
-            # Tuple and anything else not modeled above: fall back to
-            # the symbolic block path rather than guess.
+            # ``Tuple``. We do not yet have a ``_create_bound_input``
+            # branch for tuples and ``Tuple`` is not parameterizable,
+            # so there is no bucket we can place a tuple argument into.
+            # ``continue`` is still safe: ``_create_traced_block``'s
+            # fall-through ``create_dummy_input`` path creates a
+            # symbolic ``TupleValue`` dummy, matching the cached block.
+            if is_tuple_type(param_type):
+                continue
+
+            # Anything else not modeled above: abort and let the cached
+            # symbolic block path handle the call.
             return None
 
         # Skip specialization when it would not change the traced

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -34,9 +34,11 @@ from qamomile.circuit.frontend.handle import Observable, Qubit
 from qamomile.circuit.frontend.handle.array import ArrayBase, Vector
 from qamomile.circuit.frontend.handle.containers import Dict
 from qamomile.circuit.frontend.handle.primitives import Bit, Float, Handle, UInt
+from qamomile.circuit.frontend.handle.utils import get_size as _get_qubit_array_size
 from qamomile.circuit.frontend.tracer import Tracer, get_current_tracer, trace
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
+from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.types import BitType, FloatType, ObservableType, UIntType
 from qamomile.circuit.ir.value import ArrayValue, DictValue, Value
 from qamomile.circuit.transpiler.errors import FrontendTransformError
@@ -220,6 +222,11 @@ class QKernel(Generic[P, R]):
         # Lazy initialization for hierarchical Block
         self._block: Block | None = None
         self._block_building: bool = False
+        # Reentry guard for :meth:`__call__`'s call-time specialization
+        # path. While the specialized re-trace runs the kernel body,
+        # any self-call must fall back to the cached ``self.block`` to
+        # avoid unbounded re-tracing of self-recursive kernels.
+        self._specializing: bool = False
         # CallBlockOperations emitted by self-recursive calls during the
         # build get their ``block`` reference back-patched to ``self._block``
         # once ``func_to_block`` returns.  See _finalize_pending_self_calls.
@@ -483,8 +490,32 @@ class QKernel(Generic[P, R]):
         if self._block_building:
             call_op = self._emit_self_call_forward_ref(inputs_map)
         else:
-            # Ensure the block IR is compiled
-            block_ir = self.block
+            # When the call site has fully resolved either the classical
+            # bindings or the ``Vector[Qubit]`` sizes, re-trace a
+            # specialized sub-block instead of reusing the cached
+            # symbolic ``self.block``. Shape-dependent stdlib helpers
+            # (``qmc.qft`` / ``qmc.iqft`` / ``qmc.qpe``) silently no-op
+            # when their input vector has a symbolic shape; specializing
+            # here is what makes those helpers emit the correct gate
+            # sequence when wrapped inside an outer kernel. The
+            # ``_specializing`` guard breaks the re-trace loop for
+            # self-recursive kernels (see ``_extract_calltime_specialization``).
+            block_ir = None
+            if not self._specializing:
+                spec = self._extract_calltime_specialization(bound_args.arguments)
+                if spec is not None:
+                    sub_parameters, sub_bindings, sub_qubit_sizes = spec
+                    self._specializing = True
+                    try:
+                        block_ir = self._build_specialized(
+                            parameters=sub_parameters,
+                            bindings=sub_bindings,
+                            qubit_sizes=sub_qubit_sizes,
+                        )
+                    finally:
+                        self._specializing = False
+            if block_ir is None:
+                block_ir = self.block
 
             # Create the Call operation
             call_op = block_ir.call(**inputs_map)
@@ -938,27 +969,267 @@ class QKernel(Generic[P, R]):
 
         return estimate_resources(self.block, bindings=bindings)
 
+    def _extract_calltime_specialization(
+        self,
+        arguments: dict[str, Any],
+    ) -> tuple[list[str], dict[str, Any], dict[str, int]] | None:
+        """Extract call-time specialization data for a sub-kernel call.
+
+        Inspects each argument bound at the call site and decides whether
+        the sub-kernel body can be productively re-traced with concrete
+        information (constant classical values and / or known ``Vector
+        [Qubit]`` sizes). The triple returned mirrors the input contract
+        of :meth:`_create_traced_block` and is consumed by
+        :meth:`_build_specialized`.
+
+        The motivation is to make shape-dependent stdlib helpers
+        (``qmc.qft`` / ``qmc.iqft`` / ``qmc.qpe``) emit the correct gate
+        sequence when invoked through a sub-kernel call. Those helpers
+        silently fall back to a no-op when ``get_size`` of their input
+        register fails (because the shape is still symbolic in a
+        cached, never-specialized ``self.block``), so the outer
+        composition layer must re-trace the callee once the relevant
+        shapes are known.
+
+        Args:
+            arguments (dict[str, Any]): Pre-consume mapping from
+                parameter name to the caller's frontend
+                :class:`Handle`, as produced by
+                ``signature.bind(...).arguments`` in :meth:`__call__`.
+
+        Returns:
+            tuple[list[str], dict[str, Any], dict[str, int]] | None:
+                On success, a triple
+                ``(parameters, bindings, qubit_sizes)`` where
+                ``parameters`` lists classical argument names that
+                remain symbolic at the call site, ``bindings`` maps
+                classical arguments to their compile-time-known Python
+                values, and ``qubit_sizes`` maps ``Vector[Qubit]``
+                argument names to their resolved first-axis sizes.
+                Scalar ``Qubit``, scalar ``Observable``, unbound
+                ``Vector[Observable]``, and multi-dimensional qubit
+                arrays (``Matrix[Qubit]`` / ``Tensor[Qubit]``) are
+                deliberately left out of all three buckets so that
+                :meth:`_create_traced_block` falls back to its standard
+                handling for those argument positions while still
+                specializing the rest of the call. Returns ``None``
+                when no specialization is beneficial (the call adds no
+                new compile-time information over the cached symbolic
+                block) or when an argument cannot be safely handled
+                (``Tuple``, a non-parameterizable classical type that
+                also has no compile-time constant, an unbound ``Dict``
+                parameter, etc.). In the ``None`` case ``__call__``
+                falls back to ``self.block``.
+        """
+        parameters: list[str] = []
+        bindings: dict[str, Any] = {}
+        qubit_sizes: dict[str, int] = {}
+
+        for name, param in self.signature.parameters.items():
+            param_type = self.input_types.get(name, param.annotation)
+            handle = arguments.get(name)
+            if not isinstance(handle, Handle):
+                return None
+
+            # Scalar Qubit: no specialization-relevant info to extract;
+            # ``_create_traced_block`` will fall through to the regular
+            # ``create_dummy_input`` path, which yields a standalone
+            # symbolic Qubit dummy. The caller's Value is bound to that
+            # dummy at inline time, so behavior matches the symbolic
+            # block.
+            if param_type is Qubit:
+                continue
+
+            # Scalar Observable and unbound ``Vector[Observable]``:
+            # ``_create_traced_block`` already auto-tracks these as
+            # symbolic parameters regardless of the ``parameters`` list,
+            # so we let them flow through untouched. A *bound*
+            # ``Vector[Observable]`` (the caller passed concrete
+            # observables) falls into the classical-array branch below
+            # and gets baked in via ``bindings``.
+            if param_type is Observable:
+                continue
+            if (
+                is_array_type(param_type)
+                and _get_array_element_type(param_type) is Observable
+            ):
+                const_array = handle.value.get_const_array()
+                if const_array is not None:
+                    bindings[name] = const_array
+                continue
+
+            # Quantum array: only ``Vector[Qubit]`` is currently safe to
+            # specialize — ``Matrix[Qubit]`` / ``Tensor[Qubit]`` callees
+            # need multi-dim shape info that we do not yet extract, and
+            # passing a 1-element shape tuple would fail the
+            # ``create_dummy_input`` dimensionality check. For higher-
+            # rank quantum arrays, leave that argument's shape symbolic
+            # — specialization on other arguments may still proceed.
+            if (
+                is_array_type(param_type)
+                and _get_array_element_type(param_type) is Qubit
+            ):
+                if getattr(param_type, "__origin__", param_type) is not Vector:
+                    continue
+                # ``_get_qubit_array_size`` is declared over ``Vector``;
+                # the two checks above narrow ``handle`` to a
+                # ``Vector[Qubit]``, but the type system cannot see
+                # that — cast for the call.
+                try:
+                    size = _get_qubit_array_size(cast(Vector[Qubit], handle))
+                except ValueError:
+                    continue
+                qubit_sizes[name] = size
+                continue
+
+            # Classical scalar. Prefer the compile-time constant. Fall
+            # back to keeping it as a runtime parameter only when the
+            # type is parameterizable (``_validate_parameters`` rejects
+            # ``Bit`` / ``bool``); otherwise abort so the cached
+            # symbolic block path is used.
+            if param_type in (int, UInt, float, Float, bool, Bit):
+                const_value = handle.value.get_const()
+                if const_value is not None:
+                    bindings[name] = const_value
+                elif self._is_parameterizable_type(param_type):
+                    parameters.append(name)
+                else:
+                    return None
+                continue
+
+            # Classical array. Same pattern as scalars: bind when a
+            # constant array is known, otherwise either pass through as
+            # a runtime parameter (when parameterizable) or abort.
+            if is_array_type(param_type):
+                const_array = handle.value.get_const_array()
+                if const_array is not None:
+                    bindings[name] = const_array
+                elif self._is_parameterizable_type(param_type):
+                    parameters.append(name)
+                else:
+                    return None
+                continue
+
+            # Dict. ``handle.value.parameter_name()`` is set both for
+            # unbound dicts and for bound ones (see
+            # ``_create_bound_input``), so it can't distinguish the two.
+            # Use the presence of ``dict_runtime`` metadata instead — it
+            # is set if and only if the caller bound a concrete dict
+            # value, even if that dict is empty.
+            if is_dict_type(param_type):
+                if handle.value.metadata.dict_runtime is None:
+                    return None
+                bindings[name] = handle.value.get_bound_data()
+                continue
+
+            # Tuple and anything else not modeled above: fall back to
+            # the symbolic block path rather than guess.
+            return None
+
+        # Skip specialization when it would not change the traced
+        # body. Re-tracing with no new constants is wasted work and
+        # would only obscure the cached ``self.block`` path.
+        if not bindings and not qubit_sizes:
+            return None
+
+        return parameters, bindings, qubit_sizes
+
+    def _build_specialized(
+        self,
+        *,
+        parameters: list[str],
+        bindings: dict[str, Any],
+        qubit_sizes: dict[str, int],
+    ) -> Block:
+        """Trace a specialized sub-block for a call site.
+
+        Wraps :meth:`_create_traced_block` with the validations that
+        :meth:`build` performs (parameter-name validation, rebind-
+        violation check, output-name extraction) and disables
+        ``QInitOperation`` emission for ``qubit_sizes`` entries — the
+        caller's outer ``CallBlockOperation`` supplies those qubits, so
+        emitting an init here would double-allocate the register after
+        inlining.
+
+        Args:
+            parameters (list[str]): Classical argument names that
+                remain symbolic in the specialized block (typically
+                because the call site itself sees them as runtime
+                parameters of the outer kernel).
+            bindings (dict[str, Any]): Concrete Python values for
+                classical arguments, baked into the block at trace
+                time.
+            qubit_sizes (dict[str, int]): First-axis sizes for
+                ``Vector[Qubit]`` arguments. Each entry is realized as
+                a dummy input with a concrete shape (no
+                ``QInitOperation``).
+
+        Returns:
+            Block: The specialized hierarchical block, ready to be the
+                target of :meth:`Block.call` from the caller's tracer.
+        """
+        self._check_rebind_violations()
+        self._validate_parameters(parameters)
+        block = self._create_traced_block(
+            parameters,
+            bindings,
+            qubit_sizes=qubit_sizes,
+            emit_qubit_init=False,
+            emit_return_op=True,
+        )
+        block.output_names = self._extract_return_names() or []
+        return block
+
     def _create_traced_block(
         self,
         parameters: list[str],
         kwargs: dict[str, Any],
         qubit_sizes: dict[str, int] | None = None,
+        *,
+        emit_qubit_init: bool = True,
+        emit_return_op: bool = False,
     ) -> Block:
         """Trace the kernel and return a Block.
 
-        This is the shared implementation for :meth:`build` and
-        :meth:`_build_graph_with_qubit_arrays`.
+        This is the shared implementation for :meth:`build`,
+        :meth:`_build_graph_with_qubit_arrays`, and the call-time
+        specialization path used by :meth:`__call__`.
 
         Args:
-            parameters: Argument names to keep as unbound parameters.
-            kwargs: Concrete values for non-parameter arguments.
-            qubit_sizes: Optional mapping from Vector[Qubit] parameter names
-                to integer sizes.  When provided, the corresponding arguments
-                are created via ``qubit_array()`` instead of the normal dummy
-                input path.
+            parameters (list[str]): Argument names to keep as unbound
+                parameters.
+            kwargs (dict[str, Any]): Concrete values for non-parameter
+                arguments.
+            qubit_sizes (dict[str, int] | None): Optional mapping from
+                ``Vector[Qubit]`` parameter names to integer sizes. When
+                provided, the corresponding arguments are created with
+                concrete shape so shape-dependent stdlib helpers
+                (``qft`` / ``iqft`` / ``qpe``) emit the expected gate
+                sequence.
+            emit_qubit_init (bool): When True (default), entries in
+                ``qubit_sizes`` are realized via :func:`qubit_array`,
+                which emits a ``QInitOperation`` — appropriate for
+                top-level visualization / direct ``build()`` use. When
+                False, the dummy quantum array is created without a
+                ``QInitOperation`` because the call site will supply
+                the qubits through a ``CallBlockOperation``; emitting
+                an init in that case would double-allocate the
+                register after inlining.
+            emit_return_op (bool): When True, append a
+                ``ReturnOperation`` to the traced operations so the
+                inline pass can locate the cloned return Values when
+                this block is used as the target of a
+                ``CallBlockOperation`` (the call-time specialization
+                path). The default ``False`` preserves the historical
+                behavior of :meth:`build` (top-level entrypoint blocks
+                consumed by ``transpile()``), where downstream code
+                reads ``output_values`` directly and an explicit
+                ``ReturnOperation`` is unnecessary.
 
         Returns:
-            Block: The traced block.
+            Block: The traced block, with ``label_args`` populated so
+                the result is directly usable as the target of
+                :meth:`Block.call`.
         """
         if qubit_sizes is None:
             qubit_sizes = {}
@@ -997,7 +1268,20 @@ class QKernel(Generic[P, R]):
                         handle = self._create_parameter_input(param_type, name)
                     tracked_parameters[name] = handle.value
                 elif name in qubit_sizes:
-                    handle = qubit_array(qubit_sizes[name], name)
+                    if emit_qubit_init:
+                        handle = qubit_array(qubit_sizes[name], name)
+                    else:
+                        # Call-time specialization: the caller's
+                        # CallBlockOperation supplies the qubits, so we
+                        # must not emit a QInitOperation here. The
+                        # concrete shape lets stdlib helpers resolve
+                        # ``get_size`` to a real integer.
+                        handle = create_dummy_input(
+                            param_type,
+                            name,
+                            emit_init=False,
+                            shape=(qubit_sizes[name],),
+                        )
                 elif name in kwargs:
                     # Create bound value from kwargs
                     handle = self._create_bound_input(param_type, name, kwargs[name])
@@ -1005,26 +1289,51 @@ class QKernel(Generic[P, R]):
                     # Use default value as bound value
                     handle = self._create_bound_input(param_type, name, param.default)
                 else:
-                    # Create dummy input (for Qubit types)
-                    handle = create_dummy_input(param_type, name)
+                    # Quantum-typed parameters (scalar ``Qubit`` and any
+                    # ``Vector[Qubit]`` that did not get a concrete
+                    # size). When ``emit_qubit_init`` is False (call-time
+                    # specialization) the caller supplies the qubits
+                    # via ``CallBlockOperation``, so we must not emit a
+                    # ``QInitOperation`` — doing so would double-
+                    # allocate the register after inlining.
+                    handle = create_dummy_input(
+                        param_type, name, emit_init=emit_qubit_init
+                    )
 
                 dummy_inputs[name] = handle
 
             # Execute the AST-transformed function with dummy inputs
             result = self.func(**dummy_inputs)
 
-        # Extract input/output values
-        input_values = [h.value for h in dummy_inputs.values()]
+            # Extract output Values from the trace result. When
+            # ``emit_return_op`` is set we additionally emit a
+            # ReturnOperation so the inline pass can find the cloned
+            # return Values when this block is later used as a
+            # sub-call target (call-time specialization in
+            # ``QKernel.__call__``). Without an explicit
+            # ReturnOperation, ``_inline_call`` falls back to
+            # ``block.output_values`` whose Values still carry the
+            # ORIGINAL UUIDs — substitution then misses the caller-side
+            # references and downstream ops (e.g. ``qmc.measure``)
+            # lose their operand mapping.
+            output_values: list[Value] = []
+            if result is not None:
+                if isinstance(result, tuple):
+                    for r in result:
+                        if hasattr(r, "value"):
+                            output_values.append(r.value)
+                else:
+                    if hasattr(result, "value"):
+                        output_values.append(result.value)
+            if emit_return_op:
+                tracer.add_operation(
+                    ReturnOperation(operands=output_values, results=[])
+                )
 
-        output_values: list[Value] = []
-        if result is not None:
-            if isinstance(result, tuple):
-                for r in result:
-                    if hasattr(r, "value"):
-                        output_values.append(r.value)
-            else:
-                if hasattr(result, "value"):
-                    output_values.append(result.value)
+        # Extract input values for the Block. Outputs are populated
+        # inside the trace context above so the optional
+        # ReturnOperation can capture them.
+        input_values = [h.value for h in dummy_inputs.values()]
 
         param_slots = build_param_slots(
             signature=self.signature,
@@ -1037,6 +1346,7 @@ class QKernel(Generic[P, R]):
 
         return Block(
             operations=tracer.operations,
+            label_args=list(dummy_inputs.keys()),
             input_values=input_values,
             output_values=output_values,
             name=self.name,

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1006,21 +1006,22 @@ class QKernel(Generic[P, R]):
                 classical arguments to their compile-time-known Python
                 values, and ``qubit_sizes`` maps ``Vector[Qubit]``
                 argument names to their resolved first-axis sizes.
-                Scalar ``Qubit``, scalar ``Observable``, unbound
+                Arguments that cannot enter any of the three buckets
+                (scalar ``Qubit``, scalar ``Observable``, unbound
                 ``Vector[Observable]``, unbound ``Dict`` parameters,
-                and ``Tuple`` parameters are deliberately left out of
-                all three buckets so that :meth:`_create_traced_block`
-                falls back to its standard ``create_dummy_input``
-                handling for those argument positions while still
-                specializing the rest of the call. Returns ``None``
-                only when no specialization is beneficial (the call
-                adds no new compile-time information over the cached
-                symbolic block) or when an argument has a
-                non-parameterizable classical type
-                (``Bit`` / ``bool`` / ``Vector[Bit]`` / ``Vector[bool]``)
-                with no compile-time constant — that combination has
-                nowhere to live in the specialization triple. In the
-                ``None`` case ``__call__`` falls back to ``self.block``.
+                ``Tuple`` parameters, and non-parameterizable
+                classical types like ``Bit`` / ``bool`` /
+                ``Vector[Bit]`` / ``Vector[bool]`` without a
+                compile-time constant) are deliberately left out so
+                that :meth:`_create_traced_block` falls back to its
+                standard ``create_dummy_input`` path for those argument
+                positions; specialization of the rest of the call
+                proceeds normally and inline-time substitution
+                supplies the caller's actual Value. Returns ``None``
+                only when no specialization is beneficial — i.e. the
+                call adds no new compile-time information over the
+                cached symbolic block. In the ``None`` case
+                ``__call__`` falls back to ``self.block``.
 
         Raises:
             NotImplementedError: If ``arguments`` contains a quantum
@@ -1120,37 +1121,37 @@ class QKernel(Generic[P, R]):
                 continue
 
             # Classical scalar. Bind the compile-time constant when
-            # available. If not, the only way to keep the value live
-            # through the specialized trace is as a runtime parameter
-            # via the ``parameters`` list — but ``_validate_parameters``
-            # only admits ``UInt`` / ``Float`` / ``int`` / ``float`` and
-            # their arrays. ``Bit`` / ``bool`` without a constant has
-            # nowhere to go (``bindings`` needs a value, ``parameters``
-            # would be rejected downstream), so we abort and let the
-            # cached symbolic ``self.block`` handle the call.
+            # available. If not, list the name in ``parameters`` only
+            # when the type is parameterizable
+            # (``_validate_parameters`` admits ``UInt`` / ``Float`` /
+            # ``int`` / ``float`` and their arrays). For
+            # non-parameterizable types like ``Bit`` / ``bool``, neither
+            # bucket fits — but we ``continue`` past the argument
+            # rather than aborting the whole specialization:
+            # ``_create_traced_block``'s fall-through
+            # ``create_dummy_input`` path creates a symbolic dummy
+            # (matching the cached ``self.block``) and inline-time
+            # substitution supplies the caller's actual Value. The
+            # rest of the call still gets specialized.
             if param_type in (int, UInt, float, Float, bool, Bit):
                 const_value = handle.value.get_const()
                 if const_value is not None:
                     bindings[name] = const_value
                 elif self._is_parameterizable_type(param_type):
                     parameters.append(name)
-                else:
-                    return None
                 continue
 
-            # Classical array. Same dead-end logic as scalars: bind the
-            # const array when available, otherwise list as a runtime
-            # parameter when parameterizable. ``Vector[Bit]`` /
-            # ``Vector[bool]`` without a const has neither option and
-            # aborts.
+            # Classical array. Same approach as scalars: bind the const
+            # array when available, list as a runtime parameter when
+            # parameterizable, or ``continue`` and let
+            # ``_create_traced_block`` fall through for
+            # ``Vector[Bit]`` / ``Vector[bool]``.
             if is_array_type(param_type):
                 const_array = handle.value.get_const_array()
                 if const_array is not None:
                     bindings[name] = const_array
                 elif self._is_parameterizable_type(param_type):
                     parameters.append(name)
-                else:
-                    return None
                 continue
 
             # Dict. ``handle.value.parameter_name()`` is set both for

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -992,15 +992,17 @@ class QKernel(Generic[P, R]):
         shapes are known.
 
         Args:
-            arguments (dict[str, Any]): Pre-consumption mapping from
+            arguments (dict[str, Any]): The bound-argument mapping from
                 parameter name to the caller's frontend
                 :class:`Handle`, as produced by
                 ``signature.bind(...).arguments`` in :meth:`__call__`.
-                The handles are inspected here before the call site
-                consumes them, so the extractor can read
-                ``handle.value`` metadata (``get_const``,
-                ``get_const_array``, ``dict_runtime``) without
-                affecting the affine-type ledger.
+                Quantum handles in this mapping have already been
+                ``consume()``-d by :meth:`__call__` before this
+                extractor runs, but ``consume`` only updates the
+                affine-type ledger and leaves ``handle.value``
+                untouched, so the metadata reads this method performs
+                (``get_const``, ``get_const_array``, ``dict_runtime``,
+                ``get_size`` on quantum arrays) are still valid.
 
         Returns:
             tuple[list[str], dict[str, Any], dict[str, int]] | None:

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1027,9 +1027,13 @@ class QKernel(Generic[P, R]):
 
         for name, param in self.signature.parameters.items():
             param_type = self.input_types.get(name, param.annotation)
-            handle = arguments.get(name)
-            if not isinstance(handle, Handle):
-                return None
+            handle = arguments[name]
+            assert isinstance(handle, Handle), (
+                f"Internal invariant violated: argument {name!r} should "
+                f"already be a Handle by the time "
+                f"_extract_calltime_specialization runs (upstream check "
+                f"at __call__)."
+            )
 
             # Scalar Qubit: no specialization-relevant info to extract;
             # ``_create_traced_block`` will fall through to the regular

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -536,13 +536,6 @@ class TestNestedShapeDependentStdlib:
     the IQFT vanished from the transpiled circuit.
     """
 
-    def _count_composite_ops(self, ops, gate_type):
-        return sum(
-            1
-            for op in ops
-            if isinstance(op, CompositeGateOperation) and op.gate_type == gate_type
-        )
-
     @pytest.mark.parametrize("n", [1, 2, 3, 4])
     def test_classical_scalar_drives_inner_shape(self, qiskit_transpiler, n):
         """Inner kernel sized by a UInt scalar keeps its IQFT under nesting."""

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -5,7 +5,7 @@ import pytest
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.constructors import qubit_array
-from qamomile.circuit.frontend.handle import Qubit, Vector
+from qamomile.circuit.frontend.handle import Matrix, Qubit, Vector
 from qamomile.circuit.frontend.qkernel import qkernel
 from qamomile.circuit.ir.operation.composite_gate import (
     CompositeGateOperation,
@@ -16,6 +16,32 @@ from qamomile.circuit.ir.operation.operation import QInitOperation
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.stdlib.qft import IQFT, QFT, iqft, qft
 from tests.circuit.conftest import run_statevector
+
+# ---------------------------------------------------------------------------
+# Module-level kernels for the self-recursive + shape-dependent stdlib
+# regression. Self-recursive @qkernel definitions must be at module level
+# so the AST transformer can resolve the recursive name (function-local
+# closures bind the name only after the decorator has run, which fires
+# the "Closure variable is not yet bound" branch).
+# ---------------------------------------------------------------------------
+
+
+@qmc.qkernel
+def _rec_iqft(depth: qmc.UInt, qs: Vector[Qubit]) -> Vector[Qubit]:
+    """Apply IQFT and recurse ``depth`` more times. Used by the self-
+    recursion regression test in ``TestNestedShapeDependentStdlib``."""
+    qs = iqft(qs)
+    if depth > qmc.uint(0):
+        qs = _rec_iqft(depth - qmc.uint(1), qs)
+    return qs
+
+
+@qmc.qkernel
+def _rec_iqft_top(depth: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    """Wrap ``_rec_iqft`` with a concrete-size register and measure."""
+    qs = qmc.qubit_array(3, "qs")
+    qs = _rec_iqft(depth, qs)
+    return qmc.measure(qs)
 
 
 class TestQFT:
@@ -612,18 +638,89 @@ class TestNestedShapeDependentStdlib:
         # Exactly one QInit for the outer register, none from the specialized callee.
         assert len(qinits) == 1
 
+    @pytest.mark.parametrize("depth", [0, 1, 2])
+    def test_self_recursive_with_shape_dependent_stdlib_limitation(
+        self, qiskit_transpiler, depth
+    ):
+        """Documents a known limitation of call-time specialization.
+
+        ``_rec_iqft(depth, qs)`` applies ``qmc.iqft`` once and then
+        recurses ``depth`` more times, so the program semantically
+        applies IQFT ``(depth + 1)`` times. The call-time
+        specialization in :meth:`QKernel.__call__` only fires for the
+        *outermost* call: the body's recursive self-call sees
+        ``self._specializing == True`` and falls back to the cached
+        symbolic ``self.block`` where the inner ``qmc.iqft`` had no-op'd
+        on the symbolic-shape register. After ``inline ↔ partial_eval``
+        unrolling the recursion, only the outer IQFT remains in the IR.
+
+        This test pins that limitation down. If a future change relaxes
+        the ``_specializing`` guard (e.g. allows bounded
+        re-specialization for self-recursive callees with concrete
+        bindings), the expected IQFT count will rise to ``depth + 1``
+        and this test should be updated to match — the goal here is to
+        flag the behavior change consciously, not to enforce the
+        current shortcut forever.
+        """
+        block = qiskit_transpiler.to_block(_rec_iqft_top, bindings={"depth": depth})
+        block = qiskit_transpiler.substitute(block)
+        block = qiskit_transpiler.resolve_parameter_shapes(
+            block, bindings={"depth": depth}
+        )
+        block = qiskit_transpiler.inline(block)
+        block = qiskit_transpiler.unroll_recursion(block, bindings={"depth": depth})
+        iqft_ops = [
+            op
+            for op in block.operations
+            if isinstance(op, CompositeGateOperation)
+            and op.gate_type == CompositeGateType.IQFT
+        ]
+        # Documented limitation: exactly one IQFT survives regardless
+        # of ``depth``. Mathematically the kernel applies IQFT
+        # ``depth + 1`` times.
+        assert len(iqft_ops) == 1
+        assert iqft_ops[0].num_target_qubits == 3
+
+    def test_matrix_qubit_sub_kernel_raises_not_implemented(self):
+        """Call-time spec on ``Matrix[Qubit]`` callee args must error loudly.
+
+        Higher-rank quantum-array specialization is not yet wired up
+        in ``_extract_calltime_specialization``. Silently falling back
+        to the cached symbolic block would mean shape-dependent stdlib
+        (qft / iqft / qpe) applied inside the callee on the
+        ``Matrix[Qubit]`` register no-ops without warning — exactly
+        the failure mode this PR is closing for the ``Vector[Qubit]``
+        case. Raise ``NotImplementedError`` instead so the user sees
+        the unsupported case at the call site.
+        """
+
+        @qkernel
+        def inner(qs: Matrix[Qubit]) -> Matrix[Qubit]:
+            return qs
+
+        @qkernel
+        def outer() -> qmc.Vector[qmc.Bit]:
+            qs = qubit_array((2, 3), "qs")
+            qs = inner(qs)
+            return qmc.measure(qs)
+
+        with pytest.raises(NotImplementedError, match=r"Matrix\[Qubit\]"):
+            outer.build()
+
     @pytest.mark.parametrize("seed", [0, 1, 7])
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_392_cross_backend_sampling(self, n, seed):
-        """Cross-backend sampling: IQFT on |+...+> returns uniform bitstrings.
+        """Cross-backend sampling: ``IQFT|+...+>`` collapses to ``|0...0>``.
 
         Verifies that the nested-call IQFT fix produces identical
         behavior on every quantum SDK backend Qamomile ships with.
 
         The kernel prepares ``H^{⊗n}|0...0> = |+...+>`` inside an inner
-        ``prepare`` kernel that *also* applies IQFT, then measures from
-        the outer kernel. ``IQFT|+...+>`` is just ``|0...0>``, so every
-        measured bitstring must be all-zero on every backend. This
+        ``prepare`` kernel that *also* applies IQFT, then measures
+        from the outer kernel. Because ``IQFT|+...+> = |0...0>``
+        exactly, every measured bitstring must be the all-zero string
+        on every backend (any other bitstring would indicate the
+        nested-call IQFT was lost or emitted incorrectly). This
         protects both the IR-level fix and each backend's emit pass.
 
         Args:

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -681,6 +681,59 @@ class TestNestedShapeDependentStdlib:
         assert len(iqft_ops) == 1
         assert iqft_ops[0].num_target_qubits == 3
 
+    @pytest.mark.parametrize("n", [2, 3])
+    def test_runtime_vector_bit_arg_does_not_block_other_specialization(
+        self, qiskit_transpiler, n
+    ):
+        """A runtime ``Vector[Bit]`` co-argument must not block IQFT spec.
+
+        ``_extract_calltime_specialization`` previously aborted the
+        whole call when it saw a non-parameterizable runtime classical
+        without a compile-time constant — re-introducing the original
+        #392 failure mode for callees that take both a shape-relevant
+        argument and a runtime classical. The extractor now
+        ``continue``s past such arguments so specialization on the
+        shape-relevant arg still fires, and inline-time substitution
+        supplies the runtime classical Value.
+
+        The kernel below feeds a ``Vector[Bit]`` produced by a
+        measurement (so it carries no compile-time constant) into a
+        helper that also takes a concrete ``Vector[Qubit]``. The
+        IQFT inside the helper must still emit with the resolved
+        qubit-register size.
+        """
+
+        @qkernel
+        def helper(
+            qs: Vector[Qubit], flags: qmc.Vector[qmc.Bit]
+        ) -> tuple[Vector[Qubit], qmc.Vector[qmc.Bit]]:
+            qs = iqft(qs)
+            return qs, flags
+
+        @qkernel
+        def top() -> qmc.Vector[qmc.Bit]:
+            q_aux = qmc.qubit_array(2, "q_aux")
+            aux_bits = qmc.measure(q_aux)  # runtime Vector[Bit]
+            qs = qmc.qubit_array(n, "qs")
+            qs, _ = helper(qs, aux_bits)
+            return qmc.measure(qs)
+
+        block = qiskit_transpiler.to_block(top)
+        block = qiskit_transpiler.substitute(block)
+        block = qiskit_transpiler.resolve_parameter_shapes(block)
+        block = qiskit_transpiler.inline(block)
+        iqft_ops = [
+            op
+            for op in block.operations
+            if isinstance(op, CompositeGateOperation)
+            and op.gate_type == CompositeGateType.IQFT
+        ]
+        assert len(iqft_ops) == 1, (
+            f"expected IQFT specialization to fire despite runtime "
+            f"Vector[Bit] co-argument, got {len(iqft_ops)} IQFT op(s)"
+        )
+        assert iqft_ops[0].num_target_qubits == n
+
     def test_matrix_qubit_sub_kernel_raises_not_implemented(self):
         """Call-time spec on ``Matrix[Qubit]`` callee args must error loudly.
 

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -745,10 +745,11 @@ class TestNestedShapeDependentStdlib:
         symbolic block is used for the callee's behaviour on that
         argument position, so kernels that simply *take* a
         ``Matrix[Qubit]`` without applying shape-dependent stdlib to
-        it must still compose normally. (Trade-off documented in
-        SUMMARY's known-limitations entry: a callee that applies
-        ``qft`` / ``iqft`` to a ``Matrix[Qubit]`` argument continues
-        to silently no-op on those qubits.)
+        it must still compose normally. (Trade-off documented in the
+        ``Matrix[Qubit]`` / ``Tensor[Qubit]`` entry of
+        ``LIMITATIONS.md``: a callee that applies ``qft`` / ``iqft``
+        to a ``Matrix[Qubit]`` argument continues to silently no-op
+        on those qubits.)
         """
 
         @qkernel

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -734,17 +734,21 @@ class TestNestedShapeDependentStdlib:
         )
         assert iqft_ops[0].num_target_qubits == n
 
-    def test_matrix_qubit_sub_kernel_raises_not_implemented(self):
-        """Call-time spec on ``Matrix[Qubit]`` callee args must error loudly.
+    def test_matrix_qubit_sub_kernel_compiles_without_specialization(self):
+        """A nested call with a ``Matrix[Qubit]`` arg still compiles.
 
-        Higher-rank quantum-array specialization is not yet wired up
-        in ``_extract_calltime_specialization``. Silently falling back
-        to the cached symbolic block would mean shape-dependent stdlib
-        (qft / iqft / qpe) applied inside the callee on the
-        ``Matrix[Qubit]`` register no-ops without warning — exactly
-        the failure mode this PR is closing for the ``Vector[Qubit]``
-        case. Raise ``NotImplementedError`` instead so the user sees
-        the unsupported case at the call site.
+        Higher-rank quantum-array specialization is not yet
+        implemented in ``_extract_calltime_specialization`` — the
+        extractor leaves ``Matrix[Qubit]`` / ``Tensor[Qubit]``
+        arguments out of all three buckets and ``continue``s, the
+        same way it handles ``Dict`` / ``Tuple``. The cached
+        symbolic block is used for the callee's behaviour on that
+        argument position, so kernels that simply *take* a
+        ``Matrix[Qubit]`` without applying shape-dependent stdlib to
+        it must still compose normally. (Trade-off documented in
+        SUMMARY's known-limitations entry: a callee that applies
+        ``qft`` / ``iqft`` to a ``Matrix[Qubit]`` argument continues
+        to silently no-op on those qubits.)
         """
 
         @qkernel
@@ -752,13 +756,19 @@ class TestNestedShapeDependentStdlib:
             return qs
 
         @qkernel
-        def outer() -> qmc.Vector[qmc.Bit]:
+        def outer() -> Matrix[Qubit]:
             qs = qubit_array((2, 3), "qs")
             qs = inner(qs)
-            return qmc.measure(qs)
+            return qs
 
-        with pytest.raises(NotImplementedError, match=r"Matrix\[Qubit\]"):
-            outer.build()
+        # The kernel must build without error; the inner ``Matrix``
+        # argument is left symbolic at the specialization extractor
+        # and inline substitution wires it up to the caller's
+        # allocated register. (``.transpile`` is not exercised here
+        # because ``Matrix[Qubit]`` is not a valid classical-I/O
+        # entrypoint — the build path is what the regression guards.)
+        block = outer.build()
+        assert block is not None
 
     @pytest.mark.parametrize("seed", [0, 1, 7])
     @pytest.mark.parametrize("n", [1, 2, 3])

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -11,6 +11,7 @@ from qamomile.circuit.ir.operation.composite_gate import (
     CompositeGateOperation,
     CompositeGateType,
 )
+from qamomile.circuit.ir.operation.gate import MeasureVectorOperation
 from qamomile.circuit.ir.operation.operation import QInitOperation
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.stdlib.qft import IQFT, QFT, iqft, qft
@@ -765,9 +766,19 @@ class TestNestedShapeDependentStdlib:
         """The exact #392 shape: inner kernel sized by UInt keeps IQFT.
 
         Goes through the explicit pipeline so the regression bound is
-        the IR after :meth:`Transpiler.inline`, where the inner
-        ``CompositeGateOperation`` (gate_type=IQFT) must appear with the
-        expected concrete ``num_target_qubits``.
+        the IR after :meth:`Transpiler.inline`. Asserts both halves of
+        the original failure mode:
+
+        - The inner ``CompositeGateOperation`` (``gate_type=IQFT``) must
+          appear exactly once with the expected concrete
+          ``num_target_qubits`` (the original symptom).
+        - The outer ``MeasureVectorOperation`` must survive inlining,
+          with its operand pointing at the same logical register as
+          the IQFT's results. An earlier intermediate fix recovered
+          the IQFT but dropped the measure because the specialized
+          block had no ``ReturnOperation`` for the inline pass to use
+          when remapping cloned return Values; this assertion guards
+          that regression.
         """
 
         @qkernel
@@ -793,3 +804,29 @@ class TestNestedShapeDependentStdlib:
         ]
         assert len(iqft_ops) == 1
         assert iqft_ops[0].num_target_qubits == n
+
+        measure_ops = [
+            op for op in block.operations if isinstance(op, MeasureVectorOperation)
+        ]
+        assert len(measure_ops) == 1, (
+            f"expected exactly one MeasureVectorOperation, got {len(measure_ops)}"
+        )
+        # The measure must consume the post-IQFT register. Without the
+        # ``ReturnOperation`` emitted by the specialized callee trace,
+        # the inline pass would leave the measure's operand pointing
+        # at the pre-inline ArrayValue while the IQFT's qubit results
+        # point at the cloned post-inline ArrayValue — a UUID mismatch
+        # that drops the measure in the final emit. Compare register
+        # ``logical_id``s (a stable identity preserved across cloning)
+        # to pin down the operand mapping at the IR level.
+        measure_operand = measure_ops[0].operands[0]
+        iqft_parent_logical_ids = {
+            res.parent_array.logical_id
+            for res in iqft_ops[0].results
+            if res.parent_array is not None
+        }
+        assert iqft_parent_logical_ids, (
+            "IQFT result Values should carry a ``parent_array`` "
+            "pointing at the qubit register after inline"
+        )
+        assert measure_operand.logical_id in iqft_parent_logical_ids

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -522,3 +522,281 @@ class TestQFTIQFT:
             assert all(b == 0 for b in bits), (
                 f"n={n}: expected all zeros, got {bits} (count={count})"
             )
+
+
+class TestNestedShapeDependentStdlib:
+    """Regression coverage for issue #392.
+
+    A nested ``@qkernel`` call must preserve shape-dependent stdlib ops
+    (QFT / IQFT) emitted by the inner kernel — even when the inner
+    kernel's register size depends on a classical scalar argument or a
+    ``Vector[Qubit]`` whose size is only known at the outer call site.
+    Before the fix, ``QKernel.__call__`` reused the inner kernel's
+    cached symbolic block, where ``qmc.iqft`` had silently no-op'd, and
+    the IQFT vanished from the transpiled circuit.
+    """
+
+    def _count_composite_ops(self, ops, gate_type):
+        return sum(
+            1
+            for op in ops
+            if isinstance(op, CompositeGateOperation) and op.gate_type == gate_type
+        )
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 4])
+    def test_classical_scalar_drives_inner_shape(self, qiskit_transpiler, n):
+        """Inner kernel sized by a UInt scalar keeps its IQFT under nesting."""
+
+        @qkernel
+        def prepare(m: qmc.UInt) -> Vector[Qubit]:
+            qs = qubit_array(m, "qs")
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def wrapper(m: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+            qs = prepare(m)
+            return qmc.measure(qs)
+
+        executable = qiskit_transpiler.transpile(wrapper, bindings={"m": n})
+        circuit = executable.compiled_quantum[0].circuit
+
+        # Each measurement targets a single qubit / classical bit, so n
+        # qubits means exactly n ``measure`` instructions even when the
+        # outer ``Vector[Bit]`` is lowered as a vector measurement.
+        measures = [ci for ci in circuit.data if ci.operation.name == "measure"]
+        assert len(measures) == n
+        # IQFT shows up either as an inlined sequence of native gates or
+        # as a backend-annotated composite block. Accept either form.
+        assert any(
+            ci.operation.name in {"annotated", "h", "cp", "swap"} for ci in circuit.data
+        )
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 4])
+    def test_vector_qubit_helper_preserves_iqft(self, qiskit_transpiler, n):
+        """A ``Vector[Qubit]`` helper kernel keeps its IQFT under nesting."""
+
+        @qkernel
+        def apply_iqft(qs: Vector[Qubit]) -> Vector[Qubit]:
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def top() -> qmc.Vector[qmc.Bit]:
+            qs = qubit_array(n, "qs")
+            qs = apply_iqft(qs)
+            return qmc.measure(qs)
+
+        executable = qiskit_transpiler.transpile(top)
+        circuit = executable.compiled_quantum[0].circuit
+        assert circuit.num_qubits == n  # no phantom qubits
+        measures = [ci for ci in circuit.data if ci.operation.name == "measure"]
+        assert len(measures) == n
+
+    @pytest.mark.parametrize("n", [2, 3])
+    def test_call_time_specialization_does_not_emit_extra_qinit(
+        self, qiskit_transpiler, n
+    ):
+        """Specialized sub-block must not double-allocate the qubit register."""
+
+        @qkernel
+        def apply_iqft(qs: Vector[Qubit]) -> Vector[Qubit]:
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def top() -> qmc.Vector[qmc.Bit]:
+            qs = qubit_array(n, "qs")
+            qs = apply_iqft(qs)
+            return qmc.measure(qs)
+
+        block = qiskit_transpiler.to_block(top)
+        block = qiskit_transpiler.substitute(block)
+        block = qiskit_transpiler.resolve_parameter_shapes(block)
+        block = qiskit_transpiler.inline(block)
+        qinits = [op for op in block.operations if isinstance(op, QInitOperation)]
+        # Exactly one QInit for the outer register, none from the specialized callee.
+        assert len(qinits) == 1
+
+    @pytest.mark.parametrize("seed", [0, 1, 7])
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_392_cross_backend_sampling(self, n, seed):
+        """Cross-backend sampling: IQFT on |+...+> returns uniform bitstrings.
+
+        Verifies that the nested-call IQFT fix produces identical
+        behavior on every quantum SDK backend Qamomile ships with.
+
+        The kernel prepares ``H^{⊗n}|0...0> = |+...+>`` inside an inner
+        ``prepare`` kernel that *also* applies IQFT, then measures from
+        the outer kernel. ``IQFT|+...+>`` is just ``|0...0>``, so every
+        measured bitstring must be all-zero on every backend. This
+        protects both the IR-level fix and each backend's emit pass.
+
+        Args:
+            n (int): Register size, parametrized with both 1 and small
+                multi-qubit cases.
+            seed (int): RNG seed for sampler reproducibility.
+        """
+        pytest.importorskip("qiskit")
+        from qiskit.providers.basic_provider import BasicSimulator
+
+        from qamomile.qiskit import QiskitTranspiler
+
+        @qkernel
+        def prepare(m: qmc.UInt) -> Vector[Qubit]:
+            qs = qubit_array(m, "qs")
+            for i in qmc.range(m):
+                qs[i] = qmc.h(qs[i])
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def measure_top(m: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+            qs = prepare(m)
+            return qmc.measure(qs)
+
+        results: dict[str, dict[tuple, int]] = {}
+
+        # Qiskit
+        qiskit_tr = QiskitTranspiler()
+        backend = BasicSimulator()
+        backend.set_options(seed_simulator=seed)
+        exe = qiskit_tr.transpile(measure_top, bindings={"m": n})
+        job = exe.sample(qiskit_tr.executor(backend=backend), shots=512)
+        results["qiskit"] = {bits: cnt for bits, cnt in job.result().results}
+
+        # QuriParts (state-vector sampler)
+        quri_parts = pytest.importorskip("quri_parts")  # noqa: F841
+        from qamomile.quri_parts import QuriPartsTranspiler
+
+        qp_tr = QuriPartsTranspiler()
+        exe = qp_tr.transpile(measure_top, bindings={"m": n})
+        job = exe.sample(qp_tr.executor(), shots=512)
+        results["quri_parts"] = {bits: cnt for bits, cnt in job.result().results}
+
+        # CUDA-Q (optional — many CI envs lack the simulator).
+        try:
+            cudaq = pytest.importorskip("cudaq")  # noqa: F841
+            from qamomile.cudaq import CudaqTranspiler
+
+            cudaq_tr = CudaqTranspiler()
+            exe = cudaq_tr.transpile(measure_top, bindings={"m": n})
+            job = exe.sample(cudaq_tr.executor(), shots=512)
+            results["cudaq"] = {bits: cnt for bits, cnt in job.result().results}
+        except (pytest.skip.Exception, ImportError, RuntimeError):
+            pass
+
+        # IQFT followed by sampling a uniform superposition must yield
+        # only the all-zero bitstring on every backend.
+        expected_bits = tuple(0 for _ in range(n))
+        for backend_name, counts in results.items():
+            assert set(counts) == {expected_bits}, (
+                f"{backend_name}: expected {{({expected_bits})}}, got {set(counts)}"
+            )
+
+    @pytest.mark.parametrize("seed", [0, 5])
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_392_cross_backend_expval(self, n, seed):
+        """Cross-backend expval: ``<+...+|IQFT^† Z_0 IQFT|+...+> = 1``.
+
+        Pairs with :meth:`test_392_cross_backend_sampling` to exercise
+        the estimator pipeline of every backend (sampler and estimator
+        regress independently). ``IQFT|+...+> = |0...0>`` so
+        ``<Z_0> = 1`` exactly under noiseless simulation.
+
+        Args:
+            n (int): Register size.
+            seed (int): RNG seed; included so an accidental dependence
+                on a fixed initial state would be caught.
+        """
+        import qamomile.observable as qm_o
+
+        pytest.importorskip("qiskit")
+        from qamomile.qiskit import QiskitTranspiler
+
+        @qkernel
+        def prepare(m: qmc.UInt) -> Vector[Qubit]:
+            qs = qubit_array(m, "qs")
+            for i in qmc.range(m):
+                qs[i] = qmc.h(qs[i])
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def expval_top(m: qmc.UInt, obs: qmc.Observable) -> qmc.Float:
+            qs = prepare(m)
+            return qmc.expval(qs, obs)
+
+        H = qm_o.Z(0)
+        rng = np.random.default_rng(seed)
+        _ = rng.random()  # mix the seed into the RNG state for symmetry with sampling
+
+        # Qiskit
+        qiskit_tr = QiskitTranspiler()
+        exe = qiskit_tr.transpile(expval_top, bindings={"m": n, "obs": H})
+        val_q = exe.run(qiskit_tr.executor()).result()
+        assert np.isclose(val_q, 1.0, atol=1e-8), (
+            f"qiskit n={n} seed={seed}: expected <Z_0>=1, got {val_q}"
+        )
+
+        # QuriParts
+        try:
+            pytest.importorskip("quri_parts")
+            from qamomile.quri_parts import QuriPartsTranspiler
+
+            qp_tr = QuriPartsTranspiler()
+            exe = qp_tr.transpile(expval_top, bindings={"m": n, "obs": H})
+            val_qp = exe.run(qp_tr.executor()).result()
+            assert np.isclose(val_qp, 1.0, atol=1e-8), (
+                f"quri_parts n={n} seed={seed}: expected <Z_0>=1, got {val_qp}"
+            )
+        except pytest.skip.Exception:
+            pass
+
+        # CUDA-Q (optional)
+        try:
+            pytest.importorskip("cudaq")
+            from qamomile.cudaq import CudaqTranspiler
+
+            cudaq_tr = CudaqTranspiler()
+            exe = cudaq_tr.transpile(expval_top, bindings={"m": n, "obs": H})
+            val_c = exe.run(cudaq_tr.executor()).result()
+            assert np.isclose(val_c, 1.0, atol=1e-6), (
+                f"cudaq n={n} seed={seed}: expected <Z_0>=1, got {val_c}"
+            )
+        except (pytest.skip.Exception, ImportError, RuntimeError):
+            pass
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_392_reproducer_iqft_visible_after_inline(self, qiskit_transpiler, n):
+        """The exact #392 shape: inner kernel sized by UInt keeps IQFT.
+
+        Goes through the explicit pipeline so the regression bound is
+        the IR after :meth:`Transpiler.inline`, where the inner
+        ``CompositeGateOperation`` (gate_type=IQFT) must appear with the
+        expected concrete ``num_target_qubits``.
+        """
+
+        @qkernel
+        def prepare(m: qmc.UInt) -> Vector[Qubit]:
+            qs = qubit_array(m, "qs")
+            qs = iqft(qs)
+            return qs
+
+        @qkernel
+        def wrapper(m: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+            qs = prepare(m)
+            return qmc.measure(qs)
+
+        block = qiskit_transpiler.to_block(wrapper, bindings={"m": n})
+        block = qiskit_transpiler.substitute(block)
+        block = qiskit_transpiler.resolve_parameter_shapes(block, bindings={"m": n})
+        block = qiskit_transpiler.inline(block)
+        iqft_ops = [
+            op
+            for op in block.operations
+            if isinstance(op, CompositeGateOperation)
+            and op.gate_type == CompositeGateType.IQFT
+        ]
+        assert len(iqft_ops) == 1
+        assert iqft_ops[0].num_target_qubits == n


### PR DESCRIPTION
## Summary

- Sub-kernels using `qmc.qft` / `qmc.iqft` on a register whose shape comes from a classical `UInt` argument (or a caller-supplied `Vector[Qubit]` size) silently dropped those gates when called from another `@qkernel`. The wrapped circuit ran with the wrong unitary, no warning raised.
- `QKernel.__call__` now performs **call-time specialization**: when the call site has resolved either classical bindings or `Vector[Qubit]` sizes, the callee is re-traced with that concrete information and the specialized block is used as the `CallBlockOperation` target. The cached symbolic block is preserved as a fallback when no new compile-time information is available.
- Supporting changes: `_specializing` re-entry guard for self-recursive kernels; `_create_traced_block` gains `emit_qubit_init` / `emit_return_op` flags (the latter so the inline pass can find cloned return values via `ReturnOperation` rather than the un-remapped `block.output_values`); `create_dummy_input` gains an optional `shape=` kwarg for concrete shape Values; `Block.label_args` is now always populated on `_create_traced_block` output so the block is directly usable as a `Block.call(**kwargs)` target.

Fixes #392.

## Test plan

- [x] `tests/circuit/test_qft.py::TestNestedShapeDependentStdlib` (28 parametrized cases) — IR-level presence check, Vector[Qubit] helper variant, no-extra-QInit check, cross-backend sampling (Qiskit + QuriParts + optional CUDA-Q), cross-backend expval.
- [x] Full circuit test suite (`tests/circuit/`): 5197 passed, 0 regressions.
- [x] Full project test suite (`tests/ -m "not docs and not cudaq"`): 8547 passed, 0 regressions.
- [x] `uv run ruff check qamomile/ tests/` clean.
- [x] `uv run ruff format --check qamomile/ tests/` clean.
- [x] `uv run zuban check qamomile/` — branch has 71 errors, baseline `origin/main` has 85. No new errors introduced on touched files.
- [x] `/local-review` against `origin/main`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)