### PR TITLE
docs(algorithm): assert deterministic invariants in "Quantum Kernel Classification"

### DIFF
--- a/docs/en/algorithm/quantum_kernel_classification.ipynb
+++ b/docs/en/algorithm/quantum_kernel_classification.ipynb
@@ -148,6 +148,9 @@
     "    factor=0.40,\n",
     "    random_state=RANDOM_STATE,\n",
     ")\n",
+    "assert X_raw.shape == (N_SAMPLES, 2)\n",
+    "assert y.shape == (N_SAMPLES,)\n",
+    "assert set(y.tolist()) == {0, 1}\n",
     "\n",
     "X_train_raw, X_test_raw, y_train, y_test = train_test_split(\n",
     "    X_raw, y,\n",
@@ -155,6 +158,12 @@
     "    random_state=RANDOM_STATE,\n",
     "    stratify=y,\n",
     ")\n",
+    "# train + test partition recovers the whole dataset; stratify preserves\n",
+    "# the binary label set.\n",
+    "assert len(X_train_raw) + len(X_test_raw) == N_SAMPLES\n",
+    "assert X_train_raw.shape[1] == 2 and X_test_raw.shape[1] == 2\n",
+    "assert set(y_train.tolist()) == {0, 1}\n",
+    "assert set(y_test.tolist()) == {0, 1}\n",
     "\n",
     "plt.figure(figsize=(5, 4))\n",
     "plt.scatter(\n",
@@ -228,7 +237,13 @@
     "\n",
     "# scale only the nonlinear pair features\n",
     "F_train[:, 2:4] = pair_scaler.fit_transform(F_train[:, 2:4])\n",
-    "F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])"
+    "F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])\n",
+    "# Feature lifting widens (n, 2) -> (n, 4); MinMaxScaler clip=True keeps\n",
+    "# every entry inside [0, pi].\n",
+    "assert F_train.shape == (len(X_train_raw), 4)\n",
+    "assert F_test.shape == (len(X_test_raw), 4)\n",
+    "assert F_train.min() >= 0.0 and F_train.max() <= math.pi + 1e-12\n",
+    "assert F_test.min() >= 0.0 and F_test.max() <= math.pi + 1e-12"
    ]
   },
   {
@@ -442,7 +457,9 @@
     "est = overlap_kernel.estimate_resources()\n",
     "print(\"=== symbolic resource estimate ===\")\n",
     "print(\"qubits:\", est.qubits)\n",
-    "print(\"total gates:\", est.gates.total)"
+    "print(\"total gates:\", est.gates.total)\n",
+    "# The overlap circuit always acts on exactly 2 qubits, regardless of layers.\n",
+    "assert est.qubits == 2"
    ]
   },
   {
@@ -627,8 +644,18 @@
    "source": [
     "K_train = train_kernel_matrix(F_train, shots=SHOTS)\n",
     "K_train = project_to_psd_correlation(K_train)\n",
+    "# After PSD correlation projection the train Gram matrix is symmetric\n",
+    "# with unit diagonal and is positive semi-definite (no negative\n",
+    "# eigenvalues beyond the eps floor used inside the projector).\n",
+    "assert K_train.shape == (len(F_train), len(F_train))\n",
+    "assert np.allclose(K_train, K_train.T)\n",
+    "assert np.allclose(np.diag(K_train), 1.0)\n",
+    "assert float(np.linalg.eigvalsh(K_train).min()) >= -1e-9\n",
     "\n",
-    "K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)"
+    "K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)\n",
+    "# Probabilities estimated from shot counts are always in [0, 1].\n",
+    "assert K_test.shape == (len(F_test), len(F_train))\n",
+    "assert K_test.min() >= 0.0 and K_test.max() <= 1.0"
    ]
   },
   {
@@ -687,7 +714,15 @@
     "print(\"=== test accuracy ===\")\n",
     "print(\"Quantum kernel SVC :\", accuracy_score(y_test, y_pred_qk))\n",
     "print(\"Linear SVC         :\", accuracy_score(y_test, y_pred_linear))\n",
-    "print(\"RBF SVC            :\", accuracy_score(y_test, y_pred_rbf))"
+    "print(\"RBF SVC            :\", accuracy_score(y_test, y_pred_rbf))\n",
+    "# Every classifier produces exactly one prediction per test point and\n",
+    "# only emits labels drawn from the training label set.\n",
+    "assert y_pred_qk.shape == y_test.shape\n",
+    "assert y_pred_linear.shape == y_test.shape\n",
+    "assert y_pred_rbf.shape == y_test.shape\n",
+    "assert set(y_pred_qk.tolist()).issubset({0, 1})\n",
+    "assert set(y_pred_linear.tolist()).issubset({0, 1})\n",
+    "assert set(y_pred_rbf.tolist()).issubset({0, 1})"
    ]
   },
   {

--- a/docs/en/algorithm/quantum_kernel_classification.py
+++ b/docs/en/algorithm/quantum_kernel_classification.py
@@ -88,6 +88,9 @@ X_raw, y = make_circles(
     factor=0.40,
     random_state=RANDOM_STATE,
 )
+assert X_raw.shape == (N_SAMPLES, 2)
+assert y.shape == (N_SAMPLES,)
+assert set(y.tolist()) == {0, 1}
 
 X_train_raw, X_test_raw, y_train, y_test = train_test_split(
     X_raw, y,
@@ -95,6 +98,12 @@ X_train_raw, X_test_raw, y_train, y_test = train_test_split(
     random_state=RANDOM_STATE,
     stratify=y,
 )
+# train + test partition recovers the whole dataset; stratify preserves
+# the binary label set.
+assert len(X_train_raw) + len(X_test_raw) == N_SAMPLES
+assert X_train_raw.shape[1] == 2 and X_test_raw.shape[1] == 2
+assert set(y_train.tolist()) == {0, 1}
+assert set(y_test.tolist()) == {0, 1}
 
 plt.figure(figsize=(5, 4))
 plt.scatter(
@@ -150,6 +159,12 @@ F_test = lift_features(X_test_ang)
 # scale only the nonlinear pair features
 F_train[:, 2:4] = pair_scaler.fit_transform(F_train[:, 2:4])
 F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])
+# Feature lifting widens (n, 2) -> (n, 4); MinMaxScaler clip=True keeps
+# every entry inside [0, pi].
+assert F_train.shape == (len(X_train_raw), 4)
+assert F_test.shape == (len(X_test_raw), 4)
+assert F_train.min() >= 0.0 and F_train.max() <= math.pi + 1e-12
+assert F_test.min() >= 0.0 and F_test.max() <= math.pi + 1e-12
 
 # %% [markdown]
 # ## Feature Map Circuit
@@ -271,6 +286,8 @@ est = overlap_kernel.estimate_resources()
 print("=== symbolic resource estimate ===")
 print("qubits:", est.qubits)
 print("total gates:", est.gates.total)
+# The overlap circuit always acts on exactly 2 qubits, regardless of layers.
+assert est.qubits == 2
 
 # %% [markdown]
 # ## Transpile Once, Bind Many Times
@@ -396,8 +413,18 @@ def project_to_psd_correlation(K: np.ndarray, eps: float = 1e-12) -> np.ndarray:
 # %%
 K_train = train_kernel_matrix(F_train, shots=SHOTS)
 K_train = project_to_psd_correlation(K_train)
+# After PSD correlation projection the train Gram matrix is symmetric
+# with unit diagonal and is positive semi-definite (no negative
+# eigenvalues beyond the eps floor used inside the projector).
+assert K_train.shape == (len(F_train), len(F_train))
+assert np.allclose(K_train, K_train.T)
+assert np.allclose(np.diag(K_train), 1.0)
+assert float(np.linalg.eigvalsh(K_train).min()) >= -1e-9
 
 K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)
