### PR TITLE
docs(algorithm): assert deterministic invariants in "VQE for the Hydrogen Molecule"

### DIFF
--- a/docs/en/algorithm/vqe_for_hydrogen.ipynb
+++ b/docs/en/algorithm/vqe_for_hydrogen.ipynb
@@ -107,6 +107,10 @@
     "molecule = of_pyscf.run_pyscf(molecule, run_scf=True, run_fci=True)\n",
     "n_qubit = molecule.n_qubits\n",
     "n_electron = molecule.n_electrons\n",
+    "# H2 in the STO-3G basis has 2 spatial orbitals -> 4 spin orbitals -> 4 qubits,\n",
+    "# and is a 2-electron molecule.\n",
+    "assert n_qubit == 4\n",
+    "assert n_electron == 2\n",
     "fermionic_hamiltonian = of_trans.get_fermion_operator(\n",
     "    molecule.get_molecular_hamiltonian()\n",
     ")\n",
@@ -159,7 +163,8 @@
     "    return H\n",
     "\n",
     "\n",
-    "hamiltonian = openfermion_to_qamomile(jw_hamiltonian)"
+    "hamiltonian = openfermion_to_qamomile(jw_hamiltonian)\n",
+    "assert hamiltonian.num_qubits == n_qubit"
    ]
   },
   {
@@ -312,6 +317,11 @@
     "num_params = len(executable.parameter_names)\n",
     "rng = np.random.default_rng(42)\n",
     "initial_params = rng.uniform(0, np.pi, num_params)\n",
+    "# Each rep emits one RY layer (n parameters) and one RZ layer (n parameters);\n",
+    "# the final pre-CX layer adds one more RY + RZ pair. So the parameter count is\n",
+    "# (reps + 1) * 2 * n_qubit.\n",
+    "assert num_params == (reps + 1) * 2 * n_qubit\n",
+    "assert initial_params.shape == (num_params,)\n",
     "\n",
     "# Run VQE optimization\n",
     "maxiter = 1 if docs_test_mode else 50\n",
@@ -323,7 +333,11 @@
     "    options={\"disp\": True, \"maxiter\": maxiter, \"gtol\": 1e-6},\n",
     "    callback=cost_callback,\n",
     ")\n",
-    "print(result)"
+    "print(result)\n",
+    "# Variational principle: any trial energy is an upper bound on the FCI\n",
+    "# ground-state energy, regardless of how short the BFGS budget is.\n",
+    "assert result.fun >= molecule.fci_energy - 1e-9\n",
+    "assert len(result.x) == num_params"
    ]
   },
   {
@@ -511,9 +525,12 @@
     "\n",
     "n_points = 3 if docs_test_mode else 15\n",
     "bond_lengths = np.linspace(0.2, 1.5, n_points)\n",
+    "assert bond_lengths.shape == (n_points,)\n",
     "energies = []\n",
     "for bond_length in bond_lengths:\n",
     "    hamiltonian, fci_energy = hydrogen_molecule(bond_length)\n",
+    "    # H2 remains a 4-qubit problem regardless of bond length.\n",
+    "    assert hamiltonian.num_qubits == 4\n",
     "\n",
     "    executable = transpiler.transpile(\n",
     "        vqe_ansatz,\n",
@@ -531,8 +548,12 @@
     "    )\n",
     "\n",
     "    energies.append(result.fun)\n",
+    "    # Variational principle holds at every bond length.\n",
+    "    assert result.fun >= fci_energy - 1e-9\n",
     "\n",
-    "    print(\"distance: \", bond_length, \"energy: \", result.fun, \"fci_energy: \", fci_energy)"
+    "    print(\"distance: \", bond_length, \"energy: \", result.fun, \"fci_energy: \", fci_energy)\n",
+    "\n",
+    "assert len(energies) == n_points"
    ]
   },
   {

--- a/docs/en/algorithm/vqe_for_hydrogen.py
+++ b/docs/en/algorithm/vqe_for_hydrogen.py
@@ -67,6 +67,10 @@ molecule = of_chem.MolecularData(geometry, basis, multiplicity, charge, descript
 molecule = of_pyscf.run_pyscf(molecule, run_scf=True, run_fci=True)
 n_qubit = molecule.n_qubits
 n_electron = molecule.n_electrons
+# H2 in the STO-3G basis has 2 spatial orbitals -> 4 spin orbitals -> 4 qubits,
+# and is a 2-electron molecule.
+assert n_qubit == 4
+assert n_electron == 2
 fermionic_hamiltonian = of_trans.get_fermion_operator(
     molecule.get_molecular_hamiltonian()
 )
@@ -100,6 +104,7 @@ def openfermion_to_qamomile(of_h) -> qm_o.Hamiltonian:
 
 
 hamiltonian = openfermion_to_qamomile(jw_hamiltonian)
+assert hamiltonian.num_qubits == n_qubit
 
 
 # %% [markdown]
@@ -164,6 +169,11 @@ def cost_callback(param_values):
 num_params = len(executable.parameter_names)
 rng = np.random.default_rng(42)
 initial_params = rng.uniform(0, np.pi, num_params)
+# Each rep emits one RY layer (n parameters) and one RZ layer (n parameters);
+# the final pre-CX layer adds one more RY + RZ pair. So the parameter count is
+# (reps + 1) * 2 * n_qubit.
+assert num_params == (reps + 1) * 2 * n_qubit
+assert initial_params.shape == (num_params,)
 
 # Run VQE optimization
 maxiter = 1 if docs_test_mode else 50
@@ -176,6 +186,10 @@ result = minimize(
     callback=cost_callback,
 )
 print(result)
+# Variational principle: any trial energy is an upper bound on the FCI
+# ground-state energy, regardless of how short the BFGS budget is.
+assert result.fun >= molecule.fci_energy - 1e-9
+assert len(result.x) == num_params
 
 # %%
 plt.plot(cost_history)
@@ -212,9 +226,12 @@ def hydrogen_molecule(bond_length):
 
 n_points = 3 if docs_test_mode else 15
 bond_lengths = np.linspace(0.2, 1.5, n_points)
+assert bond_lengths.shape == (n_points,)
 energies = []
 for bond_length in bond_lengths:
     hamiltonian, fci_energy = hydrogen_molecule(bond_length)
+    # H2 remains a 4-qubit problem regardless of bond length.
+    assert hamiltonian.num_qubits == 4
 
     executable = transpiler.transpile(
         vqe_ansatz,
@@ -232,8 +249,12 @@ for bond_length in bond_lengths:
     )
 
     energies.append(result.fun)
+    # Variational principle holds at every bond length.
+    assert result.fun >= fci_energy - 1e-9
 
     print("distance: ", bond_length, "energy: ", result.fun, "fci_energy: ", fci_energy)
+
+assert len(energies) == n_points
 
 # %%
 plt.plot(bond_lengths, energies, "-o")

--- a/docs/ja/algorithm/vqe_for_hydrogen.ipynb
+++ b/docs/ja/algorithm/vqe_for_hydrogen.ipynb
@@ -92,7 +92,8 @@
      "iopub.status.busy": "2026-04-28T12:08:47.603836Z",
      "iopub.status.idle": "2026-04-28T12:08:47.699857Z",
      "shell.execute_reply": "2026-04-28T12:08:47.699460Z"
-    }
+    },
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
@@ -106,6 +107,10 @@
     "molecule = of_pyscf.run_pyscf(molecule, run_scf=True, run_fci=True)\n",
     "n_qubit = molecule.n_qubits\n",
     "n_electron = molecule.n_electrons\n",
