### PR TITLE
docs(algorithm): assert deterministic values in "Hybrid Quantum Neural Network"

### DIFF
--- a/docs/en/algorithm/hybrid_qnn.ipynb
+++ b/docs/en/algorithm/hybrid_qnn.ipynb
@@ -98,7 +98,11 @@
     "N_WEIGHTS_PER_LAYER = N_QUBITS * 3  # RZ, RY, RZ per qubit\n",
     "N_WEIGHTS = N_LAYERS * N_WEIGHTS_PER_LAYER\n",
     "\n",
-    "print(f\"Qubits: {N_QUBITS}, Layers: {N_LAYERS}, Trainable weights: {N_WEIGHTS}\")"
+    "print(f\"Qubits: {N_QUBITS}, Layers: {N_LAYERS}, Trainable weights: {N_WEIGHTS}\")\n",
+    "assert N_QUBITS == 4\n",
+    "assert N_LAYERS == 2\n",
+    "# N_WEIGHTS = N_LAYERS * N_QUBITS * 3 (RZ + RY + RZ per qubit per layer).\n",
+    "assert N_WEIGHTS == 24"
    ]
   },
   {
@@ -263,7 +267,14 @@
     "est = variational_ansatz.estimate_resources(\n",
     "    bindings={\"n_qubits\": N_QUBITS, \"n_layers\": N_LAYERS},\n",
     ")\n",
-    "print(est)"
+    "print(est)\n",
+    "assert est.qubits == 4\n",
+    "# 4 (input RY encoding) + 2 layers * (4 RZ + 4 RY + 4 RZ) = 28 single-qubit rotations.\n",
+    "assert est.gates.single_qubit == 28\n",
+    "# 2 layers * 3 CZs (linear chain on 4 qubits) = 6 two-qubit Cliffords.\n",
+    "assert est.gates.two_qubit == 6\n",
+    "assert est.gates.total == 34\n",
+    "assert est.gates.rotation_gates == 28"
    ]
   },
   {
@@ -341,7 +352,10 @@
     "test_weights = rng.uniform(-np.pi, np.pi, N_WEIGHTS)\n",
     "\n",
     "expvals = quantum_forward(test_inputs, test_weights)\n",
-    "print(\"Expectation values:\", expvals)"
+    "print(\"Expectation values:\", expvals)\n",
+    "# Z expectation values are bounded in [-1, 1]; one value per qubit.\n",
+    "assert expvals.shape == (N_QUBITS,)\n",
+    "assert all(-1.0 <= float(e) <= 1.0 for e in expvals)"
    ]
   },
   {
@@ -547,6 +561,9 @@
     "X_test, y_test = subset_dataset(full_test, SELECTED_CLASSES, N_TEST_PER_CLASS)\n",
     "\n",
     "print(f\"Train: {X_train.shape}, Test: {X_test.shape}\")\n",
+    "# 4 classes x N_PER_CLASS samples each; Fashion-MNIST is 1x28x28 grayscale.\n",
+    "assert X_train.shape == (N_CLASSES * N_TRAIN_PER_CLASS, 1, 28, 28)\n",
+    "assert X_test.shape == (N_CLASSES * N_TEST_PER_CLASS, 1, 28, 28)\n",
     "print(f\"Classes: {CLASS_NAMES}\")"
    ]
   },

--- a/docs/en/algorithm/hybrid_qnn.py
+++ b/docs/en/algorithm/hybrid_qnn.py
@@ -61,6 +61,10 @@ N_WEIGHTS_PER_LAYER = N_QUBITS * 3  # RZ, RY, RZ per qubit
 N_WEIGHTS = N_LAYERS * N_WEIGHTS_PER_LAYER
 
 print(f"Qubits: {N_QUBITS}, Layers: {N_LAYERS}, Trainable weights: {N_WEIGHTS}")
+assert N_QUBITS == 4
+assert N_LAYERS == 2
+# N_WEIGHTS = N_LAYERS * N_QUBITS * 3 (RZ + RY + RZ per qubit per layer).
+assert N_WEIGHTS == 24
 
 
 # %% [markdown]
@@ -142,6 +146,13 @@ est = variational_ansatz.estimate_resources(
     bindings={"n_qubits": N_QUBITS, "n_layers": N_LAYERS},
 )
 print(est)
+assert est.qubits == 4
+# 4 (input RY encoding) + 2 layers * (4 RZ + 4 RY + 4 RZ) = 28 single-qubit rotations.
+assert est.gates.single_qubit == 28
+# 2 layers * 3 CZs (linear chain on 4 qubits) = 6 two-qubit Cliffords.
+assert est.gates.two_qubit == 6
+assert est.gates.total == 34
+assert est.gates.rotation_gates == 28
 
 # %% [markdown]
 # ## Quantum Forward Pass
