### PR TITLE
docs(algorithm): assert deterministic invariants in "Introduction to Quantum Error Correction"

### DIFF
--- a/docs/en/algorithm/quantum_error_correction.ipynb
+++ b/docs/en/algorithm/quantum_error_correction.ipynb
@@ -481,7 +481,11 @@
     "        parameters=[\"theta\"],\n",
     "        runtime_bindings={\"theta\": math.pi},\n",
     "    )\n",
-    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "    # Perfect single-X correction on a pure-|1> input is fully deterministic:\n",
+    "    # every shot reads data[0] = 1.\n",
+    "    assert counts[0] == 0\n",
+    "    assert counts[1] == counts[0] + counts[1]"
    ]
   },
   {
@@ -546,7 +550,11 @@
     "        shots=2000,\n",
     "    )\n",
     "    total = counts[0] + counts[1]\n",
-    "    print(f\"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}\")"
+    "    print(f\"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}\")\n",
+    "    # Target probability sin^2(pi/6) = 0.25. With 2000 shots the standard\n",
+    "    # error is < 0.01, so a 5% window is safely outside shot noise.\n",
+    "    assert abs(counts[1] / total - 0.25) < 0.05\n",
+    "    assert total == 2000"
    ]
   },
   {
@@ -808,7 +816,11 @@
     "        phaseflip_syndrome_run,\n",
     "        bindings={\"error_pos\": error_pos},\n",
     "    )\n",
-    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "    # After perfect single-Z correction the final H sends data[0] back to\n",
+    "    # |0>, so every shot reads 0.\n",
+    "    assert counts[1] == 0\n",
+    "    assert counts[0] == counts[0] + counts[1]"
    ]
   },
   {
@@ -1096,7 +1108,11 @@
     "        runtime_bindings={\"theta\": math.pi},\n",
     "    )\n",
     "    total = counts[0] + counts[1]\n",
-    "    print(f\"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}\")"
+    "    print(f\"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}\")\n",
+    "    # The pure-|1> input survives any single Pauli error perfectly under\n",
+    "    # Shor's code, so q[0] reads 1 on every shot.\n",
+    "    assert counts[0] == 0\n",
+    "    assert counts[1] == total"
    ]
   },
   {
@@ -1260,7 +1276,12 @@
     "    parameters=[\"theta\"],\n",
     "    runtime_bindings={\"theta\": math.pi},\n",
     ")\n",
-    "print(f\"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "print(f\"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "# Failure mode: with two X errors the syndrome misidentifies a single-X\n",
+    "# error and the \"correction\" turns logical |1> into logical |0>, so every\n",
+    "# shot deterministically reads data[0] = 0 — that is what d=1 means.\n",
+    "assert counts[1] == 0\n",
+    "assert counts[0] == counts[0] + counts[1]"
    ]
   },
   {

--- a/docs/en/algorithm/quantum_error_correction.py
+++ b/docs/en/algorithm/quantum_error_correction.py
@@ -321,6 +321,10 @@ for label, error_pos in bitflip_cases:
         runtime_bindings={"theta": math.pi},
     )
     print(f"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+    # Perfect single-X correction on a pure-|1> input is fully deterministic:
+    # every shot reads data[0] = 1.
+    assert counts[0] == 0
+    assert counts[1] == counts[0] + counts[1]
 
 # %% [markdown]
 # ### 2.7 Superposition Input
@@ -343,6 +347,10 @@ for label, error_pos in bitflip_cases:
     )
     total = counts[0] + counts[1]
     print(f"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}")
+    # Target probability sin^2(pi/6) = 0.25. With 2000 shots the standard
+    # error is < 0.01, so a 5% window is safely outside shot noise.
+    assert abs(counts[1] / total - 0.25) < 0.05
+    assert total == 2000
 
 # %% [markdown]
 # ### 2.8 Limitation: Powerless Against Phase Errors
