### PR TITLE
Use CUDA-Q controlled helper kernels

### DIFF
--- a/qamomile/cudaq/emitter.py
+++ b/qamomile/cudaq/emitter.py
@@ -21,6 +21,7 @@ import enum
 import itertools
 import linecache
 import math
+from collections.abc import Callable
 from typing import Any
 
 from qamomile.circuit.transpiler.gate_emitter import MeasurementMode
@@ -128,6 +129,9 @@ class CudaqKernelArtifact:
         num_qubits: Number of qubits in the circuit.
         num_clbits: Number of classical bits in the circuit.
         source: Generated Python source code (for debugging).
+        entry_source: Generated Python source for the entry-point kernel
+            only.  ``source`` may also include helper kernels emitted
+            for ``cudaq.control``.
         execution_mode: Whether this is a STATIC or RUNNABLE kernel.
         param_count: Number of variational parameters.
     """
@@ -136,6 +140,7 @@ class CudaqKernelArtifact:
     num_qubits: int
     num_clbits: int
     source: str = ""
+    entry_source: str = ""
     execution_mode: ExecutionMode = ExecutionMode.STATIC
     param_count: int = 0
 
@@ -179,6 +184,12 @@ class CudaqKernelEmitter:
         self._num_clbits: int = 0
         self._measurement_mode: MeasurementMode = MeasurementMode.STATIC
         self._boxed_clbits: set[int] = set()
+        self._helper_sources: list[str] = []
+        self._helper_cache: dict[tuple[int, bool, tuple[str, ...]], str] = {}
+        self._helper_counter = itertools.count()
+        self._qubit_refs: dict[int, str] = {}
+        self._building_helper: bool = False
+        self._helper_param_used: bool = False
 
     @property
     def measurement_mode(self) -> MeasurementMode:
@@ -196,6 +207,31 @@ class CudaqKernelEmitter:
     def _emit(self, line: str) -> None:
         """Append an indented source line."""
         self._lines.append("    " * self._indent + line)
+
+    def _qref(self, idx: int) -> str:
+        """Return the source expression for a qubit slot.
+
+        Args:
+            idx (int): Helper-local or entry-kernel qubit slot.
+
+        Returns:
+            str: Source expression that references the slot.
+        """
+        return self._qubit_refs.get(idx, f"q[{idx}]")
+
+    def _control_ref(self, indices: list[int]) -> str:
+        """Return the source expression for a CUDA-Q control operand.
+
+        Args:
+            indices (list[int]): Control qubit slots.
+
+        Returns:
+            str: Single-qubit expression for one control, or a list
+            expression for multiple controls.
+        """
+        if len(indices) == 1:
+            return self._qref(indices[0])
+        return "[" + ", ".join(self._qref(index) for index in indices) + "]"
 
     def _clbit_ref(self, idx: int) -> str:
         """Return the source expression to read clbit *idx*.
@@ -234,6 +270,11 @@ class CudaqKernelEmitter:
         self._param_map.clear()
         self._param_count = 0
         self._lines.clear()
+        self._helper_sources.clear()
+        self._helper_cache.clear()
+        self._qubit_refs.clear()
+        self._building_helper = False
+        self._helper_param_used = False
         self._indent = 1
 
         self._emit(f"q = cudaq.qvector({num_qubits})")
@@ -281,7 +322,8 @@ class CudaqKernelEmitter:
                 sig = "def _qamomile_kernel():"
 
         body = "\n".join(self._lines)
-        source = f"@cudaq.kernel\n{sig}\n{body}\n"
+        main_source = f"@cudaq.kernel\n{sig}\n{body}\n"
+        source = "\n".join([*self._helper_sources, main_source])
 
         # Register source in linecache with a unique synthetic filename so
         # that ``inspect.getsource()`` succeeds.  CUDA-Q's decorator calls
@@ -302,9 +344,114 @@ class CudaqKernelEmitter:
 
         circuit.kernel_func = namespace["_qamomile_kernel"]
         circuit.source = source
+        circuit.entry_source = main_source
         circuit.execution_mode = mode
         circuit.param_count = self._param_count
         return circuit
