### PR TITLE
Fix normalize_problem_input to use to_hubo() for ommx.v1.Instance inputs

### DIFF
--- a/qamomile/optimization/converter.py
+++ b/qamomile/optimization/converter.py
@@ -20,25 +20,30 @@ def normalize_problem_input(
     :class:`MathematicalProblemConverter` base class and
     :class:`~qamomile.optimization.pce.PCEConverter` (which deliberately
     does not inherit from that base) both delegate to this helper so the
-    OMMX deep-copy / ``to_qubo`` semantics live in exactly one place.
+    OMMX deep-copy / ``to_hubo`` semantics live in exactly one place.
 
     For OMMX inputs, the instance is deep-copied via a bytes round-trip
-    before ``to_qubo`` is called: ``to_qubo`` mutates the instance it is
+    before ``to_hubo`` is called: ``to_hubo`` mutates the instance it is
     called on (it appends slack decision variables for non-binary vars
     and absorbs constraints into the objective via the penalty method).
     Mutating the caller's instance silently is surprising; copying first
     leaves the caller's view untouched. The deep copy retains
     original-constraint metadata internally, so downstream
     ``evaluate_samples`` reports feasibility against the user's
-    *original* constraints, and slack bits added by ``to_qubo`` are
+    *original* constraints, and slack bits added by ``to_hubo`` are
     reconstructed back into the original decision variables (e.g.,
     integers rebuilt from log-encoded slack bits) by ``evaluate_samples``
     automatically.
 
+    ``to_hubo`` is used instead of ``to_qubo`` so that both purely
+    quadratic (QUBO) and higher-order (HUBO) instances are handled
+    uniformly. For quadratic-only instances the two paths produce
+    identical :class:`BinaryModel` results.
+
     Args:
         instance (ommx.v1.Instance | BinaryModel): The combinatorial
             optimization problem. ``ommx.v1.Instance`` inputs are
-            deep-copied and converted via ``to_qubo()``; ``BinaryModel``
+            deep-copied and converted via ``to_hubo()``; ``BinaryModel``
             inputs retain their declared vartype as the target output
             vartype.
 
@@ -63,8 +68,8 @@ def normalize_problem_input(
         return None, instance.vartype, instance.change_vartype(VarType.SPIN)
     if isinstance(instance, ommx.v1.Instance):
         stored = ommx.v1.Instance.from_bytes(instance.to_bytes())
-        qubo, constant = stored.to_qubo()
-        spin_model = BinaryModel.from_qubo(qubo, constant).change_vartype(VarType.SPIN)
+        hubo, constant = stored.to_hubo()
+        spin_model = BinaryModel.from_hubo(hubo, constant).change_vartype(VarType.SPIN)
         return stored, VarType.BINARY, spin_model
     raise TypeError("instance must be ommx.v1.Instance or BinaryModel")
 
@@ -163,10 +168,15 @@ class MathematicalProblemConverter(abc.ABC):
 
         Subclasses must implement this method to build the appropriate
         Hamiltonian for their specific algorithm (e.g., Pauli-Z for QAOA,
-        QRAC-encoded for QRAO).
+        QRAC-encoded for QRAO). Oracle-based converters that do not use a cost
+        Hamiltonian (e.g., ``GASConverter``) should raise ``NotImplementedError``.
 
         Returns:
             qm_o.Hamiltonian: The cost Hamiltonian.
+
+        Raises:
+            NotImplementedError: If the converter does not expose a cost
+                Hamiltonian.
         """
         ...
 

--- a/qamomile/optimization/converter.py
+++ b/qamomile/optimization/converter.py
@@ -52,7 +52,7 @@ def normalize_problem_input(
         ``(stored_instance, original_vartype, spin_model)``.
 
         * ``stored_instance``: the deep-copied ``Instance`` for OMMX
-          inputs (post ``to_qubo``), or ``None`` for ``BinaryModel``
+          inputs (post ``to_hubo``), or ``None`` for ``BinaryModel``
           inputs.
         * ``original_vartype``: the declared vartype of the input — used
           by converters' ``decode`` paths to return results in the

--- a/qamomile/optimization/converter.py
+++ b/qamomile/optimization/converter.py
@@ -38,7 +38,7 @@ def normalize_problem_input(
     ``to_hubo`` is used instead of ``to_qubo`` so that both purely
     quadratic (QUBO) and higher-order (HUBO) instances are handled
     uniformly. For quadratic-only instances the two paths produce
-    identical :class:`BinaryModel` results.
+    equivalent optimization problems (same coefficients and vartype).
 
     Args:
         instance (ommx.v1.Instance | BinaryModel): The combinatorial

--- a/tests/optimization/test_converter_ommx_sampleset.py
+++ b/tests/optimization/test_converter_ommx_sampleset.py
@@ -598,5 +598,5 @@ def test_hubo_ommx_instance_rejected_by_qrac_with_clear_error():
 
     instance = _build_hubo_ommx_instance()
 
-    with pytest.raises(ValueError, match="higher-order"):
+    with pytest.raises(ValueError, match=r"higher[\s-]order"):
         QRAC31Converter(instance)

--- a/tests/optimization/test_converter_ommx_sampleset.py
+++ b/tests/optimization/test_converter_ommx_sampleset.py
@@ -582,7 +582,8 @@ def test_hubo_ommx_instance_builds_spin_model_with_higher_terms():
     hubo_dict, _ = ommx.v1.Instance.from_bytes(instance.to_bytes()).to_hubo()
     cubic_keys = [k for k in hubo_dict if len(k) == 3]
     assert len(cubic_keys) == 1, f"expected exactly one cubic HUBO term, got {cubic_keys}"
-    assert cubic_keys[0] == (0, 1, 2), f"unexpected cubic key {cubic_keys[0]}"
+    # Use a set comparison so index ordering within the tuple does not matter.
+    assert set(cubic_keys[0]) == {0, 1, 2}, f"unexpected cubic variables {cubic_keys[0]}"
     assert hubo_dict[cubic_keys[0]] == pytest.approx(1.0), (
         f"x0*x1*x2 coefficient must be 1.0, got {hubo_dict[cubic_keys[0]]}"
     )

--- a/tests/optimization/test_converter_ommx_sampleset.py
+++ b/tests/optimization/test_converter_ommx_sampleset.py
@@ -575,17 +575,22 @@ def test_hubo_ommx_instance_builds_spin_model_with_higher_terms():
         "spin_model.higher must contain at least one degree-3 key"
     )
 
-    # Cross-check against the raw to_hubo() output — without routing through
-    # BinaryModel.from_hubo() — so regressions in normalize_problem_input are
-    # caught independently of the BinaryModel conversion code.
-    # The objective x0*x1*x2 + x1*x3 - x0 must produce exactly one cubic key.
-    hubo_dict, _ = ommx.v1.Instance.from_bytes(instance.to_bytes()).to_hubo()
-    cubic_keys = [k for k in hubo_dict if len(k) == 3]
-    assert len(cubic_keys) == 1, f"expected exactly one cubic HUBO term, got {cubic_keys}"
-    # Use a set comparison so index ordering within the tuple does not matter.
-    assert set(cubic_keys[0]) == {0, 1, 2}, f"unexpected cubic variables {cubic_keys[0]}"
-    assert hubo_dict[cubic_keys[0]] == pytest.approx(1.0), (
-        f"x0*x1*x2 coefficient must be 1.0, got {hubo_dict[cubic_keys[0]]}"
+    # Cross-check that the cubic term survived the full normalize_problem_input
+    # → BinaryModel.from_hubo → change_vartype pipeline into spin_model.higher;
+    # this catches regressions in qamomile's conversion code, not ommx internals.
+    cubic_spin_keys = [k for k in converter.spin_model.higher if len(k) == 3]
+    assert len(cubic_spin_keys) == 1, (
+        f"expected exactly one cubic spin term, got {cubic_spin_keys}"
+    )
+    # Set comparison so index ordering within the tuple does not matter.
+    assert set(cubic_spin_keys[0]) == {0, 1, 2}, (
+        f"unexpected cubic spin variables {cubic_spin_keys[0]}"
+    )
+    # x0*x1*x2 (BINARY, coeff 1) expands to spin via prod((1-si)/2); the cubic
+    # spin coefficient is -1/8.
+    assert converter.spin_model.higher[cubic_spin_keys[0]] == pytest.approx(-1 / 8), (
+        f"x0*x1*x2 cubic spin coefficient must be -1/8, "
+        f"got {converter.spin_model.higher[cubic_spin_keys[0]]}"
     )
 
 

--- a/tests/optimization/test_converter_ommx_sampleset.py
+++ b/tests/optimization/test_converter_ommx_sampleset.py
@@ -533,3 +533,60 @@ def test_qrao_decode_empty_list_returns_empty_result():
 
     assert isinstance(sample_set, ommx.v1.SampleSet)
     assert sample_set.sample_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: HUBO ommx.v1.Instance path (normalize_problem_input)
+# ---------------------------------------------------------------------------
+
+
+def _build_hubo_ommx_instance() -> ommx.v1.Instance:
+    """Build a small HUBO ommx.v1.Instance with one cubic term.
+
+    Returns:
+        ommx.v1.Instance: Instance with objective x0*x1*x2 + x1*x3 - x0,
+        which has a degree-3 term.
+    """
+    x = [ommx.v1.DecisionVariable.binary(i) for i in range(4)]
+    return ommx.v1.Instance.from_components(
+        decision_variables=x,
+        objective=x[0] * x[1] * x[2] + x[1] * x[3] - x[0],
+        constraints=[],
+        sense=ommx.v1.Instance.MINIMIZE,
+    )
+
+
+def test_hubo_ommx_instance_builds_spin_model_with_higher_terms():
+    """A HUBO ommx.v1.Instance passed to QAOAConverter produces a spin model
+    with higher-order terms (regression for normalize_problem_input to_qubo bug).
+
+    Previously normalize_problem_input called to_qubo() which raised
+    RuntimeError for degree-3 terms.  After the fix it calls to_hubo() and
+    the cubic term survives into spin_model.higher.
+    """
+    from qamomile.optimization.binary_model import BinaryModel
+
+    instance = _build_hubo_ommx_instance()
+    converter = QAOAConverter(instance)
+
+    assert converter.spin_model.higher, "cubic term must appear in spin_model.higher"
+
+    # Cross-check: BinaryModel.from_hubo path for the same problem must agree
+    hubo_dict, constant = ommx.v1.Instance.from_bytes(instance.to_bytes()).to_hubo()
+    reference = BinaryModel.from_hubo(hubo_dict, constant)
+    assert set(converter.spin_model.higher.keys()) == set(
+        reference.change_vartype(converter.spin_model.vartype).higher.keys()
+    )
+
+
+def test_hubo_ommx_instance_rejected_by_qrac_with_clear_error():
+    """A HUBO ommx.v1.Instance passed to a QRAC converter raises ValueError
+    (not the opaque RuntimeError from to_qubo) now that normalize_problem_input
+    uses to_hubo and the converter's own guard in __post_init__ is reached.
+    """
+    from qamomile.optimization.qrao import QRAC31Converter
+
+    instance = _build_hubo_ommx_instance()
+
+    with pytest.raises(ValueError, match="higher-order"):
+        QRAC31Converter(instance)

--- a/tests/optimization/test_converter_ommx_sampleset.py
+++ b/tests/optimization/test_converter_ommx_sampleset.py
@@ -564,18 +564,27 @@ def test_hubo_ommx_instance_builds_spin_model_with_higher_terms():
     RuntimeError for degree-3 terms.  After the fix it calls to_hubo() and
     the cubic term survives into spin_model.higher.
     """
-    from qamomile.optimization.binary_model import BinaryModel
-
     instance = _build_hubo_ommx_instance()
     converter = QAOAConverter(instance)
 
     assert converter.spin_model.higher, "cubic term must appear in spin_model.higher"
 
-    # Cross-check: BinaryModel.from_hubo path for the same problem must agree
-    hubo_dict, constant = ommx.v1.Instance.from_bytes(instance.to_bytes()).to_hubo()
-    reference = BinaryModel.from_hubo(hubo_dict, constant)
-    assert set(converter.spin_model.higher.keys()) == set(
-        reference.change_vartype(converter.spin_model.vartype).higher.keys()
+    # Verify that a degree-3 key survived into the spin model.  This directly
+    # checks the property broken before the fix, independently of BinaryModel.
+    assert any(len(k) == 3 for k in converter.spin_model.higher), (
+        "spin_model.higher must contain at least one degree-3 key"
+    )
+
+    # Cross-check against the raw to_hubo() output — without routing through
+    # BinaryModel.from_hubo() — so regressions in normalize_problem_input are
+    # caught independently of the BinaryModel conversion code.
+    # The objective x0*x1*x2 + x1*x3 - x0 must produce exactly one cubic key.
+    hubo_dict, _ = ommx.v1.Instance.from_bytes(instance.to_bytes()).to_hubo()
+    cubic_keys = [k for k in hubo_dict if len(k) == 3]
+    assert len(cubic_keys) == 1, f"expected exactly one cubic HUBO term, got {cubic_keys}"
+    assert cubic_keys[0] == (0, 1, 2), f"unexpected cubic key {cubic_keys[0]}"
+    assert hubo_dict[cubic_keys[0]] == pytest.approx(1.0), (
+        f"x0*x1*x2 coefficient must be 1.0, got {hubo_dict[cubic_keys[0]]}"
     )
 
 


### PR DESCRIPTION
Previously the `ommx.v1.Instance` branch in normalize_problem_input called `to_qubo()`, which raises a `RuntimeError` for any instance whose objective contains higher-order (degree-3+) terms. This silently broke `QAOAConverter` and other converters when called with a HUBO `ommx.v1.Instance` — the error message gave no hint that the converter itself supports HUBO.

Switch to `to_hubo()` + `BinaryModel.from_hubo()`. 
The two paths are equivalent for purely quadratic instances (QUBO diagonal (i,i) entries map identically to linear (i,) tuples in from_hubo), so no existing behavior changes. 

For higher-order instances the new path succeeds and passes a correctly populated spin_model.higher through to converters that support HUBO. 

Converters that reject HUBO (`QRACConverterBase`, `FQAOAConverter`) already guard via `spin_model.higher` in `__post_init__ / degree()` in `__init__` and now raise their own clear `ValueError` rather than OMMX's opaque `RuntimeError`.

Added a test for HUBO `ommx.v1.Instance` on different converters