### PR TITLE
docs(tutorial): assert deterministic values in "Compilation and Transpilation"

### DIFF
--- a/docs/en/tutorial/10_compilation_and_transpilation.ipynb
+++ b/docs/en/tutorial/10_compilation_and_transpilation.ipynb
@@ -349,7 +349,9 @@
     "\n",
     "block = transpiler.to_block(demo_kernel, bindings=bindings, parameters=parameters)\n",
     "print(\"after to_block:   \", summarise(block))\n",
+    "assert block.kind.name == \"HIERARCHICAL\"\n",
     "print(\"parameters:       \", list(block.parameters))\n",
+    "assert list(block.parameters) == [\"theta\"]\n",
     "print(\n",
     "    \"CallBlockOps:     \",\n",
     "    sum(1 for op in block.operations if isinstance(op, CallBlockOperation)),\n",
@@ -514,8 +516,11 @@
     "\n",
     "block = transpiler.inline(block)\n",
     "print(\"after inline:     \", summarise(block))\n",
+    "assert block.kind.name == \"AFFINE\"\n",
     "print(\"CallBlockOps (deep):\", count_calls(block.operations))\n",
-    "print(\"is_affine:        \", block.is_affine())"
+    "assert count_calls(block.operations) == 0\n",
+    "print(\"is_affine:        \", block.is_affine())\n",
+    "assert block.is_affine()"
    ]
   },
   {
@@ -626,10 +631,14 @@
    "source": [
     "block = transpiler.partial_eval(block, bindings=bindings)\n",
     "print(\"after partial_eval:\", summarise(block))\n",
+    "assert block.kind.name == \"AFFINE\"\n",
     "print(\n",
     "    \"ForOperations:    \",\n",
     "    sum(1 for op in block.operations if isinstance(op, ForOperation)),\n",
-    ")"
+    ")\n",
+    "# `partial_eval` does NOT unroll the ForOperation (that decision is made\n",
+    "# later by LoopAnalyzer during emit), so the single for-loop survives.\n",
+    "assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1"
    ]
   },
   {
@@ -688,7 +697,8 @@
    ],
    "source": [
     "block = transpiler.analyze(block)\n",
-    "print(\"after analyze:    \", summarise(block))"
+    "print(\"after analyze:    \", summarise(block))\n",
+    "assert block.kind.name == \"ANALYZED\""
    ]
   },
   {
@@ -733,7 +743,10 @@
     "    print(\n",
     "        f\"  step {i}: {type(step).__name__} ({type(seg).__name__}, {len(seg.operations)} ops)\"\n",
     "    )\n",
-    "print(\"total unbound parameters:\", list(plan.parameters))"
+    "print(\"total unbound parameters:\", list(plan.parameters))\n",
+    "# NisqSegmentationStrategy enforces a single quantum segment.\n",
+    "assert len(plan.steps) == 1\n",
+    "assert list(plan.parameters) == [\"theta\"]"
    ]
   },
   {
@@ -789,6 +802,8 @@
    "source": [
     "executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)\n",
     "print(\"parameter_names:  \", executable.parameter_names)\n",
+    "# Only `theta` survives as a runtime parameter; `n` was bound at compile time.\n",
+    "assert list(executable.parameter_names) == [\"theta\"]\n",
     "print()\n",
     "print(executable.quantum_circuit)"
    ]
@@ -1264,7 +1279,9 @@
     "    )\n",
     "\n",
     "    print(\"backend circuit type: \", type(quri_exe.quantum_circuit).__name__)\n",
+    "    assert type(quri_exe.quantum_circuit).__name__ == \"LinearMappedParametricQuantumCircuit\"\n",
     "    print(\"parameter_names:      \", quri_exe.parameter_names)\n",
+    "    assert list(quri_exe.parameter_names) == [\"theta\"]\n",
     "    print()\n",
     "    for gate in quri_exe.quantum_circuit.gates:\n",
     "        print(\" \", gate)\n",

--- a/docs/en/tutorial/10_compilation_and_transpilation.py
+++ b/docs/en/tutorial/10_compilation_and_transpilation.py
@@ -246,7 +246,9 @@ parameters = ["theta"]
 
 block = transpiler.to_block(demo_kernel, bindings=bindings, parameters=parameters)
 print("after to_block:   ", summarise(block))
+assert block.kind.name == "HIERARCHICAL"
 print("parameters:       ", list(block.parameters))
+assert list(block.parameters) == ["theta"]
 print(
     "CallBlockOps:     ",
     sum(1 for op in block.operations if isinstance(op, CallBlockOperation)),
@@ -297,8 +299,11 @@ def count_calls(ops):
 
 block = transpiler.inline(block)
 print("after inline:     ", summarise(block))
+assert block.kind.name == "AFFINE"
 print("CallBlockOps (deep):", count_calls(block.operations))
+assert count_calls(block.operations) == 0
 print("is_affine:        ", block.is_affine())
+assert block.is_affine()
 
 # %% [markdown]
 # Pretty-printing again confirms that `call entangle_pair(...)` has vanished
@@ -340,10 +345,14 @@ print(pretty_print_block(block))
 # %%
 block = transpiler.partial_eval(block, bindings=bindings)
 print("after partial_eval:", summarise(block))
+assert block.kind.name == "AFFINE"
 print(
     "ForOperations:    ",
     sum(1 for op in block.operations if isinstance(op, ForOperation)),
 )
+# `partial_eval` does NOT unroll the ForOperation (that decision is made
+# later by LoopAnalyzer during emit), so the single for-loop survives.
+assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1
 
 # %% [markdown]
 # If you left a `UInt` unbound and tried to use it as a loop bound, the
@@ -376,6 +385,7 @@ print(
 # %%
 block = transpiler.analyze(block)
 print("after analyze:    ", summarise(block))
+assert block.kind.name == "ANALYZED"
 
 # %% [markdown]
 # ### 4.5 `plan` — segmenting into a `ProgramPlan`
@@ -393,6 +403,9 @@ for i, step in enumerate(plan.steps):
         f"  step {i}: {type(step).__name__} ({type(seg).__name__}, {len(seg.operations)} ops)"
     )
 print("total unbound parameters:", list(plan.parameters))
+# NisqSegmentationStrategy enforces a single quantum segment.
+assert len(plan.steps) == 1
+assert list(plan.parameters) == ["theta"]
 
 # %% [markdown]
 # The quantum segment also carries `qubit_values` and `num_qubits` so `emit`
@@ -409,6 +422,8 @@ print("total unbound parameters:", list(plan.parameters))
 # %%
 executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)
 print("parameter_names:  ", executable.parameter_names)
+# Only `theta` survives as a runtime parameter; `n` was bound at compile time.
+assert list(executable.parameter_names) == ["theta"]
 print()
 print(executable.quantum_circuit)
 
@@ -754,7 +769,9 @@ try:
     )
 
     print("backend circuit type: ", type(quri_exe.quantum_circuit).__name__)
