### PR TITLE
docs(algorithm): assert deterministic invariants in "QSCI"

### DIFF
--- a/docs/en/algorithm/qsci.ipynb
+++ b/docs/en/algorithm/qsci.ipynb
@@ -100,8 +100,7 @@
      "iopub.status.busy": "2026-05-08T02:46:03.331481Z",
      "iopub.status.idle": "2026-05-08T02:46:03.334152Z",
      "shell.execute_reply": "2026-05-08T02:46:03.333796Z"
-    },
-    "lines_to_next_cell": 1
+    }
    },
    "outputs": [
     {
@@ -125,13 +124,20 @@
     "\n",
     "exact_eigvals = np.linalg.eigvalsh(H.to_numpy())\n",
     "E_exact = float(exact_eigvals[0])\n",
-    "print(f\"Exact ground state energy: {E_exact:.6f}\")"
+    "print(f\"Exact ground state energy: {E_exact:.6f}\")\n",
+    "# eigvalsh returns ascending eigenvalues, so exact_eigvals[0] is the ground\n",
+    "# state. The 4-qubit TFIM Hilbert space is 2^n_qubits-dimensional.\n",
+    "assert H.num_qubits == n_qubits\n",
+    "assert exact_eigvals.shape == (2**n_qubits,)\n",
+    "assert E_exact == float(exact_eigvals.min())"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3febb448",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## Hardware-efficient ansatz\n",
     "\n",
@@ -213,8 +219,7 @@
      "iopub.status.busy": "2026-05-08T02:46:03.339046Z",
      "iopub.status.idle": "2026-05-08T02:46:03.355424Z",
      "shell.execute_reply": "2026-05-08T02:46:03.355031Z"
-    },
-    "lines_to_next_cell": 1
+    }
    },
    "outputs": [],
    "source": [
@@ -239,7 +244,9 @@
   {
    "cell_type": "markdown",
    "id": "7fa3868a",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## Step 1: Prepare $|\\psi_{\\mathrm{in}}\\rangle$ via a quick VQE\n",
     "\n",
@@ -279,6 +286,7 @@
     "\n",
     "rng = np.random.default_rng(0)\n",
     "init_params = rng.uniform(0, 2 * np.pi, n_params)\n",
+    "assert init_params.shape == (n_params,)\n",
     "\n",
     "maxiter = max(n_params + 2, 5 if docs_test_mode else 80)\n",
     "result = minimize(\n",
@@ -288,7 +296,11 @@
     "    options={\"maxiter\": maxiter, \"rhobeg\": 0.5},\n",
     ")\n",
     "opt_params = result.x\n",
-    "print(f\"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})\")"
+    "print(f\"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})\")\n",
+    "# Variational principle: any VQE energy is an upper bound on E_exact, no\n",
+    "# matter how short the COBYLA budget.\n",
+    "assert result.fun >= E_exact - 1e-9\n",
+    "assert opt_params.shape == (n_params,)"
    ]
   },
   {
@@ -340,7 +352,12 @@
     "sample_results.sort(key=lambda bc: bc[1], reverse=True)\n",
     "print(f\"Distinct bitstrings sampled: {len(sample_results)}\")\n",
     "for bits, c in sample_results[:5]:\n",
-    "    print(f\"  {bits}  count={c}\")"
+    "    print(f\"  {bits}  count={c}\")\n",
+    "# Distinct bitstrings cannot exceed the dimension of the Hilbert space,\n",
+    "# every shot is accounted for, and each bitstring is n_qubits long.\n",
+    "assert len(sample_results) <= 2**n_qubits\n",
+    "assert sum(c for _, c in sample_results) == shots\n",
+    "assert all(len(bits) == n_qubits for bits, _ in sample_results)"
    ]
   },
   {
@@ -394,7 +411,11 @@
     "for K, E in zip(ks, energies):\n",
     "    print(f\"K = {K:3d}   E_QSCI = {E:+.6f}   gap = {E - E_exact:+.3e}\")\n",
     "\n",
-    "assert all(E >= E_exact - 1e-9 for E in energies), \"variational bound violated\""
+    "assert all(E >= E_exact - 1e-9 for E in energies), \"variational bound violated\"\n",
+    "# Cauchy interlacing: enlarging the subspace can only lower (or keep) the\n",
+    "# minimum eigenvalue, so QSCI energies are monotonically non-increasing in K.\n",
+    "assert all(energies[i] >= energies[i + 1] - 1e-9 for i in range(len(energies) - 1))\n",
+    "assert len(energies) == len(ks)"
    ]
   },
   {

--- a/docs/en/algorithm/qsci.py
+++ b/docs/en/algorithm/qsci.py
@@ -92,6 +92,11 @@ for i in range(n_qubits):
 exact_eigvals = np.linalg.eigvalsh(H.to_numpy())
 E_exact = float(exact_eigvals[0])
 print(f"Exact ground state energy: {E_exact:.6f}")
+# eigvalsh returns ascending eigenvalues, so exact_eigvals[0] is the ground
+# state. The 4-qubit TFIM Hilbert space is 2^n_qubits-dimensional.
+assert H.num_qubits == n_qubits
+assert exact_eigvals.shape == (2**n_qubits,)
+assert E_exact == float(exact_eigvals.min())
 
 # %% [markdown]
 # ## Hardware-efficient ansatz
@@ -182,6 +187,7 @@ def cost_fn(params: np.ndarray) -> float:
 
 rng = np.random.default_rng(0)
 init_params = rng.uniform(0, 2 * np.pi, n_params)
+assert init_params.shape == (n_params,)
 
 maxiter = max(n_params + 2, 5 if docs_test_mode else 80)
 result = minimize(
@@ -192,6 +198,10 @@ result = minimize(
 )
 opt_params = result.x
 print(f"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})")
+# Variational principle: any VQE energy is an upper bound on E_exact, no
+# matter how short the COBYLA budget.
+assert result.fun >= E_exact - 1e-9
+assert opt_params.shape == (n_params,)
 
 # %% [markdown]
 # ## Step 2: Sample bitstrings in the Z basis
@@ -211,6 +221,11 @@ sample_results.sort(key=lambda bc: bc[1], reverse=True)
 print(f"Distinct bitstrings sampled: {len(sample_results)}")
 for bits, c in sample_results[:5]:
     print(f"  {bits}  count={c}")
+# Distinct bitstrings cannot exceed the dimension of the Hilbert space,
+# every shot is accounted for, and each bitstring is n_qubits long.
+assert len(sample_results) <= 2**n_qubits
+assert sum(c for _, c in sample_results) == shots
+assert all(len(bits) == n_qubits for bits, _ in sample_results)
 
 
 # %% [markdown]
@@ -235,6 +250,10 @@ for K, E in zip(ks, energies):
     print(f"K = {K:3d}   E_QSCI = {E:+.6f}   gap = {E - E_exact:+.3e}")
 
 assert all(E >= E_exact - 1e-9 for E in energies), "variational bound violated"
+# Cauchy interlacing: enlarging the subspace can only lower (or keep) the
+# minimum eigenvalue, so QSCI energies are monotonically non-increasing in K.
+assert all(energies[i] >= energies[i + 1] - 1e-9 for i in range(len(energies) - 1))
+assert len(energies) == len(ks)
 
 # %%
 fig, ax = plt.subplots(figsize=(6, 4))

--- a/docs/ja/algorithm/qsci.ipynb
+++ b/docs/ja/algorithm/qsci.ipynb
@@ -83,8 +83,7 @@
      "iopub.status.busy": "2026-05-08T02:46:15.749626Z",
      "iopub.status.idle": "2026-05-08T02:46:15.752001Z",
      "shell.execute_reply": "2026-05-08T02:46:15.751737Z"
-    },
-    "lines_to_next_cell": 1
+    }
    },
    "outputs": [
     {
@@ -108,13 +107,20 @@
     "\n",
     "exact_eigvals = np.linalg.eigvalsh(H.to_numpy())\n",
     "E_exact = float(exact_eigvals[0])\n",
-    "print(f\"Exact ground state energy: {E_exact:.6f}\")"
+    "print(f\"Exact ground state energy: {E_exact:.6f}\")\n",
+    "# eigvalsh は昇順で固有値を返すので exact_eigvals[0] が基底状態。\n",
+    "# 4 量子ビット TFIM のヒルベルト空間は 2^n_qubits 次元。\n",
+    "assert H.num_qubits == n_qubits\n",
+    "assert exact_eigvals.shape == (2**n_qubits,)\n",
+    "assert E_exact == float(exact_eigvals.min())"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "f5e9e0d6",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## ハードウェア効率の良いansatz\n",
     "\n",
@@ -193,8 +199,7 @@
      "iopub.status.busy": "2026-05-08T02:46:15.756970Z",
      "iopub.status.idle": "2026-05-08T02:46:15.770200Z",
      "shell.execute_reply": "2026-05-08T02:46:15.769893Z"
-    },
-    "lines_to_next_cell": 1
+    }
    },
    "outputs": [],
    "source": [
@@ -219,7 +224,9 @@
   {
    "cell_type": "markdown",
    "id": "d107fc59",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## ステップ1: 短いVQEで$|\\psi_{\\mathrm{in}}\\rangle$を準備\n",
     "\n",
@@ -254,6 +261,7 @@
     "\n",
     "rng = np.random.default_rng(0)\n",
     "init_params = rng.uniform(0, 2 * np.pi, n_params)\n",
+    "assert init_params.shape == (n_params,)\n",
     "\n",
     "maxiter = max(n_params + 2, 5 if docs_test_mode else 80)\n",
     "result = minimize(\n",
@@ -263,7 +271,10 @@
     "    options={\"maxiter\": maxiter, \"rhobeg\": 0.5},\n",
     ")\n",
     "opt_params = result.x\n",
-    "print(f\"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})\")"
+    "print(f\"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})\")\n",
+    "# 変分原理: COBYLA の予算がいくら短くても VQE エネルギーは E_exact の上界。\n",
+    "assert result.fun >= E_exact - 1e-9\n",
+    "assert opt_params.shape == (n_params,)"
    ]
   },
   {
@@ -313,7 +324,12 @@
     "sample_results.sort(key=lambda bc: bc[1], reverse=True)\n",
     "print(f\"Distinct bitstrings sampled: {len(sample_results)}\")\n",
     "for bits, c in sample_results[:5]:\n",
-    "    print(f\"  {bits}  count={c}\")"
+    "    print(f\"  {bits}  count={c}\")\n",
+    "# 異なるビット列数はヒルベルト空間の次元を超えず、全ショットがカウントされ、\n",
+    "# 各ビット列は n_qubits 長。\n",
+    "assert len(sample_results) <= 2**n_qubits\n",
+    "assert sum(c for _, c in sample_results) == shots\n",
+    "assert all(len(bits) == n_qubits for bits, _ in sample_results)"
    ]
   },
   {
@@ -361,7 +377,11 @@
     "for K, E in zip(ks, energies):\n",
     "    print(f\"K = {K:3d}   E_QSCI = {E:+.6f}   gap = {E - E_exact:+.3e}\")\n",
     "\n",
-    "assert all(E >= E_exact - 1e-9 for E in energies), \"variational bound violated\""
+    "assert all(E >= E_exact - 1e-9 for E in energies), \"variational bound violated\"\n",
+    "# Cauchy interlacing: 部分空間を広げると最小固有値は下がる (または変わらない) ので、\n",
+    "# QSCI エネルギーは K に対して単調非増加。\n",
+    "assert all(energies[i] >= energies[i + 1] - 1e-9 for i in range(len(energies) - 1))\n",
+    "assert len(energies) == len(ks)"
    ]
   },
   {

--- a/docs/ja/algorithm/qsci.py
+++ b/docs/ja/algorithm/qsci.py
@@ -75,6 +75,11 @@ for i in range(n_qubits):
 exact_eigvals = np.linalg.eigvalsh(H.to_numpy())
 E_exact = float(exact_eigvals[0])
 print(f"Exact ground state energy: {E_exact:.6f}")
+# eigvalsh は昇順で固有値を返すので exact_eigvals[0] が基底状態。
+# 4 量子ビット TFIM のヒルベルト空間は 2^n_qubits 次元。
+assert H.num_qubits == n_qubits
+assert exact_eigvals.shape == (2**n_qubits,)
+assert E_exact == float(exact_eigvals.min())
 
 # %% [markdown]
 # ## ハードウェア効率の良いansatz
@@ -157,6 +162,7 @@ def cost_fn(params: np.ndarray) -> float:
 
 rng = np.random.default_rng(0)
 init_params = rng.uniform(0, 2 * np.pi, n_params)
+assert init_params.shape == (n_params,)
 
 maxiter = max(n_params + 2, 5 if docs_test_mode else 80)
 result = minimize(
@@ -167,6 +173,9 @@ result = minimize(
 )
 opt_params = result.x
 print(f"VQE energy = {result.fun:+.6f}   (gap to E_exact: {result.fun - E_exact:.4e})")
+# 変分原理: COBYLA の予算がいくら短くても VQE エネルギーは E_exact の上界。
+assert result.fun >= E_exact - 1e-9
+assert opt_params.shape == (n_params,)
 
 # %% [markdown]
 # ## ステップ2: Z基底でビット列をサンプリング
@@ -184,6 +193,11 @@ sample_results.sort(key=lambda bc: bc[1], reverse=True)
 print(f"Distinct bitstrings sampled: {len(sample_results)}")
 for bits, c in sample_results[:5]:
     print(f"  {bits}  count={c}")
+# 異なるビット列数はヒルベルト空間の次元を超えず、全ショットがカウントされ、
+# 各ビット列は n_qubits 長。
+assert len(sample_results) <= 2**n_qubits
+assert sum(c for _, c in sample_results) == shots
+assert all(len(bits) == n_qubits for bits, _ in sample_results)
 
 
 # %% [markdown]
@@ -202,6 +216,10 @@ for K, E in zip(ks, energies):
     print(f"K = {K:3d}   E_QSCI = {E:+.6f}   gap = {E - E_exact:+.3e}")
 
 assert all(E >= E_exact - 1e-9 for E in energies), "variational bound violated"
+# Cauchy interlacing: 部分空間を広げると最小固有値は下がる (または変わらない) ので、
+# QSCI エネルギーは K に対して単調非増加。
+assert all(energies[i] >= energies[i + 1] - 1e-9 for i in range(len(energies) - 1))
+assert len(energies) == len(ks)
 
 # %%
 fig, ax = plt.subplots(figsize=(6, 4))


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
printed (or computed) value.

This PR adds asserts to the QSCI tutorial guarding the structural
invariants of the 4-qubit transverse-field Ising model and the
variational properties that QSCI inherits from subspace diagonalisation:

- `H.num_qubits == n_qubits`; the exact eigenspectrum has `2^n_qubits`
  entries and `E_exact` is the minimum.
- `init_params` and `opt_params` both have shape `(n_params,)`.
- VQE energy is an upper bound on `E_exact` (variational principle).
- Distinct sampled bitstrings cannot exceed the Hilbert-space dimension,
  every shot is accounted for, and each bitstring is `n_qubits` long.
- QSCI energies are monotonically non-increasing in `K`
  (Cauchy interlacing); `len(energies) == len(ks)`.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "/qsci" -v` passes locally for both EN and JA.