### PR TITLE
docs(algorithm): assert deterministic invariants in "QAOA for MaxCut"

### DIFF
--- a/docs/en/algorithm/qaoa_maxcut.ipynb
+++ b/docs/en/algorithm/qaoa_maxcut.ipynb
@@ -112,6 +112,8 @@
     "G = nx.Graph()\n",
     "G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (2, 3), (3, 4)])\n",
     "num_nodes = G.number_of_nodes()\n",
+    "assert num_nodes == 5\n",
+    "assert G.number_of_edges() == 6\n",
     "\n",
     "pos = nx.spring_layout(G, seed=42)\n",
     "plt.figure(figsize=(5, 4))\n",
@@ -192,7 +194,12 @@
     "print(f\"Variable type:          {spin_model.vartype}\")\n",
     "print(f\"Linear terms (h_i):     {spin_model.linear}\")\n",
     "print(f\"Quadratic terms (J_ij): {spin_model.quad}\")\n",
-    "print(f\"Constant:               {spin_model.constant}\")"
+    "print(f\"Constant:               {spin_model.constant}\")\n",
+    "# Spin-domain model with no linear field, one J_ij per graph edge, no offset.\n",
+    "assert spin_model.vartype.name == \"SPIN\"\n",
+    "assert spin_model.linear == {}\n",
+    "assert len(spin_model.quad) == G.number_of_edges()\n",
+    "assert spin_model.constant == 0.0"
    ]
   },
   {
@@ -260,7 +267,13 @@
     "print(f\"Optimal MaxCut value: {best_cut}\")\n",
     "print(f\"Number of optimal partitions: {len(optimal_partitions)}\")\n",
     "for part in optimal_partitions:\n",
-    "    print(f\"  {part}\")"
+    "    print(f\"  {part}\")\n",
+    "# The MaxCut of this fixed 5-node, 6-edge graph is 5; it is achieved by\n",
+    "# exactly two spin configurations related by the global flip s -> -s.\n",
+    "assert best_cut == 5\n",
+    "assert len(optimal_partitions) == 2\n",
+    "for part in optimal_partitions:\n",
+    "    assert tuple(-s for s in part) in optimal_partitions"
    ]
   },
   {
@@ -592,11 +605,17 @@
     "\n",
     "rng = np.random.default_rng(SEED)\n",
     "initial_params = rng.uniform(-np.pi / 2, np.pi / 2, 2 * p)\n",
+    "assert initial_params.shape == (2 * p,)\n",
     "\n",
     "res = minimize(cost_fn, initial_params, method=\"COBYLA\", options={\"maxiter\": maxiter})\n",
     "\n",
     "print(f\"Optimized cost: {res.fun:.4f}\")\n",
-    "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")"
+    "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")\n",
+    "assert len(cost_history) == res.nfev\n",
+    "assert len(res.x) == 2 * p\n",
+    "if docs_test_mode:\n",
+    "    # In docs test mode COBYLA is truncated at the maxiter budget.\n",
+    "    assert res.nfev == maxiter"
    ]
   },
   {
@@ -712,7 +731,11 @@
     "        best_qaoa_sample = spins\n",
     "\n",
     "print(f\"Best QAOA cut: {best_qaoa_cut}  (optimal: {best_cut})\")\n",
-    "print(f\"Best partition (spins): {best_qaoa_sample}\")"
+    "print(f\"Best partition (spins): {best_qaoa_sample}\")\n",
+    "# QAOA cannot exceed the brute-force optimum, and the distribution must\n",
+    "# account for every shot of the final sample.\n",
+    "assert best_qaoa_cut <= best_cut\n",
+    "assert sum(cut_distribution.values()) == sample_shots"
    ]
   },
   {
@@ -907,7 +930,11 @@
     "decoded_manual = spin_model.decode_from_sampleresult(result_manual)\n",
     "decoded_builtin = spin_model.decode_from_sampleresult(result_builtin)\n",
     "print(f\"Manual   mean energy: {decoded_manual.energy_mean():.4f}\")\n",
-    "print(f\"Built-in mean energy: {decoded_builtin.energy_mean():.4f}\")"
+    "print(f\"Built-in mean energy: {decoded_builtin.energy_mean():.4f}\")\n",
+    "# Same seed + bit-identical circuit ⇒ identical samples ⇒ identical mean.\n",
+    "# Any divergence here means the manual and built-in paths emitted different\n",
+    "# circuits (gate ordering, compilation difference) — not shot noise.\n",
+    "assert decoded_manual.energy_mean() == decoded_builtin.energy_mean()"
    ]
   },
   {

--- a/docs/en/algorithm/qaoa_maxcut.py
+++ b/docs/en/algorithm/qaoa_maxcut.py
@@ -72,6 +72,8 @@ import networkx as nx
 G = nx.Graph()
 G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (2, 3), (3, 4)])
 num_nodes = G.number_of_nodes()
