### PR TITLE
docs(algorithm): assert deterministic invariants in "QAOA for Graph Partitioning"

### DIFF
--- a/docs/en/algorithm/qaoa_graph_partition.ipynb
+++ b/docs/en/algorithm/qaoa_graph_partition.ipynb
@@ -195,6 +195,8 @@
     "G = nx.Graph()\n",
     "G.add_nodes_from(range(num_nodes))\n",
     "G.add_edges_from(edge_list)\n",
+    "assert G.number_of_nodes() == num_nodes\n",
+    "assert G.number_of_edges() == len(edge_list)\n",
     "\n",
     "pos = nx.spring_layout(G, seed=1)\n",
     "plt.figure(figsize=(5, 5))\n",
@@ -285,7 +287,14 @@
     "converter = QAOAConverter(instance)\n",
     "converter.spin_model = converter.spin_model.normalize_by_abs_max()\n",
     "hamiltonian = converter.get_cost_hamiltonian()\n",
-    "print(hamiltonian)"
+    "print(hamiltonian)\n",
+    "# Structural invariants of the spin model derived from this fixed instance:\n",
+    "# one qubit per vertex, no linear (single-Z) terms, and a fixed quadratic-term\n",
+    "# count once the QUBO simplifies the |V|=8, |E|=16 problem.\n",
+    "assert converter.spin_model.num_bits == num_nodes\n",
+    "assert converter.spin_model.linear == {}\n",
+    "assert len(converter.spin_model.quad) == 12\n",
+    "assert len(hamiltonian.terms) == 12"
    ]
   },
   {
@@ -578,6 +587,7 @@
     "\n",
     "rng = np.random.default_rng(900)\n",
     "initial_params = rng.uniform(0, np.pi, 2 * p)\n",
+    "assert initial_params.shape == (2 * p,)\n",
     "\n",
     "cost_history = []\n",
     "\n",
@@ -612,7 +622,12 @@
     "\n",
     "print(f\"Optimized cost: {res.fun:.3f}\")\n",
     "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")\n",