+# Probabilities estimated from shot counts are always in [0, 1].
+assert K_test.shape == (len(F_test), len(F_train))
+assert K_test.min() >= 0.0 and K_test.max() <= 1.0
 
 # %% [markdown]
 # ## Train Classifiers
@@ -427,6 +454,14 @@ print("=== test accuracy ===")
 print("Quantum kernel SVC :", accuracy_score(y_test, y_pred_qk))
 print("Linear SVC         :", accuracy_score(y_test, y_pred_linear))
 print("RBF SVC            :", accuracy_score(y_test, y_pred_rbf))
+# Every classifier produces exactly one prediction per test point and
+# only emits labels drawn from the training label set.
+assert y_pred_qk.shape == y_test.shape
+assert y_pred_linear.shape == y_test.shape
+assert y_pred_rbf.shape == y_test.shape
+assert set(y_pred_qk.tolist()).issubset({0, 1})
+assert set(y_pred_linear.tolist()).issubset({0, 1})
+assert set(y_pred_rbf.tolist()).issubset({0, 1})
 
 # %% [markdown]
 # ## Visualization

--- a/docs/ja/algorithm/quantum_kernel_classification.ipynb
+++ b/docs/ja/algorithm/quantum_kernel_classification.ipynb
@@ -140,6 +140,9 @@
     "    factor=0.40,\n",
     "    random_state=RANDOM_STATE,\n",
     ")\n",
+    "assert X_raw.shape == (N_SAMPLES, 2)\n",
+    "assert y.shape == (N_SAMPLES,)\n",
+    "assert set(y.tolist()) == {0, 1}\n",
     "\n",
     "X_train_raw, X_test_raw, y_train, y_test = train_test_split(\n",
     "    X_raw, y,\n",