+    assert type(quri_exe.quantum_circuit).__name__ == "LinearMappedParametricQuantumCircuit"
     print("parameter_names:      ", quri_exe.parameter_names)
+    assert list(quri_exe.parameter_names) == ["theta"]
     print()
     for gate in quri_exe.quantum_circuit.gates:
         print(" ", gate)

--- a/docs/ja/tutorial/10_compilation_and_transpilation.ipynb
+++ b/docs/ja/tutorial/10_compilation_and_transpilation.ipynb
@@ -309,7 +309,9 @@
     "block = transpiler.to_block(demo_kernel, bindings=bindings, parameters=parameters)\n",
     "pretty_print_block(block)\n",
     "print(\"after to_block:   \", summarise(block))\n",
+    "assert block.kind.name == \"HIERARCHICAL\"\n",
     "print(\"parameters:       \", list(block.parameters))\n",
+    "assert list(block.parameters) == [\"theta\"]\n",
     "print(\n",
     "    \"CallBlockOps:     \",\n",
     "    sum(1 for op in block.operations if isinstance(op, CallBlockOperation)),\n",
@@ -465,8 +467,11 @@
     "\n",
     "block = transpiler.inline(block)\n",
     "print(\"after inline:     \", summarise(block))\n",
+    "assert block.kind.name == \"AFFINE\"\n",
     "print(\"CallBlockOps (deep):\", count_calls(block.operations))\n",