+
+    def build_controlled_helper(
+        self,
+        num_targets: int,
+        emit_body: Callable[[], None],
+    ) -> tuple[str, bool]:
+        """Build a pure-device helper kernel for ``cudaq.control``.
+
+        Args:
+            num_targets (int): Number of target qubit arguments accepted
+                by the helper.
+            emit_body (Callable[[], None]): Callback that emits the
+                helper body into this emitter while qubit slots are mapped
+                to helper arguments.
+
+        Returns:
+            tuple[str, bool]: Helper function name, and whether the
+            caller must pass the entry-point ``thetas`` parameter list.
+
+        Raises:
+            EmitError: Propagated from ``emit_body`` when the helper
+                body cannot be emitted for CUDA-Q.
+        """
+        saved_lines = self._lines
+        saved_indent = self._indent
+        saved_qubit_refs = self._qubit_refs
+        saved_mode = self._measurement_mode
+        saved_num_clbits = self._num_clbits
+        saved_boxed_clbits = self._boxed_clbits
+        saved_suppress_trace = getattr(self, "_suppress_trace", False)
+        saved_building_helper = self._building_helper
+        saved_helper_param_used = self._helper_param_used
+
+        self._lines = []
+        self._indent = 1
+        self._qubit_refs = {i: f"t{i}" for i in range(num_targets)}
+        self._measurement_mode = MeasurementMode.STATIC
+        self._num_clbits = 0
+        self._boxed_clbits = set()
+        self._building_helper = True
+        self._helper_param_used = False
+        setattr(self, "_suppress_trace", True)
+
+        try:
+            emit_body()
+            helper_lines = self._lines
+            uses_thetas = self._helper_param_used
+            cache_key = (num_targets, uses_thetas, tuple(helper_lines))
+            cached_name = self._helper_cache.get(cache_key)
+            if cached_name is not None:
+                return cached_name, uses_thetas
+
+            helper_name = f"_qamomile_controlled_{next(self._helper_counter)}"
+            args = [f"t{i}: cudaq.qubit" for i in range(num_targets)]
+            if uses_thetas:
+                args.append("thetas: list[float]")
+            body = "\n".join(helper_lines) if helper_lines else "    pass"
+            self._helper_sources.append(
+                f"@cudaq.kernel\ndef {helper_name}({', '.join(args)}):\n{body}\n"
+            )
+            self._helper_cache[cache_key] = helper_name
+            return helper_name, uses_thetas
+        finally:
+            self._lines = saved_lines
+            self._indent = saved_indent
+            self._qubit_refs = saved_qubit_refs
+            self._measurement_mode = saved_mode
+            self._num_clbits = saved_num_clbits
+            self._boxed_clbits = saved_boxed_clbits
+            self._building_helper = saved_building_helper
+            self._helper_param_used = saved_helper_param_used
+            setattr(self, "_suppress_trace", saved_suppress_trace)
+
+    def emit_controlled_kernel_call(
+        self,
+        circuit: CudaqKernelArtifact,
+        helper_name: str,
+        control_indices: list[int],
+        target_indices: list[int],
+        uses_thetas: bool,
+    ) -> None:
+        """Emit a ``cudaq.control`` call to a generated helper kernel.
+
+        Args:
+            circuit (CudaqKernelArtifact): Artifact currently being
+                emitted.  The argument is accepted for GateEmitter
+                symmetry and tracing subclasses.
+            helper_name (str): Name of the generated helper function.
+            control_indices (list[int]): Physical control qubit slots.
+            target_indices (list[int]): Physical target qubit slots.
+            uses_thetas (bool): Whether to pass the entry-point
+                ``thetas`` parameter list to the helper.
+        """
+        del circuit
+        args = [
+            helper_name,
+            self._control_ref(control_indices),
+            *[self._qref(index) for index in target_indices],
+        ]
+        if uses_thetas:
+            args.append("thetas")
+            if self._building_helper:
+                self._helper_param_used = True
+        self._emit(f"cudaq.control({', '.join(args)})")
 
     def create_parameter(self, name: str) -> CudaqExpr:
         """Return a ``CudaqExpr`` referencing ``thetas[i]``.
@@ -324,6 +471,8 @@ class CudaqKernelEmitter:
         if name not in self._param_map:
             self._param_map[name] = self._param_count
             self._param_count += 1
+        if self._building_helper:
+            self._helper_param_used = True
         return CudaqExpr(f"thetas[{self._param_map[name]}]")
 
     # ------------------------------------------------------------------
@@ -332,35 +481,35 @@ class CudaqKernelEmitter:
 
     def emit_h(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit Hadamard gate."""
