### PR TITLE
docs(tutorial): assert deterministic values in "Parameterized QKernels"

### DIFF
--- a/docs/en/tutorial/02_parameterized_kernels.ipynb
+++ b/docs/en/tutorial/02_parameterized_kernels.ipynb
@@ -214,7 +214,8 @@
     "    bad_iteration.draw(n=4)\n",
     "except Exception as e:\n",
     "    print(f\"Error type: {type(e).__name__}\")\n",
-    "    print(f\"Error message: {e}\")"
+    "    print(f\"Error message: {e}\")\n",
+    "    assert type(e).__name__ == \"SyntaxError\""
    ]
   },
   {
@@ -347,7 +348,11 @@
     "        shots=128,\n",
     "        bindings={\"theta\": theta},\n",
     "    ).result()\n",
-    "    print(f\"theta={theta:.1f} -> {result.results}\")"
+    "    print(f\"theta={theta:.1f} -> {result.results}\")\n",
+    "    assert result.shots == 128\n",
+    "    assert sum(count for _, count in result.results) == 128\n",
+    "    # Measuring n=4 qubits -> each outcome is a 4-element bit tuple.\n",
+    "    assert all(len(outcome) == 4 for outcome, _ in result.results)"
    ]
   },
   {

--- a/docs/en/tutorial/02_parameterized_kernels.py
+++ b/docs/en/tutorial/02_parameterized_kernels.py
@@ -98,6 +98,7 @@ try:
 except Exception as e:
     print(f"Error type: {type(e).__name__}")
     print(f"Error message: {e}")
+    assert type(e).__name__ == "SyntaxError"
 
 # %% [markdown]
 # Always use index-based access: `for i in qmc.range(n): q[i] = qmc.h(q[i])`.
@@ -160,6 +161,10 @@ for theta in [0.1, 0.5, 1.0]:
         bindings={"theta": theta},
     ).result()
     print(f"theta={theta:.1f} -> {result.results}")
+    assert result.shots == 128
+    assert sum(count for _, count in result.results) == 128
+    # Measuring n=4 qubits -> each outcome is a 4-element bit tuple.
+    assert all(len(outcome) == 4 for outcome, _ in result.results)
 
 # %% [markdown]
 # The transpiled executable is reused across all three runs — only the runtime binding `{"theta": theta}` changes.

--- a/docs/ja/tutorial/02_parameterized_kernels.ipynb
+++ b/docs/ja/tutorial/02_parameterized_kernels.ipynb
@@ -214,7 +214,8 @@
     "    bad_iteration.draw(n=4)\n",
     "except Exception as e:\n",
     "    print(f\"Error type: {type(e).__name__}\")\n",
-    "    print(f\"Error message: {e}\")"
+    "    print(f\"Error message: {e}\")\n",
+    "    assert type(e).__name__ == \"SyntaxError\""
    ]
   },
   {
@@ -335,7 +336,11 @@
     "        shots=128,\n",
     "        bindings={\"theta\": theta},\n",
     "    ).result()\n",
-    "    print(f\"theta={theta:.1f} -> {result.results}\")"
+    "    print(f\"theta={theta:.1f} -> {result.results}\")\n",
+    "    assert result.shots == 128\n",
+    "    assert sum(count for _, count in result.results) == 128\n",
+    "    # n=4 量子ビット測定 → 各 outcome は 4 要素のビット tuple。\n",
+    "    assert all(len(outcome) == 4 for outcome, _ in result.results)"
    ]
   },
   {

--- a/docs/ja/tutorial/02_parameterized_kernels.py
+++ b/docs/ja/tutorial/02_parameterized_kernels.py
@@ -98,6 +98,7 @@ try:
 except Exception as e:
     print(f"Error type: {type(e).__name__}")
     print(f"Error message: {e}")
+    assert type(e).__name__ == "SyntaxError"
 
 # %% [markdown]
 # 常にインデックスベースのアクセスを使用してください：`for i in qmc.range(n): q[i] = qmc.h(q[i])`。
@@ -148,6 +149,10 @@ for theta in [0.1, 0.5, 1.0]:
         bindings={"theta": theta},
     ).result()
     print(f"theta={theta:.1f} -> {result.results}")
+    assert result.shots == 128
+    assert sum(count for _, count in result.results) == 128
+    # n=4 量子ビット測定 → 各 outcome は 4 要素のビット tuple。
+    assert all(len(outcome) == 4 for outcome, _ in result.results)
 
 # %% [markdown]
 # トランスパイル済みオブジェクトは3回の実行すべてで再利用されます。変わるのは実行時のバインディング`{"theta": theta}`だけです。


### PR DESCRIPTION
## Summary

Same intent as #418: Tutorial 02 (`docs/{en,ja}/tutorial/02_parameterized_kernels.{py,ipynb}`) runs under `pytest -m docs`, but currently `print`s deterministic values without verifying them. Adding `assert` statements next to each such `print` so the docs test fails loudly on any regression in the affine-iteration guard, the bind/sweep workflow, or the structural shape of `SampleResult` for `n`-qubit measurements.

## Asserts added

| Code block | Assert |
|---|---|
| `bad_iteration` (direct vector iteration anti-pattern) | `type(e).__name__ == "SyntaxError"` |
| Bind/sweep loop, each iteration | `result.shots == 128`, counts sum to 128, every outcome is a 4-element bit tuple |

Shot-noise exact counts are not asserted; only structural invariants are.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "02_parameterized_kernels" -v` passes for both `en/` and `ja/`.
- [x] `.ipynb` files re-synced from `.py` via `jupytext --to ipynb --update`.
- [x] EN and JA edits are parity-locked.

## Notes

Second of the planned per-tutorial assert series (after #418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)