### PR TITLE
docs(algorithm): assert deterministic invariants in "Stabilizer Formalism and the Steane Code"

### DIFF
--- a/docs/en/algorithm/steane_code.ipynb
+++ b/docs/en/algorithm/steane_code.ipynb
@@ -384,7 +384,13 @@
     "total = sum(count for _, count in result.results)\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
     "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")\n",
-    "print(f\"  distinct codewords observed: {len(result.results)}\")"
+    "print(f\"  distinct codewords observed: {len(result.results)}\")\n",
+    "# The Steane |0_L> is an equal superposition of exactly 8 even-weight\n",
+    "# Hamming codewords, so every shot reads a valid |0_L> codeword and the\n",
+    "# distribution covers at most those 8 outcomes.\n",
+    "assert total == 1024\n",
+    "assert valid == total\n",
+    "assert len(result.results) <= 8"
    ]
   },
   {
@@ -712,7 +718,12 @@
     "        valid = sum(\n",
     "            count for outcome, count in result.results if _is_steane_zero_word(outcome)\n",
     "        )\n",
-    "        print(f\"  {name:4s} | q[{pos}]  | {valid / total:.3f}\")"
+    "        print(f\"  {name:4s} | q[{pos}]  | {valid / total:.3f}\")\n",
+    "        # Steane corrects every single Pauli error on any of the 7 qubits,\n",
+    "        # so the post-correction state lies entirely in the |0_L> code\n",
+    "        # space — every shot reads a valid codeword.\n",
+    "        assert total == 128\n",
+    "        assert valid == total"
    ]
   },
   {
@@ -814,7 +825,14 @@
     ")\n",
     "odd = sum(count for outcome, count in result.results if sum(_bits7(outcome)) % 2 == 1)\n",
     "print(f\"  Hamming codeword ratio: {hamming / total:.3f}\")\n",
-    "print(f\"  odd-weight (|1_L>) fraction: {odd / total:.3f}\")"
+    "print(f\"  odd-weight (|1_L>) fraction: {odd / total:.3f}\")\n",
+    "# |+_L> is an equal superposition of all 16 Hamming codewords, so every\n",
+    "# shot reads some Hamming codeword and the odd-weight half (|1_L>) shows\n",
+    "# up roughly half the time — 5% window > 1024-shot standard error of < 0.02.\n",
+    "assert total == 1024\n",
+    "assert hamming == total\n",
+    "assert len(result.results) <= 16\n",
+    "assert abs(odd / total - 0.5) < 0.05"
    ]
   },
   {
@@ -888,7 +906,11 @@
     "result = exe.sample(_seeded_executor, shots=1024).result()\n",
     "total = sum(count for _, count in result.results)\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
-    "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")"
+    "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")\n",
+    "# H^2 = I, so the round trip restores |0_L> exactly — every shot reads a\n",
+    "# |0_L> codeword.\n",
+    "assert total == 1024\n",
+    "assert valid == total"
    ]
   },
   {

--- a/docs/en/algorithm/steane_code.py
+++ b/docs/en/algorithm/steane_code.py
@@ -244,6 +244,12 @@ total = sum(count for _, count in result.results)
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 print(f"  |0_L> codeword ratio: {valid / total:.3f}")
 print(f"  distinct codewords observed: {len(result.results)}")
+# The Steane |0_L> is an equal superposition of exactly 8 even-weight
+# Hamming codewords, so every shot reads a valid |0_L> codeword and the
+# distribution covers at most those 8 outcomes.
+assert total == 1024
+assert valid == total
+assert len(result.results) <= 8
 
 # %% [markdown]
 # ## 4. Syndrome Measurement and Correction
@@ -403,6 +409,11 @@ for name, error_type in [("X", 1), ("Y", 2), ("Z", 3)]:
             count for outcome, count in result.results if _is_steane_zero_word(outcome)
         )
         print(f"  {name:4s} | q[{pos}]  | {valid / total:.3f}")
+        # Steane corrects every single Pauli error on any of the 7 qubits,
+        # so the post-correction state lies entirely in the |0_L> code
+        # space — every shot reads a valid codeword.
+        assert total == 128
+        assert valid == total
 
 # %% [markdown]
 # A ratio of 1.000 means the state returned to the $\lvert0_L\rangle$ code space for that single Pauli error. A $Y=iXZ$ error triggers both the $X$-component and the $Z$-component correction, but in a CSS code these two are independent, so it is corrected as is.
