### PR TITLE
docs(algorithm): assert deterministic invariants in "Möttönen Amplitude Encoding"

### DIFF
--- a/docs/en/algorithm/mottonen_amplitude_encoding.ipynb
+++ b/docs/en/algorithm/mottonen_amplitude_encoding.ipynb
@@ -179,9 +179,14 @@
     "print(f\"prepared      = {np.round(sv, 4)}\")\n",
     "print(f\"target (norm) = {np.round(expected, 4)}\")\n",
     "print(f\"fidelity      = {fidelity(sv, expected):.6f}\")\n",
+    "# Target is purely deterministic from amps_real / ||amps_real|| = a / sqrt(30).\n",
+    "assert np.allclose(expected, np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0))\n",
     "assert fidelity(sv, expected) == np.float64(1.0) or np.isclose(\n",
     "    fidelity(sv, expected), 1.0, atol=ATOL_STATEVECTOR\n",
-    "), \"real amplitude encoding lost fidelity\""
+    "), \"real amplitude encoding lost fidelity\"\n",
+    "# The prepared statevector's per-basis probability is phase-invariant and\n",
+    "# must reproduce |a_i|^2 / ||a||^2 = [1, 4, 9, 16] / 30 exactly (up to ATOL).\n",
+    "assert np.allclose(np.abs(sv) ** 2, np.abs(expected) ** 2, atol=ATOL_STATEVECTOR)"
    ]
   },
   {
@@ -686,9 +691,15 @@
     "except ValueError as exc:\n",
     "    print(f\"ValueError: {exc}\")\n",
     "    raised = True\n",
+    "    message = str(exc)\n",
     "else:\n",
     "    raised = False\n",
-    "assert raised, \"expected ValueError when amps is a runtime parameter\""
+    "    message = \"\"\n",
+    "assert raised, \"expected ValueError when amps is a runtime parameter\"\n",
+    "# The error message must direct the reader to the runtime-parametric API.\n",
+    "assert \"amplitude_encoding_from_angles\" in message, (\n",
+    "    \"ValueError no longer directs users to amplitude_encoding_from_angles\"\n",
+    ")"
    ]
   },
   {

--- a/docs/en/algorithm/mottonen_amplitude_encoding.py
+++ b/docs/en/algorithm/mottonen_amplitude_encoding.py
@@ -145,9 +145,14 @@ expected = normalize(amps_real)
 print(f"prepared      = {np.round(sv, 4)}")
 print(f"target (norm) = {np.round(expected, 4)}")
 print(f"fidelity      = {fidelity(sv, expected):.6f}")
+# Target is purely deterministic from amps_real / ||amps_real|| = a / sqrt(30).
+assert np.allclose(expected, np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0))
 assert fidelity(sv, expected) == np.float64(1.0) or np.isclose(
     fidelity(sv, expected), 1.0, atol=ATOL_STATEVECTOR
 ), "real amplitude encoding lost fidelity"
+# The prepared statevector's per-basis probability is phase-invariant and
+# must reproduce |a_i|^2 / ||a||^2 = [1, 4, 9, 16] / 30 exactly (up to ATOL).
+assert np.allclose(np.abs(sv) ** 2, np.abs(expected) ** 2, atol=ATOL_STATEVECTOR)
 
 # %% [markdown]
 # Negative real amplitudes flow through the magnitude stage naturally —
@@ -381,9 +386,15 @@ try:
 except ValueError as exc:
     print(f"ValueError: {exc}")
     raised = True
+    message = str(exc)
 else:
     raised = False
+    message = ""
 assert raised, "expected ValueError when amps is a runtime parameter"
+# The error message must direct the reader to the runtime-parametric API.
+assert "amplitude_encoding_from_angles" in message, (
+    "ValueError no longer directs users to amplitude_encoding_from_angles"
+)
 
 # %% [markdown]
 # ### 4.2 `amplitude_encoding_from_angles` — compile once, re-bind many times

--- a/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb
+++ b/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb
@@ -146,9 +146,14 @@
     "print(f\"prepared      = {np.round(sv, 4)}\")\n",
     "print(f\"target (norm) = {np.round(expected, 4)}\")\n",
     "print(f\"fidelity      = {fidelity(sv, expected):.6f}\")\n",
