### PR TITLE
Fix emit value resolver array elements

### DIFF
--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -379,7 +379,7 @@ class ValueResolver:
         param operand at the call site must resolve to a value to seed the
         callee's parameter bindings.
         """
-        return self.lookup_in_bindings(operand, bindings)
+        return self.lookup_in_bindings(operand, bindings, index_array=True)
 
     def bind_block_params(
         self,
@@ -460,23 +460,100 @@ class ValueResolver:
         parent = v.parent_array
         if parent is None:
             return None
-        if parent.name in self.parameters:
+        location = self._resolve_array_element_location(
+            parent, v.element_indices, bindings
+        )
+        if location is None:
             return None
-        container = bindings.get(parent.name)
-        if container is None:
-            container = bindings.get(parent.uuid)
+        root_parent, indices = location
+        if root_parent.name in self.parameters:
+            return None
+        container = self._resolve_array_container(root_parent, bindings)
         if container is None:
             return None
 
-        for idx in v.element_indices:
-            i = self.resolve_int_value(idx, bindings)
-            if i is None:
-                return None
+        for i in indices:
             try:
                 container = container[i]
             except (IndexError, KeyError, TypeError):
                 return None
         return container
+
+    def _resolve_array_element_location(
+        self,
+        parent: "ArrayValue",
+        element_indices: tuple["Value", ...],
+        bindings: dict[str, Any],
+    ) -> tuple["ArrayValue", tuple[int, ...]] | None:
+        """Resolve an array element access to a root array and indices.
+
+        Slice affine composition is applied to the leading index because
+        Qamomile VectorView slices are one-dimensional Vector slices.
+
+        Args:
+            parent (ArrayValue): The immediate parent array on the
+                element Value. This may be a sliced view.
+            element_indices (tuple[Value, ...]): The element's indices in
+                the immediate parent array's local coordinate system.
+            bindings (dict[str, Any]): The active emit-time bindings.
+
+        Returns:
+            tuple[ArrayValue, tuple[int, ...]] | None: The root array and
+                concrete indices into its container, or ``None`` when any
+                index or slice bound is unresolved.
+        """
+        resolved_indices: list[int] = []
+        for idx in element_indices:
+            i = self.resolve_int_value(idx, bindings)
+            if i is None:
+                # Symbolic element indices stay unresolved at emit time.
+                return None
+            resolved_indices.append(i)
+
+        if not resolved_indices:
+            return parent, ()
+
+        root_index = resolved_indices[0]
+        cur = parent
+        while cur.slice_of is not None:
+            if cur.slice_start is None or cur.slice_step is None:
+                return None
+            start = self.resolve_int_value(cur.slice_start, bindings)
+            step = self.resolve_int_value(cur.slice_step, bindings)
+            if start is None or step is None:
+                # Symbolic slice bounds stay unresolved at emit time.
+                return None
+            root_index = start + step * root_index
+            cur = cur.slice_of
+
+        return cur, (root_index, *resolved_indices[1:])
+
+    def _resolve_array_container(
+        self,
+        parent: "ArrayValue",
+        bindings: dict[str, Any],
+    ) -> Any:
+        """Resolve an array parent to a concrete container for indexing.
+
+        Args:
+            parent (ArrayValue): The parent array whose element is being
+                resolved.
+            bindings (dict[str, Any]): The active emit-time bindings.
+
+        Returns:
+            Any: The concrete array-like container, or ``None`` if the
+                parent is unresolved.
+        """
+        # Prefer compile-time literal metadata over explicit bindings.
+        container = parent.get_const_array()
+        if container is not None:
+            return container
+
+        # Fall back to caller-supplied or emit-local array bindings.
+        container = bindings.get(parent.name)
+        if container is not None:
+            return container
+        return bindings.get(parent.uuid)
 
     def resolve_int_value(
         self,
@@ -493,7 +570,7 @@ class ValueResolver:
         failure to ``emit_for_unrolled``, which converts it into a hard
         compile error.
         """
-        raw = self.lookup_in_bindings(val, bindings)
+        raw = self.lookup_in_bindings(val, bindings, index_array=True)
         if raw is None:
             return None
         return self._resolve_numeric_index(raw)

