### PR TITLE
Fix deep inline draw routing for bound data

### DIFF
--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -34,7 +34,7 @@ from qamomile.circuit.ir.operation.gate import (
 )
 from qamomile.circuit.ir.operation.operation import QInitOperation
 from qamomile.circuit.ir.types.primitives import QubitType
-from qamomile.circuit.ir.value import ArrayValue, Value
+from qamomile.circuit.ir.value import ArrayValue, DictValue, Value, ValueBase
 
 from .geometry import compute_border_padding
 from .style import CircuitStyle
@@ -635,7 +635,9 @@ class CircuitAnalyzer:
                 elif isinstance(op, ForItemsOperation):
                     dict_value = op.operands[0] if op.operands else None
                     materialized = (
-                        self._materialize_dict_entries(dict_value)
+                        self._materialize_dict_entries(
+                            dict_value, param_values, logical_id_remap
+                        )
                         if dict_value is not None
                         else None
                     )
@@ -1451,7 +1453,7 @@ class CircuitAnalyzer:
 
         # Materialize entries
         materialized = (
-            self._materialize_dict_entries(dict_value)
+            self._materialize_dict_entries(dict_value, param_values, logical_id_remap)
             if dict_value is not None
             else None
         )
@@ -1789,7 +1791,7 @@ class CircuitAnalyzer:
         def add_affected(operand: Value) -> None:
             """Resolve `operand` and merge its wire indices into `affected`."""
             indices = self._resolve_operand_to_affected_qubits(
-                operand, qubit_map, logical_id_remap
+                operand, qubit_map, logical_id_remap, param_values
             )
             if indices is not None:
                 affected.update(indices)
@@ -2597,6 +2599,10 @@ class CircuitAnalyzer:
             start = s_int + st_int * start
             step = st_int * step
             cur = cur.slice_of