+    "# H2 を STO-3G 基底で扱うと、空間軌道 2 個 -> スピン軌道 4 個 -> 4 量子ビット、\n",
+    "# 電子数は 2。\n",
+    "assert n_qubit == 4\n",
+    "assert n_electron == 2\n",
     "fermionic_hamiltonian = of_trans.get_fermion_operator(\n",
     "    molecule.get_molecular_hamiltonian()\n",
     ")\n",
@@ -115,7 +120,9 @@
   {
    "cell_type": "markdown",
    "id": "d8df998b",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## Qamomile ハミルトニアンへの変換\n",
     "\n",
@@ -132,7 +139,8 @@
      "iopub.status.busy": "2026-04-28T12:08:47.701028Z",
      "iopub.status.idle": "2026-04-28T12:08:47.703375Z",
      "shell.execute_reply": "2026-04-28T12:08:47.703016Z"
-    }
+    },
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
@@ -155,13 +163,16 @@
     "    return H\n",
     "\n",
     "\n",
-    "hamiltonian = openfermion_to_qamomile(jw_hamiltonian)"
+    "hamiltonian = openfermion_to_qamomile(jw_hamiltonian)\n",
+    "assert hamiltonian.num_qubits == n_qubit"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "f40dbb7e",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## VQE アンザッツの作成\n",
     "\n",