-    "print(\"is_affine:        \", block.is_affine())"
+    "assert count_calls(block.operations) == 0\n",
+    "print(\"is_affine:        \", block.is_affine())\n",
+    "assert block.is_affine()"
    ]
   },
   {
@@ -560,10 +565,14 @@
    "source": [
     "block = transpiler.partial_eval(block, bindings=bindings)\n",
     "print(\"after partial_eval:\", summarise(block))\n",
+    "assert block.kind.name == \"AFFINE\"\n",
     "print(\n",
     "    \"ForOperations:    \",\n",
     "    sum(1 for op in block.operations if isinstance(op, ForOperation)),\n",
-    ")"
+    ")\n",
+    "# `partial_eval` は ForOperation を展開しない(展開は emit 段の LoopAnalyzer\n",
+    "# 判定)ので、for ループはそのまま 1 個残る。\n",
+    "assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1"
    ]
   },
   {
@@ -608,7 +617,8 @@
    ],
    "source": [
     "block = transpiler.analyze(block)\n",
-    "print(\"after analyze:    \", summarise(block))"
+    "print(\"after analyze:    \", summarise(block))\n",
+    "assert block.kind.name == \"ANALYZED\""
    ]
   },
   {
@@ -650,7 +660,10 @@
     "    print(\n",
     "        f\"  step {i}: {type(step).__name__} ({type(seg).__name__}, {len(seg.operations)} ops)\"\n",
     "    )\n",
-    "print(\"total unbound parameters:\", list(plan.parameters))"
+    "print(\"total unbound parameters:\", list(plan.parameters))\n",
+    "# NisqSegmentationStrategy により quantum segment は1個に制限される。\n",
+    "assert len(plan.steps) == 1\n",
+    "assert list(plan.parameters) == [\"theta\"]"
    ]
   },
   {
@@ -701,6 +714,8 @@
    "source": [
     "executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)\n",
     "print(\"parameter_names:  \", executable.parameter_names)\n",
+    "# `theta` だけが runtime parameter として残る(`n` はコンパイル時 bind 済)。\n",
+    "assert list(executable.parameter_names) == [\"theta\"]\n",
     "print()\n",
     "print(executable.quantum_circuit)"
    ]
@@ -1055,7 +1070,9 @@
     "    )\n",
     "\n",
     "    print(\"backend circuit type: \", type(quri_exe.quantum_circuit).__name__)\n",
+    "    assert type(quri_exe.quantum_circuit).__name__ == \"LinearMappedParametricQuantumCircuit\"\n",
     "    print(\"parameter_names:      \", quri_exe.parameter_names)\n",
+    "    assert list(quri_exe.parameter_names) == [\"theta\"]\n",
     "    print()\n",
     "    for gate in quri_exe.quantum_circuit.gates:\n",
     "        print(\" \", gate)\n",

--- a/docs/ja/tutorial/10_compilation_and_transpilation.py
+++ b/docs/ja/tutorial/10_compilation_and_transpilation.py
@@ -206,7 +206,9 @@ parameters = ["theta"]
 block = transpiler.to_block(demo_kernel, bindings=bindings, parameters=parameters)
 pretty_print_block(block)
 print("after to_block:   ", summarise(block))
+assert block.kind.name == "HIERARCHICAL"
 print("parameters:       ", list(block.parameters))
+assert list(block.parameters) == ["theta"]
 print(
     "CallBlockOps:     ",
     sum(1 for op in block.operations if isinstance(op, CallBlockOperation)),
@@ -248,8 +250,11 @@ def count_calls(ops):
 
 block = transpiler.inline(block)
 print("after inline:     ", summarise(block))
+assert block.kind.name == "AFFINE"
 print("CallBlockOps (deep):", count_calls(block.operations))
+assert count_calls(block.operations) == 0
 print("is_affine:        ", block.is_affine())
+assert block.is_affine()
 
 # %% [markdown]
 # 再度`pretty_print_block`で眺めると、`call entangle_pair(...)`が消え、`h`/`cx`が直接`for`本体に並んでいることが確認できます。ブロックの`kind`は`AFFINE`へ進みました。
@@ -274,10 +279,14 @@ print(pretty_print_block(block))
 # %%
 block = transpiler.partial_eval(block, bindings=bindings)
 print("after partial_eval:", summarise(block))
+assert block.kind.name == "AFFINE"
 print(
     "ForOperations:    ",
     sum(1 for op in block.operations if isinstance(op, ForOperation)),
 )
+# `partial_eval` は ForOperation を展開しない(展開は emit 段の LoopAnalyzer
+# 判定)ので、for ループはそのまま 1 個残る。
+assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1
 
 # %% [markdown]
 # `UInt`を未バインドのまま残してループ境界に使うと、下流の`validate_symbolic_shapes`パスが該当する値の名前とともに`QamomileCompileError`を送出します。これは「このカーネルは実はコンパイル時に構造化されていない」という状況を、後段での分かりにくいクラッシュではなく読みやすいエラーへ変換することを担当するパスです。
@@ -296,6 +305,7 @@ print(
 # %%
 block = transpiler.analyze(block)
 print("after analyze:    ", summarise(block))
+assert block.kind.name == "ANALYZED"
 
 # %% [markdown]
 # ### 4.5 `plan` — `ProgramPlan`へのセグメント化
@@ -310,6 +320,9 @@ for i, step in enumerate(plan.steps):
         f"  step {i}: {type(step).__name__} ({type(seg).__name__}, {len(seg.operations)} ops)"
     )
 print("total unbound parameters:", list(plan.parameters))
+# NisqSegmentationStrategy により quantum segment は1個に制限される。
+assert len(plan.steps) == 1
+assert list(plan.parameters) == ["theta"]
 
 # %% [markdown]
 # 量子セグメントは`qubit_values`と`num_qubits`も持ちます。これにより`emit`はゲートを配置する前に、バックエンド回路が必要とする量子ビット本数を把握できます。
@@ -321,6 +334,8 @@ print("total unbound parameters:", list(plan.parameters))
 # %%
 executable = transpiler.emit(plan, bindings=bindings, parameters=parameters)
 print("parameter_names:  ", executable.parameter_names)
+# `theta` だけが runtime parameter として残る(`n` はコンパイル時 bind 済)。
+assert list(executable.parameter_names) == ["theta"]
 print()
 print(executable.quantum_circuit)
 
@@ -545,7 +560,9 @@ try:
     )
 
     print("backend circuit type: ", type(quri_exe.quantum_circuit).__name__)
+    assert type(quri_exe.quantum_circuit).__name__ == "LinearMappedParametricQuantumCircuit"
     print("parameter_names:      ", quri_exe.parameter_names)
+    assert list(quri_exe.parameter_names) == ["theta"]
     print()
     for gate in quri_exe.quantum_circuit.gates:
         print(" ", gate)


### PR DESCRIPTION
## Summary

Last of the tutorial assert series. Tutorial 10 (renumbered from 09 by upstream) walks through the transpiler pipeline pass by pass. Every \`summarise(block)\` line shows a \`BlockKind\`; in-between \`print\`s report the op breakdown and surviving parameters. Adds asserts so the documented \`BlockKind\` progression (\`HIERARCHICAL → AFFINE → ANALYZED\`) and the parameter / structure invariants fail loudly on a regression.

## Asserts added

| Pass | Asserts |
|---|---|
| \`to_block\` | \`kind == HIERARCHICAL\`, \`parameters == [\"theta\"]\` |
| \`inline\` | \`kind == AFFINE\`, \`count_calls == 0\`, \`is_affine() is True\` |
| \`partial_eval\` | \`kind == AFFINE\`; the single \`ForOperation\` survives (unrolling deferred to emit's \`LoopAnalyzer\`) |
| \`analyze\` | \`kind == ANALYZED\` |
| \`plan\` | \`len(steps) == 1\` (NISQ single-quantum-segment), \`parameters == [\"theta\"]\` |
| \`emit\` | \`executable.parameter_names == [\"theta\"]\` |
| QURI Parts (inside try) | \`type(circuit).__name__ == \"LinearMappedParametricQuantumCircuit\"\`, \`parameter_names == [\"theta\"]\` |

\`pretty_print_block\` cells and the \`qfixed_demo\` walkthrough are left unchanged — their output is textual IR dumps without a single deterministic value to mirror.

## Test plan

- [x] \`uv run pytest tests/docs/test_tutorials.py -m docs -k \"10_compilation_and_transpilation\" -v\` passes for both \`en/\` and \`ja/\`.
- [x] \`.ipynb\` re-synced via \`jupytext --to ipynb --update\`.
- [x] EN and JA parity-locked.

This is the last of the per-tutorial assert series (after #418, #419, #420, #421, #422, #423, #424, #425; \`04_controlled_gates\` was skipped because the existing asserts in that file already cover every deterministic output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)