+            assert cur is not None, (
+                "[FOR DEVELOPER] slice_of must point at a parent ArrayValue while "
+                "walking a slice chain."
+            )
         return cur, start, step
 
     def _compute_slice_view_wires(
@@ -3069,26 +3075,33 @@ class CircuitAnalyzer:
 
     def _build_block_value_mappings(
         self,
-        block_value,
-        actual_inputs: list[Value],
+        block_value: Block,
+        actual_inputs: Sequence[ValueBase],
         logical_id_remap: dict[str, str],
-        param_values: dict,
+        param_values: dict[str, object],
         qubit_map: dict[str, int] | None = None,
-    ) -> tuple[dict[str, str], dict]:
-        """Build logical_id_remap and child_param_values for a nested Block.
+    ) -> tuple[dict[str, str], dict[str, object]]:
+        """Build value remaps and forwarded bindings for a nested block.
 
-        Maps dummy block input logical_ids to actual input logical_ids,
-        building the mappings needed for recursive processing.
+        Maps a callee block's formal inputs to the caller's actual
+        operands so inline drawing can resolve qubit wires, scalar
+        parameters, bound array data, and bound dict data recursively.
 
         Args:
-            block_value: Block whose input mappings to build.
-            actual_inputs: Actual input Values passed to the block.
-            logical_id_remap: Current logical_id remapping (copied, not mutated).
-            param_values: Current parameter values (copied, not mutated).
-            qubit_map: Qubit wire map for resolving array element indices.
+            block_value (Block): Callee block whose input mappings to build.
+            actual_inputs (Sequence[ValueBase]): Actual operands passed to
+                the callee block.
+            logical_id_remap (dict[str, str]): Current logical-id remapping.
+                Copied before child-specific entries are added.
+            param_values (dict[str, object]): Current parameter and bound-data
+                values. Copied before child-specific entries are added.
+            qubit_map (dict[str, int] | None): Qubit wire map for resolving
+                array element indices. Defaults to None when wire resolution
+                is not needed.
 
         Returns:
-            (new_logical_id_remap, child_param_values)
+            tuple[dict[str, str], dict[str, object]]: Child logical-id remap
+                and child parameter values for recursive inline processing.
         """
         new_logical_id_remap = dict(logical_id_remap)
 
@@ -3097,6 +3110,7 @@ class CircuitAnalyzer:
             # to get the canonical parent_[idx] key instead of the raw UUID
             if (
                 qubit_map is not None
+                and isinstance(actual_input, Value)
                 and hasattr(actual_input, "parent_array")
                 and actual_input.parent_array is not None
                 and isinstance(actual_input.type, QubitType)
@@ -3113,23 +3127,29 @@ class CircuitAnalyzer:
 
         child_param_values = dict(param_values)
         for dummy_input, actual_input in zip(block_value.input_values, actual_inputs):
-            # The IR guarantees that operands are always Value instances, so this assertion should always pass.
+            # The IR guarantees that operands implement ValueBase, so this assertion should always pass.
             # If it fails, there is a bug in the IR construction.
             assertion_message = (
-                "[FOR DEVELOPER] Operation.operands elements must be Value instances. "
+                "[FOR DEVELOPER] Operation.operands elements must be ValueBase instances. "
                 "If this assertion fails, there is a bug in the IR construction."
             )
-            assert isinstance(actual_input, Value), assertion_message
+            assert isinstance(actual_input, ValueBase), assertion_message
+            actual_lid = logical_id_remap.get(
+                actual_input.logical_id, actual_input.logical_id
+            )
             const = actual_input.get_const()
             if const is not None:
                 child_param_values[dummy_input.logical_id] = const
-            elif actual_input.logical_id in param_values:
-                pv = param_values[actual_input.logical_id]
+            elif actual_input.logical_id in param_values or actual_lid in param_values:
+                pv = param_values.get(
+                    actual_input.logical_id, param_values.get(actual_lid)
+                )
                 if isinstance(pv, (int, float)):
                     # Numeric value: store directly
                     child_param_values[dummy_input.logical_id] = pv
                 elif (
-                    hasattr(actual_input, "parent_array")
+                    isinstance(actual_input, Value)
+                    and hasattr(actual_input, "parent_array")
                     and actual_input.parent_array is not None
                     and not isinstance(actual_input.type, QubitType)
                 ):
@@ -3148,7 +3168,8 @@ class CircuitAnalyzer:
                 else:
                     child_param_values[dummy_input.logical_id] = pv
             elif (
-                hasattr(actual_input, "parent_array")
+                isinstance(actual_input, Value)
+                and hasattr(actual_input, "parent_array")
                 and actual_input.parent_array is not None
                 and not isinstance(actual_input.type, QubitType)
             ):
@@ -3171,7 +3192,7 @@ class CircuitAnalyzer:
                 child_param_values[dummy_input.logical_id] = (
                     actual_input.parameter_name() or actual_input.name
                 )
-            else:
+            elif isinstance(actual_input, Value):
                 # actual_input is a BinOp result (or similar unresolved
                 # non-parameter Value). Try numeric evaluation via
                 # graph.operations first — after top-level
@@ -3218,9 +3239,35 @@ class CircuitAnalyzer:
                                 actual_dim.logical_id
                             ]
                 const_array = actual_input.get_const_array()
+                if const_array is None:
+                    actual_lid = logical_id_remap.get(
+                        actual_input.logical_id, actual_input.logical_id
+                    )
+                    const_array = param_values.get(
+                        f"_array_data_{actual_input.logical_id}",
+                        param_values.get(f"_array_data_{actual_lid}"),
+                    )
                 if const_array is not None:
                     child_param_values[f"_array_data_{dummy_input.logical_id}"] = (
                         const_array
+                    )
+            elif isinstance(actual_input, DictValue) and hasattr(
+                dummy_input, "logical_id"
+            ):
+                bound_data = None
+                if actual_input.metadata.dict_runtime is not None:
+                    bound_data = list(actual_input.get_bound_data_items())
+                else:
+                    actual_lid = logical_id_remap.get(
+                        actual_input.logical_id, actual_input.logical_id
+                    )
+                    bound_data = param_values.get(
+                        f"_dict_data_{actual_input.logical_id}",
+                        param_values.get(f"_dict_data_{actual_lid}"),
+                    )
+                if bound_data is not None:
+                    child_param_values[f"_dict_data_{dummy_input.logical_id}"] = (
+                        bound_data
                     )
 
         return new_logical_id_remap, child_param_values
@@ -3328,7 +3375,9 @@ class CircuitAnalyzer:
 
     @staticmethod
     def _materialize_dict_entries(
-        dict_value: Value,
+        dict_value: ValueBase,
+        param_values: dict | None = None,
+        logical_id_remap: dict[str, str] | None = None,
     ) -> Sequence[tuple] | None:
         """Extract entries from a DictValue from either IR or runtime metadata.
 
@@ -3366,10 +3415,18 @@ class CircuitAnalyzer:
         otherwise treating the pair as raw Python.
 
         Args:
-            dict_value (Value): The DictValue (or compatible Value)
+            dict_value (ValueBase): The DictValue (or compatible Value)
                 whose entries should be materialized. Should carry
                 IR-level ``entries`` or runtime ``dict_runtime``
                 metadata; otherwise treated as truly unbound.
+            param_values (dict | None): Optional nested visualization
+                context. Used to forward bound dict data through
+                inlined helper calls whose formal parameter does not
+                itself carry runtime metadata.
+            logical_id_remap (dict[str, str] | None): Optional remap
+                from formal logical IDs to actual logical IDs. Used
+                with ``param_values`` when resolving forwarded bound
+                dict data.
 
         Returns:
             Sequence[tuple] | None: A sequence of ``(key, value)``
@@ -3396,10 +3453,22 @@ class CircuitAnalyzer:
         # an empty bound Dict render as a folded box even when
         # fold_loops=False.
         if (
-            hasattr(dict_value, "metadata")
+            isinstance(dict_value, DictValue)
             and dict_value.metadata.dict_runtime is not None
         ):
             return list(dict_value.get_bound_data_items())
+
+        if param_values is not None:
+            logical_id_remap = logical_id_remap or {}
+            resolved_lid = logical_id_remap.get(
+                dict_value.logical_id, dict_value.logical_id
+            )
+            for key in (
+                f"_dict_data_{dict_value.logical_id}",
+                f"_dict_data_{resolved_lid}",
+            ):
+                if key in param_values:
+                    return list(param_values[key])
 
         return None
 
@@ -4055,14 +4124,14 @@ class CircuitAnalyzer:
                 hasattr(actual_input, "logical_id")
                 and actual_input.logical_id in qubit_map
             ):