@@ -180,6 +191,9 @@ test_weights = rng.uniform(-np.pi, np.pi, N_WEIGHTS)
 
 expvals = quantum_forward(test_inputs, test_weights)
 print("Expectation values:", expvals)
+# Z expectation values are bounded in [-1, 1]; one value per qubit.
+assert expvals.shape == (N_QUBITS,)
+assert all(-1.0 <= float(e) <= 1.0 for e in expvals)
 
 # %% [markdown]
 # ## Parameter Shift Rule for Gradients
@@ -321,6 +335,9 @@ X_train, y_train = subset_dataset(full_train, SELECTED_CLASSES, N_TRAIN_PER_CLAS
 X_test, y_test = subset_dataset(full_test, SELECTED_CLASSES, N_TEST_PER_CLASS)
 
 print(f"Train: {X_train.shape}, Test: {X_test.shape}")
+# 4 classes x N_PER_CLASS samples each; Fashion-MNIST is 1x28x28 grayscale.
+assert X_train.shape == (N_CLASSES * N_TRAIN_PER_CLASS, 1, 28, 28)
+assert X_test.shape == (N_CLASSES * N_TEST_PER_CLASS, 1, 28, 28)
 print(f"Classes: {CLASS_NAMES}")
 
 

--- a/docs/ja/algorithm/hybrid_qnn.ipynb
+++ b/docs/ja/algorithm/hybrid_qnn.ipynb
@@ -98,7 +98,11 @@
     "N_WEIGHTS_PER_LAYER = N_QUBITS * 3  # 各量子ビットに RZ, RY, RZ\n",
     "N_WEIGHTS = N_LAYERS * N_WEIGHTS_PER_LAYER\n",
     "\n",
-    "print(f\"量子ビット数: {N_QUBITS}, 層数: {N_LAYERS}, 学習パラメータ数: {N_WEIGHTS}\")"
+    "print(f\"量子ビット数: {N_QUBITS}, 層数: {N_LAYERS}, 学習パラメータ数: {N_WEIGHTS}\")\n",
+    "assert N_QUBITS == 4\n",
+    "assert N_LAYERS == 2\n",
+    "# N_WEIGHTS = N_LAYERS * N_QUBITS * 3(1層あたり量子ビットごとに RZ + RY + RZ)。\n",
+    "assert N_WEIGHTS == 24"
    ]
   },
   {
@@ -262,7 +266,14 @@
     "est = variational_ansatz.estimate_resources(\n",
     "    bindings={\"n_qubits\": N_QUBITS, \"n_layers\": N_LAYERS},\n",
     ")\n",
-    "print(est)"
+    "print(est)\n",
+    "assert est.qubits == 4\n",
+    "# 入力 RY 4 + 2 層 * (RZ 4 + RY 4 + RZ 4) = 1-qubit 回転 28 個。\n",
+    "assert est.gates.single_qubit == 28\n",
+    "# 2 層 * 3 CZ(4 量子ビット線形チェーン)= 2-qubit Clifford 6 個。\n",
+    "assert est.gates.two_qubit == 6\n",
+    "assert est.gates.total == 34\n",
+    "assert est.gates.rotation_gates == 28"
    ]
   },
   {
@@ -340,7 +351,10 @@
     "test_weights = rng.uniform(-np.pi, np.pi, N_WEIGHTS)\n",
     "\n",
     "expvals = quantum_forward(test_inputs, test_weights)\n",
-    "print(\"期待値:\", expvals)"
+    "print(\"期待値:\", expvals)\n",
+    "# Z の期待値は [-1, 1]、量子ビット 1 個に 1 値。\n",
+    "assert expvals.shape == (N_QUBITS,)\n",
+    "assert all(-1.0 <= float(e) <= 1.0 for e in expvals)"
    ]
   },
   {
@@ -546,6 +560,9 @@
     "X_test, y_test = subset_dataset(full_test, SELECTED_CLASSES, N_TEST_PER_CLASS)\n",
     "\n",
     "print(f\"訓練データ: {X_train.shape}, テストデータ: {X_test.shape}\")\n",
+    "# 4 クラス × N_PER_CLASS サンプル; Fashion-MNIST は 1x28x28 グレースケール。\n",
+    "assert X_train.shape == (N_CLASSES * N_TRAIN_PER_CLASS, 1, 28, 28)\n",
+    "assert X_test.shape == (N_CLASSES * N_TEST_PER_CLASS, 1, 28, 28)\n",
     "print(f\"クラス: {CLASS_NAMES}\")"
    ]
   },