--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -458,24 +458,37 @@ class ValueResolver:
         ``None`` here.
         """
         parent = v.parent_array
+        # Only element Values carry a parent array; scalar Values cannot be
+        # indexed through this helper.
         if parent is None:
             return None
+        # Resolve a possibly sliced view element to the root array and
+        # concrete indices; symbolic indices or slice bounds intentionally
+        # fall back to unresolved.
         location = self._resolve_array_element_location(
             parent, v.element_indices, bindings
         )
         if location is None:
             return None
         root_parent, indices = location
+        # Runtime parameter arrays are symbolic even if placeholder data is
+        # present in bindings; never index them at emit time.
         if root_parent.name in self.parameters:
             return None
+        # Prefer const_array metadata, then explicit bindings for the root
+        # container. A missing container means the element stays unresolved.
         container = self._resolve_array_container(root_parent, bindings)
         if container is None:
             return None
 
+        # Descend through nested containers one index at a time; the final
+        # value of ``container`` is the resolved element, not the parent array.
         for i in indices:
             try:
                 container = container[i]
             except (IndexError, KeyError, TypeError):
+                # Out-of-range or non-indexable containers are unresolved
+                # rather than guessed.
                 return None
         return container
 
@@ -503,6 +516,8 @@ class ValueResolver:
                 index or slice bound is unresolved.
         """
         resolved_indices: list[int] = []
+        # Resolve local element indices first. Any symbolic index keeps the
+        # whole element access unresolved at emit time.
         for idx in element_indices:
             i = self.resolve_int_value(idx, bindings)
             if i is None:
@@ -510,12 +525,18 @@ class ValueResolver:
                 return None
             resolved_indices.append(i)
 
+        # No explicit element index means callers are asking for the array
+        # container itself, so there is no slice-local coordinate to compose.
         if not resolved_indices:
             return parent, ()
 
         root_index = resolved_indices[0]
         cur = parent
+        # Compose each VectorView affine map back to the root container:
+        # root_index = slice_start + slice_step * local_index.
         while cur.slice_of is not None:
+            # A sliced view must carry both affine-map operands. If either is
+            # absent, keep this access unresolved instead of inventing bounds.
             if cur.slice_start is None or cur.slice_step is None:
                 return None
             start = self.resolve_int_value(cur.slice_start, bindings)
@@ -549,7 +570,8 @@ class ValueResolver:
         if container is not None:
             return container
 
-        # Fall back to caller-supplied or emit-local array bindings.
+        # Fall back to caller-supplied or emit-local array bindings by
+        # stable public name first, then by internal UUID.
         container = bindings.get(parent.name)
         if container is not None:
             return container
