### PR TITLE
Resolve bound vector float elements

### DIFF
--- a/qamomile/circuit/transpiler/value_resolver.py
+++ b/qamomile/circuit/transpiler/value_resolver.py
@@ -20,7 +20,10 @@ deterministic resolution order:
 
 from __future__ import annotations
 
+import numbers
 from typing import Any
+
+import numpy as np
 
 
 class ValueResolver:
@@ -143,4 +146,32 @@ class ValueResolver:
                 container = container[int(index)]
             except (IndexError, KeyError, TypeError, ValueError):
                 return None
-        return container
+        return _normalize_bound_scalar(container)
+
+
+def _normalize_bound_scalar(value: Any) -> Any:
+    """Normalize NumPy-style scalar values to Python primitives.
+
+    Args:
+        value (Any): The value resolved from a compile-time container.
+
+    Returns:
+        Any: A Python ``bool``, ``int``, or ``float`` for numeric scalar
+            inputs, or the original value for non-numeric objects.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    if isinstance(value, numbers.Real):
+        return float(value)
+    if isinstance(value, np.generic):
+        item = value.item()
+        if isinstance(item, bool):
+            return item
+        if isinstance(item, numbers.Integral):
+            return int(item)
+        if isinstance(item, numbers.Real):
+            return float(item)
+        return item
+    return value

--- a/qamomile/circuit/transpiler/value_resolver.py
+++ b/qamomile/circuit/transpiler/value_resolver.py
@@ -11,8 +11,8 @@ deterministic resolution order:
 1. **Context map** — caller-supplied ``UUID → concrete value`` dict
    (e.g. ``folded_values``, ``concrete_values``).
 2. **Constant** — ``value.is_constant() → value.get_const()``.
-3. **Compile-time array element** — ``arr[i]`` resolves from
-   ``arr``'s ``const_array`` metadata or a binding for ``arr``.
+3. **Compile-time array element** — ``arr[i]`` or ``arr[a:b][i]``
+   resolves from the root array's ``const_array`` metadata or binding.
 4. **Bindings by parameter name** — ``value.is_parameter() → bindings[param_name]``.
 5. **Bindings by value name** — ``value.name → bindings[name]``.
 6. Returns ``None`` if none of the above match.
@@ -25,7 +25,7 @@ from typing import Any
 
 import numpy as np
 
-from qamomile.circuit.ir.value import ArrayValue
+from qamomile.circuit.ir.value import ArrayValue, Value
 
 
 class ValueResolver:
@@ -130,17 +130,24 @@ class ValueResolver:
         if not isinstance(parent_array, ArrayValue) or not element_indices:
             return None
 
+        root_array, element_indices = self._resolve_root_array_indices(
+            parent_array, element_indices
+        )
+        if root_array is None:
+            return None
+
         # Prefer const_array metadata because bound Vector inputs created
-        # by the frontend keep their compile-time payload on the ArrayValue
-        # itself. Since parent_array is an ArrayValue here, get_const_array
-        # is part of the IR contract and should be called directly.
-        container = parent_array.get_const_array()
+        # by the frontend keep their compile-time payload on the root
+        # ArrayValue itself. Slice views intentionally walk back to the
+        # root before this lookup so view-local indices address the same
+        # compile-time container the user originally bound.
+        container = root_array.get_const_array()
         if container is None:
             # Fall back to explicit bindings for callers that resolve an
             # element Value against a separate binding map instead of an
             # ArrayValue carrying const_array metadata.
-            parent_name = getattr(parent_array, "name", None)
-            parent_uuid = getattr(parent_array, "uuid", None)
+            parent_name = getattr(root_array, "name", None)
+            parent_uuid = getattr(root_array, "uuid", None)
             if parent_name in self._bindings:
                 container = self._bindings[parent_name]
             elif parent_uuid in self._bindings:
@@ -165,6 +172,58 @@ class ValueResolver:
                 # from the available compile-time data.
                 return None
         return _normalize_bound_scalar(container)
+
+    def _resolve_root_array_indices(
+        self,
+        parent_array: ArrayValue,
+        element_indices: tuple[Any, ...],
+    ) -> tuple[ArrayValue | None, tuple[Any, ...]]:
+        """Map view-local element indices onto the root array.
+
+        Args:
+            parent_array (ArrayValue): Array that directly owns the
+                element Value. It may be a sliced ``ArrayValue`` backing
+                a ``VectorView``.
+            element_indices (tuple[Any, ...]): Element indices local to
+                ``parent_array``.
+
+        Returns:
+            tuple[ArrayValue | None, tuple[Any, ...]]: The root array and
+                root-local indices when every slice bound can be resolved,
+                or ``(None, ())`` when the slice chain is symbolic or
+                otherwise not resolvable at compile time.
+        """
+        root_array = parent_array
+        root_indices = element_indices
+
+        # VectorView is represented as a sliced ArrayValue, not a distinct
+        # Value type. Compose each slice frame into the leading element
+        # index so view[i] resolves against the root container as
+        # root[start + step * i].
+        while root_array.slice_of is not None:
+            if not root_indices:
+                return None, ()
+
+            start = self.resolve(root_array.slice_start)
+            step = self.resolve(root_array.slice_step)
+            index = self.resolve(root_indices[0])
+            if start is None or step is None or index is None:
+                # Symbolic view bounds or symbolic indices must stay
+                # unresolved; guessing a root slot would silently pick
+                # the wrong compile-time value.
+                return None, ()
+            try:
+                root_index = int(start) + int(step) * int(index)
+            except (TypeError, ValueError):
+                return None, ()
+
+            root_indices = (
+                _constant_index_like(root_indices[0], root_index),
+                *root_indices[1:],
+            )
+            root_array = root_array.slice_of
+
+        return root_array, root_indices
 
 
 def _normalize_bound_scalar(value: Any) -> Any:
@@ -199,3 +258,25 @@ def _normalize_bound_scalar(value: Any) -> Any:
             return float(item)
         return item
     return value
+
+
+def _constant_index_like(index_value: Any, index: int) -> Any:
+    """Create a constant index Value when possible.
+
+    Args:
+        index_value (Any): Original index object from an element access.
+            Value-like inputs provide the UInt type needed to keep the
+            rewritten index compatible with later ``resolve()`` calls.
+        index (int): Concrete root-array index computed from a slice
+            affine map.
+
+    Returns:
+        Any: A constant Value with the original type when ``index_value``
+            is Value-like, otherwise the raw Python integer.
+    """
+    if hasattr(index_value, "type"):
+        return Value(
+            type=index_value.type,
+            name=getattr(index_value, "name", "idx"),
+        ).with_const(index)
+    return index

--- a/qamomile/circuit/transpiler/value_resolver.py
+++ b/qamomile/circuit/transpiler/value_resolver.py
@@ -11,9 +11,11 @@ deterministic resolution order:
 1. **Context map** — caller-supplied ``UUID → concrete value`` dict
    (e.g. ``folded_values``, ``concrete_values``).
 2. **Constant** — ``value.is_constant() → value.get_const()``.
-3. **Bindings by parameter name** — ``value.is_parameter() → bindings[param_name]``.
-4. **Bindings by value name** — ``value.name → bindings[name]``.
-5. Returns ``None`` if none of the above match.
+3. **Compile-time array element** — ``arr[i]`` resolves from
+   ``arr``'s ``const_array`` metadata or a binding for ``arr``.
+4. **Bindings by parameter name** — ``value.is_parameter() → bindings[param_name]``.
+5. **Bindings by value name** — ``value.name → bindings[name]``.
+6. Returns ``None`` if none of the above match.
 """
 
 from __future__ import annotations