@@ -481,6 +489,10 @@ for label, error_pos in phaseflip_cases:
         bindings={"error_pos": error_pos},
     )
     print(f"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+    # After perfect single-Z correction the final H sends data[0] back to
+    # |0>, so every shot reads 0.
+    assert counts[1] == 0
+    assert counts[0] == counts[0] + counts[1]
 
 # %% [markdown]
 # ### 3.7 Limitation: Only One Error Type
@@ -649,6 +661,10 @@ for name, error_type, error_pos in shor_cases:
     )
     total = counts[0] + counts[1]
     print(f"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}")
+    # The pure-|1> input survives any single Pauli error perfectly under
+    # Shor's code, so q[0] reads 1 on every shot.
+    assert counts[0] == 0
+    assert counts[1] == total
 
 # %% [markdown]
 # ### 4.7 Why It Corrects "Any Single Error"
@@ -747,6 +763,11 @@ counts = _sample_first_bit(
     runtime_bindings={"theta": math.pi},
 )
 print(f"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+# Failure mode: with two X errors the syndrome misidentifies a single-X
+# error and the "correction" turns logical |1> into logical |0>, so every
+# shot deterministically reads data[0] = 0 — that is what d=1 means.
+assert counts[1] == 0
+assert counts[0] == counts[0] + counts[1]
 
 # %% [markdown]
 # `data[0]` becomes 0, not 1. Far from fixing the state, the correction turned the logical $\lvert1\rangle$ into the logical $\lvert0\rangle$.

--- a/docs/ja/algorithm/quantum_error_correction.ipynb
+++ b/docs/ja/algorithm/quantum_error_correction.ipynb
@@ -484,7 +484,11 @@
     "        parameters=[\"theta\"],\n",
     "        runtime_bindings={\"theta\": math.pi},\n",
     "    )\n",
-    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "    # 純粋な |1> 入力に対する単一 X 訂正は完全に決定的で、各ショットが\n",
+    "    # data[0] = 1 を返す。\n",
+    "    assert counts[0] == 0\n",
+    "    assert counts[1] == counts[0] + counts[1]"
    ]
   },
   {
@@ -549,7 +553,11 @@
     "        shots=2000,\n",
     "    )\n",
     "    total = counts[0] + counts[1]\n",
-    "    print(f\"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}\")"
+    "    print(f\"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}\")\n",
+    "    # 目標確率 sin^2(pi/6) = 0.25。2000 ショットの標準誤差は < 0.01 なので、\n",
+    "    # 5% の窓ならショットノイズの外。\n",
+    "    assert abs(counts[1] / total - 0.25) < 0.05\n",
+    "    assert total == 2000"
    ]
   },
   {
@@ -811,7 +819,11 @@
     "        phaseflip_syndrome_run,\n",
     "        bindings={\"error_pos\": error_pos},\n",
     "    )\n",
-    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "    print(f\"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "    # 単一 Z 訂正が完全に効いた後、最後の H が data[0] を |0> に戻すので\n",
+    "    # 各ショットで 0 が読まれる。\n",
+    "    assert counts[1] == 0\n",
+    "    assert counts[0] == counts[0] + counts[1]"
    ]
   },
   {
@@ -1099,7 +1111,11 @@
     "        runtime_bindings={\"theta\": math.pi},\n",
     "    )\n",
     "    total = counts[0] + counts[1]\n",
-    "    print(f\"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}\")"
+    "    print(f\"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}\")\n",
+    "    # 純粋な |1> 入力は Shor 符号の下で単一 Pauli エラーを完全に乗り越え、\n",
+    "    # q[0] は各ショットで 1 を返す。\n",
+    "    assert counts[0] == 0\n",
+    "    assert counts[1] == total"
    ]
   },
   {
@@ -1263,7 +1279,12 @@
     "    parameters=[\"theta\"],\n",
     "    runtime_bindings={\"theta\": math.pi},\n",
     ")\n",
-    "print(f\"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")"
+    "print(f\"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}\")\n",
+    "# 失敗モード: 2 か所の X エラーはシンドロームを単一 X エラーと取り違えさせ、\n",
+    "# 「訂正」が論理 |1> を論理 |0> に裏返してしまう。各ショットで data[0] = 0 が\n",
+    "# 決定的に読まれる — これが d=1 の意味。\n",
+    "assert counts[1] == 0\n",
+    "assert counts[0] == counts[0] + counts[1]"
    ]
   },
   {

--- a/docs/ja/algorithm/quantum_error_correction.py
+++ b/docs/ja/algorithm/quantum_error_correction.py
@@ -325,6 +325,10 @@ for label, error_pos in bitflip_cases:
         runtime_bindings={"theta": math.pi},
     )
     print(f"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+    # 純粋な |1> 入力に対する単一 X 訂正は完全に決定的で、各ショットが
+    # data[0] = 1 を返す。
+    assert counts[0] == 0
+    assert counts[1] == counts[0] + counts[1]
 
 # %% [markdown]
 # ### 2.7 重ね合わせ入力
@@ -347,6 +351,10 @@ for label, error_pos in bitflip_cases:
     )
     total = counts[0] + counts[1]
     print(f"  {label:14s}: P(data[0]=1) = {counts[1] / total:.3f}")