@@ -571,6 +593,8 @@ class ValueResolver:
         compile error.
         """
         raw = self.lookup_in_bindings(val, bindings, index_array=True)
+        # Symbolic values, including array elements with symbolic indices,
+        # must remain unresolved so emit callers can raise or fall back.
         if raw is None:
             return None
         return self._resolve_numeric_index(raw)

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -160,6 +160,18 @@ def _h_then_full_reslice(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
 
 
 @qmc.qkernel
+def _rx_with_angle(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Apply RX(theta) through a helper qkernel."""
+    return qmc.rx(q, angle=theta)
+
+
+@qmc.qkernel
+def _phase_gate_for_view_qpe(q: qmc.Qubit, theta: float) -> qmc.Qubit:
+    """Apply a phase gate for QPE controlled-U regression tests."""
+    return qmc.p(q, theta)
+
+
+@qmc.qkernel
 def _qft_layer(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
     """Apply a shape-dependent stdlib composite inside a subkernel."""
     q = qmc.qft(q)
@@ -278,6 +290,42 @@ def vector_view_full_reslice_run(obs: qmc.Observable) -> qmc.Float:
     evens = _h_then_full_reslice(evens)
     q[0:4:2] = evens
     return qmc.expval(q, obs)
+
+
+@qmc.qkernel
+def vector_view_value_element_sample(
+    values: qmc.Vector[qmc.Float],
+) -> qmc.Vector[qmc.Bit]:
+    """Sample after passing ``values[1:3][0]`` to a helper qkernel."""
+    q = qmc.qubit_array(1, "q")
+    view = values[1:3]
+    q[0] = _rx_with_angle(q[0], view[0])
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def vector_view_value_element_run(
+    values: qmc.Vector[qmc.Float],
+    obs: qmc.Observable,
+) -> qmc.Float:
+    """Run expval after passing ``values[1:3][0]`` to a helper qkernel."""
+    q = qmc.qubit_array(1, "q")
+    view = values[1:3]
+    q[0] = _rx_with_angle(q[0], view[0])
+    return qmc.expval(q, obs)
+
+
+@qmc.qkernel
+def vector_view_qpe_parameter_sample(
+    gammas: qmc.Vector[qmc.Float],
+) -> qmc.Float:
+    """Sample QPE after binding controlled-U theta from a VectorView element."""
+    counting = qmc.qubit_array(3, name="counting")
+    target = qmc.qubit(name="target")
+    target = qmc.x(target)
+    view = gammas[1:3]
+    phase = qmc.qpe(target, counting, _phase_gate_for_view_qpe, theta=view[0])
+    return qmc.measure(phase)
 
 
 @qmc.qkernel
@@ -784,6 +832,20 @@ FRONTEND_EXECUTION_CASES = [
         },
     ),
     FrontendExecutionCase(
+        name="vector-view-value-element-helper",
+        sample_kernel=vector_view_value_element_sample,
+        run_kernel=vector_view_value_element_run,
+        sample_mode="deterministic",
+        expected_bits=(1,),
+        expected_support={(1,)},
+        expected_expval=-1.0,
+        sample_bindings={"values": np.array([0.0, math.pi, 0.0])},
+        run_bindings={
+            "values": np.array([0.0, math.pi, 0.0]),
+            "obs": qm_o.Z(0),
+        },
+    ),
+    FrontendExecutionCase(
         name="controlled-qkernel",
         sample_kernel=controlled_qkernel_sample,
         run_kernel=controlled_qkernel_run,
@@ -1021,6 +1083,26 @@ def test_frontend_pattern_run_execution(
     assert np.isclose(got, case.expected_expval, atol=1e-5), (
         f"{name} {case.name}: got {got}, expected {case.expected_expval}"
     )
+
+
+def test_vector_view_qpe_controlled_u_parameter_sample(backend: Backend) -> None:
+    """Execute QPE with controlled-U theta bound from ``gammas[1:3][0]``."""
+    name, transpiler, executor = backend
+    shots = 32
+    executable = transpiler.transpile(
+        vector_view_qpe_parameter_sample,
+        bindings={"gammas": np.array([math.pi / 4, math.pi / 2, math.pi])},
+    )
+
+    result = executable.sample(executor, shots=shots).result()
+
+    total = 0
+    for value, count in result.results:
+        assert value == pytest.approx(0.25), (
+            f"{name}: expected phase 0.25, got {value} (count={count})"
+        )
+        total += count
+    assert total == shots, f"{name}: expected {shots} shots, got {total}"
 
 
 def test_controlled_parameterized_composite_runtime_parameter(

--- a/tests/circuit/test_resolve_int_value.py
+++ b/tests/circuit/test_resolve_int_value.py
@@ -68,6 +68,167 @@ class TestResolveIntValueUuidLookup:
 class TestResolveArrayElementValue:
     """Tests for resolving bound array elements."""
 
+    def test_resolve_int_value_indexes_bound_array_element(self):
+        """Integer resolver should read array elements from explicit bindings."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds")
+        first = Value(type=UIntType(), name="idx_0").with_const(0)
+        bound = Value(
+            type=UIntType(),
+            name="bounds_0",
+            parent_array=bounds,
+            element_indices=(first,),
+        )
+        bindings = {"bounds": np.array([3], dtype=np.uint64)}
+
+        result = resolver.resolve_int_value(bound, bindings)
+
+        assert result == 3
+
+    def test_resolve_int_value_indexes_const_array_element(self):
+        """Integer resolver should read array elements from const_array metadata."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[2, 5]
+        )
+        second = Value(type=UIntType(), name="idx_1").with_const(1)
+        bound = Value(
+            type=UIntType(),
+            name="bounds_1",
+            parent_array=bounds,
+            element_indices=(second,),
+        )
+
+        result = resolver.resolve_int_value(bound, bindings={})
+
+        assert result == 5
+
+    def test_const_array_takes_precedence_over_explicit_binding(self):
+        """Const array metadata should win over explicit parent array bindings."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[7]
+        )
+        first = Value(type=UIntType(), name="idx_0").with_const(0)
+        bound = Value(
+            type=UIntType(),
+            name="bounds_0",
+            parent_array=bounds,
+            element_indices=(first,),
+        )
+        bindings = {"bounds": [3]}
+
+        result = resolver.resolve_int_value(bound, bindings)
+
+        assert result == 7
+
+    def test_symbolic_index_remains_unresolved(self):
+        """Unbound symbolic array indices should remain unresolved."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[2, 5]
+        )
+        symbolic = Value(type=UIntType(), name="i")
+        bound = Value(
+            type=UIntType(),
+            name="bounds_i",
+            parent_array=bounds,
+            element_indices=(symbolic,),
+        )
+
+        result = resolver.resolve_int_value(bound, bindings={})
+
+        assert result is None
+
+    def test_resolve_int_value_indexes_vector_view_element(self):
+        """Integer resolver should map view-local indices back to the root array."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[1, 2, 3, 4]
+        )
+        view = ArrayValue(
+            type=UIntType(),
+            name="bounds_view",
+            slice_of=bounds,
+            slice_start=Value(type=UIntType(), name="start").with_const(1),
+            slice_step=Value(type=UIntType(), name="step").with_const(2),
+        )
+        local_one = Value(type=UIntType(), name="idx_1").with_const(1)
+        bound = Value(
+            type=UIntType(),
+            name="bounds_view_1",
+            parent_array=view,
+            element_indices=(local_one,),
+        )
+
+        result = resolver.resolve_int_value(bound, bindings={})
+
+        assert result == 4
+
+    def test_resolve_int_value_indexes_nested_vector_view_element(self):
+        """Nested VectorView indices should compose every slice affine map."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[1, 2, 3, 4, 5]
+        )
+        outer = ArrayValue(
+            type=UIntType(),
+            name="outer",
+            slice_of=bounds,
+            slice_start=Value(type=UIntType(), name="outer_start").with_const(1),
+            slice_step=Value(type=UIntType(), name="outer_step").with_const(2),
+        )
+        inner = ArrayValue(
+            type=UIntType(),
+            name="inner",
+            slice_of=outer,
+            slice_start=Value(type=UIntType(), name="inner_start").with_const(1),
+            slice_step=Value(type=UIntType(), name="inner_step").with_const(1),
+        )
+        local_zero = Value(type=UIntType(), name="idx_0").with_const(0)
+        bound = Value(
+            type=UIntType(),
+            name="inner_0",
+            parent_array=inner,
+            element_indices=(local_zero,),
+        )
+
+        result = resolver.resolve_int_value(bound, bindings={})
+
+        assert result == 4
+
+    def test_symbolic_slice_bound_remains_unresolved(self):
+        """Unbound symbolic VectorView slice bounds should remain unresolved."""
+        resolver = ValueResolver()
+
+        bounds = ArrayValue(type=UIntType(), name="bounds").with_array_runtime_metadata(
+            const_array=[1, 2, 3]
+        )
+        view = ArrayValue(
+            type=UIntType(),
+            name="bounds_view",
+            slice_of=bounds,
+            slice_start=Value(type=UIntType(), name="start"),
+            slice_step=Value(type=UIntType(), name="step").with_const(1),
+        )
+        local_zero = Value(type=UIntType(), name="idx_0").with_const(0)
+        bound = Value(
+            type=UIntType(),
+            name="bounds_view_0",
+            parent_array=view,
+            element_indices=(local_zero,),
+        )
+
+        result = resolver.resolve_int_value(bound, bindings={})
+
+        assert result is None
+
     def test_numpy_integer_array_element_is_accepted(self):
         """Nested array lookups should normalize NumPy integer results."""
         resolver = ValueResolver()