@@ -22,17 +24,15 @@ from typing import Any
 
 
 class ValueResolver:
-    """Resolves IR Values to concrete Python values.
+    """Resolve IR Values to concrete Python values.
 
-    Parameters
-    ----------
-    context:
-        UUID-keyed map of already-resolved values.  The *values* may be
-        either raw Python scalars or ``Value`` objects; if a ``Value`` is
-        found its ``get_const()`` is extracted automatically.
-    bindings:
-        Name-keyed parameter bindings supplied by the user at transpile
-        time.
+    Args:
+        context (dict[str, Any] | None): UUID-keyed map of already
+            resolved values. The values may be either raw Python scalars
+            or ``Value`` objects; if a ``Value`` is found its
+            ``get_const()`` is extracted automatically.
+        bindings (dict[str, Any] | None): Name-keyed parameter
+            bindings supplied by the user at transpile time.
     """
 
     __slots__ = ("_context", "_bindings")
@@ -42,14 +42,31 @@ class ValueResolver:
         context: dict[str, Any] | None = None,
         bindings: dict[str, Any] | None = None,
     ):
+        """Create a resolver with optional context and bindings.
+
+        Args:
+            context (dict[str, Any] | None): UUID-keyed map of
+                already-resolved values. Defaults to None.
+            bindings (dict[str, Any] | None): Name-keyed parameter
+                bindings supplied by the user. Defaults to None.
+        """
         self._context = context or {}
         self._bindings = bindings or {}
 
     def resolve(self, value: Any) -> Any | None:
-        """Resolve *value* to a concrete Python value, or ``None``.
+        """Resolve a Value-like object to a concrete Python value.
 
         If *value* is not a Value-like object (no ``uuid`` attribute) it
         is returned as-is — the caller already has a concrete value.
+
+        Args:
+            value (Any): The Value-like object or already concrete value
+                to resolve.
+
+        Returns:
+            Any | None: The resolved concrete value, the original
+                concrete value for non-Value inputs, or ``None`` when no
+                resolution rule applies.
         """
         if not hasattr(value, "uuid"):
             return value  # Already concrete