-    "print(f\"Function evaluations: {res.nfev}\")"
+    "print(f\"Function evaluations: {res.nfev}\")\n",
+    "assert len(cost_history) == res.nfev\n",
+    "assert len(res.x) == 2 * p\n",
+    "if docs_test_mode:\n",
+    "    # In docs test mode COBYLA is truncated at the maxiter budget.\n",
+    "    assert res.nfev == maxiter"
    ]
   },
   {
@@ -738,7 +753,8 @@
     "print(\n",
     "    f\"Feasible samples: {total_feasible} / {total_samples} \"\n",
     "    f\"({100 * total_feasible / total_samples:.1f}%)\"\n",
-    ")"
+    ")\n",
+    "assert total_samples == 1000  # matches the hardcoded shots above"
    ]
   },
   {
@@ -788,6 +804,10 @@
     "    }\n",
     "    print(f\"Best feasible solution: {best_sample}\")\n",
     "    print(f\"Cut edges:             {best_obj}\")\n",
+    "    # Any feasible solution must satisfy the equal-partition constraint\n",
+    "    # sum(x_u) == |V|/2 exactly.\n",
+    "    assert sum(best_sample.values()) == num_nodes // 2\n",
+    "    assert best_obj >= 0\n",
     "else:\n",
     "    print(\"No feasible solution found. Try increasing p or maxiter.\")\n",
     "    best_sample = None\n",

--- a/docs/en/algorithm/qaoa_graph_partition.py
+++ b/docs/en/algorithm/qaoa_graph_partition.py
@@ -117,6 +117,8 @@ edge_list = [
 G = nx.Graph()
 G.add_nodes_from(range(num_nodes))
 G.add_edges_from(edge_list)
+assert G.number_of_nodes() == num_nodes
+assert G.number_of_edges() == len(edge_list)
 
 pos = nx.spring_layout(G, seed=1)
 plt.figure(figsize=(5, 5))
@@ -162,6 +164,13 @@ converter = QAOAConverter(instance)
 converter.spin_model = converter.spin_model.normalize_by_abs_max()
 hamiltonian = converter.get_cost_hamiltonian()
 print(hamiltonian)
+# Structural invariants of the spin model derived from this fixed instance:
+# one qubit per vertex, no linear (single-Z) terms, and a fixed quadratic-term
+# count once the QUBO simplifies the |V|=8, |E|=16 problem.
+assert converter.spin_model.num_bits == num_nodes
+assert converter.spin_model.linear == {}
+assert len(converter.spin_model.quad) == 12
+assert len(hamiltonian.terms) == 12
 
 # %% [markdown]
 # ## Transpile to an Executable Circuit
@@ -292,6 +301,7 @@ maxiter = 25 if docs_test_mode else 1000
 
 rng = np.random.default_rng(900)
 initial_params = rng.uniform(0, np.pi, 2 * p)
+assert initial_params.shape == (2 * p,)
 
 cost_history = []
 
@@ -327,6 +337,11 @@ res = minimize(
 print(f"Optimized cost: {res.fun:.3f}")
 print(f"Optimal params: {[round(v, 4) for v in res.x]}")
 print(f"Function evaluations: {res.nfev}")
+assert len(cost_history) == res.nfev
+assert len(res.x) == 2 * p
+if docs_test_mode:
+    # In docs test mode COBYLA is truncated at the maxiter budget.
+    assert res.nfev == maxiter
 
 # %%
 plt.figure(figsize=(8, 4))
@@ -382,6 +397,7 @@ print(
     f"Feasible samples: {total_feasible} / {total_samples} "
     f"({100 * total_feasible / total_samples:.1f}%)"
 )
+assert total_samples == 1000  # matches the hardcoded shots above
 
 # %% [markdown]
 # ### Best Feasible Solution
@@ -403,6 +419,10 @@ if total_feasible > 0:
     }
     print(f"Best feasible solution: {best_sample}")
     print(f"Cut edges:             {best_obj}")
+    # Any feasible solution must satisfy the equal-partition constraint
+    # sum(x_u) == |V|/2 exactly.
+    assert sum(best_sample.values()) == num_nodes // 2
+    assert best_obj >= 0
 else:
     print("No feasible solution found. Try increasing p or maxiter.")
     best_sample = None

--- a/docs/ja/algorithm/qaoa_graph_partition.ipynb
+++ b/docs/ja/algorithm/qaoa_graph_partition.ipynb
@@ -192,6 +192,8 @@
     "G = nx.Graph()\n",
     "G.add_nodes_from(range(num_nodes))\n",
     "G.add_edges_from(edge_list)\n",
+    "assert G.number_of_nodes() == num_nodes\n",
+    "assert G.number_of_edges() == len(edge_list)\n",
     "\n",
     "pos = nx.spring_layout(G, seed=1)\n",
     "plt.figure(figsize=(5, 5))\n",
@@ -277,7 +279,14 @@
     "converter = QAOAConverter(instance)\n",
     "converter.spin_model = converter.spin_model.normalize_by_abs_max()\n",
     "hamiltonian = converter.get_cost_hamiltonian()\n",
-    "print(hamiltonian)"
+    "print(hamiltonian)\n",
+    "# この固定インスタンスから導かれるスピン模型の構造的不変量:\n",
+    "# 頂点 1 個につき量子ビット 1 個、線形 (single-Z) 項は無し、|V|=8, |E|=16 の問題から\n",
+    "# QUBO 簡約を経た 2 次項の個数も決まる。\n",
+    "assert converter.spin_model.num_bits == num_nodes\n",
+    "assert converter.spin_model.linear == {}\n",
+    "assert len(converter.spin_model.quad) == 12\n",
+    "assert len(hamiltonian.terms) == 12"
    ]
   },
   {
@@ -547,6 +556,7 @@
     "\n",
     "rng = np.random.default_rng(900)\n",
     "initial_params = rng.uniform(0, np.pi, 2 * p)\n",
+    "assert initial_params.shape == (2 * p,)\n",
     "\n",
     "cost_history = []\n",
     "\n",
@@ -580,7 +590,12 @@
     "\n",
     "print(f\"Optimized cost: {res.fun:.3f}\")\n",
     "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")\n",