--- a/docs/ja/algorithm/hybrid_qnn.py
+++ b/docs/ja/algorithm/hybrid_qnn.py
@@ -61,6 +61,10 @@ N_WEIGHTS_PER_LAYER = N_QUBITS * 3  # 各量子ビットに RZ, RY, RZ
 N_WEIGHTS = N_LAYERS * N_WEIGHTS_PER_LAYER
 
 print(f"量子ビット数: {N_QUBITS}, 層数: {N_LAYERS}, 学習パラメータ数: {N_WEIGHTS}")
+assert N_QUBITS == 4
+assert N_LAYERS == 2
+# N_WEIGHTS = N_LAYERS * N_QUBITS * 3(1層あたり量子ビットごとに RZ + RY + RZ)。
+assert N_WEIGHTS == 24
 
 
 # %% [markdown]
@@ -141,6 +145,13 @@ est = variational_ansatz.estimate_resources(
     bindings={"n_qubits": N_QUBITS, "n_layers": N_LAYERS},
 )
 print(est)
+assert est.qubits == 4
+# 入力 RY 4 + 2 層 * (RZ 4 + RY 4 + RZ 4) = 1-qubit 回転 28 個。
+assert est.gates.single_qubit == 28
+# 2 層 * 3 CZ(4 量子ビット線形チェーン)= 2-qubit Clifford 6 個。
+assert est.gates.two_qubit == 6
+assert est.gates.total == 34
+assert est.gates.rotation_gates == 28
 
 # %% [markdown]
 # ## 量子フォワードパス
@@ -179,6 +190,9 @@ test_weights = rng.uniform(-np.pi, np.pi, N_WEIGHTS)
 
 expvals = quantum_forward(test_inputs, test_weights)
 print("期待値:", expvals)
+# Z の期待値は [-1, 1]、量子ビット 1 個に 1 値。
+assert expvals.shape == (N_QUBITS,)
+assert all(-1.0 <= float(e) <= 1.0 for e in expvals)
 
 # %% [markdown]
 # ## パラメータシフトルールによる勾配計算
@@ -320,6 +334,9 @@ X_train, y_train = subset_dataset(full_train, SELECTED_CLASSES, N_TRAIN_PER_CLAS
 X_test, y_test = subset_dataset(full_test, SELECTED_CLASSES, N_TEST_PER_CLASS)
 
 print(f"訓練データ: {X_train.shape}, テストデータ: {X_test.shape}")
+# 4 クラス × N_PER_CLASS サンプル; Fashion-MNIST は 1x28x28 グレースケール。
+assert X_train.shape == (N_CLASSES * N_TRAIN_PER_CLASS, 1, 28, 28)
+assert X_test.shape == (N_CLASSES * N_TEST_PER_CLASS, 1, 28, 28)
 print(f"クラス: {CLASS_NAMES}")
 
 


### PR DESCRIPTION
## Summary

First of the per-algorithm assert series (after the tutorial series in #418-#427). The HQNN tutorial trains end-to-end on a Fashion-MNIST subset; the training-side outputs (losses, accuracies, gradient magnitudes) depend on random initialisation and are intentionally not pinned. This PR adds asserts on the **front-of-tutorial deterministic values**: hyper-parameter constants, the resource estimate of the variational ansatz, the shape of the per-qubit expectation array, and the Fashion-MNIST subset shape.

## Asserts added

| Print | Assert |
|---|---|
| Hyper-parameter constants | \`N_QUBITS == 4\`, \`N_LAYERS == 2\`, \`N_WEIGHTS == 24\` |
| \`variational_ansatz.estimate_resources(...)\` | \`qubits == 4\`, \`single_qubit == 28\` (4 input RY + 2 * (4+4+4) layer rotations), \`two_qubit == 6\` (2 layers * 3 CZ on a 4-qubit linear chain), \`total == 34\`, \`rotation_gates == 28\` |
| \`expvals = quantum_forward(...)\` | \`expvals.shape == (N_QUBITS,)\` and each entry sits in \`[-1, 1]\` (Z expectation contract) |
| Fashion-MNIST subset shape | \`X_train.shape == (N_CLASSES * N_TRAIN_PER_CLASS, 1, 28, 28)\`, same for \`X_test\` -- both auto-adapt to the \`QAMOMILE_DOCS_TEST\` env-var sample-count reduction |

## Test plan

- [x] \`uv run pytest tests/docs/test_tutorials.py -m docs -k \"hybrid_qnn\" -v\` passes for both \`en/\` and \`ja/\` (~30s end-to-end including torch + quantum-layer training).
- [x] \`.ipynb\` re-synced via \`jupytext --to ipynb --update\`.
- [x] EN and JA parity-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)