### PR TITLE
Fix spurious MultipleQuantumSegmentsError for parameter-expression gate angles

### DIFF
--- a/qamomile/circuit/transpiler/passes/analyze.py
+++ b/qamomile/circuit/transpiler/passes/analyze.py
@@ -122,6 +122,15 @@ def find_measurement_derived_values(
         set[str]: The set of all UUIDs transitively derived from a
             measurement, including the seeds themselves.
     """
+    # Build a reverse adjacency map once (dependency -> dependents) so taint
+    # propagation is a linear worklist traversal instead of rescanning the
+    # whole graph for every popped node (which is O(N^2) and shows up as a
+    # compile-time cost on large kernels, since this runs on every transpile).
+    dependents: dict[str, list[str]] = {}
+    for uuid, deps in dependency_graph.items():
+        for dep in deps:
+            dependents.setdefault(dep, []).append(uuid)
+
     derived: set[str] = set()
     worklist = list(measurement_uuids)
     while worklist:
@@ -129,9 +138,9 @@ def find_measurement_derived_values(
         if current in derived:
             continue
         derived.add(current)
-        for uuid, deps in dependency_graph.items():
-            if current in deps and uuid not in derived:
-                worklist.append(uuid)
+        for dependent in dependents.get(current, ()):
+            if dependent not in derived:
+                worklist.append(dependent)
     return derived
 
 

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -627,9 +627,7 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             for op in operations:
                 if id(op) not in absorbable:
                     continue
-                if self._has_classical_sink(
-                    op, consumers, absorbable, top_level_owner
-                ):
+                if self._has_classical_sink(op, consumers, absorbable, top_level_owner):
                     absorbable.discard(id(op))
                     changed = True
         return absorbable

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -279,15 +279,16 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             v.uuid for v in block.output_values if isinstance(v, ValueBase)
         }
 
-        # Absorbable set: top-level classical ops that may be folded into the
-        # surrounding quantum segment. An op qualifies only when its results
-        # are consumed exclusively by quantum / hybrid ops, or by other
-        # absorbable classical ops that themselves ultimately feed quantum —
-        # never by a classical sink (a classical-segment op, a measurement-
-        # derived op, or a block output). Computing this transitively is what
-        # makes a chain like ``(phase * 2) - 1`` feeding a gate fully
-        # absorbable while a value read back by later classical work stays in
-        # its own classical segment.
+        # Absorbable set: classical ops (top-level or nested) whose results are
+        # consumed exclusively by quantum / hybrid ops, or by other absorbable
+        # classical ops that themselves ultimately feed quantum — never by a
+        # classical sink (a classical-segment op, a measurement-derived op, or a
+        # block output). Only top-level members are actually folded into a
+        # segment below; nested members ride inside their control-flow op and
+        # are tracked here only so the sink analysis treats a nested chain link
+        # correctly. Computing this transitively is what makes a chain like
+        # ``(phase * 2) - 1`` feeding a gate fully absorbable while a value read
+        # back by later classical work stays in its own classical segment.
         self._absorbable_op_ids = self._compute_absorbable(block.operations)
 
         current_ops: list[Operation] = []
@@ -556,10 +557,21 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
     def _compute_absorbable(self, operations: list[Operation]) -> set[int]:
         """Compute the set of classical ops safe to fold into a quantum segment.
 
-        A top-level classical op is *absorbable* when it is non-measurement,
-        feeds a quantum gate, is not a block output, and — transitively — every
-        consumer of its results is a quantum / hybrid op or another absorbable
-        classical op. This greatest-fixpoint keeps a chain of gate-angle
+        A classical op is *absorbable* when it is non-measurement, feeds a
+        quantum gate, is not a block output, and — transitively — every consumer
+        of its results is a quantum / hybrid op or another absorbable classical
+        op. Candidates include classical ops nested inside control-flow bodies
+        (e.g. ``angle = base + 1`` inside ``qmc.range``), not just top-level
+        ones: a nested chain link that ultimately feeds only quantum ops must be
+        able to qualify so a top-level op feeding it stays absorbable, while a
+        nested classical op whose result is a block output (or otherwise flows
+        to a classical sink) must NOT qualify so the op feeding it is kept out
+        of the quantum segment. Only top-level ops are actually folded into a
+        segment at segmentation time; nested ops ride inside their enclosing
+        control-flow op, so their membership here is used purely for the sink
+        analysis.
+
+        This iterate-until-stable computation keeps a chain of gate-angle
         expressions (e.g. ``(phase * 2) - 1``) absorbable while refusing to
         absorb a value that is also read back by later classical work or
         returned, which would be dropped by the (classical-op-free) quantum
@@ -569,8 +581,8 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             operations (list[Operation]): Top-level operations of the block.
 
         Returns:
-            set[int]: ``id()`` of every top-level classical op that may be
-                absorbed into the surrounding quantum segment.
+            set[int]: ``id()`` of every classical op (top-level or nested) that
+                is safe with respect to the quantum-segment absorption.
         """
 
         class ConsumerCollector(ControlFlowVisitor):
@@ -597,22 +609,13 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         collector.visit_operations(operations)
         consumers = collector.consumers
 
-        # Map every op (nested or top-level) to its top-level ancestor. A
-        # consumer's segment is decided by the top-level op that contains it:
-        # an op nested inside a quantum-effective control-flow body (e.g. a
-        # ``BinOp`` inside ``qmc.range``) rides in the quantum segment, not a
-        # classical one. Classifying a nested consumer by its own kind would
-        # wrongly treat such a chain link as a classical sink and reject a
-        # valid pure-quantum nested angle expression.
-        top_level_owner = self._build_top_level_owner(operations)
-
-        # Seed candidates: non-measurement, quantum-feeding, non-output
-        # top-level classical ops.
+        # Candidates: every classical op (recursing into control-flow bodies)
+        # that is non-measurement, quantum-feeding, and not a block output.
+        classical_ops = self._collect_classical_ops(operations)
         absorbable: set[int] = {
             id(op)
-            for op in operations
-            if op.operation_kind == OperationKind.CLASSICAL
-            and not self._is_measurement_tainted(op)
+            for op in classical_ops
+            if not self._is_measurement_tainted(op)
             and self._feeds_quantum(op)
             and not self._produces_block_output(op)
         }
@@ -620,85 +623,63 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         # Iteratively drop any candidate that has a result consumed by a
         # classical sink — a consumer that is neither a quantum/hybrid op nor a
         # (still-)absorbable classical op. Removing one op can disqualify the
-        # ops feeding it, so iterate to a fixpoint.
+        # ops feeding it, so iterate until the set stops changing.
         changed = True
         while changed:
             changed = False
-            for op in operations:
+            for op in classical_ops:
                 if id(op) not in absorbable:
                     continue
-                if self._has_classical_sink(op, consumers, absorbable, top_level_owner):
+                if self._has_classical_sink(op, consumers, absorbable):
                     absorbable.discard(id(op))
                     changed = True
         return absorbable
 
-    def _build_top_level_owner(
-        self, operations: list[Operation]
-    ) -> dict[int, Operation]:
-        """Map every operation to the top-level operation that contains it.
-
-        Walks each top-level op and, recursively, the bodies of any nested
-        control-flow op, recording the top-level ancestor for every
-        descendant. A top-level op maps to itself. Used to decide which
-        segment a (possibly nested) consumer executes in.
+    def _collect_classical_ops(self, operations: list[Operation]) -> list[Operation]:
+        """Collect every classical-kind op, recursing into control-flow bodies.
 
         Args:
-            operations (list[Operation]): Top-level operations of the block.
+            operations (list[Operation]): Operations to walk (a block's
+                top-level list or a control-flow op's nested body).
 
         Returns:
-            dict[int, Operation]: ``id(op) -> top-level ancestor op`` for every
-                op reachable from ``operations`` (including the top-level ops
-                themselves).
+            list[Operation]: Every ``OperationKind.CLASSICAL`` op reachable from
+                ``operations``, including those nested inside control flow.
         """
-        owner: dict[int, Operation] = {}
-
-        def record(op: Operation, top: Operation) -> None:
-            """Record ``top`` as the top-level owner of ``op`` and its descendants.
-
-            Args:
-                op (Operation): The current (possibly nested) operation.
-                top (Operation): The top-level ancestor of ``op``.
-
-            Returns:
-                None: Mutates the enclosing ``owner`` map in place.
-            """
-            owner[id(op)] = top
+        result: list[Operation] = []
+        for op in operations:
+            if op.operation_kind == OperationKind.CLASSICAL:
+                result.append(op)
             if isinstance(op, HasNestedOps):
                 for body in op.nested_op_lists():
-                    for inner in body:
-                        record(inner, top)
-
-        for op in operations:
-            record(op, op)
-        return owner
+                    result.extend(self._collect_classical_ops(body))
+        return result
 
     def _has_classical_sink(
         self,
         op: Operation,
         consumers: dict[str, list[Operation]],
         absorbable: set[int],
-        top_level_owner: dict[int, Operation],
     ) -> bool:
         """Return whether any result of ``op`` is read by a classical sink.
 
         A classical sink is a consumer that will run in a classical segment
-        (measurement post-processing, a non-absorbable classical expression,
-        classical control flow) and would therefore fail to read a value buried
-        in a quantum segment. The segment a consumer runs in is decided by its
-        top-level ancestor: a consumer nested inside a quantum/hybrid-effective
-        control-flow body rides in the quantum segment (not a sink), and a
-        top-level absorbable classical op joins the quantum segment too. Only
-        consumers owned by a genuinely classical top-level op are sinks.
+        (measurement post-processing, a non-absorbable classical expression, a
+        block output, classical control flow) and would therefore fail to read a
+        value buried in a quantum segment. A consumer is safe (not a sink) when
+        it is a quantum / hybrid op — including a gate nested inside a quantum
+        loop, whose own effective kind is QUANTUM/HYBRID — or another currently-
+        absorbable classical op (which may itself be nested). A nested classical
+        consumer is therefore *not* trusted on the strength of its enclosing
+        loop alone: it counts as safe only when it is itself absorbable (i.e.
+        its results, too, flow only to quantum ops and are not block outputs).
 
         Args:
             op (Operation): The candidate op whose results are checked.
             consumers (dict[str, list[Operation]]): Map from value UUID to the
                 operations that read it.
             absorbable (set[int]): ``id()`` of ops still considered absorbable
-                in the current fixpoint iteration.
-            top_level_owner (dict[int, Operation]): Map from ``id(op)`` to the
-                top-level op that contains it, as built by
-                :meth:`_build_top_level_owner`.
+                in the current iteration.
 
         Returns:
             bool: ``True`` if some result of ``op`` is consumed by a classical
@@ -710,13 +691,12 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             for consumer in consumers.get(result.uuid, ()):
                 if consumer is op:
                     continue
-                owner = top_level_owner.get(id(consumer), consumer)
-                if self._effective_kind(owner) in (
+                if self._effective_kind(consumer) in (
                     OperationKind.QUANTUM,
                     OperationKind.HYBRID,
                 ):
                     continue
-                if id(owner) in absorbable:
+                if id(consumer) in absorbable:
                     continue
                 return True
         return False

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -388,6 +388,36 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                     pending_absorbable.append(op)
                 continue
 
+            # A non-absorbable, non-measurement classical op whose result is an
+            # input to a quantum / hybrid op (a gate angle, or a controlled-gate
+            # structural parameter) cannot be placed under the single-quantum-
+            # segment model: it is *not* absorbable because it is also read by
+            # classical work or returned as a block output, so it must stay in a
+            # classical segment — but then the quantum op reads a value the
+            # classical segment never threads into the circuit and the backend
+            # silently emits a zero/garbage parameter. (When the op sits between
+            # quantum ops this also manifests as a spurious extra quantum
+            # segment; before the quantum region it produces a legal C→Q plan
+            # with a stranded value, so the multi-segment check alone misses
+            # it.) Reject explicitly here so the user gets an error instead of a
+            # wrong result. Measurement-derived ops are handled separately
+            # (``RuntimeClassicalExpr`` / mid-circuit measurement) and excluded.
+            if (
+                op_kind == OperationKind.CLASSICAL
+                and not isinstance(op, RuntimeClassicalExpr)
+                and not self._is_measurement_tainted(op)
+                and self._feeds_quantum(op)
+            ):
+                raise MultipleQuantumSegmentsError(
+                    "A classical value used as a quantum gate parameter is also "
+                    "consumed by classical work or returned as a block output, so "
+                    "it cannot be absorbed into the single quantum segment (it "
+                    "would otherwise be stranded in a classical segment and the "
+                    "gate would silently receive a zero parameter). Compute the "
+                    "value so it flows only to quantum gates, or restructure the "
+                    "kernel so the classical consumer does not share it."
+                )
+
             if current_kind is None:
                 current_kind = op_kind
 

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -293,6 +293,12 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
 
         current_ops: list[Operation] = []
         current_kind: OperationKind | None = None
+        # Parameter-expression classical ops (the gate-angle expressions this
+        # work absorbs) that appear before / outside the quantum segment. They
+        # are held here and prepended to the quantum segment once it starts, so
+        # they end up computed inside the quantum circuit regardless of where
+        # the user wrote them — never stranded in a classical prep segment.
+        pending_absorbable: list[Operation] = []
 
         for op in block.operations:
             # Skip ReturnOperation - it's a terminal operation handled separately
@@ -342,6 +348,9 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                 # Note: we stay in QUANTUM mode to accumulate consecutive measurements
                 if current_kind != OperationKind.QUANTUM:
                     current_kind = OperationKind.QUANTUM
+                if pending_absorbable:
+                    current_ops.extend(pending_absorbable)
+                    pending_absorbable = []
                 current_ops.append(op)
 
                 # Create boundary for tracking quantum-classical transition
@@ -352,6 +361,31 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                     value_ref=op.results[0].uuid if op.results else "",
                 )
                 self._boundaries.append(boundary)
+                continue
+
+            # Non-measurement parameter / structural classical ops (the
+            # gate-angle expressions this segmentation work exists for) belong
+            # in the quantum segment regardless of where they appear. Without
+            # this, an interleaved op forces a spurious
+            # quantum→classical→quantum split (``MultipleQuantumSegmentsError``)
+            # and an op written *before* the quantum segment (e.g. ``angle =
+            # -phase`` computed before ``qmc.qubit_array``) is stranded in a
+            # classical prep segment, where the backend has no gate to attach
+            # the parameter expression to and silently emits a zero angle.
+            # ``_absorbable_op_ids`` (from :meth:`_compute_absorbable`) holds
+            # exactly the ops safe to absorb: non-measurement classical ops
+            # whose results flow only to quantum ops (directly or through other
+            # absorbable classical ops) and are not block outputs. When already
+            # inside the quantum segment we append directly; otherwise we hold
+            # the op and prepend it when the quantum segment starts. Ops read
+            # back by a classical segment or returned are *not* in the set, so
+            # they stay classical (an explicit error rather than a dropped
+            # value if that forces a split).
+            if op_kind == OperationKind.CLASSICAL and id(op) in self._absorbable_op_ids:
+                if current_kind == OperationKind.QUANTUM:
+                    current_ops.append(op)
+                else:
+                    pending_absorbable.append(op)
                 continue
 
             if current_kind is None:
@@ -374,32 +408,6 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                 current_ops.append(op)
                 continue
 
-            # Parameter / structural classical ops that are *not* derived
-            # from a measurement (e.g. a gate-angle expression like
-            # ``theta=-phase`` over a runtime parameter, which constant
-            # folding cannot collapse because ``phase`` stays symbolic) must
-            # not split the surrounding quantum region. They are emit-time
-            # foldable into a backend parameter expression and belong with
-            # the gate they feed. Without this carve-out such an op forces a
-            # spurious quantum→classical→quantum boundary, raising
-            # ``MultipleQuantumSegmentsError`` for valid pure-quantum
-            # kernels (e.g. a symbolic multi-control phase inside a loop).
-            #
-            # ``_absorbable_op_ids`` (computed in :meth:`_compute_absorbable`)
-            # holds exactly the ops for which absorption is safe: non-measurement
-            # classical ops whose results are consumed *only* by quantum/hybrid
-            # ops (directly or through other absorbed classical ops) and are not
-            # block outputs. Ops read back by a classical segment or returned
-            # stay classical so the executor runs them; if that forces a split
-            # the user gets an explicit error rather than a dropped value.
-            if (
-                op_kind == OperationKind.CLASSICAL
-                and current_kind == OperationKind.QUANTUM
-                and id(op) in self._absorbable_op_ids
-            ):
-                current_ops.append(op)
-                continue
-
             if op_kind != current_kind and op_kind in (
                 OperationKind.QUANTUM,
                 OperationKind.CLASSICAL,
@@ -411,7 +419,25 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                     current_ops = []
                 current_kind = op_kind
 
+            # Entering (or continuing) the quantum segment: pull in any held
+            # parameter-expression ops so they are computed inside the quantum
+            # circuit, ahead of the gate that consumes them.
+            if current_kind == OperationKind.QUANTUM and pending_absorbable:
+                current_ops.extend(pending_absorbable)
+                pending_absorbable = []
+
             current_ops.append(op)
+
+        # Drain any held parameter-expression ops. They are normally emptied
+        # when the quantum segment started; a non-empty remainder here means a
+        # malformed multi-quantum stream (rejected downstream by the
+        # single-quantum-segment strategy), so fold them into the final segment
+        # rather than dropping them.
+        if pending_absorbable:
+            if current_kind is None:
+                current_kind = OperationKind.QUANTUM
+            current_ops.extend(pending_absorbable)
+            pending_absorbable = []
 
         # Flush final segment
         if current_ops:

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -279,6 +279,17 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             v.uuid for v in block.output_values if isinstance(v, ValueBase)
         }
 
+        # Absorbable set: top-level classical ops that may be folded into the
+        # surrounding quantum segment. An op qualifies only when its results
+        # are consumed exclusively by quantum / hybrid ops, or by other
+        # absorbable classical ops that themselves ultimately feed quantum —
+        # never by a classical sink (a classical-segment op, a measurement-
+        # derived op, or a block output). Computing this transitively is what
+        # makes a chain like ``(phase * 2) - 1`` feeding a gate fully
+        # absorbable while a value read back by later classical work stays in
+        # its own classical segment.
+        self._absorbable_op_ids = self._compute_absorbable(block.operations)
+
         current_ops: list[Operation] = []
         current_kind: OperationKind | None = None
 
@@ -373,26 +384,17 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             # ``MultipleQuantumSegmentsError`` for valid pure-quantum
             # kernels (e.g. a symbolic multi-control phase inside a loop).
             #
-            # Two guards keep the absorption safe:
-            #   * ``not _is_measurement_tainted`` — measurement-derived
-            #     classical ops are either ``RuntimeClassicalExpr`` (absorbed
-            #     above) or genuine post-processing (e.g.
-            #     ``DecodeQFixedOperation``) that must stay classical.
-            #   * ``_feeds_quantum`` — the op's result must actually be needed
-            #     by a quantum gate. A classical op whose result feeds only
-            #     later classical steps stays in its own classical segment;
-            #     absorbing it into a quantum segment would drop its value
-            #     (quantum segments never run classical ops).
-            #   * ``not _produces_block_output`` — even a gate-feeding op must
-            #     stay classical when its result is also a block output, so the
-            #     executor runs it and the returned value is surfaced rather
-            #     than silently dropped.
+            # ``_absorbable_op_ids`` (computed in :meth:`_compute_absorbable`)
+            # holds exactly the ops for which absorption is safe: non-measurement
+            # classical ops whose results are consumed *only* by quantum/hybrid
+            # ops (directly or through other absorbed classical ops) and are not
+            # block outputs. Ops read back by a classical segment or returned
+            # stay classical so the executor runs them; if that forces a split
+            # the user gets an explicit error rather than a dropped value.
             if (
                 op_kind == OperationKind.CLASSICAL
                 and current_kind == OperationKind.QUANTUM
-                and not self._is_measurement_tainted(op)
-                and self._feeds_quantum(op)
-                and not self._produces_block_output(op)
+                and id(op) in self._absorbable_op_ids
             ):
                 current_ops.append(op)
                 continue
@@ -548,6 +550,117 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         outputs = self._block_output_uuids
         for v in op.results:
             if isinstance(v, ValueBase) and v.uuid in outputs:
+                return True
+        return False
+
+    def _compute_absorbable(self, operations: list[Operation]) -> set[int]:
+        """Compute the set of classical ops safe to fold into a quantum segment.
+
+        A top-level classical op is *absorbable* when it is non-measurement,
+        feeds a quantum gate, is not a block output, and — transitively — every
+        consumer of its results is a quantum / hybrid op or another absorbable
+        classical op. This greatest-fixpoint keeps a chain of gate-angle
+        expressions (e.g. ``(phase * 2) - 1``) absorbable while refusing to
+        absorb a value that is also read back by later classical work or
+        returned, which would be dropped by the (classical-op-free) quantum
+        segment at execution time.
+
+        Args:
+            operations (list[Operation]): Top-level operations of the block.
+
+        Returns:
+            set[int]: ``id()`` of every top-level classical op that may be
+                absorbed into the surrounding quantum segment.
+        """
+
+        class ConsumerCollector(ControlFlowVisitor):
+            """Map each value UUID to the operations that read it."""
+
+            def __init__(self) -> None:
+                """Initialize the empty consumer map."""
+                self.consumers: dict[str, list[Operation]] = {}
+
+            def visit_operation(self, op: Operation) -> None:
+                """Record ``op`` as a consumer of each of its input values.
+
+                Args:
+                    op (Operation): The operation being visited.
+
+                Returns:
+                    None: Mutates ``self.consumers`` in place.
+                """
+                for v in op.all_input_values():
+                    if isinstance(v, ValueBase):
+                        self.consumers.setdefault(v.uuid, []).append(op)
+
+        collector = ConsumerCollector()
+        collector.visit_operations(operations)
+        consumers = collector.consumers
+
+        # Seed candidates: non-measurement, quantum-feeding, non-output
+        # top-level classical ops.
+        absorbable: set[int] = {
+            id(op)
+            for op in operations
+            if op.operation_kind == OperationKind.CLASSICAL
+            and not self._is_measurement_tainted(op)
+            and self._feeds_quantum(op)
+            and not self._produces_block_output(op)
+        }
+
+        # Iteratively drop any candidate that has a result consumed by a
+        # classical sink — a consumer that is neither a quantum/hybrid op nor a
+        # (still-)absorbable classical op. Removing one op can disqualify the
+        # ops feeding it, so iterate to a fixpoint.
+        changed = True
+        while changed:
+            changed = False
+            for op in operations:
+                if id(op) not in absorbable:
+                    continue
+                if self._has_classical_sink(op, consumers, absorbable):
+                    absorbable.discard(id(op))
+                    changed = True
+        return absorbable
+
+    def _has_classical_sink(
+        self,
+        op: Operation,
+        consumers: dict[str, list[Operation]],
+        absorbable: set[int],
+    ) -> bool:
+        """Return whether any result of ``op`` is read by a classical sink.
+
+        A classical sink is a consumer that is neither a quantum / hybrid
+        operation nor a currently-absorbable classical op — i.e. an op that
+        will run in a classical segment (measurement post-processing, a
+        non-absorbable classical expression, classical control flow) and would
+        therefore fail to read a value buried in a quantum segment.
+
+        Args:
+            op (Operation): The candidate op whose results are checked.
+            consumers (dict[str, list[Operation]]): Map from value UUID to the
+                operations that read it.
+            absorbable (set[int]): ``id()`` of ops still considered absorbable
+                in the current fixpoint iteration.
+
+        Returns:
+            bool: ``True`` if some result of ``op`` is consumed by a classical
+                sink, ``False`` otherwise.
+        """
+        for result in op.results:
+            if not isinstance(result, ValueBase):
+                continue
+            for consumer in consumers.get(result.uuid, ()):
+                if consumer is op:
+                    continue
+                if self._effective_kind(consumer) in (
+                    OperationKind.QUANTUM,
+                    OperationKind.HYBRID,
+                ):
+                    continue
+                if id(consumer) in absorbable:
+                    continue
                 return True
         return False
 

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -22,6 +22,11 @@ from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.types.primitives import BitType, QubitType, UIntType
 from qamomile.circuit.ir.value import ArrayValue, Value, ValueBase
 from qamomile.circuit.transpiler.passes import Pass
+from qamomile.circuit.transpiler.passes.analyze import (
+    build_dependency_graph,
+    find_measurement_derived_values,
+    find_measurement_results,
+)
 from qamomile.circuit.transpiler.passes.control_flow_visitor import ControlFlowVisitor
 from qamomile.circuit.transpiler.passes.validate_while import ValidateWhileContractPass
 from qamomile.circuit.transpiler.segments import (
@@ -235,6 +240,34 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         segments: list[Segment] = []
         self._boundaries: list[HybridBoundary] = []
 
+        # Measurement-taint set: every value transitively derived from a
+        # measurement result. Computed with the same dataflow utilities as
+        # ``AnalyzePass`` / ``ClassicalLoweringPass`` so the three passes
+        # agree on what "measurement-derived" means. Used below to decide
+        # whether a classical op interleaved in a quantum region is a
+        # genuine post-measurement computation (must split off into its own
+        # classical segment) or a parameter / structural expression that
+        # merely feeds a quantum gate (can stay in the quantum segment).
+        dependency_graph = build_dependency_graph(block.operations)
+        measurement_uuids = find_measurement_results(block.operations)
+        self._measurement_tainted = find_measurement_derived_values(
+            dependency_graph, measurement_uuids
+        )
+
+        # Quantum-needed set: every value transitively required to compute
+        # the operands of a quantum / hybrid operation. A non-measurement
+        # classical op may only be absorbed into a quantum segment when its
+        # result feeds a quantum gate (directly or through a chain of other
+        # classical expressions). A classical op whose result is *not* needed
+        # by any quantum op — e.g. a block output or a value consumed only by
+        # downstream classical post-processing — must stay in its own
+        # classical segment so the executor actually runs it and the
+        # orchestrator can surface its result; absorbing it into a quantum
+        # segment would silently drop its value.
+        self._quantum_needed = self._compute_quantum_needed(
+            block.operations, dependency_graph
+        )
+
         current_ops: list[Operation] = []
         current_kind: OperationKind | None = None
 
@@ -318,6 +351,36 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                 current_ops.append(op)
                 continue
 
+            # Parameter / structural classical ops that are *not* derived
+            # from a measurement (e.g. a gate-angle expression like
+            # ``theta=-phase`` over a runtime parameter, which constant
+            # folding cannot collapse because ``phase`` stays symbolic) must
+            # not split the surrounding quantum region. They are emit-time
+            # foldable into a backend parameter expression and belong with
+            # the gate they feed. Without this carve-out such an op forces a
+            # spurious quantum→classical→quantum boundary, raising
+            # ``MultipleQuantumSegmentsError`` for valid pure-quantum
+            # kernels (e.g. a symbolic multi-control phase inside a loop).
+            #
+            # Two guards keep the absorption safe:
+            #   * ``not _is_measurement_tainted`` — measurement-derived
+            #     classical ops are either ``RuntimeClassicalExpr`` (absorbed
+            #     above) or genuine post-processing (e.g.
+            #     ``DecodeQFixedOperation``) that must stay classical.
+            #   * ``_feeds_quantum`` — the op's result must actually be needed
+            #     by a quantum gate. A classical op whose result is a block
+            #     output or feeds only later classical steps stays in its own
+            #     classical segment; absorbing it into a quantum segment would
+            #     drop its value (quantum segments never run classical ops).
+            if (
+                op_kind == OperationKind.CLASSICAL
+                and current_kind == OperationKind.QUANTUM
+                and not self._is_measurement_tainted(op)
+                and self._feeds_quantum(op)
+            ):
+                current_ops.append(op)
+                continue
+
             if op_kind != current_kind and op_kind in (
                 OperationKind.QUANTUM,
                 OperationKind.CLASSICAL,
@@ -340,6 +403,117 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         self._compute_segment_io(segments, block)
 
         return segments
+
+    def _compute_quantum_needed(
+        self,
+        operations: list[Operation],
+        dependency_graph: dict[str, set[str]],
+    ) -> set[str]:
+        """Collect every value required to compute a quantum op's inputs.
+
+        Seeds from the input values of every quantum / hybrid operation
+        (walked recursively through control flow) and back-propagates through
+        ``dependency_graph`` so that a chain of classical expressions feeding
+        a gate angle (e.g. ``(phase * 2) - 1``) is fully covered, not just the
+        expression directly wired to the gate.
+
+        Args:
+            operations (list[Operation]): Top-level operations of the block.
+            dependency_graph (dict[str, set[str]]): ``result_uuid ->
+                set(operand_uuid, ...)`` as produced by
+                ``build_dependency_graph``.
+
+        Returns:
+            set[str]: UUIDs of all values transitively needed by a quantum or
+                hybrid operation.
+        """
+
+        class QuantumInputCollector(ControlFlowVisitor):
+            """Collect input-value UUIDs of every quantum / hybrid operation."""
+
+            def __init__(self) -> None:
+                """Initialize the empty input-UUID accumulator."""
+                self.inputs: set[str] = set()
+
+            def visit_operation(self, op: Operation) -> None:
+                """Record the input-value UUIDs of a quantum / hybrid op.
+
+                Args:
+                    op (Operation): The operation being visited.
+
+                Returns:
+                    None: Mutates ``self.inputs`` in place.
+                """
+                if op.operation_kind in (
+                    OperationKind.QUANTUM,
+                    OperationKind.HYBRID,
+                ):
+                    for v in op.all_input_values():
+                        if isinstance(v, ValueBase):
+                            self.inputs.add(v.uuid)
+
+        collector = QuantumInputCollector()
+        collector.visit_operations(operations)
+
+        needed: set[str] = set()
+        worklist = list(collector.inputs)
+        while worklist:
+            current = worklist.pop()
+            if current in needed:
+                continue
+            needed.add(current)
+            for dep in dependency_graph.get(current, ()):
+                if dep not in needed:
+                    worklist.append(dep)
+        return needed
+
+    def _is_measurement_tainted(self, op: Operation) -> bool:
+        """Return whether ``op`` participates in the measurement dataflow.
+
+        An operation is measurement-tainted when any of its input values or
+        results is transitively derived from a measurement result (per the
+        taint set computed in :meth:`_build_segments_list`). Such ops are
+        genuine classical post-processing and must be kept in their own
+        classical segment; non-tainted classical ops are parameter /
+        structural expressions that can stay inside a quantum segment.
+
+        Args:
+            op (Operation): The operation to classify.
+
+        Returns:
+            bool: ``True`` if any input value or result UUID is in the
+                measurement-taint set, ``False`` otherwise.
+        """
+        tainted = self._measurement_tainted
+        for v in op.results:
+            if isinstance(v, ValueBase) and v.uuid in tainted:
+                return True
+        for v in op.all_input_values():
+            if isinstance(v, ValueBase) and v.uuid in tainted:
+                return True
+        return False
+
+    def _feeds_quantum(self, op: Operation) -> bool:
+        """Return whether ``op``'s result is needed by a quantum operation.
+
+        Checks the quantum-needed set computed in
+        :meth:`_build_segments_list`. Only classical ops that feed a quantum
+        gate (directly or through a chain of other classical expressions) may
+        be absorbed into a quantum segment; ops whose results are block
+        outputs or feed only classical post-processing must stay classical.
+
+        Args:
+            op (Operation): The operation to classify.
+
+        Returns:
+            bool: ``True`` if any result UUID is in the quantum-needed set,
+                ``False`` otherwise.
+        """
+        needed = self._quantum_needed
+        for v in op.results:
+            if isinstance(v, ValueBase) and v.uuid in needed:
+                return True
+        return False
 
     def _effective_kind(self, op: Operation) -> OperationKind:
         """Determine the effective kind of an operation.

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -597,6 +597,15 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         collector.visit_operations(operations)
         consumers = collector.consumers
 
+        # Map every op (nested or top-level) to its top-level ancestor. A
+        # consumer's segment is decided by the top-level op that contains it:
+        # an op nested inside a quantum-effective control-flow body (e.g. a
+        # ``BinOp`` inside ``qmc.range``) rides in the quantum segment, not a
+        # classical one. Classifying a nested consumer by its own kind would
+        # wrongly treat such a chain link as a classical sink and reject a
+        # valid pure-quantum nested angle expression.
+        top_level_owner = self._build_top_level_owner(operations)
+
         # Seed candidates: non-measurement, quantum-feeding, non-output
         # top-level classical ops.
         absorbable: set[int] = {
@@ -618,24 +627,70 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             for op in operations:
                 if id(op) not in absorbable:
                     continue
-                if self._has_classical_sink(op, consumers, absorbable):
+                if self._has_classical_sink(
+                    op, consumers, absorbable, top_level_owner
+                ):
                     absorbable.discard(id(op))
                     changed = True
         return absorbable
+
+    def _build_top_level_owner(
+        self, operations: list[Operation]
+    ) -> dict[int, Operation]:
+        """Map every operation to the top-level operation that contains it.
+
+        Walks each top-level op and, recursively, the bodies of any nested
+        control-flow op, recording the top-level ancestor for every
+        descendant. A top-level op maps to itself. Used to decide which
+        segment a (possibly nested) consumer executes in.
+
+        Args:
+            operations (list[Operation]): Top-level operations of the block.
+
+        Returns:
+            dict[int, Operation]: ``id(op) -> top-level ancestor op`` for every
+                op reachable from ``operations`` (including the top-level ops
+                themselves).
+        """
+        owner: dict[int, Operation] = {}
+
+        def record(op: Operation, top: Operation) -> None:
+            """Record ``top`` as the top-level owner of ``op`` and its descendants.
+
+            Args:
+                op (Operation): The current (possibly nested) operation.
+                top (Operation): The top-level ancestor of ``op``.
+
+            Returns:
+                None: Mutates the enclosing ``owner`` map in place.
+            """
+            owner[id(op)] = top
+            if isinstance(op, HasNestedOps):
+                for body in op.nested_op_lists():
+                    for inner in body:
+                        record(inner, top)
+
+        for op in operations:
+            record(op, op)
+        return owner
 
     def _has_classical_sink(
         self,
         op: Operation,
         consumers: dict[str, list[Operation]],
         absorbable: set[int],
+        top_level_owner: dict[int, Operation],
     ) -> bool:
         """Return whether any result of ``op`` is read by a classical sink.
 
-        A classical sink is a consumer that is neither a quantum / hybrid
-        operation nor a currently-absorbable classical op — i.e. an op that
-        will run in a classical segment (measurement post-processing, a
-        non-absorbable classical expression, classical control flow) and would
-        therefore fail to read a value buried in a quantum segment.
+        A classical sink is a consumer that will run in a classical segment
+        (measurement post-processing, a non-absorbable classical expression,
+        classical control flow) and would therefore fail to read a value buried
+        in a quantum segment. The segment a consumer runs in is decided by its
+        top-level ancestor: a consumer nested inside a quantum/hybrid-effective
+        control-flow body rides in the quantum segment (not a sink), and a
+        top-level absorbable classical op joins the quantum segment too. Only
+        consumers owned by a genuinely classical top-level op are sinks.
 
         Args:
             op (Operation): The candidate op whose results are checked.
@@ -643,6 +698,9 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
                 operations that read it.
             absorbable (set[int]): ``id()`` of ops still considered absorbable
                 in the current fixpoint iteration.
+            top_level_owner (dict[int, Operation]): Map from ``id(op)`` to the
+                top-level op that contains it, as built by
+                :meth:`_build_top_level_owner`.
 
         Returns:
             bool: ``True`` if some result of ``op`` is consumed by a classical
@@ -654,12 +712,13 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             for consumer in consumers.get(result.uuid, ()):
                 if consumer is op:
                     continue
-                if self._effective_kind(consumer) in (
+                owner = top_level_owner.get(id(consumer), consumer)
+                if self._effective_kind(owner) in (
                     OperationKind.QUANTUM,
                     OperationKind.HYBRID,
                 ):
                     continue
-                if id(consumer) in absorbable:
+                if id(owner) in absorbable:
                     continue
                 return True
         return False

--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -268,6 +268,17 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             block.operations, dependency_graph
         )
 
+        # Block-output set: UUIDs the block returns. A classical op producing
+        # one of these must stay in a classical segment even if it also feeds
+        # a quantum gate — the executor only runs classical segments, so
+        # absorbing such an op would drop its returned value (the orchestrator
+        # would surface ``None``). Keeping it classical instead surfaces the
+        # value, and if that forces a quantum-segment split the user gets an
+        # explicit error rather than a silently wrong result.
+        self._block_output_uuids = {
+            v.uuid for v in block.output_values if isinstance(v, ValueBase)
+        }
+
         current_ops: list[Operation] = []
         current_kind: OperationKind | None = None
 
@@ -368,15 +379,20 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
             #     above) or genuine post-processing (e.g.
             #     ``DecodeQFixedOperation``) that must stay classical.
             #   * ``_feeds_quantum`` — the op's result must actually be needed
-            #     by a quantum gate. A classical op whose result is a block
-            #     output or feeds only later classical steps stays in its own
-            #     classical segment; absorbing it into a quantum segment would
-            #     drop its value (quantum segments never run classical ops).
+            #     by a quantum gate. A classical op whose result feeds only
+            #     later classical steps stays in its own classical segment;
+            #     absorbing it into a quantum segment would drop its value
+            #     (quantum segments never run classical ops).
+            #   * ``not _produces_block_output`` — even a gate-feeding op must
+            #     stay classical when its result is also a block output, so the
+            #     executor runs it and the returned value is surfaced rather
+            #     than silently dropped.
             if (
                 op_kind == OperationKind.CLASSICAL
                 and current_kind == OperationKind.QUANTUM
                 and not self._is_measurement_tainted(op)
                 and self._feeds_quantum(op)
+                and not self._produces_block_output(op)
             ):
                 current_ops.append(op)
                 continue
@@ -512,6 +528,26 @@ class SegmentationPass(Pass[Block, ProgramPlan]):
         needed = self._quantum_needed
         for v in op.results:
             if isinstance(v, ValueBase) and v.uuid in needed:
+                return True
+        return False
+
+    def _produces_block_output(self, op: Operation) -> bool:
+        """Return whether any result of ``op`` is a block output value.
+
+        Block outputs must be produced inside a classical segment so the
+        executor runs the op and the orchestrator can surface the value;
+        such ops are therefore never absorbed into a quantum segment.
+
+        Args:
+            op (Operation): The operation to classify.
+
+        Returns:
+            bool: ``True`` if any result UUID is in the block-output set,
+                ``False`` otherwise.
+        """
+        outputs = self._block_output_uuids
+        for v in op.results:
+            if isinstance(v, ValueBase) and v.uuid in outputs:
                 return True
         return False
 

--- a/qamomile/cudaq/emitter.py
+++ b/qamomile/cudaq/emitter.py
@@ -21,10 +21,17 @@ import enum
 import itertools
 import linecache
 import math
+import re
 from collections.abc import Callable
 from typing import Any
 
 from qamomile.circuit.transpiler.gate_emitter import MeasurementMode
+
+# Matches the ``thetas`` parameter identifier as a whole word (e.g. ``thetas[0]``
+# or ``cudaq.control(..., thetas)``) without matching unrelated identifiers that
+# merely contain the substring (e.g. ``thetas_count``). Used to detect whether a
+# generated helper body references the entry-point parameter list.
+_THETAS_REFERENCE = re.compile(r"\bthetas\b")
 
 
 def _to_expr(value: Any) -> str:
@@ -400,11 +407,13 @@ class CudaqKernelEmitter:
             # reference before the helper body is built and then reused from
             # the resolver cache, so the flag may stay unset even though the
             # emitted body references ``thetas``. Scan the body as a backstop:
-            # if any line mentions ``thetas`` the helper must take the
-            # entry-point parameter list, otherwise CUDA-Q rejects the helper
-            # with "Invalid variable name 'thetas' is not defined".
+            # if any line mentions ``thetas`` (matched as a whole-word token so
+            # identifiers like ``thetas_count`` do not false-positive) the
+            # helper must take the entry-point parameter list, otherwise CUDA-Q
+            # rejects the helper with "Invalid variable name 'thetas' is not
+            # defined".
             uses_thetas = self._helper_param_used or any(
-                "thetas" in line for line in helper_lines
+                _THETAS_REFERENCE.search(line) for line in helper_lines
             )
             cache_key = (num_targets, uses_thetas, tuple(helper_lines))
             cached_name = self._helper_cache.get(cache_key)

--- a/qamomile/cudaq/emitter.py
+++ b/qamomile/cudaq/emitter.py
@@ -394,7 +394,18 @@ class CudaqKernelEmitter:
         try:
             emit_body()
             helper_lines = self._lines
-            uses_thetas = self._helper_param_used
+            # ``_helper_param_used`` is set when ``create_parameter`` runs
+            # inside the helper-building context. A gate-angle *expression*
+            # (e.g. ``theta=-phase``) can be resolved to a ``thetas[i]``
+            # reference before the helper body is built and then reused from
+            # the resolver cache, so the flag may stay unset even though the
+            # emitted body references ``thetas``. Scan the body as a backstop:
+            # if any line mentions ``thetas`` the helper must take the
+            # entry-point parameter list, otherwise CUDA-Q rejects the helper
+            # with "Invalid variable name 'thetas' is not defined".
+            uses_thetas = self._helper_param_used or any(
+                "thetas" in line for line in helper_lines
+            )
             cache_key = (num_targets, uses_thetas, tuple(helper_lines))
             cached_name = self._helper_cache.get(cache_key)
             if cached_name is not None:

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -20,6 +20,7 @@ import pytest
 import qamomile.circuit as qmc
 import qamomile.observable as qm_o
 from qamomile.circuit.transpiler.errors import EmitError
+from qamomile.circuit.transpiler.segments import MultipleQuantumSegmentsError
 
 Backend = tuple[str, Any, Any]
 SampleMode = Literal["deterministic", "uniform", "bell"]
@@ -812,6 +813,28 @@ def classical_output_after_quantum_run(phase: qmc.Float) -> qmc.Float:
     return phase * 2.0
 
 
+# --- Regression: a value feeding both a gate and later classical work ---
+#
+# ``t = phase * 2`` here feeds a quantum gate (``rx``) *and* a later classical
+# computation (``t + 1``, a block output). Absorbing ``t`` into the quantum
+# segment would let the later classical segment read a value that never executed
+# (the quantum segment runs no classical ops), silently miscompiling. The
+# absorbable-set fixpoint refuses to absorb ``t``, so the kernel raises an
+# explicit ``MultipleQuantumSegmentsError`` instead of producing a wrong result.
+
+
+@qmc.qkernel
+def value_feeding_gate_and_classical_run(
+    phase: qmc.Float,
+) -> tuple[qmc.Vector[qmc.Bit], qmc.Float]:
+    """Use a parameter expression as both a gate angle and a classical output."""
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    angle = phase * 2.0
+    q[0] = qmc.rx(q[0], angle)
+    return qmc.measure(q), angle + 1.0
+
+
 @dataclasses.dataclass(frozen=True)
 class FrontendExecutionCase:
     """Describe one frontend pattern with paired sample and run kernels."""
@@ -1315,3 +1338,19 @@ def test_classical_output_after_quantum_op_is_preserved(backend: Backend) -> Non
     got = executable.run(executor, bindings={"phase": 3.0}).result()
     assert got is not None, f"{name}: classical output was dropped (got None)"
     assert np.isclose(got, 6.0, atol=1e-8), f"{name}: got {got}, expected 6.0"
+
+
+def test_value_feeding_gate_and_classical_is_not_miscompiled(
+    backend: Backend,
+) -> None:
+    """A value used by both a gate and later classical work is not absorbed.
+
+    Guards the absorbable-set fixpoint: a classical op whose result feeds a
+    quantum gate but is also read by a later classical computation must not be
+    folded into the quantum segment (which would let the later classical segment
+    read a value that never executed). The kernel must raise an explicit
+    ``MultipleQuantumSegmentsError`` rather than silently miscompiling.
+    """
+    _name, transpiler, _executor = backend
+    with pytest.raises(MultipleQuantumSegmentsError):
+        transpiler.transpile(value_feeding_gate_and_classical_run, parameters=["phase"])

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -731,6 +731,87 @@ def sliced_pauli_evolve_run(
     return qmc.expval(q, obs)
 
 
+# --- Regression: parameter-expression gate angle must not split segments ---
+#
+# A gate angle that is an *expression* over a runtime parameter (e.g.
+# ``theta=-phase``) lowers to a classical ``BinOp`` that constant folding
+# cannot collapse while ``phase`` stays symbolic. When such an op is
+# interleaved between quantum operations the segmentation pass used to flush
+# the quantum region and start a new one, producing a spurious
+# ``MultipleQuantumSegmentsError`` even though the kernel has no
+# measurement-dependent control flow. These kernels reproduce that shape
+# (a quantum op precedes the negated-angle gate so the ``BinOp`` is genuinely
+# interleaved) and check both sample and expval paths across backends.
+
+
+@qmc.qkernel
+def interleaved_param_expr_sample(phase: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    """Sample ``rx(q, -phase)`` interleaved after a quantum op."""
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    q[0] = qmc.rx(q[0], -phase)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def interleaved_param_expr_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+    """Run expval of ``rx(q, -phase)`` interleaved after a quantum op."""
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    q[0] = qmc.rx(q[0], -phase)
+    return qmc.expval(q, obs)
+
+
+# --- Regression: reported symbolic multi-control phase inside a loop ---
+#
+# The originally reported case (a QSVT / block-encoding circuit): a symbolic
+# multi-control ``qmc.control(qmc.p, num_controls=<symbolic>)`` driven by a
+# negated runtime angle inside a ``qmc.range`` loop. With ``num_controls`` =
+# ``n - 1`` = 1 here, the operation is equivalent to a single concrete
+# ``qmc.cp``; the test asserts the two transpile and execute to the same
+# expectation value, which only holds once the spurious segment split is
+# fixed.
+
+
+@qmc.qkernel
+def symbolic_mc_phase_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+    """Run expval of a symbolic multi-control phase with a negated angle."""
+    q = qmc.qubit_array(2, "q")
+    for i in qmc.range(2):
+        q[i] = qmc.h(q[i])
+    num_signal = qmc.uint(2)
+    cphase = qmc.control(qmc.p, num_controls=num_signal - 1)
+    q[0:1], q[1] = cphase(q[0:1], q[1], theta=-phase)
+    return qmc.expval(q, obs)
+
+
+@qmc.qkernel
+def cp_phase_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+    """Concrete ``qmc.cp`` equivalent of :func:`symbolic_mc_phase_run`."""
+    q = qmc.qubit_array(2, "q")
+    for i in qmc.range(2):
+        q[i] = qmc.h(q[i])
+    q[0], q[1] = qmc.cp(q[0], q[1], -phase)
+    return qmc.expval(q, obs)
+
+
+# --- Regression: a classical output computed after a quantum op is preserved ---
+#
+# The segment carve-out above only absorbs a non-measurement classical op into
+# the quantum segment when its result feeds a quantum gate. A classical
+# parameter expression that is instead a *block output* (and feeds no gate)
+# must remain a real classical segment so the executor runs it and the
+# orchestrator surfaces its value — absorbing it would silently return ``None``.
+
+
+@qmc.qkernel
+def classical_output_after_quantum_run(phase: qmc.Float) -> qmc.Float:
+    """Return a parameter expression computed after an unrelated quantum op."""
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    return phase * 2.0
+
+
 @dataclasses.dataclass(frozen=True)
 class FrontendExecutionCase:
     """Describe one frontend pattern with paired sample and run kernels."""
@@ -1135,3 +1216,102 @@ def test_bound_control_indices_duplicate_rejected(backend: Backend) -> None:
             bound_control_indices_sample,
             bindings={"n": 2, "i": 0, "j": 0},
         )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 42])
+def test_interleaved_param_expr_angle_sample_and_run(
+    backend: Backend, seed: int
+) -> None:
+    """A runtime-parameter angle expression must not split quantum segments.
+
+    Regression for the spurious ``MultipleQuantumSegmentsError`` raised when a
+    gate-angle expression (``rx(q, -phase)``) over a runtime parameter is
+    interleaved between quantum operations. Checks the negated angle is applied
+    with the correct sign on both the sample and expval paths.
+    """
+    name, transpiler, executor = backend
+    rng = np.random.default_rng(seed)
+    # Include boundary angles (0, pi, 2*pi) alongside a random one.
+    angles = [0.0, math.pi, 2 * math.pi, float(rng.uniform(0.1, 2 * math.pi - 0.1))]
+    shots = 4096
+
+    sample_executable = transpiler.transpile(
+        interleaved_param_expr_sample, parameters=["phase"]
+    )
+    run_executable = transpiler.transpile(
+        interleaved_param_expr_run,
+        bindings={"obs": qm_o.Y(0)},
+        parameters=["phase"],
+    )
+
+    for phase in angles:
+        counts = _counts(
+            sample_executable.sample(
+                executor, shots=shots, bindings={"phase": phase}
+            ).result()
+        )
+        # State is rx(-phase)|1>, so P(measure 1) = cos^2(phase / 2).
+        expected_one_freq = math.cos(phase / 2) ** 2
+        one_freq = counts.get((1,), 0) / shots
+        assert abs(one_freq - expected_one_freq) < 0.06, (
+            f"{name}: seed={seed} phase={phase} one-frequency "
+            f"{one_freq:.3f}, expected {expected_one_freq:.3f}"
+        )
+
+        got = run_executable.run(executor, bindings={"phase": phase}).result()
+        # <Y> on rx(-phase)|1> is -sin(phase); a dropped sign would flip it.
+        expected_expval = -math.sin(phase)
+        assert np.isclose(got, expected_expval, atol=1e-5), (
+            f"{name}: seed={seed} phase={phase} got {got}, expected {expected_expval}"
+        )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 42])
+def test_symbolic_multi_control_phase_in_loop_matches_cp(
+    backend: Backend, seed: int
+) -> None:
+    """Reported symbolic multi-control phase in a loop matches its cp equivalent.
+
+    Regression for the originally reported QSVT / block-encoding failure: a
+    symbolic-count multi-control phase with a negated runtime angle inside a
+    ``qmc.range`` loop must transpile to a single quantum segment and produce
+    the same expectation value as the concrete ``qmc.cp`` circuit.
+    """
+    name, transpiler, executor = backend
+    rng = np.random.default_rng(seed)
+    obs = qm_o.X(0) * qm_o.X(1)
+    angles = [0.0, math.pi, 2 * math.pi, float(rng.uniform(0.1, 2 * math.pi - 0.1))]
+
+    symbolic_executable = transpiler.transpile(
+        symbolic_mc_phase_run, bindings={"obs": obs}, parameters=["phase"]
+    )
+    cp_executable = transpiler.transpile(
+        cp_phase_run, bindings={"obs": obs}, parameters=["phase"]
+    )
+
+    for phase in angles:
+        symbolic_value = symbolic_executable.run(
+            executor, bindings={"phase": phase}
+        ).result()
+        cp_value = cp_executable.run(executor, bindings={"phase": phase}).result()
+        assert np.isclose(symbolic_value, cp_value, atol=1e-8), (
+            f"{name}: seed={seed} phase={phase} symbolic {symbolic_value} != "
+            f"cp {cp_value}"
+        )
+
+
+def test_classical_output_after_quantum_op_is_preserved(backend: Backend) -> None:
+    """A classical block output computed after a quantum op must be returned.
+
+    Guards the segmentation carve-out: a non-measurement classical op whose
+    result is a block output (and feeds no gate) must stay in its own classical
+    segment so the executor runs it, rather than being absorbed into the quantum
+    segment and silently dropped (returning ``None``).
+    """
+    name, transpiler, executor = backend
+    executable = transpiler.transpile(
+        classical_output_after_quantum_run, parameters=["phase"]
+    )
+    got = executable.run(executor, bindings={"phase": 3.0}).result()
+    assert got is not None, f"{name}: classical output was dropped (got None)"
+    assert np.isclose(got, 6.0, atol=1e-8), f"{name}: got {got}, expected 6.0"

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -839,13 +839,13 @@ def value_feeding_gate_and_classical_run(
 #
 # ``base = phase * 2`` is a top-level classical op, but the next link of the
 # chain (``angle = base + 1``) lives inside the ``qmc.range`` loop body. The
-# absorbable-set fixpoint classifies a consumer by the top-level op that
-# contains it: the nested ``angle = base + 1`` rides in the (quantum-effective)
-# loop's segment, so ``base`` is still absorbed rather than being treated as
-# feeding a classical sink. Without that ownership-aware classification the
-# kernel spuriously raised ``MultipleQuantumSegmentsError``. The loop index is
-# used so the loop unrolls and the kernel actually executes; both qubits end up
-# in state ``rx(2 * phase + 1) |0>``.
+# absorbable-set analysis seeds nested classical ops as candidates too, so the
+# nested ``angle = base + 1`` is itself absorbable (it feeds only the gate), and
+# ``base`` — feeding it — stays absorbable rather than being treated as feeding
+# a classical sink. Without nested candidates the kernel spuriously raised
+# ``MultipleQuantumSegmentsError``. The loop index is used so the loop unrolls
+# and the kernel actually executes; both qubits end up in state
+# ``rx(2 * phase + 1) |0>``.
 
 
 @qmc.qkernel
@@ -868,6 +868,30 @@ def nested_classical_chain_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Flo
         angle = base + 1.0
         q[i] = qmc.rx(q[i], angle)
     return qmc.expval(q, obs)
+
+
+# --- Regression: a nested classical op whose result is a block output ---
+#
+# ``base = phase * 2`` feeds a gate (``rx``) and a nested ``out = base + 1``
+# whose result is returned. ``out`` runs inside the loop body, so it cannot be
+# surfaced as a block output from the quantum segment. The absorbable-set
+# analysis must therefore refuse to absorb ``base`` (the nested ``out`` is a
+# classical sink because it is a block output), so the kernel raises an explicit
+# ``MultipleQuantumSegmentsError`` instead of silently returning ``None`` for the
+# ``out`` field.
+
+
+@qmc.qkernel
+def nested_classical_output_run(
+    phase: qmc.Float,
+) -> tuple[qmc.Vector[qmc.Bit], qmc.Float]:
+    """Return a nested classical value that also feeds a gate angle."""
+    q = qmc.qubit_array(1, "q")
+    base = phase * 2.0
+    for i in qmc.range(1):
+        q[0] = qmc.rx(q[0], base)
+        out = base + 1.0
+    return qmc.measure(q), out
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1389,6 +1413,21 @@ def test_value_feeding_gate_and_classical_is_not_miscompiled(
     _name, transpiler, _executor = backend
     with pytest.raises(MultipleQuantumSegmentsError):
         transpiler.transpile(value_feeding_gate_and_classical_run, parameters=["phase"])
+
+
+def test_nested_classical_output_is_not_miscompiled(backend: Backend) -> None:
+    """A nested classical op that is also a block output is not absorbed.
+
+    Guards against silent data corruption: a top-level value feeding both a gate
+    and a nested classical op whose result is returned must not be absorbed just
+    because the nested op rides in a quantum loop. The nested op is a block
+    output (a classical sink), so the kernel must raise an explicit
+    ``MultipleQuantumSegmentsError`` rather than transpiling and returning
+    ``None`` for the classical output field.
+    """
+    _name, transpiler, _executor = backend
+    with pytest.raises(MultipleQuantumSegmentsError):
+        transpiler.transpile(nested_classical_output_run, parameters=["phase"])
 
 
 @pytest.mark.parametrize("seed", [0, 1, 2, 42])

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -1549,8 +1549,8 @@ def test_nested_classical_chain_in_loop_sample_and_run(
 ) -> None:
     """A classical chain split across a loop boundary must not split segments.
 
-    Regression for the absorbable-set fixpoint's ownership-aware classification:
-    a top-level parameter expression (``base = phase * 2``) whose next chain link
+    Regression for the absorbable-set analysis covering nested classical ops: a
+    top-level parameter expression (``base = phase * 2``) whose next chain link
     (``angle = base + 1``) lives inside a ``qmc.range`` body must still be
     absorbed into the single quantum segment. Both qubits end up in
     ``rx(2 * phase + 1) |0>``, checked on the sample and expval paths.

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -835,6 +835,41 @@ def value_feeding_gate_and_classical_run(
     return qmc.measure(q), angle + 1.0
 
 
+# --- Regression: a classical chain split across a control-flow boundary ---
+#
+# ``base = phase * 2`` is a top-level classical op, but the next link of the
+# chain (``angle = base + 1``) lives inside the ``qmc.range`` loop body. The
+# absorbable-set fixpoint classifies a consumer by the top-level op that
+# contains it: the nested ``angle = base + 1`` rides in the (quantum-effective)
+# loop's segment, so ``base`` is still absorbed rather than being treated as
+# feeding a classical sink. Without that ownership-aware classification the
+# kernel spuriously raised ``MultipleQuantumSegmentsError``. The loop index is
+# used so the loop unrolls and the kernel actually executes; both qubits end up
+# in state ``rx(2 * phase + 1) |0>``.
+
+
+@qmc.qkernel
+def nested_classical_chain_sample(phase: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    """Sample a nested classical chain (`base` top-level, `angle` in a loop)."""
+    q = qmc.qubit_array(2, "q")
+    base = phase * 2.0
+    for i in qmc.range(2):
+        angle = base + 1.0
+        q[i] = qmc.rx(q[i], angle)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def nested_classical_chain_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+    """Run expval of a nested classical chain split across a loop boundary."""
+    q = qmc.qubit_array(2, "q")
+    base = phase * 2.0
+    for i in qmc.range(2):
+        angle = base + 1.0
+        q[i] = qmc.rx(q[i], angle)
+    return qmc.expval(q, obs)
+
+
 @dataclasses.dataclass(frozen=True)
 class FrontendExecutionCase:
     """Describe one frontend pattern with paired sample and run kernels."""
@@ -1354,3 +1389,53 @@ def test_value_feeding_gate_and_classical_is_not_miscompiled(
     _name, transpiler, _executor = backend
     with pytest.raises(MultipleQuantumSegmentsError):
         transpiler.transpile(value_feeding_gate_and_classical_run, parameters=["phase"])
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 42])
+def test_nested_classical_chain_in_loop_sample_and_run(
+    backend: Backend, seed: int
+) -> None:
+    """A classical chain split across a loop boundary must not split segments.
+
+    Regression for the absorbable-set fixpoint's ownership-aware classification:
+    a top-level parameter expression (``base = phase * 2``) whose next chain link
+    (``angle = base + 1``) lives inside a ``qmc.range`` body must still be
+    absorbed into the single quantum segment. Both qubits end up in
+    ``rx(2 * phase + 1) |0>``, checked on the sample and expval paths.
+    """
+    name, transpiler, executor = backend
+    rng = np.random.default_rng(seed)
+    angles = [0.0, math.pi, 2 * math.pi, float(rng.uniform(0.1, 2 * math.pi - 0.1))]
+    shots = 2048
+
+    sample_executable = transpiler.transpile(
+        nested_classical_chain_sample, parameters=["phase"]
+    )
+    run_executable = transpiler.transpile(
+        nested_classical_chain_run,
+        bindings={"obs": qm_o.Y(0) + qm_o.Y(1)},
+        parameters=["phase"],
+    )
+
+    for phase in angles:
+        effective = 2.0 * phase + 1.0
+        counts = _counts(
+            sample_executable.sample(
+                executor, shots=shots, bindings={"phase": phase}
+            ).result()
+        )
+        # Each qubit is rx(2*phase + 1)|0>, so P(qubit == 1) = sin^2(effective/2).
+        expected_one_freq = math.sin(effective / 2) ** 2
+        for qubit in range(2):
+            one_freq = sum(c for bits, c in counts.items() if bits[qubit] == 1) / shots
+            assert abs(one_freq - expected_one_freq) < 0.06, (
+                f"{name}: seed={seed} phase={phase} qubit={qubit} one-frequency "
+                f"{one_freq:.3f}, expected {expected_one_freq:.3f}"
+            )
+
+        got = run_executable.run(executor, bindings={"phase": phase}).result()
+        # <Y> on rx(theta)|0> is -sin(theta); summed over the two qubits.
+        expected_expval = 2.0 * (-math.sin(effective))
+        assert np.isclose(got, expected_expval, atol=1e-5), (
+            f"{name}: seed={seed} phase={phase} got {got}, expected {expected_expval}"
+        )

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -763,6 +763,37 @@ def interleaved_param_expr_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Flo
     return qmc.expval(q, obs)
 
 
+# --- Regression: parameter-expression angle computed before quantum init ---
+#
+# ``angle = -phase`` is computed before ``qmc.qubit_array`` (before any quantum
+# op). Its ``BinOp`` lands before the quantum segment, so a position-naive
+# absorption (only firing while already inside the quantum segment) would leave
+# it stranded in a classical prep segment, where the backend has no gate to bind
+# the parameter expression to and silently emits a zero angle. The segmentation
+# holds such a leading parameter-expression op and prepends it to the quantum
+# segment, so the gate gets the real angle regardless of where it was written.
+
+
+@qmc.qkernel
+def pre_init_param_expr_sample(phase: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    """Sample ``rx(q, -phase)`` whose angle is computed before qubit_array."""
+    angle = -phase
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    q[0] = qmc.rx(q[0], angle)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def pre_init_param_expr_run(phase: qmc.Float, obs: qmc.Observable) -> qmc.Float:
+    """Run expval of ``rx(q, -phase)`` whose angle is computed before init."""
+    angle = -phase
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.x(q[0])
+    q[0] = qmc.rx(q[0], angle)
+    return qmc.expval(q, obs)
+
+
 # --- Regression: reported symbolic multi-control phase inside a loop ---
 #
 # The originally reported case (a QSVT / block-encoding circuit): a symbolic
@@ -1342,6 +1373,51 @@ def test_interleaved_param_expr_angle_sample_and_run(
 
         got = run_executable.run(executor, bindings={"phase": phase}).result()
         # <Y> on rx(-phase)|1> is -sin(phase); a dropped sign would flip it.
+        expected_expval = -math.sin(phase)
+        assert np.isclose(got, expected_expval, atol=1e-5), (
+            f"{name}: seed={seed} phase={phase} got {got}, expected {expected_expval}"
+        )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 42])
+def test_pre_init_param_expr_angle_sample_and_run(backend: Backend, seed: int) -> None:
+    """A gate-angle expression computed before quantum init must still apply.
+
+    Regression for the silent miscompile where ``angle = -phase`` written before
+    ``qmc.qubit_array`` was stranded in a classical prep segment and the gate
+    received a zero angle. Checks the negated angle is applied with the correct
+    sign on both the sample and expval paths, identical to the interleaved case.
+    """
+    name, transpiler, executor = backend
+    rng = np.random.default_rng(seed)
+    angles = [0.0, math.pi, 2 * math.pi, float(rng.uniform(0.1, 2 * math.pi - 0.1))]
+    shots = 2048
+
+    sample_executable = transpiler.transpile(
+        pre_init_param_expr_sample, parameters=["phase"]
+    )
+    run_executable = transpiler.transpile(
+        pre_init_param_expr_run,
+        bindings={"obs": qm_o.Y(0)},
+        parameters=["phase"],
+    )
+
+    for phase in angles:
+        counts = _counts(
+            sample_executable.sample(
+                executor, shots=shots, bindings={"phase": phase}
+            ).result()
+        )
+        # State is rx(-phase)|1>, so P(measure 1) = cos^2(phase / 2).
+        expected_one_freq = math.cos(phase / 2) ** 2
+        one_freq = counts.get((1,), 0) / shots
+        assert abs(one_freq - expected_one_freq) < 0.06, (
+            f"{name}: seed={seed} phase={phase} one-frequency "
+            f"{one_freq:.3f}, expected {expected_one_freq:.3f}"
+        )
+
+        got = run_executable.run(executor, bindings={"phase": phase}).result()
+        # <Y> on rx(-phase)|1> is -sin(phase); a zero angle would give 0.
         expected_expval = -math.sin(phase)
         assert np.isclose(got, expected_expval, atol=1e-5), (
             f"{name}: seed={seed} phase={phase} got {got}, expected {expected_expval}"

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -1233,7 +1233,7 @@ def test_interleaved_param_expr_angle_sample_and_run(
     rng = np.random.default_rng(seed)
     # Include boundary angles (0, pi, 2*pi) alongside a random one.
     angles = [0.0, math.pi, 2 * math.pi, float(rng.uniform(0.1, 2 * math.pi - 0.1))]
-    shots = 4096
+    shots = 2048
 
     sample_executable = transpiler.transpile(
         interleaved_param_expr_sample, parameters=["phase"]

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -866,6 +866,25 @@ def value_feeding_gate_and_classical_run(
     return qmc.measure(q), angle + 1.0
 
 
+@qmc.qkernel
+def pre_init_gate_and_classical_run(
+    phase: qmc.Float, obs: qmc.Observable
+) -> tuple[qmc.Float, qmc.Float]:
+    """Use a value as a gate angle and a classical output, computed before init.
+
+    Same dual-use as ``value_feeding_gate_and_classical_run`` but the value is
+    built before ``qmc.qubit_array``, so it lands before the quantum segment.
+    That produces a legal C->Q->Expval plan (no quantum-segment split), so the
+    stranded gate parameter must be caught by an explicit check rather than the
+    multiple-segments error.
+    """
+    angle = phase * 2.0
+    out = angle + 1.0
+    q = qmc.qubit_array(1, "q")
+    q[0] = qmc.rx(q[0], angle)
+    return qmc.expval(q, obs), out
+
+
 # --- Regression: a classical chain split across a control-flow boundary ---
 #
 # ``base = phase * 2`` is a top-level classical op, but the next link of the
@@ -1504,6 +1523,24 @@ def test_nested_classical_output_is_not_miscompiled(backend: Backend) -> None:
     _name, transpiler, _executor = backend
     with pytest.raises(MultipleQuantumSegmentsError):
         transpiler.transpile(nested_classical_output_run, parameters=["phase"])
+
+
+def test_pre_init_gate_and_classical_is_not_miscompiled(backend: Backend) -> None:
+    """A dual-use value built before quantum init must not silently miscompile.
+
+    A value used as both a gate angle and a classical output, computed before
+    ``qmc.qubit_array``, yields a legal C->Q->Expval plan (no quantum-segment
+    split), so it is not caught by the multiple-segments error. The gate would
+    otherwise receive a stranded zero parameter, so the transpiler must reject
+    it explicitly instead of returning a wrong result.
+    """
+    _name, transpiler, _executor = backend
+    with pytest.raises(MultipleQuantumSegmentsError):
+        transpiler.transpile(
+            pre_init_gate_and_classical_run,
+            bindings={"obs": qm_o.Y(0)},
+            parameters=["phase"],
+        )
 
 
 @pytest.mark.parametrize("seed", [0, 1, 2, 42])

--- a/tests/transpiler/backends/test_quri_parts_symbolic.py
+++ b/tests/transpiler/backends/test_quri_parts_symbolic.py
@@ -162,12 +162,13 @@ class TestCombineSymbolicNonLinear:
 class TestSymbolicEndToEnd:
     """End-to-end transpile + bind + sample/estimate with symbolic angles.
 
-    Note: top-level ``rx(q, theta * 2.0)`` patterns (BinOp directly between
-    quantum gates without an enclosing for-items loop) are rejected by the
-    segmentation pass with ``MultipleQuantumSegmentsError`` on every backend
-    — this is a separate, pre-existing constraint of the NISQ segmentation
-    strategy, not a QURI-Parts-specific issue. The realistic and supported
-    pattern is BinOp-inside-loop, which the QAOA tests below exercise.
+    Note: a top-level ``rx(q, theta * 2.0)`` pattern (a BinOp gate angle
+    between quantum gates, without an enclosing for-items loop) is now
+    supported on every backend — the segmentation pass absorbs such a
+    non-measurement parameter-expression op into the surrounding quantum
+    segment instead of splitting on it (see the cross-backend
+    ``test_interleaved_param_expr_angle_sample_and_run``). The
+    BinOp-inside-loop pattern the QAOA tests below exercise is supported too.
     """
 
     def test_controlled_gate_before_runtime_param_sample_and_expval(self):


### PR DESCRIPTION
## Summary

A pure-quantum kernel (no measurement-dependent control flow) failed to transpile with `MultipleQuantumSegmentsError: Found N quantum segments. Only single quantum execution is supported.` whenever a gate angle was an *expression* over a runtime parameter — e.g. `qmc.rx(q, -phase)` or a symbolic multi-control phase `qmc.control(qmc.p, num_controls=...)(..., theta=-phase)` — and that expression appeared between quantum operations. The kernel drew correctly with `.draw()` but raised the error at `transpile()` / `to_circuit()`; the equivalent circuit written with the concrete single-control `qmc.cp` transpiled fine. Reported from a QSVT / block-encoding circuit (BACKLOG-8410).

Root cause: the negated angle `-phase` (and parameter expressions generally) lowers to a classical `BinOp`. When the parameter stays symbolic at runtime, constant folding cannot collapse it to a literal, so the `BinOp` reaches the segmentation stage as a top-level classical op sitting between quantum operations. `SegmentationPass` flushed the running quantum segment on any classical op (other than the already-handled measurement-derived `RuntimeClassicalExpr`), creating a spurious `quantum -> classical -> quantum` boundary and therefore more than one quantum segment, which `NisqSegmentationStrategy` rejects. Because `QInitOperation` is always the first quantum op, any parameter-expression gate angle with a runtime parameter triggered the split — not only the symbolic multi-control case in the report.

Fix (`qamomile/circuit/transpiler/passes/separate.py`): the segmentation pass now keeps a non-measurement classical op inside the surrounding quantum segment instead of forcing a split, guarded by two conditions:

- `not _is_measurement_tainted(op)` — the op must not be derived from a measurement result (measurement-derived ops are either `RuntimeClassicalExpr`, already absorbed, or genuine post-processing such as `DecodeQFixedOperation`, which must stay classical).
- `_feeds_quantum(op)` — the op's result must actually be needed by a quantum gate (directly or through a chain of classical expressions). A classical op whose result is a block output or feeds only later classical post-processing stays in its own classical segment so the executor runs it and the orchestrator surfaces its value; absorbing it would silently drop the value.

The measurement-taint and quantum-needed sets are computed with the same `analyze.py` dataflow utilities used by `AnalyzePass` and `ClassicalLoweringPass`, so all three passes agree on what is measurement-derived. `_compute_quantum_needed` back-propagates from the `all_input_values()` of every quantum/hybrid op so multi-op chains like `(phase * 2) - 1` feeding a gate angle are fully covered. The IR is unchanged — parameter-expression angles continue to be folded into backend parameter expressions at emit time.

## Test plan

New cross-backend execution tests in `tests/circuit/test_frontend_cross_backend_execution.py` (via the existing `backend` fixture, `importorskip` for Qiskit / QURI Parts / CUDA-Q), parametrized over seeds `[0, 1, 2, 42]` with boundary angles `0`, `pi`, `2*pi` plus a random one, exercising both the sample and expval paths:

- `test_interleaved_param_expr_angle_sample_and_run` — `rx(q, -phase)` interleaved after a quantum op; checks `P(1) = cos^2(phase/2)` (sample) and `<Y> = -sin(phase)` (expval, whose sign would flip if the negation were dropped).
- `test_symbolic_multi_control_phase_in_loop_matches_cp` — the reported symbolic multi-control phase with a negated runtime angle inside a `qmc.range` loop; asserts it produces the same expectation value as the concrete `qmc.cp` equivalent (`obs = X(0)*X(1)`, phase-sensitive).
- `test_classical_output_after_quantum_op_is_preserved` — guards the `_feeds_quantum` half: a classical block output (`phase * 2.0`) computed after a quantum op stays a classical segment and is returned (6.0 for phase=3.0) rather than being silently dropped.

Verification:
- Reproduced the failure before the fix; confirmed transpile + execution after, including correct angle sign on the expval path and exact agreement with the `qmc.cp` equivalent.
- `uv run ruff check qamomile/ tests/` — clean.
- `uv run ruff format --check qamomile/ tests/` — clean.
- `uv run zuban check qamomile/` — clean.
- `uv run pytest tests/` — 7824 passed, 514 skipped, 1 xfailed, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KanivKTRTXpJrPDdMGFDzM)_