@@ -306,6 +317,10 @@
     "num_params = len(executable.parameter_names)\n",
     "rng = np.random.default_rng(42)\n",
     "initial_params = rng.uniform(0, np.pi, num_params)\n",
+    "# 各 rep は RY 層 (n パラメータ) と RZ 層 (n パラメータ) を、最後の追加層も\n",
+    "# RY + RZ ペアをもう 1 つ出すので、パラメータ数は (reps + 1) * 2 * n_qubit。\n",
+    "assert num_params == (reps + 1) * 2 * n_qubit\n",
+    "assert initial_params.shape == (num_params,)\n",
     "\n",
     "# VQE 最適化を実行します\n",
     "maxiter = 1 if docs_test_mode else 50\n",
@@ -317,7 +332,10 @@
     "    options={\"disp\": True, \"maxiter\": maxiter, \"gtol\": 1e-6},\n",
     "    callback=cost_callback,\n",
     ")\n",
-    "print(result)"
+    "print(result)\n",
+    "# 変分原理: BFGS の予算が短くても、試行エネルギーは FCI 基底エネルギーの上界。\n",
+    "assert result.fun >= molecule.fci_energy - 1e-9\n",
+    "assert len(result.x) == num_params"
    ]
   },
   {
@@ -330,7 +348,8 @@
      "iopub.status.busy": "2026-04-28T12:08:51.995335Z",
      "iopub.status.idle": "2026-04-28T12:08:52.021853Z",
      "shell.execute_reply": "2026-04-28T12:08:52.021529Z"
-    }
+    },
+    "lines_to_next_cell": 2
    },
    "outputs": [
     {
@@ -360,7 +379,9 @@
   {
    "cell_type": "markdown",
    "id": "2531b2cb",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "## 原子同士の距離を変更する"
    ]
@@ -502,9 +523,12 @@
     "\n",
     "n_points = 3 if docs_test_mode else 15\n",
     "bond_lengths = np.linspace(0.2, 1.5, n_points)\n",
+    "assert bond_lengths.shape == (n_points,)\n",
     "energies = []\n",
     "for bond_length in bond_lengths:\n",
     "    hamiltonian, fci_energy = hydrogen_molecule(bond_length)\n",
+    "    # 結合長を変えても H2 は 4 量子ビット問題のまま。\n",
+    "    assert hamiltonian.num_qubits == 4\n",
     "\n",
     "    executable = transpiler.transpile(\n",
     "        vqe_ansatz,\n",
@@ -522,8 +546,12 @@
     "    )\n",
     "\n",
     "    energies.append(result.fun)\n",
+    "    # 変分原理はどの結合長でも成り立つ。\n",
+    "    assert result.fun >= fci_energy - 1e-9\n",
     "\n",
-    "    print(\"distance: \", bond_length, \"energy: \", result.fun, \"fci_energy: \", fci_energy)"
+    "    print(\"distance: \", bond_length, \"energy: \", result.fun, \"fci_energy: \", fci_energy)\n",
+    "\n",
+    "assert len(energies) == n_points"
    ]
   },
   {

--- a/docs/ja/algorithm/vqe_for_hydrogen.py
+++ b/docs/ja/algorithm/vqe_for_hydrogen.py
@@ -67,6 +67,10 @@ molecule = of_chem.MolecularData(geometry, basis, multiplicity, charge, descript
 molecule = of_pyscf.run_pyscf(molecule, run_scf=True, run_fci=True)
 n_qubit = molecule.n_qubits
 n_electron = molecule.n_electrons
+# H2 を STO-3G 基底で扱うと、空間軌道 2 個 -> スピン軌道 4 個 -> 4 量子ビット、
+# 電子数は 2。
+assert n_qubit == 4
+assert n_electron == 2
 fermionic_hamiltonian = of_trans.get_fermion_operator(
     molecule.get_molecular_hamiltonian()
 )
@@ -100,6 +104,7 @@ def openfermion_to_qamomile(of_h) -> qm_o.Hamiltonian:
 
 
 hamiltonian = openfermion_to_qamomile(jw_hamiltonian)
+assert hamiltonian.num_qubits == n_qubit
 
 
 # %% [markdown]
@@ -164,6 +169,10 @@ def cost_callback(param_values):
 num_params = len(executable.parameter_names)
 rng = np.random.default_rng(42)
 initial_params = rng.uniform(0, np.pi, num_params)
+# 各 rep は RY 層 (n パラメータ) と RZ 層 (n パラメータ) を、最後の追加層も
+# RY + RZ ペアをもう 1 つ出すので、パラメータ数は (reps + 1) * 2 * n_qubit。
+assert num_params == (reps + 1) * 2 * n_qubit
+assert initial_params.shape == (num_params,)
 
 # VQE 最適化を実行します
 maxiter = 1 if docs_test_mode else 50
@@ -176,6 +185,9 @@ result = minimize(
     callback=cost_callback,
 )
 print(result)
+# 変分原理: BFGS の予算が短くても、試行エネルギーは FCI 基底エネルギーの上界。
+assert result.fun >= molecule.fci_energy - 1e-9
+assert len(result.x) == num_params
 
 # %%
 plt.plot(cost_history)
@@ -212,9 +224,12 @@ def hydrogen_molecule(bond_length):
 
 n_points = 3 if docs_test_mode else 15
 bond_lengths = np.linspace(0.2, 1.5, n_points)
+assert bond_lengths.shape == (n_points,)
 energies = []
 for bond_length in bond_lengths:
     hamiltonian, fci_energy = hydrogen_molecule(bond_length)
+    # 結合長を変えても H2 は 4 量子ビット問題のまま。
+    assert hamiltonian.num_qubits == 4
 
     executable = transpiler.transpile(
         vqe_ansatz,
@@ -232,8 +247,12 @@ for bond_length in bond_lengths:
     )
 
     energies.append(result.fun)
+    # 変分原理はどの結合長でも成り立つ。
+    assert result.fun >= fci_energy - 1e-9
 
     print("distance: ", bond_length, "energy: ", result.fun, "fci_energy: ", fci_energy)
+
+assert len(energies) == n_points
 
 # %%
 plt.plot(bond_lengths, energies, "-o")


### PR DESCRIPTION
## Summary

Closes the systematic effort to make `docs/{en,ja}/algorithm/`
tutorials double as a regression check by asserting every deterministic
invariant they claim.

This PR adds asserts to the VQE-for-H2 tutorial — the last item in the
algorithm series:

- **Molecule**: H2 in STO-3G is a 4-qubit, 2-electron problem; the
  qubit Hamiltonian inherits the qubit count from the molecule.
- **Ansatz**: parameter count is `(reps + 1) * 2 * n_qubit`;
  `initial_params` has the matching shape.
- **Variational principle**: `result.fun >= fci_energy` at the
  reference bond length and at every bond length in the dissociation
  scan.
- **Dissociation scan**: visits `n_points` bond lengths and produces
  one optimised energy per point.

EN and JA receive parallel changes. `.ipynb` files are re-synced via
`jupytext --to ipynb --update`.

## Test plan

- [x] `uv run pytest tests/docs/test_tutorials.py -m docs -k "vqe_for_hydrogen" -v` passes locally for both EN and JA.