### PR TITLE
docs(tutorial): assert deterministic values in "Your First Quantum Kernel"

### DIFF
--- a/docs/en/tutorial/01_your_first_quantum_kernel.ipynb
+++ b/docs/en/tutorial/01_your_first_quantum_kernel.ipynb
@@ -220,7 +220,9 @@
    "source": [
     "est = biased_coin.estimate_resources()\n",
     "print(\"qubits:\", est.qubits)\n",
-    "print(\"total gates:\", est.gates.total)"
+    "assert est.qubits == 1\n",
+    "print(\"total gates:\", est.gates.total)\n",
+    "assert est.gates.total == 1"
    ]
   },
   {
@@ -289,7 +291,9 @@
     "# .result() blocks until the job completes and returns a SampleResult.\n",
     "result = job.result()\n",
     "\n",
-    "print(\"sample results:\", result.results)"
+    "print(\"sample results:\", result.results)\n",
+    "assert result.shots == 256\n",
+    "assert sum(count for _, count in result.results) == 256"
    ]
   },
   {
@@ -434,7 +438,9 @@
     "    biased_coin,\n",
     "    bindings={\"theta\": math.pi / 4},\n",
     ")\n",
-    "print(qiskit_circuit)"
+    "print(qiskit_circuit)\n",
+    "assert qiskit_circuit.num_qubits == 1\n",
+    "assert qiskit_circuit.num_clbits == 1"
    ]
   },
   {
@@ -538,7 +544,11 @@
     ")\n",
     "\n",
     "for outcome, count in demo_result.results:\n",
-    "    print(f\"  outcome={outcome}, count={count}\")"
+    "    print(f\"  outcome={outcome}, count={count}\")\n",
+    "assert demo_result.shots == 256\n",
+    "assert sum(count for _, count in demo_result.results) == 256\n",
+    "# Bell state |Phi+>: only (0,0) and (1,1) outcomes appear.\n",
+    "assert all(outcome in {(0, 0), (1, 1)} for outcome, _ in demo_result.results)"
    ]
   },
   {
@@ -621,7 +631,8 @@
     "    bad_rebind.draw()\n",
     "except Exception as e:\n",
     "    print(f\"Error type: {type(e).__name__}\")\n",
-    "    print(f\"Error message: {e}\")"
+    "    print(f\"Error message: {e}\")\n",
+    "    assert type(e).__name__ == \"QubitConsumedError\""
    ]
   },
   {

--- a/docs/en/tutorial/01_your_first_quantum_kernel.py
+++ b/docs/en/tutorial/01_your_first_quantum_kernel.py
@@ -112,7 +112,9 @@ biased_coin.draw(theta=0.6)
 # %%
 est = biased_coin.estimate_resources()
 print("qubits:", est.qubits)
+assert est.qubits == 1
 print("total gates:", est.gates.total)
+assert est.gates.total == 1
 
 # %% [markdown]
 # For this simple qkernel the numbers are concrete, but for parameterized qkernels they become symbolic SymPy expressions — we will explore this in detail in [Tutorial 02](02_parameterized_kernels.ipynb).
@@ -150,6 +152,8 @@ job = exe.sample(
 result = job.result()
 
 print("sample results:", result.results)
+assert result.shots == 256
+assert sum(count for _, count in result.results) == 256
 
 # %% [markdown]
 # Let's unpack the three concepts:
@@ -203,6 +207,8 @@ qiskit_circuit = transpiler.to_circuit(
     bindings={"theta": math.pi / 4},
 )
 print(qiskit_circuit)
+assert qiskit_circuit.num_qubits == 1
+assert qiskit_circuit.num_clbits == 1
 
 # %% [markdown]
 # ## Multi-Qubit Example
@@ -239,6 +245,10 @@ demo_result = (
 
 for outcome, count in demo_result.results:
     print(f"  outcome={outcome}, count={count}")
+assert demo_result.shots == 256
+assert sum(count for _, count in demo_result.results) == 256
+# Bell state |Phi+>: only (0,0) and (1,1) outcomes appear.
+assert all(outcome in {(0, 0), (1, 1)} for outcome, _ in demo_result.results)
 
 # %% [markdown]
 # Notice two patterns here:
@@ -283,6 +293,7 @@ try:
 except Exception as e:
     print(f"Error type: {type(e).__name__}")
     print(f"Error message: {e}")
+    assert type(e).__name__ == "QubitConsumedError"
 
 # %% [markdown]
 # The fix is simple: always write `q = qmc.h(q)`, not just `qmc.h(q)`.

--- a/docs/ja/tutorial/01_your_first_quantum_kernel.ipynb
+++ b/docs/ja/tutorial/01_your_first_quantum_kernel.ipynb
@@ -216,7 +216,9 @@
    "source": [
     "est = biased_coin.estimate_resources()\n",
     "print(\"qubits:\", est.qubits)\n",
-    "print(\"total gates:\", est.gates.total)"
+    "assert est.qubits == 1\n",
+    "print(\"total gates:\", est.gates.total)\n",
+    "assert est.gates.total == 1"
    ]
   },
   {
@@ -285,7 +287,9 @@
     "# .result()はジョブが完了するまで待ち、SampleResultを返します。\n",
     "result = job.result()\n",
     "\n",
-    "print(\"sample results:\", result.results)"
+    "print(\"sample results:\", result.results)\n",
+    "assert result.shots == 256\n",
+    "assert sum(count for _, count in result.results) == 256"
    ]
   },
   {
@@ -422,7 +426,9 @@
     "    biased_coin,\n",
     "    bindings={\"theta\": math.pi / 4},\n",
     ")\n",
-    "print(qiskit_circuit)"
+    "print(qiskit_circuit)\n",
+    "assert qiskit_circuit.num_qubits == 1\n",
+    "assert qiskit_circuit.num_clbits == 1"
    ]
   },
   {
@@ -526,7 +532,11 @@
     ")\n",
     "\n",
     "for outcome, count in demo_result.results:\n",
-    "    print(f\"  outcome={outcome}, count={count}\")"
+    "    print(f\"  outcome={outcome}, count={count}\")\n",
+    "assert demo_result.shots == 256\n",
+    "assert sum(count for _, count in demo_result.results) == 256\n",
+    "# Bell 状態 |Phi+>: (0,0) と (1,1) のみが出現する。\n",
+    "assert all(outcome in {(0, 0), (1, 1)} for outcome, _ in demo_result.results)"
    ]
   },
   {
@@ -604,7 +614,8 @@
     "    bad_rebind.draw()\n",
     "except Exception as e:\n",
     "    print(f\"Error type: {type(e).__name__}\")\n",
-    "    print(f\"Error message: {e}\")"
+    "    print(f\"Error message: {e}\")\n",
+    "    assert type(e).__name__ == \"QubitConsumedError\""
    ]
   },
   {

--- a/docs/ja/tutorial/01_your_first_quantum_kernel.py
+++ b/docs/ja/tutorial/01_your_first_quantum_kernel.py
@@ -108,7 +108,9 @@ biased_coin.draw(theta=0.6)
 # %%
 est = biased_coin.estimate_resources()
 print("qubits:", est.qubits)
+assert est.qubits == 1
 print("total gates:", est.gates.total)
+assert est.gates.total == 1
 
 # %% [markdown]
 # この量子カーネルでは具体的な数値が返りますが、パラメータ付き量子カーネルではSymPyを用いた代数的なリソース推定も可能です —[チュートリアル02](02_parameterized_kernels.ipynb)で詳しく扱います。
@@ -146,6 +148,8 @@ job = exe.sample(
 result = job.result()
 
 print("sample results:", result.results)
+assert result.shots == 256
+assert sum(count for _, count in result.results) == 256
 
 # %% [markdown]
 # 3つの概念を押さえておきましょう：
@@ -191,6 +195,8 @@ qiskit_circuit = transpiler.to_circuit(
     bindings={"theta": math.pi / 4},
 )
 print(qiskit_circuit)
+assert qiskit_circuit.num_qubits == 1
+assert qiskit_circuit.num_clbits == 1
 
 # %% [markdown]
 # ## 複数量子ビットの例
@@ -227,6 +233,10 @@ demo_result = (
 
 for outcome, count in demo_result.results:
     print(f"  outcome={outcome}, count={count}")
+assert demo_result.shots == 256
+assert sum(count for _, count in demo_result.results) == 256
+# Bell 状態 |Phi+>: (0,0) と (1,1) のみが出現する。
+assert all(outcome in {(0, 0), (1, 1)} for outcome, _ in demo_result.results)
 
 # %% [markdown]
 # 2つのパターンに注目してください：
@@ -266,6 +276,7 @@ try:
 except Exception as e:
     print(f"Error type: {type(e).__name__}")
     print(f"Error message: {e}")
+    assert type(e).__name__ == "QubitConsumedError"
 
 # %% [markdown]
 # 修正は簡単です：`qmc.h(q)`ではなく、常に`q = qmc.h(q)`と書いてください。


### PR DESCRIPTION
## Summary

Tutorial 01 (`docs/{en,ja}/tutorial/01_your_first_quantum_kernel.{py,ipynb}`) is part of Qamomile's docs test suite — it runs under `pytest -m docs` via `tests/docs/test_tutorials.py`. The tutorial currently `print`s several deterministic values (resource counts, sample-result invariants, transpiled-circuit shape, the affine-violation error type), but does not actually verify them, so a regression would only produce quietly-wrong output rather than a test failure.

This PR adds `assert` statements next to each such `print`, so the docs test fails loudly on any regression in `estimate_resources()`, `SampleResult`, `to_circuit()`, or the affine-type system.

## Asserts added

| Print statement | Assert |
|---|---|
| `est.qubits` (biased_coin) | `== 1` |
| `est.gates.total` (biased_coin) | `== 1` |
| `result.results` (biased_coin sample) | `result.shots == 256`, counts sum to `256` |
| `qiskit_circuit` (`to_circuit`) | `num_qubits == 1`, `num_clbits == 1` |
| `demo_result.results` (two_qubit_demo) | shots/counts invariants + Bell-state outcomes ⊆ `{(0,0), (1,1)}` |
| `Error type` (bad_rebind) | `type(e).__name__ == "QubitConsumedError"` |

Shot-based exact counts are not asserted (they are subject to sampling noise); only structural invariants (shots, counts sum, Bell-state outcome set) are.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "01_your_first_quantum_kernel" -v` passes for both `en/` and `ja/`.
- [x] `.ipynb` files re-synced from `.py` via `jupytext --to ipynb --update` so the committed render stays in sync.
- [x] EN and JA edits are parity-locked.

## Notes

This is the first of a planned series of small, per-tutorial PRs that walk through `docs/{en,ja}/{tutorial,algorithm}/` and add asserts to every deterministic value the tutorials display. Splitting per tutorial keeps the diffs small and the work easy to hand off mid-series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)