-        self._emit(f"h(q[{qubit}])")
+        self._emit(f"h({self._qref(qubit)})")
 
     def emit_x(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit Pauli-X gate."""
-        self._emit(f"x(q[{qubit}])")
+        self._emit(f"x({self._qref(qubit)})")
 
     def emit_y(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit Pauli-Y gate."""
-        self._emit(f"y(q[{qubit}])")
+        self._emit(f"y({self._qref(qubit)})")
 
     def emit_z(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit Pauli-Z gate."""
-        self._emit(f"z(q[{qubit}])")
+        self._emit(f"z({self._qref(qubit)})")
 
     def emit_s(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit S (phase) gate."""
-        self._emit(f"s(q[{qubit}])")
+        self._emit(f"s({self._qref(qubit)})")
 
     def emit_sdg(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit S-dagger gate."""
-        self._emit(f"sdg(q[{qubit}])")
+        self._emit(f"sdg({self._qref(qubit)})")
 
     def emit_t(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit T gate."""
-        self._emit(f"t(q[{qubit}])")
+        self._emit(f"t({self._qref(qubit)})")
 
     def emit_tdg(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
         """Emit T-dagger gate."""
-        self._emit(f"tdg(q[{qubit}])")
+        self._emit(f"tdg({self._qref(qubit)})")
 
     # ------------------------------------------------------------------
     # Single-qubit rotation gates
@@ -378,25 +527,25 @@ class CudaqKernelEmitter:
         self, circuit: CudaqKernelArtifact, qubit: int, angle: float | Any
     ) -> None:
         """Emit RX rotation gate."""
-        self._emit(f"rx({self._angle_expr(angle)}, q[{qubit}])")
+        self._emit(f"rx({self._angle_expr(angle)}, {self._qref(qubit)})")
 
     def emit_ry(
         self, circuit: CudaqKernelArtifact, qubit: int, angle: float | Any
     ) -> None:
         """Emit RY rotation gate."""
-        self._emit(f"ry({self._angle_expr(angle)}, q[{qubit}])")
+        self._emit(f"ry({self._angle_expr(angle)}, {self._qref(qubit)})")
 
     def emit_rz(
         self, circuit: CudaqKernelArtifact, qubit: int, angle: float | Any
     ) -> None:
         """Emit RZ rotation gate."""
-        self._emit(f"rz({self._angle_expr(angle)}, q[{qubit}])")
+        self._emit(f"rz({self._angle_expr(angle)}, {self._qref(qubit)})")
 
     def emit_p(
         self, circuit: CudaqKernelArtifact, qubit: int, angle: float | Any
     ) -> None:
         """Emit phase gate (R1)."""
-        self._emit(f"r1({self._angle_expr(angle)}, q[{qubit}])")
+        self._emit(f"r1({self._angle_expr(angle)}, {self._qref(qubit)})")
 
     # ------------------------------------------------------------------
     # Two-qubit gates
@@ -404,15 +553,15 @@ class CudaqKernelEmitter:
 
     def emit_cx(self, circuit: CudaqKernelArtifact, control: int, target: int) -> None:
         """Emit CNOT (controlled-X) gate."""
-        self._emit(f"x.ctrl(q[{control}], q[{target}])")
+        self._emit(f"x.ctrl({self._qref(control)}, {self._qref(target)})")
 
     def emit_cz(self, circuit: CudaqKernelArtifact, control: int, target: int) -> None:
         """Emit controlled-Z gate."""
-        self._emit(f"z.ctrl(q[{control}], q[{target}])")
+        self._emit(f"z.ctrl({self._qref(control)}, {self._qref(target)})")
 
     def emit_swap(self, circuit: CudaqKernelArtifact, qubit1: int, qubit2: int) -> None:
         """Emit SWAP gate."""
-        self._emit(f"swap(q[{qubit1}], q[{qubit2}])")
+        self._emit(f"swap({self._qref(qubit1)}, {self._qref(qubit2)})")
 
     # ------------------------------------------------------------------
     # Two-qubit rotation gates
@@ -438,11 +587,11 @@ class CudaqKernelEmitter:
         else:
             half = f"({a}) * 0.5"
             neg_half = f"({a}) * (-0.5)"
-        self._emit(f"rz({half}, q[{target}])")
-        self._emit(f"x.ctrl(q[{control}], q[{target}])")
-        self._emit(f"rz({neg_half}, q[{target}])")
-        self._emit(f"x.ctrl(q[{control}], q[{target}])")
-        self._emit(f"rz({half}, q[{control}])")
+        self._emit(f"rz({half}, {self._qref(target)})")
+        self._emit(f"x.ctrl({self._qref(control)}, {self._qref(target)})")
+        self._emit(f"rz({neg_half}, {self._qref(target)})")
+        self._emit(f"x.ctrl({self._qref(control)}, {self._qref(target)})")
+        self._emit(f"rz({half}, {self._qref(control)})")
 
     def emit_rzz(
         self,
@@ -459,9 +608,9 @@ class CudaqKernelEmitter:
             CNOT(q1, q2)
         """
         a = self._angle_expr(angle)
-        self._emit(f"x.ctrl(q[{qubit1}], q[{qubit2}])")
-        self._emit(f"rz({a}, q[{qubit2}])")
-        self._emit(f"x.ctrl(q[{qubit1}], q[{qubit2}])")
+        self._emit(f"x.ctrl({self._qref(qubit1)}, {self._qref(qubit2)})")
+        self._emit(f"rz({a}, {self._qref(qubit2)})")
+        self._emit(f"x.ctrl({self._qref(qubit1)}, {self._qref(qubit2)})")
 
     # ------------------------------------------------------------------
     # Three-qubit gates
@@ -494,9 +643,9 @@ class CudaqKernelEmitter:
         codegen produces the exact source contract expected by the tracing
         test emitter, without double-recording primitive gate calls.
         """
-        self._emit(f"ry({math.pi / 4}, q[{target}])")
-        self._emit(f"x.ctrl(q[{control}], q[{target}])")
-        self._emit(f"ry({-math.pi / 4}, q[{target}])")
+        self._emit(f"ry({math.pi / 4}, {self._qref(target)})")
+        self._emit(f"x.ctrl({self._qref(control)}, {self._qref(target)})")
+        self._emit(f"ry({-math.pi / 4}, {self._qref(target)})")
 
     def emit_cy(self, circuit: CudaqKernelArtifact, control: int, target: int) -> None:
         """Emit controlled-Y via decomposition.
@@ -506,9 +655,9 @@ class CudaqKernelEmitter:
         :meth:`emit_ch` for why this is inlined rather than delegating to
         :func:`emit_decomposition`.
         """
-        self._emit(f"sdg(q[{target}])")
-        self._emit(f"x.ctrl(q[{control}], q[{target}])")
-        self._emit(f"s(q[{target}])")
+        self._emit(f"sdg({self._qref(target)})")
+        self._emit(f"x.ctrl({self._qref(control)}, {self._qref(target)})")
+        self._emit(f"s({self._qref(target)})")
 
     def emit_crx(
         self,
@@ -519,7 +668,7 @@ class CudaqKernelEmitter:
     ) -> None:
         """Emit controlled-RX gate."""
         a = self._angle_expr(angle)
-        self._emit(f"rx.ctrl({a}, q[{control}], q[{target}])")
+        self._emit(f"rx.ctrl({a}, {self._qref(control)}, {self._qref(target)})")
 
     def emit_cry(
         self,
@@ -530,7 +679,7 @@ class CudaqKernelEmitter:
     ) -> None:
         """Emit controlled-RY gate."""
         a = self._angle_expr(angle)
-        self._emit(f"ry.ctrl({a}, q[{control}], q[{target}])")
+        self._emit(f"ry.ctrl({a}, {self._qref(control)}, {self._qref(target)})")
 
     def emit_crz(
         self,
@@ -541,7 +690,7 @@ class CudaqKernelEmitter:
     ) -> None:
         """Emit controlled-RZ gate."""
         a = self._angle_expr(angle)
-        self._emit(f"rz.ctrl({a}, q[{control}], q[{target}])")
+        self._emit(f"rz.ctrl({a}, {self._qref(control)}, {self._qref(target)})")
 
     # ------------------------------------------------------------------
     # Measurement
@@ -561,7 +710,7 @@ class CudaqKernelEmitter:
         """
         if self.measurement_mode == MeasurementMode.STATIC:
             return
-        self._emit(self._clbit_store(clbit, f"mz(q[{qubit}])"))
+        self._emit(self._clbit_store(clbit, f"mz({self._qref(qubit)})"))
         self._measurement_map[clbit] = qubit
 
     # ------------------------------------------------------------------
@@ -605,8 +754,8 @@ class CudaqKernelEmitter:
         target_idx: int,
     ) -> None:
         """Emit multi-controlled X using ``x.ctrl(c0, c1, ..., target)``."""
-        args = ", ".join(f"q[{i}]" for i in control_indices)
-        self._emit(f"x.ctrl({args}, q[{target_idx}])")
+        args = ", ".join(self._qref(i) for i in control_indices)
+        self._emit(f"x.ctrl({args}, {self._qref(target_idx)})")
 
     # ------------------------------------------------------------------
     # Control flow support

--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -17,13 +17,23 @@ import dataclasses
 from typing import TYPE_CHECKING, Any, Sequence
 
 from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.arithmetic_operations import RuntimeClassicalExpr
 from qamomile.circuit.ir.operation.control_flow import (
     ForItemsOperation,
     ForOperation,
+    HasNestedOps,
     IfOperation,
     WhileOperation,
 )
-from qamomile.circuit.ir.operation.gate import GateOperation, GateOperationType
+from qamomile.circuit.ir.operation.expval import ExpvalOp
+from qamomile.circuit.ir.operation.gate import (
+    ControlledUOperation,
+    GateOperation,
+    GateOperationType,
+    MeasureOperation,
+    MeasureQFixedOperation,
+    MeasureVectorOperation,
+)
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.transpiler.errors import EmitError
 from qamomile.circuit.transpiler.executable import (
@@ -407,6 +417,151 @@ def _has_runtime_control_flow(
     return False
 
 
+def _validate_controlled_helper_unitary_ops(
+    operations: Sequence[Operation],
+    bindings: dict[str, Any],
+) -> None:
+    """Validate that a CUDA-Q controlled helper is unitary-only.
+
+    Args:
+        operations (Sequence[Operation]): Operations in the helper block
+            or in a nested control-flow body.
+        bindings (dict[str, Any]): Emit-time bindings used to decide
+            whether ``if`` conditions are compile-time constants.
+
+    Raises:
+        EmitError: If the controlled target contains measurement,
+            expectation-value computation, runtime classical state, or
+            measurement-dependent control flow.
+    """
+    non_unitary_ops = (
+        MeasureOperation,
+        MeasureVectorOperation,
+        MeasureQFixedOperation,
+        ExpvalOp,
+        RuntimeClassicalExpr,
+    )
+    for op in operations:
+        if isinstance(op, non_unitary_ops):
+            raise EmitError(
+                f"CUDA-Q cudaq.control helper kernels must be unitary-only; "
+                f"found {type(op).__name__}.",
+                operation="ControlledUOperation",
+            )
+        if isinstance(op, WhileOperation):
+            raise EmitError(
+                "CUDA-Q cudaq.control helper kernels must be unitary-only; "
+                "runtime while-loops are not supported inside a controlled target.",
+                operation="ControlledUOperation",
+            )
+        if isinstance(op, IfOperation):
+            resolved_condition = resolve_if_condition(op.condition, bindings)
+            if resolved_condition is None:
+                raise EmitError(
+                    "CUDA-Q cudaq.control helper kernels must be unitary-only; "
+                    "measurement-dependent if-statements are not supported inside "
+                    "a controlled target.",
+                    operation="ControlledUOperation",
+                )
+            selected_ops = (
+                op.true_operations if resolved_condition else op.false_operations
+            )
+            _validate_controlled_helper_unitary_ops(selected_ops, bindings)
+            continue
+        if isinstance(op, ControlledUOperation) and op.block is not None:
+            _validate_controlled_helper_unitary_ops(op.block.operations, bindings)
+        if isinstance(op, HasNestedOps):
+            for nested in op.nested_op_lists():
+                _validate_controlled_helper_unitary_ops(nested, bindings)
+
+
+def _build_helper_qubit_map(
+    block_value: Any,
+    target_slots: list[int],
+    emit_pass: Any,
+    bindings: dict[str, Any],
+) -> QubitMap:
+    """Build a helper-local ``QubitMap`` for a controlled block.
+
+    Args:
+        block_value (Any): Inner block whose quantum inputs are mapped.
+        target_slots (list[int]): Helper-local qubit slots, one per
+            flattened target qubit argument.
+        emit_pass (Any): Emit pass used to resolve symbolic vector
+            shapes.
+        bindings (dict[str, Any]): Bindings used for shape resolution.
+
+    Returns:
+        QubitMap: Mapping accepted by ``StandardEmitPass._emit_operations``.
+
+    Raises:
+        EmitError: If a vector input length cannot be resolved, is
+            negative, or requires more target slots than the controlled
+            call supplied.
+    """
+    from qamomile.circuit.ir.value import ArrayValue
+
+    helper_map: QubitMap = {}
+    quantum_inputs = [
+        iv
+        for iv in getattr(block_value, "input_values", [])
+        if hasattr(iv, "type") and iv.type.is_quantum()
+    ]
+
+    slot = 0
+    for input_value in quantum_inputs:
+        if isinstance(input_value, ArrayValue):
+            length: int | None = None
+            if input_value.shape:
+                size_value = input_value.shape[0]
+                if size_value.is_constant():
+                    length = int(size_value.get_const())
+                else:
+                    length = emit_pass._resolver.resolve_int_value(size_value, bindings)
+            if length is None:
+                shape_name = (
+                    input_value.shape[0].name if input_value.shape else "<no shape>"
+                )
+                raise EmitError(
+                    f"CUDA-Q controlled helper: cannot resolve "
+                    f"Vector[Qubit] input length for {input_value.name!r}; "
+                    f"bind {shape_name!r} before transpilation.",
+                    operation="ControlledUOperation",
+                )
+            if length < 0:
+                raise EmitError(
+                    f"CUDA-Q controlled helper: Vector[Qubit] input "
+                    f"{input_value.name!r} resolved to a negative length "
+                    f"({length}).",
+                    operation="ControlledUOperation",
+                )
+            if slot + length > len(target_slots):
+                raise EmitError(
+                    f"CUDA-Q controlled helper inner block requires at least "
+                    f"{slot + length} target qubit slot(s), but only "
+                    f"{len(target_slots)} are available.",
+                    operation="ControlledUOperation",
+                )
+            if length:
+                helper_map[QubitAddress(input_value.uuid)] = target_slots[slot]
+            for i in range(length):
+                helper_map[QubitAddress(input_value.uuid, i)] = target_slots[slot + i]
+            slot += length
+            continue
+
+        if slot >= len(target_slots):
+            raise EmitError(
+                f"CUDA-Q controlled helper inner block requires at least "
+                f"{slot + 1} target qubit slot(s), but only "
+                f"{len(target_slots)} are available.",
+                operation="ControlledUOperation",
+            )
+        helper_map[QubitAddress(input_value.uuid)] = target_slots[slot]
+        slot += 1
+
+    return helper_map
+
+
 def _collect_loop_carried_clbits(
     operations: list[Operation],
     clbit_map: ClbitMap,
@@ -572,59 +727,76 @@ class CudaqEmitPass(StandardEmitPass[CudaqKernelArtifact]):
         power: int,
         bindings: dict[str, Any],
     ) -> None:
-        """Emit controlled-U using CUDA-Q native multi-control.
+        """Emit controlled-U through a generated CUDA-Q helper kernel.
 
-        CUDA-Q supports ``kernel.<gate>([controls], target)`` for
-        multi-controlled single-qubit gates.  This override handles
-        multi-control by iterating over the block body and emitting each
-        gate with native multi-control.
-
-        An operand-to-target resolver maps each inner gate's operand to
-        the correct physical target index based on block input positions,
-        rather than hardcoding ``target_indices[0]``.
-
-        For single-control cases, compile-time resolvable ``ForOperation``
-        loops are unrolled and their body gates emitted with correct
-        operand-to-target mapping.  Multi-control helpers with non-gate
-        operations raise ``EmitError``.
+        Generates a pure-device ``@cudaq.kernel`` for the wrapped
+        Qamomile block and emits ``cudaq.control(helper, controls,
+        *targets)`` in the outer kernel.  This uses CUDA-Q's native
+        controlled-kernel support instead of decomposing the helper
+        gate-by-gate.
 
         Args:
-            circuit: The CUDA-Q kernel artifact being built.
-            block_value: The block value containing operations to control.
-            num_controls: Number of control qubits.
-            control_indices: Physical indices of control qubits.
-            target_indices: Physical indices of target qubits.
-            power: Number of times to repeat the controlled operation.
-            bindings: Parameter bindings.
+            circuit (CudaqKernelArtifact): The CUDA-Q kernel artifact
+                being built.
+            block_value (Any): The block value containing operations to
+                control.
+            num_controls (int): Number of control qubits.
+            control_indices (list[int]): Physical indices of control
+                qubits.
+            target_indices (list[int]): Physical indices of target
+                qubits.
+            power (int): Number of times to repeat the controlled
+                operation.
+            bindings (dict[str, Any]): Parameter bindings local to the
+                controlled block.
 
         Raises:
-            EmitError: When the block body contains unsupported operations
-                or operand-to-target resolution fails.
+            EmitError: When the controlled block is missing operations or
+                contains non-unitary runtime constructs.
         """
         if not hasattr(block_value, "operations"):
             raise EmitError(
                 "Cannot emit controlled operation: block has no operations.",
                 operation="ControlledUOperation",
             )
+        if num_controls <= 0:
+            raise EmitError(
+                "CUDA-Q cudaq.control requires at least one control qubit.",
+                operation="ControlledUOperation",
+            )
 
-        # Build operand-to-target map from block inputs, propagated
-        # through SSA versions.
-        block_qubit_map = _build_block_qubit_map(
-            block_value, target_indices, self, bindings
+        _validate_controlled_helper_unitary_ops(block_value.operations, bindings)
+
+        helper_targets = list(range(len(target_indices)))
+        helper_qubit_map = _build_helper_qubit_map(
+            block_value, helper_targets, self, bindings
         )
 
         emitter: CudaqKernelEmitter = self._emitter  # type: ignore[assignment]
 
-        for _ in range(power):
-            self._emit_cudaq_controlled_ops(
+        def emit_body() -> None:
+            """Emit the wrapped block body into the helper source."""
+            self._emit_operations(
                 circuit,
                 block_value.operations,
-                num_controls,
+                helper_qubit_map,
+                {},
+                bindings,
+                force_unroll=True,
+            )
+
+        helper_name, uses_thetas = emitter.build_controlled_helper(
+            len(target_indices),
+            emit_body,
+        )
+
+        for _ in range(power):
+            emitter.emit_controlled_kernel_call(
+                circuit,
+                helper_name,
                 control_indices,
                 target_indices,
-                block_qubit_map,
-                emitter,
-                bindings,
+                uses_thetas,
             )
 
     def _emit_cudaq_controlled_ops(
@@ -1009,7 +1181,9 @@ class CudaqExecutor(QuantumExecutor[CudaqKernelArtifact]):
             spin_op = hamiltonian  # type: ignore[unreachable]
 
         if isinstance(circuit, BoundCudaqKernelArtifact):
-            result = cudaq.observe(circuit.kernel_func, spin_op, circuit.param_values)  # type: ignore[operator]
+            result: Any = cudaq.observe(
+                circuit.kernel_func, spin_op, circuit.param_values
+            )  # type: ignore[operator]
         else:
             if params is not None:
                 result = cudaq.observe(circuit.kernel_func, spin_op, list(params))  # type: ignore[operator]

--- a/tests/transpiler/backends/_cudaq_source_assertions.py
+++ b/tests/transpiler/backends/_cudaq_source_assertions.py
@@ -287,9 +287,10 @@ def assert_inspect_source_matches_artifact(circuit: CudaqKernelArtifact) -> None
     kernel_source = inspect.getsource(circuit.kernel_func.kernelFunction)
     expected_source = circuit.entry_source or circuit.source
     assert _canonical_ast(kernel_source) == _canonical_ast(expected_source), (
-        "inspect.getsource() returned source that differs from CudaqKernelArtifact.source.\n"
+        "inspect.getsource() returned source that differs from the artifact "
+        "entry source.\n"
         f"inspect.getsource():\n{kernel_source}\n"
-        f"artifact.source:\n{expected_source}"
+        f"artifact entry source:\n{expected_source}"
     )
 
 

--- a/tests/transpiler/backends/_cudaq_source_assertions.py
+++ b/tests/transpiler/backends/_cudaq_source_assertions.py
@@ -203,6 +203,21 @@ class _ExpectedCudaqSourceBuilder:
             else:
                 self._emit(f"x(q[{target}])")
             return
+        if kind == "controlled_kernel_call":
+            helper_name, controls, targets, uses_thetas = args
+            if len(controls) == 1:
+                control_src = f"q[{controls[0]}]"
+            else:
+                control_src = "[" + ", ".join(f"q[{index}]" for index in controls) + "]"
+            call_args = [
+                helper_name,
+                control_src,
+                *[f"q[{index}]" for index in targets],
+            ]
+            if uses_thetas:
+                call_args.append("thetas")
+            self._emit(f"cudaq.control({', '.join(call_args)})")
+            return
         if kind == "measure":
             qubit, clbit = args
             if self._mode == ExecutionMode.RUNNABLE:
@@ -257,11 +272,12 @@ def assert_traced_source_matches_artifact(
     ).build(_get_trace(circuit))
 
     expected_ast = _canonical_ast(expected)
-    actual_ast = _canonical_ast(circuit.source)
+    actual_source = circuit.entry_source or circuit.source
+    actual_ast = _canonical_ast(actual_source)
     assert actual_ast == expected_ast, (
         "Generated CUDA-Q source does not match the traced emission contract.\n"
         f"Expected source:\n{expected}\n"
-        f"Actual source:\n{circuit.source}"
+        f"Actual source:\n{actual_source}"
     )
 
 
@@ -269,10 +285,11 @@ def assert_inspect_source_matches_artifact(circuit: CudaqKernelArtifact) -> None
     """Assert that ``inspect.getsource`` resolves to the artifact source."""
     assert circuit.kernel_func is not None, "Expected finalized CUDA-Q kernel."
     kernel_source = inspect.getsource(circuit.kernel_func.kernelFunction)
-    assert _canonical_ast(kernel_source) == _canonical_ast(circuit.source), (
+    expected_source = circuit.entry_source or circuit.source
+    assert _canonical_ast(kernel_source) == _canonical_ast(expected_source), (
         "inspect.getsource() returned source that differs from CudaqKernelArtifact.source.\n"
         f"inspect.getsource():\n{kernel_source}\n"
-        f"artifact.source:\n{circuit.source}"
+        f"artifact.source:\n{expected_source}"
     )
 
 
@@ -297,6 +314,8 @@ class TracingCudaqKernelEmitter(CudaqKernelEmitter):
         return finalized
 
     def _record(self, circuit: CudaqKernelArtifact, kind: str, *args: Any) -> None:
+        if getattr(self, "_suppress_trace", False):
+            return
         _get_trace(circuit).append(EmissionAction(kind, args))
 
     def emit_h(self, circuit: CudaqKernelArtifact, qubit: int) -> None:
@@ -460,6 +479,30 @@ class TracingCudaqKernelEmitter(CudaqKernelEmitter):
             target_idx,
         )
         super().emit_multi_controlled_x(circuit, control_indices, target_idx)
+
+    def emit_controlled_kernel_call(
+        self,
+        circuit: CudaqKernelArtifact,
+        helper_name: str,
+        control_indices: list[int],
+        target_indices: list[int],
+        uses_thetas: bool,
+    ) -> None:
+        self._record(
+            circuit,
+            "controlled_kernel_call",
+            helper_name,
+            list(control_indices),
+            list(target_indices),
+            uses_thetas,
+        )
+        super().emit_controlled_kernel_call(
+            circuit,
+            helper_name,
+            control_indices,
+            target_indices,
+            uses_thetas,
+        )
 
     def emit_if_start(
         self, circuit: CudaqKernelArtifact, clbit: int, value: int = 1

--- a/tests/transpiler/backends/test_cudaq_frontend.py
+++ b/tests/transpiler/backends/test_cudaq_frontend.py
@@ -2571,8 +2571,8 @@ class TestCudaqHelperKernelSemanticsContract:
             f"Multi-control second-target helper: expected |1011>, got statevector {sv}"
         )
 
-    def test_helper_body_with_loop_multi_control_raises_emit_error(self):
-        """Multi-control helper body with ForOperation should raise EmitError."""
+    def test_helper_body_with_loop_multi_control_uses_cudaq_control(self):
+        """Multi-control helper body with ForOperation uses cudaq.control."""
 
         @qmc.qkernel
         def loop_gate(q0: qmc.Qubit, q1: qmc.Qubit) -> tuple[qmc.Qubit, qmc.Qubit]:
@@ -2591,8 +2591,17 @@ class TestCudaqHelperKernelSemanticsContract:
             q[0], q[1], q[2], q[3] = cc(q[0], q[1], q[2], q[3])
             return qmc.measure(q)
 
-        with pytest.raises(EmitError, match="Unsupported operation"):
-            _transpile_and_get_circuit(circuit)
+        _, qc = _transpile_and_get_circuit(circuit, smoke_test=True)
+        sv = _run_statevector(qc)
+        expected = computational_basis_state(4, 0b1111)
+        assert statevectors_equal(sv, expected)
+        _assert_source_contains(
+            qc,
+            "def _qamomile_controlled_0(t0: cudaq.qubit, t1: cudaq.qubit):",
+            "x(t0)",
+            "x(t1)",
+            "cudaq.control(_qamomile_controlled_0, [q[0], q[1]], q[2], q[3])",
+        )
 
     def test_existing_ccx_happy_path_regression(self):
         """Existing CCX (Toffoli) happy path must not regress."""
@@ -3787,7 +3796,126 @@ class TestControlledSubRoutines:
         _, qc = _transpile_and_get_circuit(circuit, smoke_test=True)
         assert qc.num_qubits == 2
         assert qc.execution_mode == ExecutionMode.STATIC
-        _assert_source_contains(qc, "def _qamomile_kernel():", "q = cudaq.qvector(2)")
+        _assert_source_contains(
+            qc,
+            "def _qamomile_controlled_0(t0: cudaq.qubit):",
+            "h(t0)",
+            "x(t0)",
+            "def _qamomile_kernel():",
+            "q = cudaq.qvector(2)",
+            "cudaq.control(_qamomile_controlled_0, q[0], q[1])",
+        )
+
+    def test_controlled_parametric_kernel_uses_cudaq_control(self):
+        """A controlled parametric helper is emitted via cudaq.control."""
+
+        @qmc.qkernel
+        def ry_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+            q = qmc.ry(q, theta)
+            return q
+
+        controlled_ry = qmc.control(ry_gate)
+
+        @qmc.qkernel
+        def circuit(theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(2, "q")
+            q[0], q[1] = controlled_ry(q[0], q[1], theta=theta)
+            return qmc.measure(q)
+
+        _, qc = _transpile_and_get_circuit(circuit, parameters=["theta"])
+        _assert_source_contains(
+            qc,
+            "def _qamomile_controlled_0(t0: cudaq.qubit, thetas: list[float]):",
+            "ry(thetas[0], t0)",
+            "def _qamomile_kernel(thetas: list[float]):",
+            "cudaq.control(_qamomile_controlled_0, q[0], q[1], thetas)",
+        )
+
+    def test_nested_controlled_parametric_helper_forwards_thetas(self):
+        """A nested controlled helper forwards runtime parameters."""
+
+        @qmc.qkernel
+        def ry_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+            q = qmc.ry(q, theta)
+            return q
+
+        controlled_ry = qmc.control(ry_gate)
+
+        @qmc.qkernel
+        def inner_controlled(
+            control: qmc.Qubit, target: qmc.Qubit, theta: qmc.Float
+        ) -> tuple[qmc.Qubit, qmc.Qubit]:
+            control, target = controlled_ry(control, target, theta=theta)
+            return control, target
+
+        nested_controlled = qmc.control(inner_controlled)
+
+        @qmc.qkernel
+        def circuit(theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(3, "q")
+            q[0], q[1], q[2] = nested_controlled(q[0], q[1], q[2], theta=theta)
+            return qmc.measure(q)
+
+        _, qc = _transpile_and_get_circuit(circuit, parameters=["theta"])
+        _assert_source_contains(
+            qc,
+            "def _qamomile_controlled_0(t0: cudaq.qubit, thetas: list[float]):",
+            "ry(thetas[0], t0)",
+            "def _qamomile_controlled_1(t0: cudaq.qubit, t1: cudaq.qubit, thetas: list[float]):",
+            "cudaq.control(_qamomile_controlled_0, t0, t1, thetas)",
+            "cudaq.control(_qamomile_controlled_1, q[0], q[1], q[2], thetas)",
+        )
+
+    def test_controlled_multi_control_helper_uses_cudaq_control(self):
+        """A multi-control helper uses CUDA-Q's controlled-kernel API."""
+
+        @qmc.qkernel
+        def hx_gate(q: qmc.Qubit) -> qmc.Qubit:
+            q = qmc.h(q)
+            q = qmc.x(q)
+            return q
+
+        controlled_hx = qmc.control(hx_gate, num_controls=2)
+
+        @qmc.qkernel
+        def circuit() -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(3, "q")
+            q[0] = qmc.x(q[0])
+            q[1] = qmc.x(q[1])
+            q[0], q[1], q[2] = controlled_hx(q[0], q[1], q[2])
+            return qmc.measure(q)
+
+        _, qc = _transpile_and_get_circuit(circuit, smoke_test=True)
+        _assert_source_contains(
+            qc,
+            "def _qamomile_controlled_0(t0: cudaq.qubit):",
+            "h(t0)",
+            "x(t0)",
+            "cudaq.control(_qamomile_controlled_0, [q[0], q[1]], q[2])",
+        )
+
+    def test_identical_controlled_helpers_are_reused(self):
+        """Identical generated helper kernels share one CUDA-Q helper."""
+
+        @qmc.qkernel
+        def hx_gate(q: qmc.Qubit) -> qmc.Qubit:
+            q = qmc.h(q)
+            q = qmc.x(q)
+            return q
+
+        controlled_hx = qmc.control(hx_gate)
+
+        @qmc.qkernel
+        def circuit() -> qmc.Vector[qmc.Bit]:
+            q = qmc.qubit_array(3, "q")
+            q[0] = qmc.x(q[0])
+            q[0], q[1] = controlled_hx(q[0], q[1])
+            q[0], q[2] = controlled_hx(q[0], q[2])
+            return qmc.measure(q)
+
+        _, qc = _transpile_and_get_circuit(circuit, smoke_test=True)
+        assert qc.source.count("def _qamomile_controlled_") == 1
+        assert qc.source.count("cudaq.control(_qamomile_controlled_0") == 2
 
     def test_controlled_power_2(self):
         """A powered controlled phase helper transpiles."""


### PR DESCRIPTION
## Summary
- Emit Qamomile controlled blocks for CUDA-Q as helper kernels passed to cudaq.control(...).
- Preserve entry-point source separately from helper source for source assertions and inspect.getsource.
- Track helper runtime-parameter usage explicitly and reuse identical helper bodies.

## Validation
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run pytest tests/transpiler/backends/test_cudaq_frontend.py -q -m cudaq
- uv run zuban check qamomile/cudaq/transpiler.py qamomile/cudaq/emitter.py
- uv run zuban check qamomile/ reports 76 baseline errors; verified the same count on main at d0059e09.