@@ -147,6 +150,11 @@
     "    random_state=RANDOM_STATE,\n",
     "    stratify=y,\n",
     ")\n",
+    "# train + test 分割は全データを覆い、stratify が両クラスを保持する。\n",
+    "assert len(X_train_raw) + len(X_test_raw) == N_SAMPLES\n",
+    "assert X_train_raw.shape[1] == 2 and X_test_raw.shape[1] == 2\n",
+    "assert set(y_train.tolist()) == {0, 1}\n",
+    "assert set(y_test.tolist()) == {0, 1}\n",
     "\n",
     "plt.figure(figsize=(5, 4))\n",
     "plt.scatter(\n",
@@ -219,7 +227,13 @@
     "\n",
     "# 非線形ペア特徴のみスケーリング\n",
     "F_train[:, 2:4] = pair_scaler.fit_transform(F_train[:, 2:4])\n",
-    "F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])"
+    "F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])\n",
+    "# リフティングで (n, 2) -> (n, 4)、MinMaxScaler の clip=True により全要素が\n",
+    "# [0, pi] に収まる。\n",
+    "assert F_train.shape == (len(X_train_raw), 4)\n",
+    "assert F_test.shape == (len(X_test_raw), 4)\n",
+    "assert F_train.min() >= 0.0 and F_train.max() <= math.pi + 1e-12\n",
+    "assert F_test.min() >= 0.0 and F_test.max() <= math.pi + 1e-12"
    ]
   },
   {
@@ -430,7 +444,9 @@
     "est = overlap_kernel.estimate_resources()\n",
     "print(\"=== symbolic resource estimate ===\")\n",
     "print(\"qubits:\", est.qubits)\n",
-    "print(\"total gates:\", est.gates.total)"
+    "print(\"total gates:\", est.gates.total)\n",
+    "# overlap 回路は layers にかかわらず常に 2 量子ビット上で動作する。\n",
+    "assert est.qubits == 2"
    ]
   },
   {
@@ -609,8 +625,17 @@
    "source": [
     "K_train = train_kernel_matrix(F_train, shots=SHOTS)\n",
     "K_train = project_to_psd_correlation(K_train)\n",
+    "# PSD 相関射影後、訓練 Gram 行列は対称・対角 1.0・半正定値 (eps 床より下に\n",
+    "# 落ち込まない) のいずれも満たす。\n",
+    "assert K_train.shape == (len(F_train), len(F_train))\n",
+    "assert np.allclose(K_train, K_train.T)\n",
+    "assert np.allclose(np.diag(K_train), 1.0)\n",
+    "assert float(np.linalg.eigvalsh(K_train).min()) >= -1e-9\n",
     "\n",
-    "K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)"
+    "K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)\n",
+    "# ショット数から推定された確率は常に [0, 1] に収まる。\n",
+    "assert K_test.shape == (len(F_test), len(F_train))\n",
+    "assert K_test.min() >= 0.0 and K_test.max() <= 1.0"
    ]
   },
   {
@@ -669,7 +694,15 @@
     "print(\"=== test accuracy ===\")\n",
     "print(\"Quantum kernel SVC :\", accuracy_score(y_test, y_pred_qk))\n",
     "print(\"Linear SVC         :\", accuracy_score(y_test, y_pred_linear))\n",
-    "print(\"RBF SVC            :\", accuracy_score(y_test, y_pred_rbf))"
+    "print(\"RBF SVC            :\", accuracy_score(y_test, y_pred_rbf))\n",
+    "# どの分類器もテスト点 1 つにつき 1 個の予測を返し、ラベルは訓練ラベル集合に\n",
+    "# 収まる。\n",
+    "assert y_pred_qk.shape == y_test.shape\n",
+    "assert y_pred_linear.shape == y_test.shape\n",
+    "assert y_pred_rbf.shape == y_test.shape\n",
+    "assert set(y_pred_qk.tolist()).issubset({0, 1})\n",
+    "assert set(y_pred_linear.tolist()).issubset({0, 1})\n",
+    "assert set(y_pred_rbf.tolist()).issubset({0, 1})"
    ]
   },
   {

--- a/docs/ja/algorithm/quantum_kernel_classification.py
+++ b/docs/ja/algorithm/quantum_kernel_classification.py
@@ -80,6 +80,9 @@ X_raw, y = make_circles(
     factor=0.40,
     random_state=RANDOM_STATE,
 )
+assert X_raw.shape == (N_SAMPLES, 2)
+assert y.shape == (N_SAMPLES,)
+assert set(y.tolist()) == {0, 1}
 
 X_train_raw, X_test_raw, y_train, y_test = train_test_split(
     X_raw, y,
@@ -87,6 +90,11 @@ X_train_raw, X_test_raw, y_train, y_test = train_test_split(
     random_state=RANDOM_STATE,
     stratify=y,
 )
+# train + test 分割は全データを覆い、stratify が両クラスを保持する。
+assert len(X_train_raw) + len(X_test_raw) == N_SAMPLES
+assert X_train_raw.shape[1] == 2 and X_test_raw.shape[1] == 2
+assert set(y_train.tolist()) == {0, 1}
+assert set(y_test.tolist()) == {0, 1}
 
 plt.figure(figsize=(5, 4))
 plt.scatter(
@@ -141,6 +149,12 @@ F_test = lift_features(X_test_ang)
 # 非線形ペア特徴のみスケーリング
 F_train[:, 2:4] = pair_scaler.fit_transform(F_train[:, 2:4])
 F_test[:, 2:4] = pair_scaler.transform(F_test[:, 2:4])
+# リフティングで (n, 2) -> (n, 4)、MinMaxScaler の clip=True により全要素が
+# [0, pi] に収まる。
+assert F_train.shape == (len(X_train_raw), 4)
+assert F_test.shape == (len(X_test_raw), 4)
+assert F_train.min() >= 0.0 and F_train.max() <= math.pi + 1e-12
+assert F_test.min() >= 0.0 and F_test.max() <= math.pi + 1e-12
 
 # %% [markdown]
 # ## 特徴マップ回路
@@ -259,6 +273,8 @@ est = overlap_kernel.estimate_resources()
 print("=== symbolic resource estimate ===")
 print("qubits:", est.qubits)
 print("total gates:", est.gates.total)
+# overlap 回路は layers にかかわらず常に 2 量子ビット上で動作する。
+assert est.qubits == 2
 
 # %% [markdown]
 # ## 一度トランスパイル、何度もバインド
@@ -378,8 +394,17 @@ def project_to_psd_correlation(K: np.ndarray, eps: float = 1e-12) -> np.ndarray:
 # %%
 K_train = train_kernel_matrix(F_train, shots=SHOTS)
 K_train = project_to_psd_correlation(K_train)
+# PSD 相関射影後、訓練 Gram 行列は対称・対角 1.0・半正定値 (eps 床より下に
+# 落ち込まない) のいずれも満たす。
+assert K_train.shape == (len(F_train), len(F_train))
+assert np.allclose(K_train, K_train.T)
+assert np.allclose(np.diag(K_train), 1.0)
+assert float(np.linalg.eigvalsh(K_train).min()) >= -1e-9
 
 K_test = cross_kernel_matrix(F_test, F_train, shots=SHOTS)
+# ショット数から推定された確率は常に [0, 1] に収まる。
+assert K_test.shape == (len(F_test), len(F_train))
+assert K_test.min() >= 0.0 and K_test.max() <= 1.0
 
 # %% [markdown]
 # ## 分類器の学習
@@ -409,6 +434,14 @@ print("=== test accuracy ===")
 print("Quantum kernel SVC :", accuracy_score(y_test, y_pred_qk))
 print("Linear SVC         :", accuracy_score(y_test, y_pred_linear))
 print("RBF SVC            :", accuracy_score(y_test, y_pred_rbf))
+# どの分類器もテスト点 1 つにつき 1 個の予測を返し、ラベルは訓練ラベル集合に
+# 収まる。
+assert y_pred_qk.shape == y_test.shape
+assert y_pred_linear.shape == y_test.shape
+assert y_pred_rbf.shape == y_test.shape
+assert set(y_pred_qk.tolist()).issubset({0, 1})
+assert set(y_pred_linear.tolist()).issubset({0, 1})
+assert set(y_pred_rbf.tolist()).issubset({0, 1})
 
 # %% [markdown]
 # ## 可視化


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
invariant.

This PR adds asserts to the quantum-kernel SVM tutorial guarding the
structural invariants of the make_circles + lift pipeline, the
overlap-kernel circuit shape, and the SVM output:

- `make_circles` produces an `(N_SAMPLES, 2)` feature array with a
  binary label set `{0, 1}`; `train_test_split` + `stratify` covers
  the whole dataset and preserves the label set in both halves.
- Feature lifting widens `(n, 2) -> (n, 4)`; MinMaxScaler `clip=True`
  keeps every entry in `[0, pi]`.
- The overlap kernel circuit always acts on exactly 2 qubits
  regardless of layers.
- After PSD correlation projection `K_train` is symmetric, has unit
  diagonal, and is positive semi-definite to within the projector
  `eps` floor; `K_test` entries (overlap probabilities) stay in
  `[0, 1]`.
- All three SVMs (quantum, linear, RBF) emit one label per test point
  drawn from the training label set.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "quantum_kernel_classification" -v` passes locally for both EN and JA.