+assert num_nodes == 5
+assert G.number_of_edges() == 6
 
 pos = nx.spring_layout(G, seed=42)
 plt.figure(figsize=(5, 4))
@@ -123,6 +125,11 @@ print(f"Variable type:          {spin_model.vartype}")
 print(f"Linear terms (h_i):     {spin_model.linear}")
 print(f"Quadratic terms (J_ij): {spin_model.quad}")
 print(f"Constant:               {spin_model.constant}")
+# Spin-domain model with no linear field, one J_ij per graph edge, no offset.
+assert spin_model.vartype.name == "SPIN"
+assert spin_model.linear == {}
+assert len(spin_model.quad) == G.number_of_edges()
+assert spin_model.constant == 0.0
 
 # %% [markdown]
 # > **Note:** `BinaryModel` also provides `from_qubo()` and `from_hubo()` for
@@ -156,6 +163,12 @@ print(f"Optimal MaxCut value: {best_cut}")
 print(f"Number of optimal partitions: {len(optimal_partitions)}")
 for part in optimal_partitions:
     print(f"  {part}")
+# The MaxCut of this fixed 5-node, 6-edge graph is 5; it is achieved by
+# exactly two spin configurations related by the global flip s -> -s.
+assert best_cut == 5
+assert len(optimal_partitions) == 2
+for part in optimal_partitions:
+    assert tuple(-s for s in part) in optimal_partitions
 
 # %% [markdown]
 # ## QAOA Circuit: The Idea
@@ -357,11 +370,17 @@ def cost_fn(params):
 
 rng = np.random.default_rng(SEED)
 initial_params = rng.uniform(-np.pi / 2, np.pi / 2, 2 * p)
+assert initial_params.shape == (2 * p,)
 
 res = minimize(cost_fn, initial_params, method="COBYLA", options={"maxiter": maxiter})
 
 print(f"Optimized cost: {res.fun:.4f}")
 print(f"Optimal params: {[round(v, 4) for v in res.x]}")
+assert len(cost_history) == res.nfev
+assert len(res.x) == 2 * p
+if docs_test_mode:
+    # In docs test mode COBYLA is truncated at the maxiter budget.
+    assert res.nfev == maxiter
 
 # %%
 plt.figure(figsize=(8, 4))