+    # 目標確率 sin^2(pi/6) = 0.25。2000 ショットの標準誤差は < 0.01 なので、
+    # 5% の窓ならショットノイズの外。
+    assert abs(counts[1] / total - 0.25) < 0.05
+    assert total == 2000
 
 # %% [markdown]
 # ### 2.8 限界:位相エラーには無力
@@ -485,6 +493,10 @@ for label, error_pos in phaseflip_cases:
         bindings={"error_pos": error_pos},
     )
     print(f"  {label:14s}: data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+    # 単一 Z 訂正が完全に効いた後、最後の H が data[0] を |0> に戻すので
+    # 各ショットで 0 が読まれる。
+    assert counts[1] == 0
+    assert counts[0] == counts[0] + counts[1]
 
 # %% [markdown]
 # ### 3.7 限界:片方のエラーしか直せない
@@ -653,6 +665,10 @@ for name, error_type, error_pos in shor_cases:
     )
     total = counts[0] + counts[1]
     print(f"  {name:6s} | q[{error_pos}]  | {counts[1] / total:.3f}")
+    # 純粋な |1> 入力は Shor 符号の下で単一 Pauli エラーを完全に乗り越え、
+    # q[0] は各ショットで 1 を返す。
+    assert counts[0] == 0
+    assert counts[1] == total
 
 # %% [markdown]
 # ### 4.7 なぜ「任意の単一エラー」を訂正できるのか
@@ -751,6 +767,11 @@ counts = _sample_first_bit(
     runtime_bindings={"theta": math.pi},
 )
 print(f"  data[0]=0 -> {counts[0]:3d}, data[0]=1 -> {counts[1]:3d}")
+# 失敗モード: 2 か所の X エラーはシンドロームを単一 X エラーと取り違えさせ、
+# 「訂正」が論理 |1> を論理 |0> に裏返してしまう。各ショットで data[0] = 0 が
+# 決定的に読まれる — これが d=1 の意味。
+assert counts[1] == 0
+assert counts[0] == counts[0] + counts[1]
 
 # %% [markdown]
 # `data[0]` は 1 ではなく 0 になります。訂正が状態を直すどころか、論理 $\lvert1\rangle$ を論理 $\lvert0\rangle$ に変えてしまいました。


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every
correction-success-rate that the prose claims.

This PR adds asserts to the QEC introduction tutorial:

- **3-qubit bit-flip code on logical |1>**: under perfect single-X
  correction every shot reads `data[0] = 1` (all four cases).
- **3-qubit bit-flip code on the superposition input** (`theta = pi/3`):
  `P(data[0] = 1)` stays within 5% of `sin^2(pi/6) = 0.25`, well
  outside the 2000-shot standard error of `< 0.01`.
- **3-qubit phase-flip code on logical |0_L> = |+++>**: after the final
  `H` every shot reads `data[0] = 0` (all four cases).
- **Shor's 9-qubit code on logical |1>**: under any single Pauli error
  every shot reads `q[0] = 1` (X / Y / Z across the three blocks).
- **Failure mode (two X errors on the bit-flip code)**: the prose claim
  "data[0] becomes 0, not 1" is now asserted — every shot reads 0
  and the d=1 limit bites deterministically.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "quantum_error_correction" -v` passes locally for both EN and JA.