-    "print(f\"Function evaluations: {res.nfev}\")"
+    "print(f\"Function evaluations: {res.nfev}\")\n",
+    "assert len(cost_history) == res.nfev\n",
+    "assert len(res.x) == 2 * p\n",
+    "if docs_test_mode:\n",
+    "    # docs テストモードでは COBYLA は maxiter の予算で打ち切られる。\n",
+    "    assert res.nfev == maxiter"
    ]
   },
   {
@@ -699,7 +714,8 @@
     "print(\n",
     "    f\"Feasible samples: {total_feasible} / {total_samples} \"\n",
     "    f\"({100 * total_feasible / total_samples:.1f}%)\"\n",
-    ")"
+    ")\n",
+    "assert total_samples == 1000  # 上のハードコードされた shots と一致"
    ]
   },
   {
@@ -744,6 +760,9 @@
     "    }\n",
     "    print(f\"Best feasible solution: {best_sample}\")\n",
     "    print(f\"Cut edges:             {best_obj}\")\n",
+    "    # 実行可能解は等分割制約 sum(x_u) == |V|/2 をきっちり満たしているはず。\n",
+    "    assert sum(best_sample.values()) == num_nodes // 2\n",
+    "    assert best_obj >= 0\n",
     "else:\n",
     "    print(\"No feasible solution found. Try increasing p or maxiter.\")\n",
     "    best_sample = None\n",

--- a/docs/ja/algorithm/qaoa_graph_partition.py
+++ b/docs/ja/algorithm/qaoa_graph_partition.py
@@ -114,6 +114,8 @@ edge_list = [
 G = nx.Graph()
 G.add_nodes_from(range(num_nodes))
 G.add_edges_from(edge_list)
+assert G.number_of_nodes() == num_nodes
+assert G.number_of_edges() == len(edge_list)
 
 pos = nx.spring_layout(G, seed=1)
 plt.figure(figsize=(5, 5))
@@ -154,6 +156,13 @@ converter = QAOAConverter(instance)
 converter.spin_model = converter.spin_model.normalize_by_abs_max()
 hamiltonian = converter.get_cost_hamiltonian()
 print(hamiltonian)
+# この固定インスタンスから導かれるスピン模型の構造的不変量:
+# 頂点 1 個につき量子ビット 1 個、線形 (single-Z) 項は無し、|V|=8, |E|=16 の問題から
+# QUBO 簡約を経た 2 次項の個数も決まる。
+assert converter.spin_model.num_bits == num_nodes
+assert converter.spin_model.linear == {}
+assert len(converter.spin_model.quad) == 12
+assert len(hamiltonian.terms) == 12
 
 # %% [markdown]
 # ## 実行可能な回路へのトランスパイル
@@ -261,6 +270,7 @@ maxiter = 25 if docs_test_mode else 1000
 
 rng = np.random.default_rng(900)
 initial_params = rng.uniform(0, np.pi, 2 * p)
+assert initial_params.shape == (2 * p,)
 
 cost_history = []
 
@@ -295,6 +305,11 @@ res = minimize(
 print(f"Optimized cost: {res.fun:.3f}")
 print(f"Optimal params: {[round(v, 4) for v in res.x]}")
 print(f"Function evaluations: {res.nfev}")
+assert len(cost_history) == res.nfev
+assert len(res.x) == 2 * p
+if docs_test_mode:
+    # docs テストモードでは COBYLA は maxiter の予算で打ち切られる。
+    assert res.nfev == maxiter
 
 # %%
 plt.figure(figsize=(8, 4))
@@ -343,6 +358,7 @@ print(
     f"Feasible samples: {total_feasible} / {total_samples} "
     f"({100 * total_feasible / total_samples:.1f}%)"
 )
+assert total_samples == 1000  # 上のハードコードされた shots と一致
 
 # %% [markdown]
 # ### 最良の実行可能解
@@ -359,6 +375,9 @@ if total_feasible > 0:
     }
     print(f"Best feasible solution: {best_sample}")
     print(f"Cut edges:             {best_obj}")
+    # 実行可能解は等分割制約 sum(x_u) == |V|/2 をきっちり満たしているはず。
+    assert sum(best_sample.values()) == num_nodes // 2
+    assert best_obj >= 0
 else:
     print("No feasible solution found. Try increasing p or maxiter.")
     best_sample = None


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
printed value.

This PR adds asserts to the graph-partition QAOA tutorial guarding the
structural invariants that follow from the fixed problem instance
(|V|=8, |E|=16, p=5), the COBYLA budget under docs test mode, and the
equal-partition feasibility constraint on the best feasible solution.

Specifically:
- Graph node / edge counts match the input data.
- Spin model has 8 qubits, no linear terms, 12 quadratic terms; cost
  Hamiltonian carries 12 terms.
- Initial QAOA parameter vector has shape (2p,) and `res.x` matches.
- In docs test mode, COBYLA consumes the full `maxiter` budget.
- Sample count equals the hardcoded 1000 shots.
- Any feasible bitstring sums to |V|/2, so `best_feasible` must too;
  `best_obj` is non-negative.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "qaoa_graph_partition" -v` passes locally for both EN and JA.