@@ -67,14 +84,63 @@ class ValueResolver:
         if hasattr(value, "is_constant") and value.is_constant():
             return value.get_const()
 
-        # 3. Bindings by parameter name
+        # 3. Compile-time array element
+        array_element = self._resolve_array_element(value)
+        if array_element is not None:
+            return array_element
+
+        # 4. Bindings by parameter name
         if hasattr(value, "is_parameter") and value.is_parameter():
             param_name = value.parameter_name()
             if param_name and param_name in self._bindings:
                 return self._bindings[param_name]
 
-        # 4. Bindings by value name
+        # 5. Bindings by value name
         if hasattr(value, "name") and value.name and value.name in self._bindings:
             return self._bindings[value.name]
 
         return None
+
+    def _resolve_array_element(self, value: Any) -> Any | None:
+        """Resolve an array-element Value from compile-time array data.
+
+        Args:
+            value (Any): The Value-like object to inspect. It may be an
+                element Value with ``parent_array`` and
+                ``element_indices`` metadata.
+
+        Returns:
+            Any | None: The indexed element when every index resolves and
+                the parent array has compile-time data. Returns ``None``
+                when the value is not an array element, the parent has no
+                compile-time data, an index is symbolic, or indexing
+                fails.
+        """
+        parent_array = getattr(value, "parent_array", None)
+        element_indices = getattr(value, "element_indices", None)
+        if parent_array is None or not element_indices:
+            return None
+
+        container = None
+        get_const_array = getattr(parent_array, "get_const_array", None)
+        if callable(get_const_array):
+            container = get_const_array()
+        if container is None:
+            parent_name = getattr(parent_array, "name", None)
+            parent_uuid = getattr(parent_array, "uuid", None)
+            if parent_name in self._bindings:
+                container = self._bindings[parent_name]
+            elif parent_uuid in self._bindings:
+                container = self._bindings[parent_uuid]
+        if container is None:
+            return None
+
+        for index_value in element_indices:
+            index = self.resolve(index_value)
+            if index is None:
+                return None
+            try:
+                container = container[int(index)]
+            except (IndexError, KeyError, TypeError, ValueError):
+                return None
+        return container