-                # The IR guarantees that operands are always Value instances,
-                # so this assertion should always pass.
+                # The IR guarantees that operands implement the ValueBase
+                # protocol, so this assertion should always pass.
                 # If it fails, there is a bug in the IR construction.
                 assertion_message = (
-                    "[FOR DEVELOPER] Operation.operands elements must be Value instances. "
+                    "[FOR DEVELOPER] Operation.operands elements must be ValueBase instances. "
                     "If this assertion fails, there is a bug in the IR construction."
                 )
-                assert isinstance(actual_input, Value), assertion_message
+                assert isinstance(actual_input, ValueBase), assertion_message
                 const = actual_input.get_const()
                 if const is not None:
                     params.append(self._format_parameter(const))

--- a/tests/circuit/test_drawer_inline_depth.py
+++ b/tests/circuit/test_drawer_inline_depth.py
@@ -1,0 +1,171 @@
+"""Regression tests for deep inline drawing qubit routing."""
+
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.algorithm.qaoa import qaoa_state
+from qamomile.circuit.ir.operation.gate import GateOperationType
+from qamomile.circuit.visualization.analyzer import CircuitAnalyzer
+from qamomile.circuit.visualization.style import DEFAULT_STYLE
+from qamomile.circuit.visualization.visual_ir import (
+    VFoldedBlock,
+    VGate,
+    VInlineBlock,
+    VisualCircuit,
+    VisualNode,
+    VUnfoldedSequence,
+)
+
+
+@qmc.qkernel
+def _indexed_cx(
+    q: qmc.Vector[qmc.Qubit],
+    pairs: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Apply CX to the first pair stored in a bound matrix.
+
+    Args:
+        q (qmc.Vector[qmc.Qubit]): Qubit register to update.
+        pairs (qmc.Matrix[qmc.UInt]): Matrix whose first row stores
+            the control and target indices.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register.
+    """
+    q[pairs[0, 0]], q[pairs[0, 1]] = qmc.cx(q[pairs[0, 0]], q[pairs[0, 1]])
+    return q
+
+
+@qmc.qkernel
+def _forward_indexed_cx(
+    q: qmc.Vector[qmc.Qubit],
+    pairs: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Forward bound matrix data through one helper before applying CX.
+
+    Args:
+        q (qmc.Vector[qmc.Qubit]): Qubit register to update.
+        pairs (qmc.Matrix[qmc.UInt]): Matrix containing CX operand indices.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register.
+    """
+    q = _indexed_cx(q, pairs)
+    return q
+
+
+@qmc.qkernel
+def _indexed_cx_state(
+    pairs: qmc.Matrix[qmc.UInt],
+) -> qmc.Vector[qmc.Qubit]:
+    """Create three qubits and apply a nested matrix-indexed CX.
+
+    Args:
+        pairs (qmc.Matrix[qmc.UInt]): Matrix containing CX operand indices.
+
+    Returns:
+        qmc.Vector[qmc.Qubit]: Updated qubit register.
+    """
+    q = qmc.qubit_array(3, "q")
+    q = _forward_indexed_cx(q, pairs)
+    return q
+
+
+def _build_visual_circuit(
+    kernel: Any,
+    *,
+    analyzer_kwargs: dict[str, object],
+    kernel_kwargs: dict[str, object] | None = None,
+) -> VisualCircuit:
+    """Build a VisualCircuit directly from a qkernel for assertions.
+
+    Args:
+        kernel (Any): QKernel-like object that can build a visualization graph.
+        analyzer_kwargs (dict): Keyword arguments passed to CircuitAnalyzer.
+        kernel_kwargs (dict | None): Concrete draw-time bindings for the qkernel.
+
+    Returns:
+        VisualCircuit: Visual IR for assertion inspection.
+    """
+    graph = kernel._build_graph_for_visualization(**(kernel_kwargs or {}))
+    analyzer = CircuitAnalyzer(graph, DEFAULT_STYLE, **analyzer_kwargs)
+    qubit_map, qubit_names, num_qubits = analyzer.build_qubit_map(graph)
+    return analyzer.build_visual_ir(graph, qubit_map, qubit_names, num_qubits)
+
+
+def _walk_gates(nodes: list[VisualNode]) -> list[VGate]:
+    """Collect VGate nodes recursively from inline and unfolded children.
+
+    Args:
+        nodes (list[VisualNode]): Visual nodes to traverse.
+
+    Returns:
+        list[VGate]: Gate nodes found in traversal order.
+    """
+    gates: list[VGate] = []
+    for node in nodes:
+        if isinstance(node, VGate):
+            gates.append(node)
+        elif isinstance(node, VInlineBlock):
+            gates.extend(_walk_gates(node.children))
+        elif isinstance(node, VUnfoldedSequence):
+            for iteration in node.iterations:
+                gates.extend(_walk_gates(iteration))
+        elif isinstance(node, VFoldedBlock):
+            continue
+    return gates
+
+
+@pytest.mark.parametrize("inline_depth", [2, 3, 5])
+def test_nested_inline_matrix_indices_route_multi_qubit_gate(inline_depth):
+    """Deep inline drawing must preserve matrix-indexed CX operands."""
+    vc = _build_visual_circuit(
+        _indexed_cx_state,
+        kernel_kwargs={"pairs": [[1, 2]]},
+        analyzer_kwargs={
+            "inline": True,
+            "fold_loops": False,
+            "inline_depth": inline_depth,
+        },
+    )
+
+    cx_indices = [
+        gate.qubit_indices
+        for gate in _walk_gates(vc.children)
+        if gate.gate_type == GateOperationType.CX
+    ]
+    assert cx_indices == [[1, 2]]
+
+
+@pytest.mark.parametrize("inline_depth", [3, 5])
+def test_qaoa_state_deep_inline_routes_rzz_from_bound_dict(inline_depth):
+    """Deep inline drawing must preserve QAOA dict-indexed RZZ operands."""
+    vc = _build_visual_circuit(
+        qaoa_state,
+        kernel_kwargs={
+            "p": 1,
+            "quad": {(1, 2): 1.0},
+            "linear": {},
+            "n": 3,
+            "gammas": [1.0],
+            "betas": [1.0],
+        },
+        analyzer_kwargs={
+            "inline": True,
+            "fold_loops": False,
+            "inline_depth": inline_depth,
+        },
+    )
+
+    rzz_indices = [
+        gate.qubit_indices
+        for gate in _walk_gates(vc.children)
+        if gate.gate_type == GateOperationType.RZZ
+    ]
+    assert rzz_indices == [[1, 2]]


### PR DESCRIPTION
## Summary

Fix deep inline circuit drawing so bound array data and bound dictionary data are forwarded through nested inlined qkernel calls. This prevents multi-qubit gates whose operands are resolved from matrices or dict keys from collapsing onto the first qubit row at higher inline depths.

Add regressions for a nested matrix-indexed CX and for qaoa_state with a bound quadratic dict, both drawn with inline=True, fold_loops=False, and deep inline_depth values.

## Tests

- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run pytest tests/circuit/test_drawer_inline_depth.py tests/circuit/test_drawer_slice.py tests/circuit/algorithm/test_qaoa.py -q
- QAOA draw smoke with inline_depth=5

Type checking was skipped at the user request; full zuban currently fails on main with pre-existing errors.
