### PR TITLE
docs(tutorial): assert deterministic values in "Hermitian Decomposition"

### DIFF
--- a/docs/en/tutorial/09_hermitian_decomposition.ipynb
+++ b/docs/en/tutorial/09_hermitian_decomposition.ipynb
@@ -102,7 +102,9 @@
     "h_field = 0.7\n",
     "M = -np.kron(Z, Z) - h_field * (np.kron(I2, X) + np.kron(X, I2))\n",
     "print(\"shape:\", M.shape)\n",
-    "print(\"Hermitian:\", np.allclose(M, M.conj().T))"
+    "assert M.shape == (4, 4)\n",
+    "print(\"Hermitian:\", np.allclose(M, M.conj().T))\n",
+    "assert np.allclose(M, M.conj().T)"
    ]
   },
   {
@@ -145,6 +147,8 @@
    "source": [
     "H_mat = HermitianMatrix(M)\n",
     "print(\"num_qubits:\", H_mat.num_qubits)\n",
+    "# 4x4 matrix -> log2(4) = 2 qubits.\n",
+    "assert H_mat.num_qubits == 2\n",
     "\n",
     "H_op = H_mat.to_hamiltonian()\n",
     "print(\"constant:\", H_op.constant)\n",
@@ -274,7 +278,8 @@
     "        \"t\": t_value,\n",
     "    },\n",
     ")\n",
-    "print(qiskit_circuit)"
+    "print(qiskit_circuit)\n",
+    "assert qiskit_circuit.num_qubits == 2"
    ]
   },
   {

--- a/docs/en/tutorial/09_hermitian_decomposition.py
+++ b/docs/en/tutorial/09_hermitian_decomposition.py
@@ -68,7 +68,9 @@ I2 = np.eye(2, dtype=complex)
 h_field = 0.7
 M = -np.kron(Z, Z) - h_field * (np.kron(I2, X) + np.kron(X, I2))
 print("shape:", M.shape)
+assert M.shape == (4, 4)
 print("Hermitian:", np.allclose(M, M.conj().T))
+assert np.allclose(M, M.conj().T)
 
 # %% [markdown]
 # ## Wrap and Decompose
@@ -80,6 +82,8 @@ print("Hermitian:", np.allclose(M, M.conj().T))
 # %%
 H_mat = HermitianMatrix(M)
 print("num_qubits:", H_mat.num_qubits)
+# 4x4 matrix -> log2(4) = 2 qubits.
+assert H_mat.num_qubits == 2
 
 H_op = H_mat.to_hamiltonian()
 print("constant:", H_op.constant)
@@ -139,6 +143,7 @@ qiskit_circuit = transpiler.to_circuit(
     },
 )
 print(qiskit_circuit)
+assert qiskit_circuit.num_qubits == 2
 
 # %% [markdown]
 # ## Verify Against the Exact Exponential

--- a/docs/ja/tutorial/09_hermitian_decomposition.ipynb
+++ b/docs/ja/tutorial/09_hermitian_decomposition.ipynb
@@ -102,7 +102,9 @@
     "h_field = 0.7\n",
     "M = -np.kron(Z, Z) - h_field * (np.kron(I2, X) + np.kron(X, I2))\n",
     "print(\"shape:\", M.shape)\n",
-    "print(\"Hermitian:\", np.allclose(M, M.conj().T))"
+    "assert M.shape == (4, 4)\n",
+    "print(\"Hermitian:\", np.allclose(M, M.conj().T))\n",
+    "assert np.allclose(M, M.conj().T)"
    ]
   },
   {
@@ -145,6 +147,8 @@
    "source": [
     "H_mat = HermitianMatrix(M)\n",
     "print(\"num_qubits:\", H_mat.num_qubits)\n",
+    "# 4x4 行列 → log2(4) = 2 量子ビット。\n",
+    "assert H_mat.num_qubits == 2\n",
     "\n",
     "H_op = H_mat.to_hamiltonian()\n",
     "print(\"constant:\", H_op.constant)\n",
@@ -274,7 +278,8 @@
     "        \"t\": t_value,\n",
     "    },\n",
     ")\n",
-    "print(qiskit_circuit)"
+    "print(qiskit_circuit)\n",
+    "assert qiskit_circuit.num_qubits == 2"
    ]
   },
   {

--- a/docs/ja/tutorial/09_hermitian_decomposition.py
+++ b/docs/ja/tutorial/09_hermitian_decomposition.py
@@ -68,7 +68,9 @@ I2 = np.eye(2, dtype=complex)
 h_field = 0.7
 M = -np.kron(Z, Z) - h_field * (np.kron(I2, X) + np.kron(X, I2))
 print("shape:", M.shape)
+assert M.shape == (4, 4)
 print("Hermitian:", np.allclose(M, M.conj().T))
+assert np.allclose(M, M.conj().T)
 
 # %% [markdown]
 # ## ラップして分解する
@@ -80,6 +82,8 @@ print("Hermitian:", np.allclose(M, M.conj().T))
 # %%
 H_mat = HermitianMatrix(M)
 print("num_qubits:", H_mat.num_qubits)
+# 4x4 行列 → log2(4) = 2 量子ビット。
+assert H_mat.num_qubits == 2
 
 H_op = H_mat.to_hamiltonian()
 print("constant:", H_op.constant)
@@ -139,6 +143,7 @@ qiskit_circuit = transpiler.to_circuit(
     },
 )
 print(qiskit_circuit)
+assert qiskit_circuit.num_qubits == 2
 
 # %% [markdown]
 # ## 厳密な指数関数との比較による検証


### PR DESCRIPTION
## Summary

Eighth of the per-tutorial assert series (after #418-#424). Tutorial 09 (renumbered from 08 by upstream; new \`04_controlled_gates\` was inserted) already has strong asserts on \`H_op.terms\` and on the post-circuit fidelity vs. exact matrix exponential. This PR backfills the four \`print\` statements at the front of the pipeline that did not have a companion assert.

## Asserts added

| Print | Assert |
|---|---|
| \`M.shape\` | \`M.shape == (4, 4)\` |
| \`np.allclose(M, M.conj().T)\` | \`assert np.allclose(M, M.conj().T)\` |
| \`H_mat.num_qubits\` | \`H_mat.num_qubits == 2\` (log2(4) = 2) |
| \`print(qiskit_circuit)\` | \`qiskit_circuit.num_qubits == 2\` |

The existing block asserts on \`H_op.terms\`, each coefficient, \`H_op.constant\`, and \`fidelity\` are left unchanged.

## Test plan

- [x] \`uv run pytest tests/docs/test_tutorials.py -m docs -k \"09_hermitian_decomposition\" -v\` passes for both \`en/\` and \`ja/\`.
- [x] \`.ipynb\` re-synced via \`jupytext --to ipynb --update\`.
- [x] EN and JA parity-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)