@@ -452,6 +463,13 @@ hamming = sum(
 odd = sum(count for outcome, count in result.results if sum(_bits7(outcome)) % 2 == 1)
 print(f"  Hamming codeword ratio: {hamming / total:.3f}")
 print(f"  odd-weight (|1_L>) fraction: {odd / total:.3f}")
+# |+_L> is an equal superposition of all 16 Hamming codewords, so every
+# shot reads some Hamming codeword and the odd-weight half (|1_L>) shows
+# up roughly half the time — 5% window > 1024-shot standard error of < 0.02.
+assert total == 1024
+assert hamming == total
+assert len(result.results) <= 16
+assert abs(odd / total - 0.5) < 0.05
 
 # %% [markdown]
 # The Hamming codeword ratio is 1.000, and odd-weight codewords appear about half the time. Unlike $\lvert0_L\rangle$, which produces only even-weight codewords, this confirms the state has moved to $\lvert+_L\rangle$.
@@ -478,6 +496,10 @@ result = exe.sample(_seeded_executor, shots=1024).result()
 total = sum(count for _, count in result.results)
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 print(f"  |0_L> codeword ratio: {valid / total:.3f}")
+# H^2 = I, so the round trip restores |0_L> exactly — every shot reads a
+# |0_L> codeword.
+assert total == 1024
+assert valid == total
 
 # %% [markdown]
 # The ratio is 1.000 — two transversal Hadamards return to $\lvert0_L\rangle$. The seven physical $H$ gates indeed act as the logical $\bar H$.

--- a/docs/ja/algorithm/steane_code.ipynb
+++ b/docs/ja/algorithm/steane_code.ipynb
@@ -384,7 +384,12 @@
     "total = sum(count for _, count in result.results)\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
     "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")\n",
-    "print(f\"  distinct codewords observed: {len(result.results)}\")"
+    "print(f\"  distinct codewords observed: {len(result.results)}\")\n",
+    "# Steane の |0_L> はちょうど 8 つの偶重み Hamming 符号語の均等重ね合わせなので、\n",
+    "# 各ショットは有効な |0_L> 符号語を返し、分布は高々その 8 通りに収まる。\n",
+    "assert total == 1024\n",
+    "assert valid == total\n",
+    "assert len(result.results) <= 8"
    ]
   },
   {
@@ -700,7 +705,12 @@
     "        valid = sum(\n",
     "            count for outcome, count in result.results if _is_steane_zero_word(outcome)\n",
     "        )\n",
-    "        print(f\"  {name:4s} | q[{pos}]  | {valid / total:.3f}\")"
+    "        print(f\"  {name:4s} | q[{pos}]  | {valid / total:.3f}\")\n",
+    "        # Steane は 7 量子ビット上の任意の単一 Pauli エラーを訂正するので、\n",
+    "        # 訂正後の状態は完全に |0_L> 符号空間に収まり、各ショットは有効な\n",
+    "        # 符号語を返す。\n",
+    "        assert total == 128\n",
+    "        assert valid == total"
    ]
   },
   {
@@ -802,7 +812,14 @@
     ")\n",
     "odd = sum(count for outcome, count in result.results if sum(_bits7(outcome)) % 2 == 1)\n",
     "print(f\"  Hamming codeword ratio: {hamming / total:.3f}\")\n",
-    "print(f\"  odd-weight (|1_L>) fraction: {odd / total:.3f}\")"
+    "print(f\"  odd-weight (|1_L>) fraction: {odd / total:.3f}\")\n",
+    "# |+_L> は 16 個の Hamming 符号語の均等重ね合わせ。各ショットは何らかの\n",
+    "# Hamming 符号語を返し、奇重み (|1_L>) 半分は約半数 — 1024 ショットの\n",
+    "# 標準誤差 < 0.02 に対して 5% の窓は安全側。\n",
+    "assert total == 1024\n",
+    "assert hamming == total\n",
+    "assert len(result.results) <= 16\n",
+    "assert abs(odd / total - 0.5) < 0.05"
    ]
   },
   {
@@ -876,7 +893,10 @@
     "result = exe.sample(_seeded_executor, shots=1024).result()\n",
     "total = sum(count for _, count in result.results)\n",
     "valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))\n",
-    "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")"
+    "print(f\"  |0_L> codeword ratio: {valid / total:.3f}\")\n",
+    "# H^2 = I なので往復で |0_L> がそのまま復元される — 各ショットは |0_L> 符号語。\n",
+    "assert total == 1024\n",
+    "assert valid == total"
    ]
   },
   {

--- a/docs/ja/algorithm/steane_code.py
+++ b/docs/ja/algorithm/steane_code.py
@@ -244,6 +244,11 @@ total = sum(count for _, count in result.results)
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 print(f"  |0_L> codeword ratio: {valid / total:.3f}")
 print(f"  distinct codewords observed: {len(result.results)}")
+# Steane の |0_L> はちょうど 8 つの偶重み Hamming 符号語の均等重ね合わせなので、
+# 各ショットは有効な |0_L> 符号語を返し、分布は高々その 8 通りに収まる。
+assert total == 1024
+assert valid == total
+assert len(result.results) <= 8
 
 # %% [markdown]
 # ## 4. シンドローム測定と訂正
@@ -403,6 +408,11 @@ for name, error_type in [("X", 1), ("Y", 2), ("Z", 3)]:
             count for outcome, count in result.results if _is_steane_zero_word(outcome)
         )
         print(f"  {name:4s} | q[{pos}]  | {valid / total:.3f}")
