### PR TITLE
docs: add v0.12.6 release notes

### DIFF
--- a/docs/en/myst.yml
+++ b/docs/en/myst.yml
@@ -38,6 +38,7 @@ project:
     - title: Release Notes
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md
         - file: release_notes/v0_12_4.md
         - file: release_notes/v0_12_3.md

--- a/docs/en/release_notes/index.md
+++ b/docs/en/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # Release Notes
 
+- [v0.12.6](v0_12_6) — circuit inversion with `qmc.inverse` (built-in gates, `@qkernel`s, QFT/IQFT), `qmc.modular_increment` / `qmc.modular_decrement` basis-state arithmetic, job/result types importable from `qamomile.circuit`
 - [v0.12.5](v0_12_5) — `PCEConverter` / `PCEEncoder` for Pauli Correlation Encoding, seeded QURI Parts sampling, measured `Vector[Bit]` condition fixes, and `qmc.expval` fixes for `Vector` elements
 - [v0.12.4](v0_12_4) — `qmc.controlled` renamed to `qmc.control` with a more expressive symbolic mode, higher-order Ising model construction via `BinaryModel.from_higher_ising`, unary `-` on `Float` handles
 - [v0.12.3](v0_12_3) — Python-style `Vector` slicing, `commutator(a, b)` for Pauli-Hamiltonians, `computational_basis_state` algorithm helper