@@ -90,6 +251,24 @@ class TestResolveArrayElementValue:
 
         assert result == 1
         assert isinstance(result, int)
+
+    def test_operand_for_binding_indexes_array_element(self):
+        """Sub-block local bindings should receive concrete array elements."""
+        resolver = ValueResolver()
+
+        gammas = ArrayValue(type=FloatType(), name="gammas")
+        second = Value(type=UIntType(), name="idx_1").with_const(1)
+        gamma = Value(
+            type=FloatType(),
+            name="gammas_1",
+            parent_array=gammas,
+            element_indices=(second,),
+        )
+        bindings = {"gammas": np.array([0.1, 0.2])}
+
+        result = resolver.resolve_operand_for_binding(gamma, bindings)
+
+        assert result == np.float64(0.2)
 
 
 class TestResolveClassicalScalarNormalization:

--- a/tests/transpiler/test_emit_base.py
+++ b/tests/transpiler/test_emit_base.py
@@ -1033,6 +1033,34 @@ def binop_pow_circuit(n: qmc.UInt, theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
     return qmc.measure(q)
 
 
+@qmc.qkernel
+def array_element_loop_bound_circuit(
+    bounds: qmc.Vector[qmc.UInt], theta: qmc.Float
+) -> qmc.Vector[qmc.Bit]:
+    """Apply RX(theta) using ``bounds[0]`` as an emit-time loop bound."""
+    q = qmc.qubit_array(4, "q")
+    for i in qmc.range(bounds[0]):
+        q[i] = qmc.rx(q[i], angle=theta)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def apply_rx_helper(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    """Apply RX(theta) through a helper kernel."""
+    return qmc.rx(q, angle=theta)
+
+
+@qmc.qkernel
+def vector_view_element_helper_circuit(
+    slopes_p: qmc.Vector[qmc.Float],
+) -> qmc.Vector[qmc.Bit]:
+    """Pass ``view[0]`` from ``slopes_p[1:3]`` into a helper kernel."""
+    q = qmc.qubit_array(1, "q")
+    view = slopes_p[1:3]
+    q[0] = apply_rx_helper(q[0], view[0])
+    return qmc.measure(q)
+
+
 # ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------
@@ -1183,3 +1211,30 @@ class TestUIntBinOpFolding:
             assert np.isclose(angle, theta), (
                 f"RX[{i}] angle {angle} != expected {theta}"
             )
+
+
+class TestEmitArrayElementResolution:
+    """Integration coverage for array elements resolved during emit."""
+
+    def test_bound_uint_array_element_executes_as_loop_bound(self) -> None:
+        """``qmc.range(bounds[0])`` executes the expected deterministic flips."""
+        transpiler = QiskitTranspiler()
+        exe = transpiler.transpile(
+            array_element_loop_bound_circuit,
+            bindings={"bounds": np.array([3], dtype=np.uint64), "theta": np.pi},
+        )
+        results = exe.sample(transpiler.executor(), shots=200).result().results
+
+        assert results == [((1, 1, 1, 0), 200)]
+
+    def test_vector_view_element_executes_through_helper_kernel(self) -> None:
+        """``view[0]`` passed to a helper executes with the root array element."""
+        transpiler = QiskitTranspiler()
+        slopes = np.array([0.1, np.pi, 0.7], dtype=np.float64)
+        exe = transpiler.transpile(
+            vector_view_element_helper_circuit,
+            bindings={"slopes_p": slopes},
+        )
+        results = exe.sample(transpiler.executor(), shots=200).result().results
+
+        assert results == [((1,), 200)]


### PR DESCRIPTION
## Summary

Fix emit-side value resolution for bound Vector elements, including VectorView slice elements, so loop bounds, helper-kernel arguments, and controlled-QPE sub-block parameters resolve to concrete values during emission.

## Details
- Enable array-element lookup for integer resolution and block-parameter binding.
- Resolve sliced VectorView elements by composing the slice affine map back to the root bound container.
- Prefer const_array metadata over explicit bindings when both are present, while keeping runtime-parameter arrays unresolved.
- Add frontend execution regressions for bound Vector elements, sliced VectorView elements, and controlled-QPE theta binding.

## Validation
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- uv run pytest -m "" tests/circuit/test_frontend_cross_backend_execution.py -k "vector-view-value-element-helper or vector_view_qpe_controlled_u_parameter_sample" -q -rs