--- a/qamomile/circuit/transpiler/value_resolver.py
+++ b/qamomile/circuit/transpiler/value_resolver.py
@@ -25,6 +25,8 @@ from typing import Any
 
 import numpy as np
 
+from qamomile.circuit.ir.value import ArrayValue
+
 
 class ValueResolver:
     """Resolve IR Values to concrete Python values.
@@ -121,14 +123,22 @@ class ValueResolver:
         """
         parent_array = getattr(value, "parent_array", None)
         element_indices = getattr(value, "element_indices", None)
-        if parent_array is None or not element_indices:
+        # Only array-element Values have both an ArrayValue parent and
+        # element indices. Plain scalar Values should fall through to the
+        # later parameter/name lookup rules instead of being treated as
+        # failed array accesses.
+        if not isinstance(parent_array, ArrayValue) or not element_indices:
             return None
 
-        container = None
-        get_const_array = getattr(parent_array, "get_const_array", None)
-        if callable(get_const_array):
-            container = get_const_array()
+        # Prefer const_array metadata because bound Vector inputs created
+        # by the frontend keep their compile-time payload on the ArrayValue
+        # itself. Since parent_array is an ArrayValue here, get_const_array
+        # is part of the IR contract and should be called directly.
+        container = parent_array.get_const_array()
         if container is None:
+            # Fall back to explicit bindings for callers that resolve an
+            # element Value against a separate binding map instead of an
+            # ArrayValue carrying const_array metadata.
             parent_name = getattr(parent_array, "name", None)
             parent_uuid = getattr(parent_array, "uuid", None)
             if parent_name in self._bindings:
@@ -136,15 +146,23 @@ class ValueResolver:
             elif parent_uuid in self._bindings:
                 container = self._bindings[parent_uuid]
         if container is None:
+            # No compile-time source exists, so the element must remain
+            # symbolic. Returning None lets the caller preserve that state
+            # rather than inventing a placeholder value.
             return None
 
         for index_value in element_indices:
+            # Every index must be concrete before we can safely index the
+            # Python container. Symbolic indices intentionally stop
+            # resolution here to avoid silently selecting the wrong element.
             index = self.resolve(index_value)
             if index is None:
                 return None
             try:
                 container = container[int(index)]
             except (IndexError, KeyError, TypeError, ValueError):
+                # Shape/type mismatches mean this Value is not resolvable
+                # from the available compile-time data.
                 return None
         return _normalize_bound_scalar(container)
 