@@ -411,6 +430,10 @@ for sample, _energy, occ in zip(
 
 print(f"Best QAOA cut: {best_qaoa_cut}  (optimal: {best_cut})")
 print(f"Best partition (spins): {best_qaoa_sample}")
+# QAOA cannot exceed the brute-force optimum, and the distribution must
+# account for every shot of the final sample.
+assert best_qaoa_cut <= best_cut
+assert sum(cut_distribution.values()) == sample_shots
 
 # %%
 cuts = sorted(cut_distribution.keys())
@@ -510,6 +533,10 @@ decoded_manual = spin_model.decode_from_sampleresult(result_manual)
 decoded_builtin = spin_model.decode_from_sampleresult(result_builtin)
 print(f"Manual   mean energy: {decoded_manual.energy_mean():.4f}")
 print(f"Built-in mean energy: {decoded_builtin.energy_mean():.4f}")
+# Same seed + bit-identical circuit ⇒ identical samples ⇒ identical mean.
+# Any divergence here means the manual and built-in paths emitted different
+# circuits (gate ordering, compilation difference) — not shot noise.
+assert decoded_manual.energy_mean() == decoded_builtin.energy_mean()
 
 # %% [markdown]
 # ## Summary

--- a/docs/ja/algorithm/qaoa_maxcut.ipynb
+++ b/docs/ja/algorithm/qaoa_maxcut.ipynb
@@ -102,6 +102,8 @@
     "G = nx.Graph()\n",
     "G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (2, 3), (3, 4)])\n",
     "num_nodes = G.number_of_nodes()\n",
+    "assert num_nodes == 5\n",
+    "assert G.number_of_edges() == 6\n",
     "\n",
     "pos = nx.spring_layout(G, seed=42)\n",
     "plt.figure(figsize=(5, 4))\n",
@@ -178,7 +180,12 @@
     "print(f\"Variable type:          {spin_model.vartype}\")\n",
     "print(f\"Linear terms (h_i):     {spin_model.linear}\")\n",
     "print(f\"Quadratic terms (J_ij): {spin_model.quad}\")\n",
-    "print(f\"Constant:               {spin_model.constant}\")"
+    "print(f\"Constant:               {spin_model.constant}\")\n",
+    "# スピン領域のモデルで、線形項は無し、各辺に 1 つの J_ij、定数項も無し。\n",
+    "assert spin_model.vartype.name == \"SPIN\"\n",
+    "assert spin_model.linear == {}\n",
+    "assert len(spin_model.quad) == G.number_of_edges()\n",
+    "assert spin_model.constant == 0.0"
    ]
   },
   {
@@ -240,7 +247,13 @@
     "print(f\"Optimal MaxCut value: {best_cut}\")\n",
     "print(f\"Number of optimal partitions: {len(optimal_partitions)}\")\n",
     "for part in optimal_partitions:\n",
-    "    print(f\"  {part}\")"
+    "    print(f\"  {part}\")\n",
+    "# この固定された 5 ノード 6 辺のグラフでは MaxCut は 5、それを達成する\n",
+    "# スピン配置は大域反転 s -> -s で結ばれる 2 通りだけ。\n",
+    "assert best_cut == 5\n",
+    "assert len(optimal_partitions) == 2\n",
+    "for part in optimal_partitions:\n",
+    "    assert tuple(-s for s in part) in optimal_partitions"
    ]
   },
   {
@@ -542,11 +555,17 @@
     "\n",
     "rng = np.random.default_rng(SEED)\n",
     "initial_params = rng.uniform(-np.pi / 2, np.pi / 2, 2 * p)\n",
+    "assert initial_params.shape == (2 * p,)\n",
     "\n",
     "res = minimize(cost_fn, initial_params, method=\"COBYLA\", options={\"maxiter\": maxiter})\n",
     "\n",
     "print(f\"Optimized cost: {res.fun:.4f}\")\n",
-    "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")"
+    "print(f\"Optimal params: {[round(v, 4) for v in res.x]}\")\n",
+    "assert len(cost_history) == res.nfev\n",
+    "assert len(res.x) == 2 * p\n",
+    "if docs_test_mode:\n",
+    "    # docs テストモードでは COBYLA は maxiter の予算で打ち切られる。\n",
+    "    assert res.nfev == maxiter"
    ]
   },
   {
@@ -659,7 +678,11 @@
     "        best_qaoa_sample = spins\n",
     "\n",
     "print(f\"Best QAOA cut: {best_qaoa_cut}  (optimal: {best_cut})\")\n",
-    "print(f\"Best partition (spins): {best_qaoa_sample}\")"
+    "print(f\"Best partition (spins): {best_qaoa_sample}\")\n",
+    "# QAOA は全探索の最適値を超えられず、分布は最終サンプルの全ショットを\n",
+    "# 漏れなく数え上げているはず。\n",
+    "assert best_qaoa_cut <= best_cut\n",
+    "assert sum(cut_distribution.values()) == sample_shots"
    ]
   },
   {
@@ -842,7 +865,11 @@
     "decoded_manual = spin_model.decode_from_sampleresult(result_manual)\n",
     "decoded_builtin = spin_model.decode_from_sampleresult(result_builtin)\n",
     "print(f\"Manual   mean energy: {decoded_manual.energy_mean():.4f}\")\n",
-    "print(f\"Built-in mean energy: {decoded_builtin.energy_mean():.4f}\")"
+    "print(f\"Built-in mean energy: {decoded_builtin.energy_mean():.4f}\")\n",
+    "# 同じシード + ビット単位で同一の回路 ⇒ サンプル列も平均も完全一致するはず。\n",
+    "# 差分が出る場合は手動版と組み込み版がビット単位で異なる回路を emit したという\n",
+    "# サイン (ゲート順序やコンパイル経路の差) であり、shot noise の残差ではない。\n",
+    "assert decoded_manual.energy_mean() == decoded_builtin.energy_mean()"
    ]
   },
   {

--- a/docs/ja/algorithm/qaoa_maxcut.py
+++ b/docs/ja/algorithm/qaoa_maxcut.py
@@ -62,6 +62,8 @@ import networkx as nx
 G = nx.Graph()
 G.add_edges_from([(0, 1), (0, 2), (1, 2), (1, 3), (2, 3), (3, 4)])
 num_nodes = G.number_of_nodes()
+assert num_nodes == 5
+assert G.number_of_edges() == 6
 
 pos = nx.spring_layout(G, seed=42)
 plt.figure(figsize=(5, 4))
@@ -109,6 +111,11 @@ print(f"Variable type:          {spin_model.vartype}")
 print(f"Linear terms (h_i):     {spin_model.linear}")
 print(f"Quadratic terms (J_ij): {spin_model.quad}")
 print(f"Constant:               {spin_model.constant}")
+# スピン領域のモデルで、線形項は無し、各辺に 1 つの J_ij、定数項も無し。
+assert spin_model.vartype.name == "SPIN"
+assert spin_model.linear == {}
+assert len(spin_model.quad) == G.number_of_edges()
+assert spin_model.constant == 0.0
 
 # %% [markdown]
 # > **Note:** `BinaryModel`はQUBO向けの`from_qubo()`や高次版の`from_hubo()`も提供しており、割当問題や制約（ペナルティ項）を伴う問題のようにバイナリ領域で自然に定式化される問題に利用できます。QUBO/JijModelingベースのワークフローについては[QAOAによるグラフ分割](qaoa_graph_partition)を参照してください。
@@ -136,6 +143,12 @@ print(f"Optimal MaxCut value: {best_cut}")
 print(f"Number of optimal partitions: {len(optimal_partitions)}")
 for part in optimal_partitions:
     print(f"  {part}")
+# この固定された 5 ノード 6 辺のグラフでは MaxCut は 5、それを達成する
+# スピン配置は大域反転 s -> -s で結ばれる 2 通りだけ。
+assert best_cut == 5
+assert len(optimal_partitions) == 2
+for part in optimal_partitions:
+    assert tuple(-s for s in part) in optimal_partitions
 
 # %% [markdown]
 # ## QAOA回路: 基本的な考え方
@@ -307,11 +320,17 @@ def cost_fn(params):
 
 rng = np.random.default_rng(SEED)
 initial_params = rng.uniform(-np.pi / 2, np.pi / 2, 2 * p)
+assert initial_params.shape == (2 * p,)
 
 res = minimize(cost_fn, initial_params, method="COBYLA", options={"maxiter": maxiter})
 
 print(f"Optimized cost: {res.fun:.4f}")
 print(f"Optimal params: {[round(v, 4) for v in res.x]}")
+assert len(cost_history) == res.nfev
+assert len(res.x) == 2 * p
+if docs_test_mode:
+    # docs テストモードでは COBYLA は maxiter の予算で打ち切られる。
+    assert res.nfev == maxiter
 
 # %%
 plt.figure(figsize=(8, 4))
@@ -358,6 +377,10 @@ for sample, _energy, occ in zip(
 
 print(f"Best QAOA cut: {best_qaoa_cut}  (optimal: {best_cut})")
 print(f"Best partition (spins): {best_qaoa_sample}")
+# QAOA は全探索の最適値を超えられず、分布は最終サンプルの全ショットを
+# 漏れなく数え上げているはず。
+assert best_qaoa_cut <= best_cut
+assert sum(cut_distribution.values()) == sample_shots
 
 # %%
 cuts = sorted(cut_distribution.keys())
@@ -445,6 +468,10 @@ decoded_manual = spin_model.decode_from_sampleresult(result_manual)
 decoded_builtin = spin_model.decode_from_sampleresult(result_builtin)
 print(f"Manual   mean energy: {decoded_manual.energy_mean():.4f}")
 print(f"Built-in mean energy: {decoded_builtin.energy_mean():.4f}")
+# 同じシード + ビット単位で同一の回路 ⇒ サンプル列も平均も完全一致するはず。
+# 差分が出る場合は手動版と組み込み版がビット単位で異なる回路を emit したという
+# サイン (ゲート順序やコンパイル経路の差) であり、shot noise の残差ではない。
+assert decoded_manual.energy_mean() == decoded_builtin.energy_mean()
 
 # %% [markdown]
 # ## まとめ


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
printed value.

This PR adds asserts to the from-scratch MaxCut QAOA tutorial guarding
the structural invariants that follow from the fixed 5-node, 6-edge
graph, the COBYLA budget under docs test mode, and the manual /
built-in qaoa_state equivalence:

- Graph: 5 nodes, 6 edges.
- Spin model: SPIN domain, no linear field, one J_ij per graph edge,
  zero constant.
- Brute-force optimum is 5, achieved by exactly two configurations
  related by global spin flip s -> -s.
- Initial QAOA parameter vector has shape (2p,); res.x matches.
- In docs test mode, COBYLA consumes the full maxiter budget.
- QAOA's best cut cannot exceed the brute-force optimum; the cut
  distribution accounts for every shot.
- Manual and built-in qaoa_state paths produce identical mean energies
  under a shared simulator seed — identical circuits + identical seed
  must yield identical samples.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "qaoa_maxcut" -v` passes locally for both EN and JA.