+        # Steane は 7 量子ビット上の任意の単一 Pauli エラーを訂正するので、
+        # 訂正後の状態は完全に |0_L> 符号空間に収まり、各ショットは有効な
+        # 符号語を返す。
+        assert total == 128
+        assert valid == total
 
 # %% [markdown]
 # 比率が 1.000 なら、その単一 Pauli エラーに対して状態が $\lvert0_L\rangle$ の符号空間に戻ったことを意味します。$Y=iXZ$ のエラーは $X$ 成分と $Z$ 成分の訂正の両方を引き起こしますが、CSS 符号ではこの2つが独立なので、そのまま訂正できます。
@@ -452,6 +462,13 @@ hamming = sum(
 odd = sum(count for outcome, count in result.results if sum(_bits7(outcome)) % 2 == 1)
 print(f"  Hamming codeword ratio: {hamming / total:.3f}")
 print(f"  odd-weight (|1_L>) fraction: {odd / total:.3f}")
+# |+_L> は 16 個の Hamming 符号語の均等重ね合わせ。各ショットは何らかの
+# Hamming 符号語を返し、奇重み (|1_L>) 半分は約半数 — 1024 ショットの
+# 標準誤差 < 0.02 に対して 5% の窓は安全側。
+assert total == 1024
+assert hamming == total
+assert len(result.results) <= 16
+assert abs(odd / total - 0.5) < 0.05
 
 # %% [markdown]
 # Hamming 符号語の比率は 1.000 で、奇数重みの符号語も約半分現れます。偶数重みしか出ない $\lvert0_L\rangle$ とは異なる ― 状態が $\lvert+_L\rangle$ に移っていることが確認できます。
@@ -478,6 +495,9 @@ result = exe.sample(_seeded_executor, shots=1024).result()
 total = sum(count for _, count in result.results)
 valid = sum(count for outcome, count in result.results if _is_steane_zero_word(outcome))
 print(f"  |0_L> codeword ratio: {valid / total:.3f}")
+# H^2 = I なので往復で |0_L> がそのまま復元される — 各ショットは |0_L> 符号語。
+assert total == 1024
+assert valid == total
 
 # %% [markdown]
 # 比率は 1.000 ― 2回の transversal Hadamard で $\lvert0_L\rangle$ に戻りました。7つの物理 $H$ が、確かに論理 $\bar H$ として働いています。


### PR DESCRIPTION
## Summary

Continues the systematic effort to make `docs/{en,ja}/{tutorial,algorithm}/`
articles double as a regression check by asserting every deterministic
invariant the prose claims.

This PR adds asserts to the Steane code tutorial:

- **Encoding |0_L>**: every shot reads an even-weight Hamming codeword,
  and at most 8 distinct codewords appear (there are 8 even-weight
  Hamming codewords).
- **All 21 single-Pauli errors** on any of the 7 qubits are corrected
  exactly — every shot reads a |0_L> codeword.
- **Transversal H sends |0_L> -> |+_L>**: every shot reads some Hamming
  codeword (16 total), and the odd-weight (|1_L>) fraction is within
  5% of 0.5 (well outside the 1024-shot standard error of < 0.02).
- **Two transversal Hadamards** restore |0_L> exactly (H^2 = I): every
  shot reads a |0_L> codeword.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "steane_code" -v` passes locally for both EN and JA.