@@ -159,6 +177,8 @@ def _normalize_bound_scalar(value: Any) -> Any:
         Any: A Python ``bool``, ``int``, or ``float`` for numeric scalar
             inputs, or the original value for non-numeric objects.
     """
+    # bool is an Integral subclass, so preserve it before the integer
+    # branch. This keeps Bit values from becoming 0/1 integers.
     if isinstance(value, bool):
         return value
     if isinstance(value, numbers.Integral):
@@ -166,6 +186,10 @@ def _normalize_bound_scalar(value: Any) -> Any:
     if isinstance(value, numbers.Real):
         return float(value)
     if isinstance(value, np.generic):
+        # NumPy scalar arrays return np.generic instances on indexing.
+        # Convert only scalar NumPy values; arbitrary object-array
+        # payloads should pass through unchanged unless item() itself
+        # unwraps a NumPy scalar into a Python primitive.
         item = value.item()
         if isinstance(item, bool):
             return item

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -148,6 +148,83 @@ def test_vector_float_element_helper_transpiles_with_bindings():
     assert sum(count for _value, count in result.results) == 16
 
 
+@pytest.mark.skipif(not _HAS_QISKIT, reason="qiskit not installed")
+def test_vector_float_slice_element_helper_transpiles_with_bindings():
+    """A sliced ``Vector[qmc.Float]`` element resolves through ``-angle / 2``."""
+
+    @qmc.qkernel
+    def circuit(slopes_p: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(1, name="qs")
+        view = slopes_p[1:3]
+        qs[0] = qmc.ry(qs[0], -view[0] / 2)
+        return qmc.measure(qs)
+
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        circuit, bindings={"slopes_p": np.array([0.1, 0.3, 0.5])}
+    )
+    ry_angles = [
+        float(instruction.operation.params[0])
+        for instruction in exe.quantum_circuit.data
+        if instruction.operation.name == "ry"
+    ]
+
+    assert ry_angles == pytest.approx([-0.15])
+
+
+class TestVectorFloatSliceElementRegression:
+    """Sliced bound ``Vector[qmc.Float]`` elements compile and execute."""
+
+    @pytest.mark.parametrize("transpiler_factory", BACKENDS)
+    def test_sliced_vector_float_element_expval_runs(self, transpiler_factory):
+        """A main-regression slice element emits the expected rotation angle.
+
+        The user-facing pattern is ``view = slopes_p[1:3]`` followed by
+        ``-view[0] / 2``. On main, the sliced element does not resolve to
+        the root bound value before transpilation; this test pins the
+        fixed path by executing the emitted circuit on every available
+        SDK backend.
+        """
+
+        @qmc.qkernel
+        def circuit(slopes_p: qmc.Vector[qmc.Float], obs: qmc.Observable) -> qmc.Float:
+            qs = qmc.qubit_array(1, name="qs")
+            view = slopes_p[1:3]
+            qs[0] = qmc.ry(qs[0], -view[0] / 2)
+            return qmc.expval(qs, obs)
+
+        slopes = np.array([0.1, 0.3, 0.5])
+        expected = math.cos(-0.15)
+        obs = qm_o.Hamiltonian.zero(num_qubits=1) + qm_o.Z(0)
+        transpiler = transpiler_factory()
+        exe = transpiler.transpile(circuit, bindings={"slopes_p": slopes, "obs": obs})
+        got = exe.run(transpiler.executor()).result()
+
+        assert np.isclose(got, expected, atol=1e-6), (
+            f"[{transpiler_factory.__name__}] expected <Z>={expected}, got {got}"
+        )
+
+    @pytest.mark.parametrize("transpiler_factory", BACKENDS)
+    def test_sliced_vector_float_element_sampling_runs(self, transpiler_factory):
+        """The same slice-element regression deterministically samples all-zero."""
+
+        @qmc.qkernel
+        def circuit(slopes_p: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(1, name="qs")
+            view = slopes_p[1:3]
+            qs[0] = qmc.ry(qs[0], -view[0] / 2)
+            return qmc.measure(qs)
+
+        transpiler = transpiler_factory()
+        exe = transpiler.transpile(
+            circuit, bindings={"slopes_p": np.array([0.1, 0.0, 0.5])}
+        )
+        result = exe.sample(transpiler.executor(), shots=64).result()
+
+        assert sum(count for _value, count in result.results) == 64
+        assert result.results == [((0,), 64)]
+
+
 class TestNegCancelsRotation:
     """``ry(theta)`` followed by ``ry(-theta)`` is the identity."""
 

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -89,9 +89,63 @@ BACKENDS = [
 _BOUNDARY_ANGLES = [0.0, math.pi, 2.0 * math.pi, -0.7]
 
 
+def _manual_cry_half_angle(
+    ctrl: qmc.Qubit, tgt: qmc.Qubit, angle: float
+) -> tuple[qmc.Qubit, qmc.Qubit]:
+    """Decompose CRY with the same symbolic half-angle form users write.
+
+    Args:
+        ctrl (qmc.Qubit): Control qubit consumed by the decomposition.
+        tgt (qmc.Qubit): Target qubit consumed by the decomposition.
+        angle (float): Rotation angle. Tests intentionally pass a
+            ``qmc.Float`` value through this annotation to mirror user
+            helper code written with a Python ``float`` annotation.
+
+    Returns:
+        tuple[qmc.Qubit, qmc.Qubit]: Updated control and target qubits.
+    """
+    tgt = qmc.ry(tgt, angle / 2)
+    ctrl, tgt = qmc.cx(ctrl, tgt)
+    tgt = qmc.ry(tgt, -angle / 2)
+    ctrl, tgt = qmc.cx(ctrl, tgt)
+    return ctrl, tgt
+
+
 def test_float_handle_exposes_neg():
     """``qamomile.circuit.Float`` implements ``__neg__`` (issue #329 fix)."""
     assert hasattr(qmc.Float, "__neg__")
+
+
+def test_vector_float_element_helper_supports_negated_half_angle():
+    """A ``Vector[qmc.Float]`` element can flow through ``-angle / 2``."""
+
+    @qmc.qkernel
+    def circuit(slopes_p: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(2, name="qs")
+        qs[0], qs[1] = _manual_cry_half_angle(qs[0], qs[1], slopes_p[0])
+        return qmc.measure(qs)
+
+    block = circuit.build(slopes_p=np.array([0.3]))
+
+    assert block.operations
+
+
+@pytest.mark.skipif(not _HAS_QISKIT, reason="qiskit not installed")
+def test_vector_float_element_helper_transpiles_with_bindings():
+    """Qiskit transpilation accepts the user-reported ``-angle / 2`` pattern."""
+
+    @qmc.qkernel
+    def circuit(slopes_p: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(2, name="qs")
+        qs[0], qs[1] = _manual_cry_half_angle(qs[0], qs[1], slopes_p[0])
+        return qmc.measure(qs)
+
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(circuit, bindings={"slopes_p": np.array([0.3])})
+    result = exe.sample(transpiler.executor(), shots=16).result()
+
+    assert exe.quantum_circuit.num_qubits == 2
+    assert sum(count for _value, count in result.results) == 16
 
 
 class TestNegCancelsRotation:

--- a/tests/transpiler/test_value_resolver_array_elements.py
+++ b/tests/transpiler/test_value_resolver_array_elements.py
@@ -1,0 +1,67 @@
+"""Unit tests for shared compile-time array-element value resolution."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from qamomile.circuit.ir.types import ObservableType
+from qamomile.circuit.ir.types.primitives import BitType, FloatType, UIntType
+from qamomile.circuit.ir.value import ArrayValue, Value
+from qamomile.circuit.transpiler.value_resolver import ValueResolver
+
+
+def _array_element(array_type: Any, name: str = "values") -> Value:
+    """Create a one-dimensional array-element Value.
+
+    Args:
+        array_type (Any): Element type assigned to the parent
+            ``ArrayValue`` and returned element ``Value``.
+        name (str): Parent array name used for binding lookup. Defaults
+            to ``"values"``.
+
+    Returns:
+        Value: A Value representing ``name[0]`` with constant index 0.
+    """
+    parent = ArrayValue(
+        type=array_type,
+        name=name,
+        shape=(Value(type=UIntType(), name="dim").with_const(1),),
+    )
+    index = Value(type=UIntType(), name="idx").with_const(0)
+    return Value(
+        type=array_type,
+        name=f"{name}[0]",
+        parent_array=parent,
+        element_indices=(index,),
+    )
+
+
+@pytest.mark.parametrize(
+    ("array_type", "value", "expected", "expected_type"),
+    [
+        (FloatType(), np.float32(0.25), 0.25, float),
+        (UIntType(), np.int64(7), 7, int),
+        (BitType(), np.bool_(True), True, bool),
+    ],
+)
+def test_bound_array_element_normalizes_numpy_scalar(
+    array_type, value, expected, expected_type
+):
+    """A bound ndarray element resolves to Python primitives, not NumPy scalars."""
+    resolved = ValueResolver(bindings={"values": np.array([value])}).resolve(
+        _array_element(array_type)
+    )
+
+    assert resolved == expected
+    assert type(resolved) is expected_type
+
+
+def test_bound_array_element_preserves_non_numeric_object():
+    """A bound object-array element resolves without numeric coercion."""
+    marker = object()
+    resolved = ValueResolver(
+        bindings={"values": np.array([marker], dtype=object)}
+    ).resolve(_array_element(ObservableType()))
+
+    assert resolved is marker

--- a/tests/transpiler/test_value_resolver_array_elements.py
+++ b/tests/transpiler/test_value_resolver_array_elements.py
@@ -7,7 +7,12 @@ import pytest
 
 from qamomile.circuit.ir.types import ObservableType
 from qamomile.circuit.ir.types.primitives import BitType, FloatType, UIntType
-from qamomile.circuit.ir.value import ArrayValue, Value
+from qamomile.circuit.ir.value import (
+    ArrayRuntimeMetadata,
+    ArrayValue,
+    Value,
+    ValueMetadata,
+)
 from qamomile.circuit.transpiler.value_resolver import ValueResolver
 
 
@@ -65,3 +70,63 @@ def test_bound_array_element_preserves_non_numeric_object():
     ).resolve(_array_element(ObservableType()))
 
     assert resolved is marker
+
+
+def test_sliced_array_element_resolves_from_root_const_array():
+    """A sliced array element maps its local index back to root const_array data."""
+    root = ArrayValue(
+        type=FloatType(),
+        name="values",
+        shape=(Value(type=UIntType(), name="dim").with_const(4),),
+        metadata=ValueMetadata(
+            array_runtime=ArrayRuntimeMetadata(
+                const_array=np.array([0.1, 0.3, 0.5, 0.7])
+            )
+        ),
+    )
+    sliced = ArrayValue(
+        type=FloatType(),
+        name="values[slice]",
+        shape=(Value(type=UIntType(), name="slice_dim").with_const(2),),
+        slice_of=root,
+        slice_start=Value(type=UIntType(), name="start").with_const(1),
+        slice_step=Value(type=UIntType(), name="step").with_const(2),
+    )
+    element = Value(
+        type=FloatType(),
+        name="values[slice][1]",
+        parent_array=sliced,
+        element_indices=(Value(type=UIntType(), name="idx").with_const(1),),
+    )
+
+    assert ValueResolver().resolve(element) == 0.7
+
+
+def test_sliced_array_element_resolves_from_root_binding():
+    """A sliced array element maps its local index back to root bound data."""
+    root = ArrayValue(
+        type=UIntType(),
+        name="values",
+        shape=(Value(type=UIntType(), name="dim").with_const(4),),
+    )
+    sliced = ArrayValue(
+        type=UIntType(),
+        name="values[slice]",
+        shape=(Value(type=UIntType(), name="slice_dim").with_const(2),),
+        slice_of=root,
+        slice_start=Value(type=UIntType(), name="start").with_const(1),
+        slice_step=Value(type=UIntType(), name="step").with_const(2),
+    )
+    element = Value(
+        type=UIntType(),
+        name="values[slice][1]",
+        parent_array=sliced,
+        element_indices=(Value(type=UIntType(), name="idx").with_const(1),),
+    )
+
+    resolved = ValueResolver(bindings={"values": np.array([2, 4, 6, 8])}).resolve(
+        element
+    )
+
+    assert resolved == 8
+    assert type(resolved) is int


### PR DESCRIPTION
## Summary
- Resolve compile-time bound Vector element values through the shared transpiler ValueResolver.
- Add regression coverage for the user-reported manual CRY half-angle pattern using -angle / 2, including Qiskit transpilation and sampling.

## Tests
- uv run pytest tests/circuit/test_float_neg.py tests/circuit/test_parameter_array_shape.py tests/circuit/test_qkernel_literal_promotion.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/