### PR TITLE
Narrow UInt multiplication return type via typing.overload

### DIFF
--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import overload
 
 from qamomile.circuit.ir.operation.arithmetic_operations import (
     BinOpKind,
@@ -149,8 +150,29 @@ class UInt(ArithmeticMixin, Handle):
         _emit_binop(coerced.value, self.value, result, BinOpKind.SUB)
         return result
 
-    # UInt-specific multiplication (handles float case differently)
+    # UInt-specific multiplication (handles float case differently).
+    # The result type is fully determined by the operand at runtime, so
+    # @overload narrows it: integral operands keep the result a UInt
+    # (valid as a Vector index), only a Python float widens it to Float.
+    @overload
+    def __mul__(self, other: "int | UInt") -> "UInt": ...
+
+    @overload
+    def __mul__(self, other: float) -> "Float": ...
+
     def __mul__(self, other) -> "UInt | Float":
+        """Multiply this UInt by an integer-like or float operand.
+
+        Args:
+            other (int | UInt | float): The right-hand operand. An ``int``
+                or ``UInt`` keeps the product unsigned-integral; a Python
+                ``float`` promotes the product to a floating-point result.
+
+        Returns:
+            UInt | Float: A ``UInt`` when ``other`` is ``int``/``UInt``,
+                or a ``Float`` when ``other`` is a Python ``float``. The
+                two cases are distinguished statically via ``@overload``.
+        """
         if isinstance(other, float):
             other_value = Value(type=FloatType(), name="").with_const(other)
             result = self._make_float_result()
@@ -160,7 +182,24 @@ class UInt(ArithmeticMixin, Handle):
         # Use mixin's default implementation for int/UInt
         return super().__mul__(other)  # type: ignore
 
+    @overload
+    def __rmul__(self, other: "int | UInt") -> "UInt": ...
+
+    @overload
+    def __rmul__(self, other: float) -> "Float": ...
+
     def __rmul__(self, other) -> "UInt | Float":
+        """Multiply an integer-like or float operand by this UInt.
+
+        Multiplication is commutative, so this delegates to ``__mul__``.
+
+        Args:
+            other (int | UInt | float): The left-hand operand.
+
+        Returns:
+            UInt | Float: A ``UInt`` for ``int``/``UInt`` operands, a
+                ``Float`` for a Python ``float`` operand.
+        """
         return self.__mul__(other)
 
     # UInt-specific true division (always returns Float)


### PR DESCRIPTION
## Summary

`UInt.__mul__` / `__rmul__` were annotated `-> "UInt | Float"`, so an
expression like `3 * b` (with `b: UInt`, e.g. a `qmc.range` loop
variable) was statically typed `UInt | Float` and rejected as a `Vector`
index, which only accepts `int | UInt`:

```
Argument of type "UInt | Float" cannot be assigned to parameter "index"
of type "int | UInt" in function "__setitem__"
```

The code ran and transpiled correctly — this was a static-type false
positive.

This PR adds `typing.overload` signatures so the result narrows by
operand:

- `UInt * (int | UInt)` -> `UInt` (valid as a `Vector` index)
- `UInt * float` -> `Float`

Runtime behaviour is completely unchanged — the implementation body is
identical, only type annotations and docstrings are added.

Resolves Notion BACKLOG-8271 and BACKLOG-8004 (duplicate backlogs for
the same fix).

## Verification

- The repro `q[3 * b]` no longer produces a type error.
- `uv run zuban check qamomile/` baseline drops from 85 to 83 errors:
  two pre-existing false positives are fixed, none introduced.
- `uv run ruff check` / `ruff format --check` clean.
- Frontend regression tests pass (`tests/circuit/`).

## Note

`UInt * Float` (a `UInt` handle times a `Float` *handle*, as opposed to
a Python `float`) is no longer statically accepted by either overload.
This case is uncommon and its runtime behaviour is itself dubious (it
currently returns a `UInt`), so the narrow `int | UInt` / `float`
overloads — matching the original BACKLOG-8004 proposal — are the
intended scope here. No call site in `qamomile/` relies on it.

## Test plan

- [x] `uv run zuban check qamomile/` — no regression (85 -> 83)
- [x] `uv run ruff check qamomile/ tests/` — clean
- [x] `uv run ruff format --check qamomile/ tests/` — clean
- [x] `uv run pytest tests/circuit/` frontend suite — pass
- [x] Repro `q[3 * b]` type-checks clean

https://claude.ai/code/session_01F4tDu5QXLG2uuipTRdEKCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4tDu5QXLG2uuipTRdEKCn)_