### PR TITLE
Use dedicated symbols for controlled gates

### DIFF
--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -33,6 +33,7 @@ from qamomile.circuit.ir.operation.gate import (
     MeasureVectorOperation,
 )
 from qamomile.circuit.ir.operation.operation import QInitOperation
+from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.types.primitives import QubitType
 from qamomile.circuit.ir.value import ArrayValue, Value
 
@@ -1000,7 +1001,12 @@ class CircuitAnalyzer:
             u_name = getattr(op.block, "name", "U") or "U"
             power_val = self._resolve_controlled_u_power(op, param_values)
             label = f"{u_name}^{power_val}" if power_val > 1 else u_name
-            box_width = self._estimate_label_box_width(label)
+            controlled_gate_type = self._controlled_u_single_gate_type(op, power_val)
+            box_width = (
+                self.style.gate_width
+                if controlled_gate_type is not None
+                else self._estimate_label_box_width(label)
+            )
             # Control qubits first, then target qubits
             control_indices: list[int] = []
             for qval in op.control_operands:
@@ -1022,6 +1028,7 @@ class CircuitAnalyzer:
                 qubit_indices=control_indices + target_indices,
                 estimated_width=box_width,
                 kind=VGateKind.CONTROLLED_U_BOX,
+                gate_type=controlled_gate_type,
                 box_width=box_width,
                 control_count=len(control_indices),
             )
@@ -1029,6 +1036,46 @@ class CircuitAnalyzer:
         raise TypeError(
             f"Unsupported operation type for _build_vgate: {type(op).__name__}"
         )
+
+    def _controlled_u_single_gate_type(
+        self, op: ControlledUOperation, power: int
+    ) -> GateOperationType | None:
+        """Return the wrapped gate type when controlled-U is a single gate.
+
+        Args:
+            op (ControlledUOperation): Controlled operation whose wrapped
+                block may contain one concrete `GateOperation`.
+            power (int): Resolved controlled-U power. Values greater than one
+                are left in box form so the exponent remains visible.
+
+        Returns:
+            GateOperationType | None: Wrapped gate type when the controlled
+                block is exactly one gate plus an optional return operation;
+                otherwise None.
+        """
+        if power != 1:
+            return None
+        block = op.block
+        if block is None:
+            return None
+        body_ops = [
+            body_op
+            for body_op in block.operations
+            if not isinstance(body_op, ReturnOperation)
+        ]
+        if len(body_ops) != 1 or not isinstance(body_ops[0], GateOperation):
+            return None
+        gate_type = body_ops[0].gate_type
+        if gate_type not in {
+            GateOperationType.X,
+            GateOperationType.Z,
+            GateOperationType.CX,
+            GateOperationType.CZ,
+            GateOperationType.SWAP,
+            GateOperationType.TOFFOLI,
+        }:
+            return None
+        return gate_type
 
     def _build_vexpval(
         self,

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -706,6 +706,11 @@ class MatplotlibRenderer:
         )
         ax.add_line(line)
 
+        if self._draw_vcontrolled_u_special_gate(
+            ax, node.gate_type, x_pos, control_y, target_y
+        ):
+            return
+
         # Draw control dots
         for y in control_y:
             self._draw_control_dot(ax, x_pos, y)
@@ -742,6 +747,57 @@ class MatplotlibRenderer:
                 fontsize=self.style.font_size,
                 zorder=PORDER_TEXT,
             )