--- a/docs/en/release_notes/v0_12_6.md
+++ b/docs/en/release_notes/v0_12_6.md
@@ -1,0 +1,87 @@
+# Qamomile v0.12.6
+
+Qamomile v0.12.6 adds circuit inversion: `qmc.inverse` turns a built-in gate, a whole `@qkernel`, or QFT/IQFT into its inverse, and the result is called exactly like the original. New arithmetic primitives `qmc.modular_increment` / `qmc.modular_decrement` shift a computational-basis register by ±1 modulo 2^n and compose with `qmc.control`. The job and result types used by `sample()` / `run()` executions are now importable directly from `qamomile.circuit`. This release also fixes transpilation of parameter-expression gate angles, value resolution for bound `Vector` elements, `qmc.expval` qubit mapping, and HUBO instance handling in the optimization converters.
+
+```
+pip install qamomile==0.12.6
+```
+
+## New Features
+
+### Circuit inversion with `qmc.inverse`
+
+`qmc.inverse(target)` returns the inverse of a built-in gate function, a `@qkernel`, or a stdlib QFT function. Built-in fixed gates map to their adjoint counterparts (`qmc.inverse(qmc.s)` is `qmc.sdg`, self-inverse gates such as `qmc.h` and `qmc.cx` map to themselves), rotation gates (`rx`, `ry`, `rz`, `p`, `cp`, `rzz`) negate their angle, and `qmc.inverse(qmc.qft)` returns `qmc.iqft` directly so backend-native composite emission stays available. Broadcasting over `Vector[Qubit]` works the same as for the forward gates ([#445](https://github.com/Jij-Inc/Qamomile/pull/445)).
+
+For a `@qkernel`, the wrapper is called with the same arguments as the original kernel and applies the body in reverse with each operation inverted. Nested kernel calls, composite gates, `qmc.control(...)` results, `qmc.pauli_evolve` (the evolution time is negated), and `qmc.range` loops (the iteration order is reversed without unrolling) are all inverted recursively, and inverting a kernel that itself calls `qmc.inverse(...)` cancels the nested inverse back to the original operations.
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def layer(q: qmc.Qubit, angle: qmc.Float) -> qmc.Qubit:
+    q = qmc.h(q)
+    q = qmc.rz(q, angle)
+    return q
+
+@qmc.qkernel
+def roundtrip(angle: qmc.Float) -> qmc.Bit:
+    q = qmc.qubit("q")
+    q = layer(q, angle)
+    q = qmc.inverse(layer)(q, angle)  # uncompute: q is back to |0>
+    return qmc.measure(q)
+
+executable = QiskitTranspiler().transpile(roundtrip, bindings={"angle": 0.37})
+```
+
+Kernels containing `if` / `while` / `for ... in qmc.items(...)` control flow, or `qmc.range` bounds that are still symbolic when the inverse wrapper is traced, are not supported and raise `NotImplementedError` (a loop bound supplied via `bindings` resolves fine); kernels that allocate qubits internally are also rejected. See `LIMITATIONS.md` in the repository for the exact control-flow boundaries.
+
+### Modular increment and decrement
+
+`qmc.modular_increment` and `qmc.modular_decrement` apply `|j> -> |j ± 1 mod 2^n>` to a little-endian qubit register (`q[0]` is the least-significant bit). The construction is QFT-free, built from X and multi-controlled X gates, and controlled variants are composed with the existing control machinery: `qmc.control(qmc.modular_increment, num_controls=1)`. Both kernels are also importable from `qamomile.circuit.algorithm.arithmetic` ([#453](https://github.com/Jij-Inc/Qamomile/pull/453)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def plus_one(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(n, name="q")
+    q[1] = qmc.x(q[1])            # prepare |j=2> (little-endian)
+    q = qmc.modular_increment(q)  # |j=2> -> |j=3>
+    return qmc.measure(q)
+
+executable = QiskitTranspiler().transpile(plus_one, bindings={"n": 3})
+```
+
+On the QURI Parts backend these primitives are only partially supported, because the emitter cannot yet produce the multi-controlled X gates needed for wider registers; see `LIMITATIONS.md` in the repository for the exact boundaries.
+
+### Job and result types under `qamomile.circuit`
+
+`SampleResult`, `SampleJob`, `RunJob`, `ExpvalJob`, `Job`, and `JobStatus` are now re-exported from `qamomile.circuit`. These are the types around job execution: `executable.sample()` returns a `SampleJob` whose `.result()` is a `SampleResult`, `executable.run()` returns a `RunJob` or an `ExpvalJob`, and `Job` / `JobStatus` are the common base class and status enum. Annotations like `qmc.SampleResult` no longer need the internal `qamomile.circuit.transpiler.job` import path, which remains importable for backward compatibility ([#407](https://github.com/Jij-Inc/Qamomile/pull/407)).
+
+```python
+import qamomile.circuit as qmc
+
+def best_bitstring(result: qmc.SampleResult) -> tuple[int, ...]:
+    """Pick the most sampled measurement outcome."""
+    ((value, _count),) = result.most_common(1)
+    return value
+```
+
+## Bug Fixes
+
+- **Parameter-expression gate angles no longer raise a spurious `MultipleQuantumSegmentsError`.** In a pure-quantum kernel, using an arithmetic expression over a runtime parameter as a gate angle — `qmc.rx(q, -phase)`, a symbolic multi-control phase with `theta=-phase`, or longer chains like `(phase * 2) - 1` — incorrectly split the program into multiple quantum segments at transpile time. Such expressions now stay inside the surrounding quantum segment and are folded into backend parameter expressions at emit time ([#455](https://github.com/Jij-Inc/Qamomile/pull/455)).
+- **Compile-time-bound `Vector` elements resolve at emit time.** Bound vector elements and sliced-view elements used as gate angles (e.g. the manual controlled-RY half-angle pattern `-angle[i] / 2`), loop bounds, helper-kernel arguments, or controlled-QPE parameters previously failed to resolve during emission, and the QPE library decomposition could not extract phases from bound array elements. All of these now resolve back to the root container, while runtime-parameter arrays and symbolic indices stay symbolic ([#454](https://github.com/Jij-Inc/Qamomile/pull/454), [#457](https://github.com/Jij-Inc/Qamomile/pull/457), [#458](https://github.com/Jij-Inc/Qamomile/pull/458)).
+- **`qmc.expval` binds the right qubits in more layouts.** Tuple-form `qmc.expval((q[i],), obs)` keeps the caller register's identity through inlined sub-kernels ([#448](https://github.com/Jij-Inc/Qamomile/pull/448)), and whole-`Vector` observables now remap Pauli indices through the compiled qubit map instead of falling back to identity when the register does not start at physical qubit 0 ([#449](https://github.com/Jij-Inc/Qamomile/pull/449)).
+- **Controlled composite gates over parameterized sub-kernel slices can now emit on Qiskit.** `qmc.control(...)` of a sub-kernel that receives a classical `UInt` width and applies QFT to a `q[:m]` slice previously raised `EmitError`. Backends whose controlled-U emitter can convert the nested block to a gate (Qiskit) now execute it; backends that fall back to gate-by-gate controlled emission still reject this shape ([#453](https://github.com/Jij-Inc/Qamomile/pull/453)).
+- **Optimization converters accept HUBO `ommx.v1.Instance` inputs.** Problem normalization now converts instances through `to_hubo()`, so objectives with degree-3+ terms reach the converters that support HUBO (such as `QAOAConverter`) instead of failing with an opaque `RuntimeError`; converters that do not support HUBO raise a clear `ValueError` ([#459](https://github.com/Jij-Inc/Qamomile/pull/459)).
+
+## Documentation
+
+- [**Tutorial 04 — Controlled Gates**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.6/docs/en/tutorial/04_controlled_gates.ipynb) reworks the rejected-patterns section into "Rejected and edge-case patterns": the controlled QFT over a sub-kernel `UInt` slice now runs as a supported Qiskit example instead of asserting an expected `EmitError` ([#453](https://github.com/Jij-Inc/Qamomile/pull/453)).
+- [**Quantum Error Correction**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.6/docs/en/algorithm/quantum_error_correction.ipynb) imports `SampleResult` from the public `qamomile.circuit` path ([#407](https://github.com/Jij-Inc/Qamomile/pull/407)).
+
+## Learn More
+
+- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)

--- a/docs/en/release_notes/v0_12_6.md
+++ b/docs/en/release_notes/v0_12_6.md
@@ -34,7 +34,7 @@ def roundtrip(angle: qmc.Float) -> qmc.Bit:
 executable = QiskitTranspiler().transpile(roundtrip, bindings={"angle": 0.37})
 ```
 
-Kernels containing `if` / `while` / `for ... in qmc.items(...)` control flow, or `qmc.range` bounds that are still symbolic when the inverse wrapper is traced, are not supported and raise `NotImplementedError` (a loop bound supplied via `bindings` resolves fine); kernels that allocate qubits internally are also rejected. See `LIMITATIONS.md` in the repository for the exact control-flow boundaries.
+Kernels containing `if` / `while` / `for ... in qmc.items(...)` control flow, or `qmc.range` bounds that are still symbolic when the inverse wrapper is traced, are not supported and raise `NotImplementedError` (a loop bound supplied via `bindings` resolves fine); kernels that allocate qubits internally are also rejected.
 
 ### Modular increment and decrement
 
@@ -54,7 +54,7 @@ def plus_one(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
 executable = QiskitTranspiler().transpile(plus_one, bindings={"n": 3})
 ```
 
-On the QURI Parts backend these primitives are only partially supported, because the emitter cannot yet produce the multi-controlled X gates needed for wider registers; see `LIMITATIONS.md` in the repository for the exact boundaries.
+On the QURI Parts backend support is currently partial: the plain shifts run on registers of up to two qubits, and the controlled variants only on single-qubit registers.
 
 ### Job and result types under `qamomile.circuit`
 

--- a/docs/ja/myst.yml
+++ b/docs/ja/myst.yml
@@ -38,6 +38,7 @@ project:
     - title: リリースノート
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md
         - file: release_notes/v0_12_4.md
         - file: release_notes/v0_12_3.md

--- a/docs/ja/release_notes/index.md
+++ b/docs/ja/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # リリースノート
 
+- [v0.12.6](v0_12_6) — `qmc.inverse`による回路の逆操作(ビルトインゲート・`@qkernel`・QFT/IQFT)、計算基底レジスタの算術`qmc.modular_increment` / `qmc.modular_decrement`、job型・結果型を`qamomile.circuit`からimport可能に
 - [v0.12.5](v0_12_5) — Pauli Correlation Encoding用の`PCEConverter` / `PCEEncoder`、QURI Partsサンプリングへのseed指定、測定済み`Vector[Bit]`を使う条件分岐の修正、`Vector`要素の`qmc.expval`修正
 - [v0.12.4](v0_12_4) — `qmc.controlled`を`qmc.control`に改名しsymbolic modeの表現力を強化、`BinaryModel.from_higher_ising`による高次Isingモデルからの構築をサポート、`Float`ハンドルへの単項マイナス`-`を追加
 - [v0.12.3](v0_12_3) — Python風の`Vector`スライシング、Pauli-Hamiltonian同士の`commutator(a, b)`、`computational_basis_state`アルゴリズムヘルパー

--- a/docs/ja/release_notes/v0_12_6.md
+++ b/docs/ja/release_notes/v0_12_6.md
@@ -34,7 +34,7 @@ def roundtrip(angle: qmc.Float) -> qmc.Bit:
 executable = QiskitTranspiler().transpile(roundtrip, bindings={"angle": 0.37})
 ```
 
-`if` / `while` / `for ... in qmc.items(...)`の制御フローを含む量子カーネルや、inverse wrapperのトレース時点でループ範囲がsymbolicなままの量子カーネルはサポートしておらず、`NotImplementedError`になります(`bindings`で与えたループ範囲は問題なく解決されます)。内部で量子ビットを確保する量子カーネルも拒否されます。制御フローまわりの正確な境界はリポジトリの`LIMITATIONS.md`を参照してください。
+`if` / `while` / `for ... in qmc.items(...)`の制御フローを含む量子カーネルや、inverse wrapperのトレース時点でループ範囲がsymbolicなままの量子カーネルはサポートしておらず、`NotImplementedError`になります(`bindings`で与えたループ範囲は問題なく解決されます)。内部で量子ビットを確保する量子カーネルも拒否されます。
 
 ### modular incrementとmodular decrement
 
@@ -54,7 +54,7 @@ def plus_one(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
 executable = QiskitTranspiler().transpile(plus_one, bindings={"n": 3})
 ```
 
-QURI Partsでは、広いレジスタに必要なmulti-controlled Xゲートをまだ出力できないため、これらのプリミティブのサポートは部分的です。正確な範囲はリポジトリの`LIMITATIONS.md`を参照してください。
+QURI Partsでのサポートは現状部分的で、通常のシフトは2量子ビット以下のレジスタ、制御版は1量子ビットのレジスタに限られます。
 
 ### `qamomile.circuit`配下のjob型・結果型
 
@@ -74,7 +74,7 @@ def best_bitstring(result: qmc.SampleResult) -> tuple[int, ...]:
 - **runtime parameterの式をゲート角度に使っても、誤った`MultipleQuantumSegmentsError`にならなくなりました**。測定に依存する制御フローを持たない純粋な量子カーネルで、`qmc.rx(q, -phase)`、symbolicなmulti-control phaseへの`theta=-phase`、`(phase * 2) - 1`のような連鎖した式をゲート角度に使うと、トランスパイル時にプログラムが複数のquantum segmentへ誤って分割されていました。これらの式はquantum segmentの内側に保持され、emit時に各SDKのparameter式へ畳み込まれるようになりました([#455](https://github.com/Jij-Inc/Qamomile/pull/455))。
 - **`bindings`で与えた`Vector`要素の値がemit時に解決されるようになりました**。`bindings`で与えた`Vector`の要素やスライスビューの要素を、ゲート角度(手書きのcontrolled-RY半角パターン`-angle[i] / 2`など)、ループ範囲、補助量子カーネルの引数、controlled QPEのパラメータに使うと、これまでemit時に値を解決できず失敗していました。QPEを個別ゲートへ分解する経路でも、こうした配列要素から位相を取り出せませんでした。いずれもルートの配列まで遡って解決されるようになり、runtime parameterの配列やsymbolicなindexはsymbolicなまま保持されます([#454](https://github.com/Jij-Inc/Qamomile/pull/454)、[#457](https://github.com/Jij-Inc/Qamomile/pull/457)、[#458](https://github.com/Jij-Inc/Qamomile/pull/458))。
 - **より多くのレジスタ配置で`qmc.expval`が正しい量子ビットを参照するようになりました**。タプル形式の`qmc.expval((q[i],), obs)`は、inlineされた量子カーネルを経由しても呼び出し元レジスタとの対応を保つようになりました([#448](https://github.com/Jij-Inc/Qamomile/pull/448))。また、`Vector`全体に対するobservableのPauli indexは、レジスタが物理量子ビット0から始まらない配置でも正しい量子ビットへ対応付けられるようになりました([#449](https://github.com/Jij-Inc/Qamomile/pull/449))。
-- **パラメータ化したスライスへのcontrolled composite gateがQiskitで実行できるようになりました**。古典の`UInt`幅を受け取り`q[:m]`スライスにQFTを適用する量子カーネルを`qmc.control(...)`すると、これまで`EmitError`になっていました。入れ子のブロックをゲートへ変換できるSDK(Qiskit)では実行できるようになり、その変換を持たないSDKでは引き続き拒否されます([#453](https://github.com/Jij-Inc/Qamomile/pull/453))。
+- **パラメータ化したスライスへのcontrolled composite gateがQiskitで実行できるようになりました**。古典の`UInt`幅を受け取り`q[:m]`スライスにQFTを適用する量子カーネルを`qmc.control(...)`すると、これまで`EmitError`になっていました。入れ子のブロックをゲートへ変換できるSDK(Qiskit)では実行できるようになり、その変換ができずゲート単位の合成に回る場合は引き続き拒否されます([#453](https://github.com/Jij-Inc/Qamomile/pull/453))。
 - **最適化converterがHUBOの`ommx.v1.Instance`入力を受け付けるようになりました**。問題の正規化が`to_hubo()`経由で変換するようになったため、3次以上の項を持つ目的関数も、分かりにくい`RuntimeError`で失敗せずにHUBO対応のconverter(`QAOAConverter`など)へ渡るようになりました。HUBO非対応のconverterは明確な`ValueError`を送出します([#459](https://github.com/Jij-Inc/Qamomile/pull/459))。
 
 ## ドキュメント

--- a/docs/ja/release_notes/v0_12_6.md
+++ b/docs/ja/release_notes/v0_12_6.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.6
 
-Qamomile v0.12.6では、回路の逆操作を作る`qmc.inverse`を追加しました。ビルトインゲート、`@qkernel`全体、QFT/IQFTをそのまま逆操作に変換でき、得られた逆操作は元と同じように呼び出せます。また、計算基底のレジスタを2^nを法として±1シフトする算術プリミティブ`qmc.modular_increment` / `qmc.modular_decrement`を追加し、`qmc.control`とも組み合わせられます。`sample()` / `run()`実行まわりのjob型・結果型は`qamomile.circuit`から直接importできるようになりました。さらに、runtime parameterの式をゲート角度に使ったときのトランスパイル、`bindings`で与えた`Vector`要素の値解決、`qmc.expval`が参照する量子ビットの対応付け、最適化converterのHUBOインスタンス対応の不具合も修正しています。
+Qamomile v0.12.6では、回路の逆操作を作る`qmc.inverse`を追加しました。ビルトインゲート、`@qkernel`全体、QFT/IQFTをそのまま逆操作に変換でき、得られた逆操作は元と同じように呼び出せます。また、計算基底のレジスタを2^nを法として±1シフトする算術プリミティブ`qmc.modular_increment` / `qmc.modular_decrement`を追加しました。さらに、`sample()` / `run()`実行まわりのjob型・結果型は`qamomile.circuit`から直接importできるようになりました。不具合他王として、runtime parameterの式をゲート角度に使ったときのトランスパイル、`bindings`で与えた`Vector`要素の値解決、`qmc.expval`が参照する量子ビットの対応付け、最適化converterのHUBOインスタンス対応もしています。
 
 ```
 pip install qamomile==0.12.6

--- a/docs/ja/release_notes/v0_12_6.md
+++ b/docs/ja/release_notes/v0_12_6.md
@@ -1,0 +1,87 @@
+# Qamomile v0.12.6
+
+Qamomile v0.12.6では、回路の逆操作を作る`qmc.inverse`を追加しました。ビルトインゲート、`@qkernel`全体、QFT/IQFTをそのまま逆操作に変換でき、得られた逆操作は元と同じように呼び出せます。また、計算基底のレジスタを2^nを法として±1シフトする算術プリミティブ`qmc.modular_increment` / `qmc.modular_decrement`を追加し、`qmc.control`とも組み合わせられます。`sample()` / `run()`実行まわりのjob型・結果型は`qamomile.circuit`から直接importできるようになりました。さらに、runtime parameterの式をゲート角度に使ったときのトランスパイル、`bindings`で与えた`Vector`要素の値解決、`qmc.expval`が参照する量子ビットの対応付け、最適化converterのHUBOインスタンス対応の不具合も修正しています。
+
+```
+pip install qamomile==0.12.6
+```
+
+## 新機能
+
+### `qmc.inverse`による回路の逆操作
+
+`qmc.inverse(target)`は、ビルトインゲート関数、`@qkernel`、stdlibのQFT関数の逆操作を返します。固定ゲートは対応する随伴ゲートになり(`qmc.inverse(qmc.s)`は`qmc.sdg`、`qmc.h`や`qmc.cx`のような自己逆ゲートはそれ自身)、回転ゲート(`rx`、`ry`、`rz`、`p`、`cp`、`rzz`)は角度の符号が反転します。`qmc.inverse(qmc.qft)`は`qmc.iqft`をそのまま返すため、composite gateをネイティブに出力できるSDKではその経路が維持されます。`Vector[Qubit]`へのbroadcastも順方向のゲートと同じように動きます([#445](https://github.com/Jij-Inc/Qamomile/pull/445))。
+
+`@qkernel`に対しては、元の量子カーネルと同じ引数で呼び出せるwrapperが返り、本体を逆順にしつつ各操作を逆にして適用します。入れ子の量子カーネル呼び出し、composite gate、`qmc.control(...)`の結果、`qmc.pauli_evolve`(発展時間の符号を反転)、`qmc.range`ループ(unrollせずに反復順を逆転)も再帰的に逆変換されます。`qmc.inverse(...)`を呼ぶ量子カーネル自体を逆変換すると、入れ子のinverseは打ち消されて元の操作列に戻ります。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def layer(q: qmc.Qubit, angle: qmc.Float) -> qmc.Qubit:
+    q = qmc.h(q)
+    q = qmc.rz(q, angle)
+    return q
+
+@qmc.qkernel
+def roundtrip(angle: qmc.Float) -> qmc.Bit:
+    q = qmc.qubit("q")
+    q = layer(q, angle)
+    q = qmc.inverse(layer)(q, angle)  # uncomputeでqは|0>に戻る
+    return qmc.measure(q)
+
+executable = QiskitTranspiler().transpile(roundtrip, bindings={"angle": 0.37})
+```
+
+`if` / `while` / `for ... in qmc.items(...)`の制御フローを含む量子カーネルや、inverse wrapperのトレース時点でループ範囲がsymbolicなままの量子カーネルはサポートしておらず、`NotImplementedError`になります(`bindings`で与えたループ範囲は問題なく解決されます)。内部で量子ビットを確保する量子カーネルも拒否されます。制御フローまわりの正確な境界はリポジトリの`LIMITATIONS.md`を参照してください。
+
+### modular incrementとmodular decrement
+
+`qmc.modular_increment`と`qmc.modular_decrement`は、little-endianの量子ビットレジスタ(`q[0]`が最下位ビット)に`|j> -> |j ± 1 mod 2^n>`を適用します。構成はQFTを使わず、Xゲートとmulti-controlled Xゲートだけで組み立てられています。制御版は専用APIではなく、`qmc.control(qmc.modular_increment, num_controls=1)`のように既存の制御機構との組み合わせで作ります。どちらの量子カーネルも`qamomile.circuit.algorithm.arithmetic`からimportできます([#453](https://github.com/Jij-Inc/Qamomile/pull/453))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def plus_one(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(n, name="q")
+    q[1] = qmc.x(q[1])            # |j=2>を準備(little-endian)
+    q = qmc.modular_increment(q)  # |j=2> -> |j=3>
+    return qmc.measure(q)
+
+executable = QiskitTranspiler().transpile(plus_one, bindings={"n": 3})
+```
+
+QURI Partsでは、広いレジスタに必要なmulti-controlled Xゲートをまだ出力できないため、これらのプリミティブのサポートは部分的です。正確な範囲はリポジトリの`LIMITATIONS.md`を参照してください。
+
+### `qamomile.circuit`配下のjob型・結果型
+
+`SampleResult`、`SampleJob`、`RunJob`、`ExpvalJob`、`Job`、`JobStatus`を`qamomile.circuit`から再エクスポートしました。これらは`sample()` / `run()`実行まわりの型です。`executable.sample()`は`SampleJob`を返し、その`.result()`が`SampleResult`になります。`executable.run()`は`RunJob`または`ExpvalJob`を返し、`Job` / `JobStatus`は共通の基底クラスとステータスのenumです。`qmc.SampleResult`のような型注釈のために内部パス`qamomile.circuit.transpiler.job`をimportする必要はなくなりました。内部パスも後方互換性のため引き続きimportできます([#407](https://github.com/Jij-Inc/Qamomile/pull/407))。
+
+```python
+import qamomile.circuit as qmc
+
+def best_bitstring(result: qmc.SampleResult) -> tuple[int, ...]:
+    """最も多くサンプルされた測定結果を返す。"""
+    ((value, _count),) = result.most_common(1)
+    return value
+```
+
+## バグ修正
+
+- **runtime parameterの式をゲート角度に使っても、誤った`MultipleQuantumSegmentsError`にならなくなりました**。測定に依存する制御フローを持たない純粋な量子カーネルで、`qmc.rx(q, -phase)`、symbolicなmulti-control phaseへの`theta=-phase`、`(phase * 2) - 1`のような連鎖した式をゲート角度に使うと、トランスパイル時にプログラムが複数のquantum segmentへ誤って分割されていました。これらの式はquantum segmentの内側に保持され、emit時に各SDKのparameter式へ畳み込まれるようになりました([#455](https://github.com/Jij-Inc/Qamomile/pull/455))。
+- **`bindings`で与えた`Vector`要素の値がemit時に解決されるようになりました**。`bindings`で与えた`Vector`の要素やスライスビューの要素を、ゲート角度(手書きのcontrolled-RY半角パターン`-angle[i] / 2`など)、ループ範囲、補助量子カーネルの引数、controlled QPEのパラメータに使うと、これまでemit時に値を解決できず失敗していました。QPEを個別ゲートへ分解する経路でも、こうした配列要素から位相を取り出せませんでした。いずれもルートの配列まで遡って解決されるようになり、runtime parameterの配列やsymbolicなindexはsymbolicなまま保持されます([#454](https://github.com/Jij-Inc/Qamomile/pull/454)、[#457](https://github.com/Jij-Inc/Qamomile/pull/457)、[#458](https://github.com/Jij-Inc/Qamomile/pull/458))。
+- **より多くのレジスタ配置で`qmc.expval`が正しい量子ビットを参照するようになりました**。タプル形式の`qmc.expval((q[i],), obs)`は、inlineされた量子カーネルを経由しても呼び出し元レジスタとの対応を保つようになりました([#448](https://github.com/Jij-Inc/Qamomile/pull/448))。また、`Vector`全体に対するobservableのPauli indexは、レジスタが物理量子ビット0から始まらない配置でも正しい量子ビットへ対応付けられるようになりました([#449](https://github.com/Jij-Inc/Qamomile/pull/449))。
+- **パラメータ化したスライスへのcontrolled composite gateがQiskitで実行できるようになりました**。古典の`UInt`幅を受け取り`q[:m]`スライスにQFTを適用する量子カーネルを`qmc.control(...)`すると、これまで`EmitError`になっていました。入れ子のブロックをゲートへ変換できるSDK(Qiskit)では実行できるようになり、その変換を持たないSDKでは引き続き拒否されます([#453](https://github.com/Jij-Inc/Qamomile/pull/453))。
+- **最適化converterがHUBOの`ommx.v1.Instance`入力を受け付けるようになりました**。問題の正規化が`to_hubo()`経由で変換するようになったため、3次以上の項を持つ目的関数も、分かりにくい`RuntimeError`で失敗せずにHUBO対応のconverter(`QAOAConverter`など)へ渡るようになりました。HUBO非対応のconverterは明確な`ValueError`を送出します([#459](https://github.com/Jij-Inc/Qamomile/pull/459))。
+
+## ドキュメント
+
+- [**チュートリアル04 — 制御ゲート**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.6/docs/ja/tutorial/04_controlled_gates.ipynb)では、却下パターンの節を「rejectされるパターンとedge case」として再構成しました。`UInt`スライスを使う量子カーネルへのcontrolled QFTは、`EmitError`を期待するケースではなく、Qiskitで実行されるサポート例になりました([#453](https://github.com/Jij-Inc/Qamomile/pull/453))。
+- [**量子誤り訂正入門**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.6/docs/ja/algorithm/quantum_error_correction.ipynb)では、`SampleResult`を公開パスの`qamomile.circuit`からimportするようになりました([#407](https://github.com/Jij-Inc/Qamomile/pull/407))。
+
+## さらに詳しく
+
+- [GitHubリポジトリ](https://github.com/Jij-Inc/Qamomile)


### PR DESCRIPTION
## Summary

- Add English and Japanese v0.12.6 release notes based on the v0.12.5-to-latest-main diff: circuit inversion via `qmc.inverse` (#445), `qmc.modular_increment` / `qmc.modular_decrement` arithmetic primitives (#453), job/result type re-exports from `qamomile.circuit` (#407), and the bug fixes from #448, #449, #454, #455, #457, #458, #459.
- Update release note indexes and MyST TOCs so v0.12.6 appears first.

## Verification

- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run pytest -m "" tests/docs/test_tag_whitelist.py`
- Executed every release-note snippet with Qiskit transpile and sample: the inverse roundtrip measures all zeros, the modular increment maps the prepared basis state 2 to 3, and the `SampleResult` helper returns the expected bitstring.
- Cross-checked the prose claims (gate inverse mappings, exception types, QURI Parts modular-arithmetic boundaries, expval and segmentation fix descriptions, PR attribution) against the code with codex until it reported no findings, for both the EN and JA files.

🤖 Generated with Claude Code