### PR TITLE
Fix slice broadcast through inline (sub-kernel call) emit path

### DIFF
--- a/qamomile/circuit/transpiler/passes/value_mapping.py
+++ b/qamomile/circuit/transpiler/passes/value_mapping.py
@@ -318,9 +318,9 @@ class ValueSubstitutor:
             fields are left unchanged.
         """
         new_parent_array = v.parent_array
-        if v.parent_array is not None and v.parent_array.uuid in self._value_map:
-            sub_pa = self._chase_transitive(v.parent_array)
-            if isinstance(sub_pa, ArrayValue):
+        if v.parent_array is not None:
+            sub_pa = self.substitute_value(v.parent_array)
+            if isinstance(sub_pa, ArrayValue) and sub_pa is not v.parent_array:
                 new_parent_array = sub_pa
 
         new_element_indices = v.element_indices
@@ -349,9 +349,12 @@ class ValueSubstitutor:
                 new_shape = tuple(new_shape_list)
 
             new_slice_of = v.slice_of
-            if v.slice_of is not None and v.slice_of.uuid in self._value_map:
-                sub_slice_of = self._chase_transitive(v.slice_of)
-                if isinstance(sub_slice_of, ArrayValue):
+            if v.slice_of is not None:
+                sub_slice_of = self.substitute_value(v.slice_of)
+                if (
+                    isinstance(sub_slice_of, ArrayValue)
+                    and sub_slice_of is not v.slice_of
+                ):
                     new_slice_of = sub_slice_of
             new_slice_start = v.slice_start
             if v.slice_start is not None and v.slice_start.uuid in self._value_map:
@@ -461,11 +464,22 @@ class ValueSubstitutor:
             new_shape: tuple[Value, ...] | None = None
             changed = False
 
-            # Check if this is an array element whose parent_array should be substituted
-            if v.parent_array is not None and v.parent_array.uuid in self._value_map:
-                new_parent = self._chase_transitive(v.parent_array)
-                if isinstance(new_parent, ArrayValue):
-                    new_parent_array = new_parent
+            # Substitute the parent_array.  ``v.parent_array`` itself may
+            # not be in the map (it can be a freshly-cloned slice-view
+            # ``ArrayValue`` whose own ``slice_of`` is the callee dummy
+            # being substituted), so a direct ``uuid in self._value_map``
+            # check would leave the parent_array's stale internal fields
+            # in place.  Recursing through ``substitute_value`` walks the
+            # parent_array's fields so the slice chain is rewritten
+            # consistently when a sub-kernel containing
+            # ``qs[a:b] = qmc.h(qs[a:b])`` is inlined.
+            if v.parent_array is not None:
+                sub_parent = self.substitute_value(v.parent_array)
+                if (
+                    isinstance(sub_parent, ArrayValue)
+                    and sub_parent is not v.parent_array
+                ):
+                    new_parent_array = sub_parent
                     changed = True
 
             # Also check element_indices for substitution
@@ -520,9 +534,16 @@ class ValueSubstitutor:
                 new_slice_start_v = v.slice_start
                 new_slice_step_v = v.slice_step
 
-                if v.slice_of is not None and v.slice_of.uuid in self._value_map:
-                    sub_slice_of = self._chase_transitive(v.slice_of)
-                    if isinstance(sub_slice_of, ArrayValue):
+                # ``slice_of`` may also point at a freshly-cloned sliced
+                # ``ArrayValue`` whose own slice metadata still references
+                # the callee dummy.  Recurse through ``substitute_value``
+                # so nested slices (slice-of-slice) get rewritten too.
+                if v.slice_of is not None:
+                    sub_slice_of = self.substitute_value(v.slice_of)
+                    if (
+                        isinstance(sub_slice_of, ArrayValue)
+                        and sub_slice_of is not v.slice_of
+                    ):
                         new_slice_of_v = sub_slice_of
                         slice_meta_changed = True
 

--- a/tests/circuit/test_slice_pattern_correctness.py
+++ b/tests/circuit/test_slice_pattern_correctness.py
@@ -366,6 +366,411 @@ class TestInlineSliceAssignBroadcast:
         assert int(est.gates.total) == 3
 
 
+# Module-scope sub-kernels used by ``TestInlineCallSliceBroadcast``.
+# They live at module scope (rather than as class attributes) for the
+# same name-resolution reason as ``_h_all``: the entry kernels reference
+# them by bare name, which is looked up via the function's
+# ``__globals__``.
+
+
+@qmc.qkernel
+def _slice_broadcast_inner(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Apply ``qs[0:2] = qmc.h(qs[0:2])`` inside a sub-kernel.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register whose first two
+            qubits are broadcast-H'd in-place.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The same register with the slice
+            assignment applied.
+    """
+    qs[0:2] = qmc.h(qs[0:2])
+    return qs
+
+
+@qmc.qkernel
+def _symbolic_slice_inner(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Apply ``qs[0:n-1] = qmc.h(qs[0:n-1])`` with symbolic bound.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register; the slice covers
+            every element except the last.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The same register with the symbolic
+            slice broadcast applied.
+    """
+    n = qs.shape[0]
+    qs[0 : n - 1] = qmc.h(qs[0 : n - 1])
+    return qs
+
+
+@qmc.qkernel
+def _nested_slice_inner(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Apply a slice-of-slice broadcast inside a sub-kernel.
+
+    Builds ``s1 = qs[0:4]`` (a view) and then broadcasts H on
+    ``s1[0:2]`` (a view of a view).  The two-level slice chain
+    stresses recursive ``slice_of`` rewriting through ``InlinePass``.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 4.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to
+            ``qs[0]`` and ``qs[1]``.
+    """
+    s1 = qs[0:4]
+    s1[0:2] = qmc.h(s1[0:2])
+    qs[0:4] = s1
+    return qs
+
+
+@qmc.qkernel
+def _multi_slice_inner(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Apply two independent slice broadcasts in the same sub-kernel.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 4.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to every
+            element via two non-overlapping slice broadcasts.
+    """
+    qs[0:2] = qmc.h(qs[0:2])
+    qs[2:4] = qmc.h(qs[2:4])
+    return qs
+
+
+@qmc.qkernel
+def _slice_and_scalar_inner(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Mix a slice broadcast with a scalar element gate.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 3.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to
+            ``qs[0]`` / ``qs[1]`` via slice broadcast and to ``qs[2]``
+            via a scalar element gate.
+    """
+    qs[0:2] = qmc.h(qs[0:2])
+    qs[2] = qmc.h(qs[2])
+    return qs
+
+
+@qmc.qkernel
+def _slice_inner_for_two_level(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Innermost slice broadcast for the two-level inline chain.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to
+            ``qs[0]`` and ``qs[1]``.
+    """
+    qs[0:2] = qmc.h(qs[0:2])
+    return qs
+
+
+@qmc.qkernel
+def _slice_mid_for_two_level(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Mid layer that forwards to ``_slice_inner_for_two_level``.
+
+    Used as the intermediate level in the entry → mid → innermost
+    chain so the slice broadcast is reached after two levels of
+    inlining.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The same register, with the innermost
+            slice broadcast applied.
+    """
+    qs = _slice_inner_for_two_level(qs)
+    return qs
+
+
+# Deep-chain helpers for the four-level inline test.  Each layer simply
+# forwards to the next, so the entire chain only does one slice
+# broadcast at the innermost level.  The chain stresses that
+# ``InlinePass`` rewrites slice metadata consistently across an
+# arbitrary number of inline levels — the recursive ``substitute_value``
+# in ``ValueSubstitutor`` is bounded only by the depth of the call /
+# slice graph, so a chain that compiles at depth 4 also compiles at
+# any greater depth.
+
+
+@qmc.qkernel
+def _deep_chain_l0(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Innermost layer of the deep-inline chain — performs the slice broadcast.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to
+            ``qs[0]`` and ``qs[1]``.
+    """
+    qs[0:2] = qmc.h(qs[0:2])
+    return qs
+
+
+@qmc.qkernel
+def _deep_chain_l1(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Second-to-innermost forwarder for the deep-inline chain.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with the innermost slice
+            broadcast applied.
+    """
+    qs = _deep_chain_l0(qs)
+    return qs
+
+
+@qmc.qkernel
+def _deep_chain_l2(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Mid forwarder for the deep-inline chain.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with the innermost slice
+            broadcast applied.
+    """
+    qs = _deep_chain_l1(qs)
+    return qs
+
+
+@qmc.qkernel
+def _deep_chain_l3(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Outermost forwarder for the deep-inline chain (entry sees this).
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with the innermost slice
+            broadcast applied.
+    """
+    qs = _deep_chain_l2(qs)
+    return qs
+
+
+# Companion helpers that wrap a slice-of-slice inside a multi-level
+# inline chain — the slice broadcast lives two levels of inlining deep
+# AND inside a slice view of a slice, so the recursion through
+# ``substitute_value`` must walk both the inline chain and the slice
+# chain at the same time.
+
+
+@qmc.qkernel
+def _nested_slice_innermost(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Innermost layer for the nested-slice deep-inline chain.
+
+    Builds ``s1 = qs[0:4]`` and broadcasts H on ``s1[0:2]``.  The two
+    slice levels are walked by emit-time root resolution; the outer
+    inline call must have rewritten ``s1.slice_of`` to the caller's
+    actual register for that walk to terminate at a real qubit.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 4.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with H applied to
+            ``qs[0]`` and ``qs[1]``.
+    """
+    s1 = qs[0:4]
+    s1[0:2] = qmc.h(s1[0:2])
+    qs[0:4] = s1
+    return qs
+
+
+@qmc.qkernel
+def _nested_slice_mid(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Mid layer that forwards to ``_nested_slice_innermost``.
+
+    Args:
+        qs (qmc.Vector[qmc.Qubit]): Quantum register of length >= 4.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The register with the slice-of-slice
+            broadcast applied at the innermost level.
+    """
+    qs = _nested_slice_innermost(qs)
+    return qs
+
+
+@qmc.qkernel
+def _view_arg_slicer(view: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+    """Re-slice a ``Vector[Qubit]`` parameter and apply a slice broadcast.
+
+    The caller is expected to pass a ``VectorView`` (e.g.
+    ``q[0::2]``); the sub-kernel further slices it with ``view[0:2]``
+    and applies H.  The two slice levels chain through ``InlinePass``.
+
+    Args:
+        view (qmc.Vector[qmc.Qubit]): Vector or view of length >= 2.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: The same handle with H applied to
+            ``view[0]`` and ``view[1]``.
+    """
+    view[0:2] = qmc.h(view[0:2])
+    return view
+
+
+class TestInlineCallSliceBroadcast:
+    """Slice broadcast lives in a sub-kernel and is reached via inline.
+
+    Companion to :class:`TestInlineSliceAssignBroadcast`, which covers
+    the same ``qs[a:b] = qmc.h(qs[a:b])`` pattern written directly in
+    the entry kernel.  This class is a regression net for the bug
+    where ``InlinePass`` left a sliced ``ArrayValue``'s ``slice_of``
+    pointing at the callee's cloned ``qs`` parameter even after the
+    parameter itself was substituted to the caller's register.  The
+    emit pass then chased the stale UUID on the element values inside
+    the broadcast loop and aborted with ``QubitIndexResolutionError``.
+
+    Each test transpiles on every supported backend and compares the
+    resulting statevector to an analytical Qiskit reference, so a
+    structural regression that compiles but emits the wrong qubit
+    indices is also caught.
+    """
+
+    @qmc.qkernel
+    def _kern_concrete() -> qmc.Vector[qmc.Bit]:
+        """Concrete slice ``qs[0:2]`` broadcast reached through inline."""
+        qs = qmc.qubit_array(3, "qs")
+        qs = _slice_broadcast_inner(qs)
+        return qmc.measure(qs)
+
+    def test_concrete_transpile_and_statevector_match(self):
+        """The inlined ``qs[0:2] = qmc.h(qs[0:2])`` applies H to qs[0]/qs[1] only."""
+        expected_sv = _reference_statevector(3, [0, 1])
+        _assert_cross_backend_matches(self._kern_concrete, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_symbolic(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+        """Symbolic slice ``qs[0:n-1]`` broadcast reached through inline."""
+        qs = qmc.qubit_array(n, "qs")
+        qs = _symbolic_slice_inner(qs)
+        return qmc.measure(qs)
+
+    @pytest.mark.parametrize("n", [3, 5, 7])
+    def test_symbolic_transpile_and_statevector_match(self, n: int):
+        """``qs[0:n-1]`` covers every qubit except the last across multiple sizes."""
+        expected_sv = _reference_statevector(n, list(range(n - 1)))
+        _assert_cross_backend_matches(self._kern_symbolic, {"n": n}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_nested_slice() -> qmc.Vector[qmc.Bit]:
+        """Slice-of-slice broadcast reached through inline."""
+        qs = qmc.qubit_array(6, "qs")
+        qs = _nested_slice_inner(qs)
+        return qmc.measure(qs)
+
+    def test_nested_slice_transpile_and_statevector_match(self):
+        """``s1 = qs[0:4]; s1[0:2] = h(s1[0:2])`` applies H to qs[0]/qs[1]."""
+        expected_sv = _reference_statevector(6, [0, 1])
+        _assert_cross_backend_matches(self._kern_nested_slice, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_multi_slice() -> qmc.Vector[qmc.Bit]:
+        """Two independent slice broadcasts inside the inlined sub-kernel."""
+        qs = qmc.qubit_array(4, "qs")
+        qs = _multi_slice_inner(qs)
+        return qmc.measure(qs)
+
+    def test_multi_slice_transpile_and_statevector_match(self):
+        """Both ``qs[0:2]`` and ``qs[2:4]`` broadcasts survive inlining."""
+        expected_sv = _reference_statevector(4, [0, 1, 2, 3])
+        _assert_cross_backend_matches(self._kern_multi_slice, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_slice_and_scalar() -> qmc.Vector[qmc.Bit]:
+        """Slice broadcast plus a scalar element gate inside the sub-kernel."""
+        qs = qmc.qubit_array(3, "qs")
+        qs = _slice_and_scalar_inner(qs)
+        return qmc.measure(qs)
+
+    def test_slice_and_scalar_transpile_and_statevector_match(self):
+        """Mixing slice and scalar element gates in one inlined sub-kernel works."""
+        expected_sv = _reference_statevector(3, [0, 1, 2])
+        _assert_cross_backend_matches(self._kern_slice_and_scalar, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_two_level_inline() -> qmc.Vector[qmc.Bit]:
+        """Entry → mid → innermost chain; slice broadcast lives in the innermost."""
+        qs = qmc.qubit_array(3, "qs")
+        qs = _slice_mid_for_two_level(qs)
+        return qmc.measure(qs)
+
+    def test_two_level_inline_transpile_and_statevector_match(self):
+        """Slice metadata survives two levels of inlining."""
+        expected_sv = _reference_statevector(3, [0, 1])
+        _assert_cross_backend_matches(self._kern_two_level_inline, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_view_arg_inner_slice(num: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+        """Pass ``q[0::2]`` to a sub-kernel that further slices it."""
+        q = qmc.qubit_array(num, "q")
+        evens = q[0::2]
+        evens = _view_arg_slicer(evens)
+        q[0::2] = evens
+        return qmc.measure(q)
+
+    def test_view_arg_inner_slice_transpile_and_statevector_match(self):
+        """Slice chain ``q[0::2][0:2]`` resolves to root qubits q[0] / q[2]."""
+        # num=6: evens = q[0::2] = {q[0], q[2], q[4]}.  The sub-kernel
+        # applies H to view[0:2] = {evens[0], evens[1]} = {q[0], q[2]}.
+        expected_sv = _reference_statevector(6, [0, 2])
+        _assert_cross_backend_matches(
+            self._kern_view_arg_inner_slice, {"num": 6}, expected_sv
+        )
+
+    @qmc.qkernel
+    def _kern_four_level_inline() -> qmc.Vector[qmc.Bit]:
+        """Four-level inline chain (entry → l3 → l2 → l1 → l0) with slice broadcast at the innermost.
+
+        Exercises that ``InlinePass`` rewrites slice metadata
+        consistently across an arbitrary depth of inline calls; the
+        recursive ``substitute_value`` in ``ValueSubstitutor`` is
+        bounded only by the depth of the call / slice graph, so a
+        depth-4 chain that compiles also compiles at any greater
+        depth.
+        """
+        qs = qmc.qubit_array(3, "qs")
+        qs = _deep_chain_l3(qs)
+        return qmc.measure(qs)
+
+    def test_four_level_inline_transpile_and_statevector_match(self):
+        """Slice metadata survives four levels of inlining."""
+        expected_sv = _reference_statevector(3, [0, 1])
+        _assert_cross_backend_matches(self._kern_four_level_inline, {}, expected_sv)
+
+    @qmc.qkernel
+    def _kern_nested_slice_two_level_inline() -> qmc.Vector[qmc.Bit]:
+        """Nested slice (slice-of-slice) reached through two levels of inline."""
+        qs = qmc.qubit_array(6, "qs")
+        qs = _nested_slice_mid(qs)
+        return qmc.measure(qs)
+
+    def test_nested_slice_two_level_inline_transpile_and_statevector_match(self):
+        """Slice-of-slice broadcast through two levels of inlining."""
+        expected_sv = _reference_statevector(6, [0, 1])
+        _assert_cross_backend_matches(
+            self._kern_nested_slice_two_level_inline, {}, expected_sv
+        )
+
+
 class TestTopLevelSliceWithBodyLoop:
     """``evens = q[0::2]; for i ...; q[0::2] = evens``."""
 


### PR DESCRIPTION
## Summary

Slice assignment broadcast (e.g. `qs[a:b] = qmc.h(qs[a:b])`) only worked when written directly in the entry kernel. When the same pattern lived in a sub-kernel and the sub was invoked via inline from another kernel, emit failed with `QubitIndexResolutionError: Computed qubit ID '<qs_slice_uuid>_0' not found in qubit_map`. The bug was present from the original slice-broadcast commit (1953c81e) — sub-kernel-via-inline was simply never covered by tests.

Root cause: `ValueSubstitutor.substitute_value` and `_resubstitute_fields` were rewriting `parent_array` / `slice_of` only when the field's own UUID appeared in the substitution map. For an element value inside a callee's broadcast loop the chain is `element.parent_array = sliced_av_clone` (a freshly-cloned UUID not in the map) and `sliced_av_clone.slice_of = qs_param_clone` (a UUID that *is* in the map). A shallow direct-lookup check missed the nested reference, so emit walked a stale `slice_of` pointing at the inner block's input parameter rather than the outer-allocated array.

Fix: substitute `parent_array` and `slice_of` by recursing through `substitute_value` so the slice chain is walked field-by-field and every transitively referenced callee dummy is rewritten consistently. The recursion is bounded by the depth of the call / slice graph, so this works for arbitrarily deep sub-kernel chains and arbitrarily deep nested slices.

## Test plan

- [x] New regression class `TestInlineCallSliceBroadcast` in `tests/circuit/test_slice_pattern_correctness.py` with 11 cases covering: concrete slice, symbolic slice over `n ∈ {3, 5, 7}`, slice-of-slice, multi-slice, slice + scalar mix, two-level inline, four-level inline, nested slice through two-level inline, and `VectorView` passed as a sub-kernel argument with further re-slicing inside.
- [x] Cross-backend execution (Qiskit / QuriParts / CUDA-Q) via the existing `_assert_cross_backend_matches` helper; statevector comparison against an analytic Qiskit reference for every backend that imports successfully.
- [x] Existing slice / inline / transpiler tests remain green: `tests/circuit/test_slice_pattern_correctness.py`, `tests/circuit/test_vector_slicing.py`, `tests/circuit/test_drawer_slice.py`, `tests/transpiler/` all pass (5935 passed, 465 skipped on `tests/circuit/ tests/transpiler/`).
- [x] `ruff check qamomile/ tests/` clean; `ruff format --check qamomile/ tests/` clean.
- [x] `zuban check qamomile/` introduces 0 new errors (the 81 reported errors are pre-existing on `main`, verified by re-running against the base branch).
- [x] `/local-review` clean (P0–P3 all zero).