+    "# ターゲットは amps_real / ||amps_real|| = a / sqrt(30) で純粋に決定的。\n",
+    "assert np.allclose(expected, np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0))\n",
     "assert np.isclose(fidelity(sv, expected), 1.0, atol=ATOL_STATEVECTOR), (\n",
     "    \"実振幅エンコーディングのfidelityが落ちています\"\n",
-    ")"
+    ")\n",
+    "# 状態ベクトルの基底ごとの確率は位相不変であり、\n",
+    "# |a_i|^2 / ||a||^2 = [1, 4, 9, 16] / 30 を ATOL 内で再現する必要がある。\n",
+    "assert np.allclose(np.abs(sv) ** 2, np.abs(expected) ** 2, atol=ATOL_STATEVECTOR)"
    ]
   },
   {
@@ -597,9 +602,15 @@
     "except ValueError as exc:\n",
     "    print(f\"ValueError: {exc}\")\n",
     "    raised = True\n",
+    "    message = str(exc)\n",
     "else:\n",
     "    raised = False\n",
-    "assert raised, \"ampsをruntime parameterにすると ValueError が出るはず\""
+    "    message = \"\"\n",
+    "assert raised, \"ampsをruntime parameterにすると ValueError が出るはず\"\n",
+    "# エラーメッセージは runtime-parametric API を案内している必要がある。\n",
+    "assert \"amplitude_encoding_from_angles\" in message, (\n",
+    "    \"ValueError が amplitude_encoding_from_angles を案内していません\"\n",
+    ")"
    ]
   },
   {

--- a/docs/ja/algorithm/mottonen_amplitude_encoding.py
+++ b/docs/ja/algorithm/mottonen_amplitude_encoding.py
@@ -112,9 +112,14 @@ expected = normalize(amps_real)
 print(f"prepared      = {np.round(sv, 4)}")
 print(f"target (norm) = {np.round(expected, 4)}")
 print(f"fidelity      = {fidelity(sv, expected):.6f}")
+# ターゲットは amps_real / ||amps_real|| = a / sqrt(30) で純粋に決定的。
+assert np.allclose(expected, np.array([1.0, 2.0, 3.0, 4.0]) / np.sqrt(30.0))
 assert np.isclose(fidelity(sv, expected), 1.0, atol=ATOL_STATEVECTOR), (
     "実振幅エンコーディングのfidelityが落ちています"
 )
+# 状態ベクトルの基底ごとの確率は位相不変であり、
+# |a_i|^2 / ||a||^2 = [1, 4, 9, 16] / 30 を ATOL 内で再現する必要がある。
+assert np.allclose(np.abs(sv) ** 2, np.abs(expected) ** 2, atol=ATOL_STATEVECTOR)
 
 # %% [markdown]
 # 負の実数振幅は magnitude 段を自然に通過します — 葉レベルの$R_y$角は符号付きの`arctan2`として取られるため、追加の位相段なしで符号が捕捉されます。したがって状態$a = (1, -1, 1, -1)$は`RY`と`CNOT`のみで準備されます。
@@ -292,9 +297,15 @@ try:
 except ValueError as exc:
     print(f"ValueError: {exc}")
     raised = True
+    message = str(exc)
 else:
     raised = False
+    message = ""
 assert raised, "ampsをruntime parameterにすると ValueError が出るはず"
+# エラーメッセージは runtime-parametric API を案内している必要がある。
+assert "amplitude_encoding_from_angles" in message, (
+    "ValueError が amplitude_encoding_from_angles を案内していません"
+)
 
 # %% [markdown]
 # ### 4.2 `amplitude_encoding_from_angles` — 1度コンパイルして何度も再バインド


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
printed value. The Möttönen amplitude-encoding tutorial was already mostly
covered (fidelities, gate counts, runtime-parameter counts, sampling
deviations, expval); this PR closes the two remaining gaps:

- **§1 target distribution.** `target (norm)` for `a = (1, 2, 3, 4)` is
  pure numpy normalization and equals `a / sqrt(30)` exactly — now asserted
  directly. The phase-invariant per-basis probability `|sv|^2` is also
  asserted against `[1, 4, 9, 16] / 30` as defense-in-depth alongside the
  existing fidelity assert.
- **§4.1 directing error message.** The tutorial explicitly claims that
  the `ValueError` raised when `amps` is left as a runtime parameter
  points the reader at `amplitude_encoding_from_angles`. That claim is
  now asserted: the message must contain that identifier verbatim.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "mottonen_amplitude_encoding" -v` passes locally for both EN and JA.