+
+    def _draw_vcontrolled_u_special_gate(
+        self,
+        ax: Axes,
+        gate_type: GateOperationType | None,
+        x_pos: float,
+        control_y: list[float],
+        target_y: list[float],
+    ) -> bool:
+        """Draw a controlled built-in gate without falling back to a box.
+
+        Args:
+            ax (Axes): Matplotlib Axes to draw on.
+            gate_type (GateOperationType | None): Built-in gate type wrapped
+                by the `ControlledUOperation`.
+            x_pos (float): X coordinate of the operation.
+            control_y (list[float]): Y coordinates of explicit control wires.
+            target_y (list[float]): Y coordinates of wrapped-gate operands.
+
+        Returns:
+            bool: True when a dedicated symbol was drawn; False when the
+                caller should draw the generic controlled-U box.
+        """
+        if gate_type is None or not target_y:
+            return False
+
+        if gate_type == GateOperationType.SWAP:
+            if len(target_y) != 2:
+                return False
+            for y in control_y:
+                self._draw_control_dot(ax, x_pos, y)
+            for y in target_y:
+                self._draw_swap_x(ax, x_pos, y)
+            return True
+
+        if gate_type in {
+            GateOperationType.X,
+            GateOperationType.CX,
+            GateOperationType.TOFFOLI,
+        }:
+            for y in control_y + target_y[:-1]:
+                self._draw_control_dot(ax, x_pos, y)
+            self._draw_target_x(ax, x_pos, target_y[-1])
+            return True
+
+        if gate_type in {GateOperationType.Z, GateOperationType.CZ}:
+            for y in control_y + target_y:
+                self._draw_control_dot(ax, x_pos, y)
+            return True
+
+        return False
 
     def _draw_vexpval(
         self,

--- a/tests/circuit/test_drawer_controlled.py
+++ b/tests/circuit/test_drawer_controlled.py
@@ -1,0 +1,247 @@
+"""Regression tests for dedicated rendering of controlled built-in gates."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from typing import Any
+
+import matplotlib.patches as mpatches
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.ir.operation.gate import GateOperationType
+from qamomile.circuit.visualization.analyzer import CircuitAnalyzer
+from qamomile.circuit.visualization.drawer import MatplotlibDrawer
+from qamomile.circuit.visualization.style import DEFAULT_STYLE
+from qamomile.circuit.visualization.visual_ir import VGate, VGateKind
+
+
+@qmc.qkernel
+def _x_gate(q: qmc.Qubit) -> qmc.Qubit:
+    """Apply X as a wrapped single-gate qkernel.
+
+    Args:
+        q (qmc.Qubit): Input qubit.
+
+    Returns:
+        qmc.Qubit: Output qubit after X.
+    """
+    return qmc.x(q)
+
+
+@qmc.qkernel
+def _z_gate(q: qmc.Qubit) -> qmc.Qubit:
+    """Apply Z as a wrapped single-gate qkernel.
+
+    Args:
+        q (qmc.Qubit): Input qubit.
+
+    Returns:
+        qmc.Qubit: Output qubit after Z.
+    """
+    return qmc.z(q)
+
+
+@qmc.qkernel
+def _cx_gate(c: qmc.Qubit, t: qmc.Qubit) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Apply CX as a wrapped single-gate qkernel.
+
+    Args:
+        c (qmc.Qubit): Control qubit.
+        t (qmc.Qubit): Target qubit.
+
+    Returns:
+        tuple[qmc.Qubit, qmc.Qubit]: Output control and target qubits.
+    """
+    return qmc.cx(c, t)
+
+
+@qmc.qkernel
+def _cz_gate(c: qmc.Qubit, t: qmc.Qubit) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Apply CZ as a wrapped single-gate qkernel.
+
+    Args:
+        c (qmc.Qubit): Control qubit.
+        t (qmc.Qubit): Target qubit.
+
+    Returns:
+        tuple[qmc.Qubit, qmc.Qubit]: Output control and target qubits.
+    """
+    return qmc.cz(c, t)
+
+
+@qmc.qkernel
+def _swap_gate(a: qmc.Qubit, b: qmc.Qubit) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Apply SWAP as a wrapped single-gate qkernel.
+
+    Args:
+        a (qmc.Qubit): First qubit.
+        b (qmc.Qubit): Second qubit.
+
+    Returns:
+        tuple[qmc.Qubit, qmc.Qubit]: Output qubits after SWAP.
+    """
+    return qmc.swap(a, b)
+
+
+@qmc.qkernel
+def _ccx_gate(
+    c0: qmc.Qubit, c1: qmc.Qubit, t: qmc.Qubit
+) -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply Toffoli as a wrapped single-gate qkernel.
+
+    Args:
+        c0 (qmc.Qubit): First control qubit.
+        c1 (qmc.Qubit): Second control qubit.
+        t (qmc.Qubit): Target qubit.
+
+    Returns:
+        tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]: Output control and target qubits.
+    """
+    return qmc.ccx(c0, c1, t)
+
+
+@qmc.qkernel
+def _controlled_x_kernel() -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Apply controlled X so the drawer can use the CX symbol."""
+    q = qmc.qubit_array(2, "q")
+    cx = qmc.controlled(_x_gate)
+    return cx(q[0], q[1])
+
+
+@qmc.qkernel
+def _controlled_z_kernel() -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Apply controlled Z so the drawer can use the CZ-dot symbol."""
+    q = qmc.qubit_array(2, "q")
+    cz = qmc.controlled(_z_gate)
+    return cz(q[0], q[1])
+
+
+@qmc.qkernel
+def _controlled_cx_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply controlled CX so the drawer can use the Toffoli-style symbol."""
+    q = qmc.qubit_array(3, "q")
+    ccx = qmc.controlled(_cx_gate)
+    return ccx(q[0], q[1], q[2])
+
+
+@qmc.qkernel
+def _controlled_cz_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply controlled CZ so the drawer can use the CCZ-style symbol."""
+    q = qmc.qubit_array(3, "q")
+    ccz = qmc.controlled(_cz_gate)
+    return ccz(q[0], q[1], q[2])
+
+
+@qmc.qkernel
+def _controlled_swap_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply controlled SWAP so the drawer can use the Fredkin symbol."""
+    q = qmc.qubit_array(3, "q")
+    cswap = qmc.controlled(_swap_gate)
+    return cswap(q[0], q[1], q[2])
+
+
+@qmc.qkernel
+def _controlled_builtin_swap_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply controlled built-in SWAP so the synthesized wrapper is covered."""
+    q = qmc.qubit_array(3, "q")
+    cswap = qmc.controlled(qmc.swap)
+    return cswap(q[0], q[1], q[2])
+
+
+@qmc.qkernel
+def _controlled_ccx_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Apply controlled Toffoli so the drawer can use a multi-control X symbol."""
+    q = qmc.qubit_array(4, "q")
+    cccx = qmc.controlled(_ccx_gate)
+    return cccx(q[0], q[1], q[2], q[3])
+
+
+@qmc.qkernel
+def _powered_controlled_swap_kernel() -> tuple[qmc.Qubit, qmc.Qubit, qmc.Qubit]:
+    """Keep powered controlled SWAP as a box so the exponent is visible."""
+    q = qmc.qubit_array(3, "q")
+    cswap = qmc.controlled(_swap_gate)
+    return cswap(q[0], q[1], q[2], power=2)
+
+
+def _controlled_u_nodes(kernel: Any) -> list[VGate]:
+    """Build controlled-U visual nodes from a kernel.
+
+    Args:
+        kernel (Any): QKernel whose visual IR should be inspected.
+
+    Returns:
+        list[VGate]: Controlled-U visual nodes found in the top-level block.
+    """
+    graph = kernel._build_graph_for_visualization()
+    analyzer = CircuitAnalyzer(graph, DEFAULT_STYLE)
+    qubit_map, qubit_names, num_qubits = analyzer.build_qubit_map(graph)
+    vc = analyzer.build_visual_ir(graph, qubit_map, qubit_names, num_qubits)
+    return [
+        node
+        for node in vc.children
+        if isinstance(node, VGate) and node.kind == VGateKind.CONTROLLED_U_BOX
+    ]
+
+
+@pytest.mark.parametrize(
+    ("kernel", "gate_type", "qubit_indices"),
+    [
+        pytest.param(_controlled_x_kernel, GateOperationType.X, [0, 1], id="x"),
+        pytest.param(_controlled_z_kernel, GateOperationType.Z, [0, 1], id="z"),
+        pytest.param(_controlled_cx_kernel, GateOperationType.CX, [0, 1, 2], id="cx"),
+        pytest.param(_controlled_cz_kernel, GateOperationType.CZ, [0, 1, 2], id="cz"),
+        pytest.param(
+            _controlled_swap_kernel,
+            GateOperationType.SWAP,
+            [0, 1, 2],
+            id="swap",
+        ),
+        pytest.param(
+            _controlled_builtin_swap_kernel,
+            GateOperationType.SWAP,
+            [0, 1, 2],
+            id="builtin-swap",
+        ),
+        pytest.param(
+            _controlled_ccx_kernel,
+            GateOperationType.TOFFOLI,
+            [0, 1, 2, 3],
+            id="toffoli",
+        ),
+    ],
+)
+def test_controlled_single_gate_nodes_remember_dedicated_gate_type(
+    kernel, gate_type, qubit_indices
+):
+    """Controlled wrappers around dedicated gates carry their gate type."""
+    nodes = _controlled_u_nodes(kernel)
+    assert len(nodes) == 1
+    assert nodes[0].gate_type == gate_type
+    assert nodes[0].control_count == 1
+    assert nodes[0].qubit_indices == qubit_indices
+    assert nodes[0].estimated_width == DEFAULT_STYLE.gate_width
+
+
+def test_powered_controlled_swap_stays_generic_box():
+    """Powered controlled SWAP remains boxed because the power matters."""
+    nodes = _controlled_u_nodes(_powered_controlled_swap_kernel)
+    assert len(nodes) == 1
+    assert nodes[0].gate_type is None
+    assert nodes[0].estimated_width > DEFAULT_STYLE.gate_width
+
+
+def test_controlled_swap_draws_symbols_instead_of_target_box():
+    """Controlled SWAP renders as a control dot plus SWAP markers."""
+    fig = MatplotlibDrawer.draw_kernel(_controlled_swap_kernel)
+    ax = fig.axes[0]
+
+    rounded_boxes = [
+        patch for patch in ax.patches if isinstance(patch, mpatches.FancyBboxPatch)
+    ]
+    control_dots = [patch for patch in ax.patches if isinstance(patch, mpatches.Circle)]
+
+    assert rounded_boxes == []
+    assert len(control_dots) == 1


### PR DESCRIPTION
## Summary

This PR updates the circuit drawer so controlled wrappers around simple built-in gates can reuse the drawer's dedicated gate symbols instead of always falling back to a generic controlled-U box. Controlled SWAP now renders as a Fredkin-style control dot plus SWAP markers, and controlled X/Z/CX/CZ/Toffoli wrappers also use their dedicated visual forms when the wrapped block is exactly one supported gate.

The IR and backend emission semantics are unchanged. The new behavior is carried as visualization metadata in the analyzer and consumed by the matplotlib renderer.

## Testing

- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run pytest tests/circuit/test_drawer_controlled.py tests/circuit/test_drawer_slice.py tests/circuit/test_drawer_for_items.py -q

Type checking was intentionally skipped per maintainer instruction during local review.