### PR TITLE
Fix Möttönen wrapper qubit resolution

### DIFF
--- a/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/value_resolver.py
@@ -6,6 +6,7 @@ import numbers
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from qamomile.circuit.ir.value import resolve_root_qubit_address
 from qamomile.circuit.transpiler.errors import EmitError, ResolutionFailureReason
 from qamomile.circuit.transpiler.passes.emit_support.qubit_address import (
     QubitAddress,
@@ -29,14 +30,25 @@ class QubitResolutionResult:
 def resolve_qubit_key(qubit: "Value") -> tuple[QubitAddress | None, bool]:
     """Resolve a qubit Value to its allocation key.
 
-    Returns a ``(QubitAddress | None, is_array_element)`` tuple.
+    Args:
+        qubit (Value): Qubit value to resolve. Array elements with a
+            constant index are resolved through their full ``slice_of``
+            chain to the root array address.
+
+    Returns:
+        tuple[QubitAddress | None, bool]: ``(address, is_array_element)``.
+            ``address`` is the root-space address for a resolvable array
+            element, ``None`` for an array element whose index or slice
+            bounds are symbolic at this binding-free stage, and a scalar
+            UUID address for non-array qubits.
     """
     if qubit.parent_array is not None and qubit.element_indices:
-        parent_uuid = qubit.parent_array.uuid
         idx_value = qubit.element_indices[0]
         if idx_value.is_constant():
-            idx = int(idx_value.get_const())
-            return QubitAddress(parent_uuid, idx), True
+            resolved = resolve_root_qubit_address(qubit)
+            if resolved is not None:
+                root_uuid, idx = resolved
+                return QubitAddress(root_uuid, idx), True
         return None, True
     return QubitAddress(qubit.uuid), False
 

--- a/qamomile/circuit/transpiler/passes/inline.py
+++ b/qamomile/circuit/transpiler/passes/inline.py
@@ -480,9 +480,16 @@ class InlinePass(Pass[Block, Block]):
         # Map block's input values to operation's qubit arguments
         # Since uuid is now unique per Value, we can use simple uuid mapping
         local_map: dict[str, Value] = {}
+        arg_substitutor = ValueSubstitutor(value_map, transitive=True)
 
         for block_input, qubit_arg in zip(impl.input_values, qubit_args):
-            resolved_arg = value_map.get(qubit_arg.uuid, qubit_arg)
+            # Composite implementation inputs are scalar qubits, but the
+            # call-site operands may be array-element Values whose own UUIDs
+            # are unmapped while their parent arrays are mapped to caller
+            # arrays. Substitute the full value so parent_array fields move
+            # with the call-site scope, mirroring _inline_call()'s argument
+            # resolution.
+            resolved_arg = cast(Value, arg_substitutor.substitute_value(qubit_arg))
 
             # Get the cloned version of the input value
             cloned_input = remapper.clone_value(block_input)

--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -95,6 +95,44 @@ if TYPE_CHECKING:
 CudaqControlledQubitMap = dict[str | QubitAddress, int]
 
 
+def _cudaq_slice_root_slots_available(
+    array_value: ArrayValue,
+    vector_slots: dict[str, list[int]],
+    qubit_map: CudaqControlledQubitMap,
+    emit_pass: Any,
+    bindings: dict[str, Any],
+) -> bool:
+    """Return whether a sliced vector's root physical slots are available.
+
+    Args:
+        array_value (ArrayValue): Sliced Vector[Qubit] value whose root
+            availability should be checked.
+        vector_slots (dict[str, list[int]]): Cached vector UUID to physical
+            slot table carried by the CUDA-Q controlled fallback walker.
+        qubit_map (CudaqControlledQubitMap): UUID/address to physical qubit map.
+        emit_pass (Any): Emit pass whose resolver folds root shape values.
+        bindings (dict[str, Any]): Active controlled-body bindings.
+
+    Returns:
+        bool: True when the non-sliced root is registered in ``vector_slots`` or
+            every root element address can be found in ``qubit_map``.
+    """
+    root = array_value
+    while root.is_slice():
+        if root.slice_of is None:
+            return False
+        root = root.slice_of
+
+    if root.uuid in vector_slots:
+        return True
+    if not root.shape:
+        return False
+    size = emit_pass._resolver.resolve_int_value(root.shape[0], bindings)
+    if size is None or size < 0:
+        return False
+    return all(QubitAddress(root.uuid, i) in qubit_map for i in range(size))
+
+
 def _build_block_qubit_map(
     block_value: Any,
     target_indices: list[int],
@@ -225,13 +263,13 @@ def _seed_vector_element_uuid(
 ) -> None:
     """Seed ``qubit_map`` with a Vector[Qubit] element operand's UUID.
 
-    Resolves an ``operand`` that addresses an element of a ``Vector[Qubit]``
-    input (i.e., ``operand.parent_array`` matches a registered vector
-    and ``operand.element_indices[0]`` resolves under ``bindings``) to
-    its physical target via ``vector_slots`` and stores it under
-    ``operand.uuid``.
+    Resolves an ``operand`` that addresses an element of a registered
+    ``Vector[Qubit]`` input, including an element of a slice view over a
+    registered root vector, to its physical target via ``vector_slots`` and
+    stores it under ``operand.uuid``.
     Non-element operands (scalar ``Qubit`` inputs already seeded by
-    ``_build_block_qubit_map``) are skipped silently.
+    ``_build_block_qubit_map``) and elements whose parent/root vector is not
+    available are skipped silently so direct UUID mappings can still resolve.
 
     Args:
         operand (Any): A gate operand to seed.
@@ -246,25 +284,41 @@ def _seed_vector_element_uuid(
             including loop-local values when emitting an unrolled loop.
 
     Raises:
-        EmitError: Raised in three situations, all of which would
-            otherwise degenerate into a downstream "Missing qubit
-            mapping ..." assertion in ``_emit_cudaq_controlled_ops``.
-            (1) A Vector[Qubit] element addressed by the inner block
-            uses an element index that cannot be resolved under the
-            current bindings.
-            (2) The element index is outside the declared Vector
-            length (``elem_idx < 0`` or ``elem_idx >= len(slots)``); the
-            inner block addresses a slot past what the controlled-U
-            was wired up with.
+        EmitError: Raised when a recognized Vector[Qubit] element uses an
+            index that cannot be resolved under the current bindings, or when
+            the resolved index is outside the registered/sliced slot range. A
+            slice parent may also propagate ``EmitError`` from slice length or
+            slice-bound resolution.
     """
     parent = getattr(operand, "parent_array", None)
     if parent is None:
         return
-    if parent.uuid not in vector_slots:
-        return
     indices = tuple(getattr(operand, "element_indices", ()))
     if not indices:
         return
+
+    if (
+        isinstance(parent, ArrayValue)
+        and parent.uuid in vector_slots
+        and not parent.is_slice()
+    ):
+        slots = vector_slots[parent.uuid]
+    elif isinstance(parent, ArrayValue) and parent.is_slice():
+        if not _cudaq_slice_root_slots_available(
+            parent, vector_slots, qubit_map, emit_pass, bindings
+        ):
+            return
+        slots = _resolve_cudaq_array_slots(
+            parent,
+            vector_slots,
+            qubit_map,
+            emit_pass,
+            bindings,
+            operation="ControlledUOperation",
+        )
+    else:
+        return
+
     idx_val = indices[0]
     if idx_val.is_constant():
         elem_idx = int(idx_val.get_const())
@@ -292,7 +346,6 @@ def _seed_vector_element_uuid(
                 operation="ControlledUOperation",
             )
         elem_idx = int(resolved)
-    slots = vector_slots[parent.uuid]
     if elem_idx < 0 or elem_idx >= len(slots):
         # Silently skipping leaves the element's UUID unmapped in
         # ``qubit_map``, which later trips a hard ``AssertionError``
@@ -465,7 +518,7 @@ def _resolve_cudaq_array_slots(
             f"{operation}, got {type(array_value).__name__}.",
             operation=operation,
         )
-    if array_value.uuid in vector_slots:
+    if not array_value.is_slice() and array_value.uuid in vector_slots:
         return list(vector_slots[array_value.uuid])
     if not array_value.shape:
         raise EmitError(
@@ -516,7 +569,7 @@ def _resolve_cudaq_array_slots(
             slice_slots.append(parent_slots[parent_idx])
         vector_slots[array_value.uuid] = slice_slots
         if slice_slots:
-            qubit_map.setdefault(array_value.uuid, slice_slots[0])
+            qubit_map[array_value.uuid] = slice_slots[0]
         return slice_slots
 
     slots: list[int] = []

--- a/tests/_cudaq_isolation.py
+++ b/tests/_cudaq_isolation.py
@@ -1,0 +1,78 @@
+"""Keep CUDA-Q out of pytest processes that will not run CUDA-Q tests.
+
+Why this exists: ``cudaq`` imports ``torch`` at import time, and torch,
+qiskit-aer, and cudaq each bundle their own copy of LLVM's OpenMP runtime
+(``libomp.dylib``). Loading more than one OpenMP runtime into a single
+process is undefined behavior; on macOS arm64 it manifests as a
+segmentation fault inside AerSimulator's worker threads once the
+cudaq/torch libraries are resident. The minimal reproduction is running
+``tests/transpiler/backends/test_cudaq.py`` before
+``tests/transpiler/test_pauli_evolve_vector_observable.py``: the former's
+module-level ``pytest.importorskip("cudaq")`` executes during collection
+even when every cudaq test is deselected by the default
+``-m "not docs and not quri_parts and not cudaq"`` addopts, and the
+latter then crashes inside AerSimulator.
+
+The fix has two halves, enforced by ``tests/test_cudaq_import_isolation.py``:
+
+- ``tests/conftest.py`` skips collecting the modules listed in
+  :data:`CUDAQ_MODULE_LEVEL_IMPORTERS` whenever the active marker
+  expression cannot select a cudaq-marked test anyway.
+- Tests that import cudaq lazily (inside the test body) must carry
+  ``pytest.mark.cudaq`` so that default runs never load cudaq
+  mid-session either. They still run in the dedicated ``-m cudaq`` CI
+  jobs, which execute no qiskit-aer simulations in the same process.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+#: Test modules (rootdir-relative POSIX paths) that import ``cudaq`` at
+#: module scope, i.e. during collection. Every entry must also carry
+#: ``pytestmark = pytest.mark.cudaq``; tests/test_cudaq_import_isolation.py
+#: keeps this table in sync with the actual test sources.
+CUDAQ_MODULE_LEVEL_IMPORTERS: frozenset[str] = frozenset(
+    {
+        "tests/transpiler/backends/test_cudaq.py",
+        "tests/transpiler/backends/test_cudaq_frontend.py",
+    }
+)
+
+
+@lru_cache(maxsize=None)
+def markexpr_can_select_cudaq(markexpr: str) -> bool:
+    """Return whether a ``-m`` expression could select a cudaq-marked test.
+
+    Evaluates ``markexpr`` against two hypothetical test items — one whose
+    only mark is ``cudaq`` and one carrying every mark — and reports
+    whether either would be selected. When both are rejected, no test
+    bearing the ``cudaq`` mark can run in this session, so the modules in
+    :data:`CUDAQ_MODULE_LEVEL_IMPORTERS` need not be collected at all.
+
+    Args:
+        markexpr (str): The raw ``-m`` option value. An empty or blank
+            string means no marker filtering, i.e. cudaq tests are
+            selectable.
+
+    Returns:
+        bool: True when a cudaq-marked test could be selected (collect the
+            cudaq modules as usual); False when the expression provably
+            deselects all of them.
+    """
+    expression = markexpr.strip()
+    if not expression:
+        return True
+    try:
+        from _pytest.mark.expression import Expression
+
+        compiled = Expression.compile(expression)
+        cudaq_only_item = compiled.evaluate(lambda name, **kwargs: name == "cudaq")
+        all_marks_item = compiled.evaluate(lambda name, **kwargs: True)
+        return cudaq_only_item or all_marks_item
+    except Exception:
+        # ``Expression`` is private pytest API. If it drifts on a pytest
+        # upgrade, recognize only the stock exclusion spelling and
+        # otherwise keep collecting as before — never wrongly hide tests.
+        return re.search(r"\bnot\s+cudaq\b", expression) is None

--- a/tests/circuit/algorithm/state_preparation/test_computational_basis_state.py
+++ b/tests/circuit/algorithm/state_preparation/test_computational_basis_state.py
@@ -161,9 +161,11 @@ class TestComputationalBasisStateSample:
         results = _sample_compile_time(_quri_parts_transpiler(), n, bits, shots)
         _assert_deterministic_sample(results, bits, shots)
 
+    @pytest.mark.cudaq
     @pytest.mark.parametrize("n", _SIZES)
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_cudaq(self, n: int, seed: int) -> None:
+        """CUDA-Q leg; ``-m cudaq`` sessions only (see tests/_cudaq_isolation.py)."""
         rng = np.random.default_rng(seed)
         bits = _random_bits(rng, n)
         shots = 64
@@ -198,9 +200,11 @@ class TestComputationalBasisStateRuntimeBits:
         results = _sample_runtime_bits(_quri_parts_transpiler(), n, bits, shots)
         _assert_deterministic_sample(results, bits, shots)
 
+    @pytest.mark.cudaq
     @pytest.mark.parametrize("n", _SIZES)
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_cudaq(self, n: int, seed: int) -> None:
+        """CUDA-Q leg; ``-m cudaq`` sessions only (see tests/_cudaq_isolation.py)."""
         rng = np.random.default_rng(seed)
         bits = _random_bits(rng, n)
         shots = 64
@@ -241,9 +245,11 @@ class TestComputationalBasisStateExpval:
             f"quri_parts expval={observed}, expected={expected}"
         )
 
+    @pytest.mark.cudaq
     @pytest.mark.parametrize("n", _SIZES)
     @pytest.mark.parametrize("seed", _SEEDS)
     def test_cudaq(self, n: int, seed: int) -> None:
+        """CUDA-Q leg; ``-m cudaq`` sessions only (see tests/_cudaq_isolation.py)."""
         rng = np.random.default_rng(seed)
         bits = _random_bits(rng, n)
         coeffs = rng.uniform(-1.0, 1.0, size=n).tolist()
@@ -275,9 +281,11 @@ class TestComputationalBasisStateBoundary:
         results = _sample_compile_time(_quri_parts_transpiler(), n, bits, shots)
         _assert_deterministic_sample(results, bits, shots)
 
+    @pytest.mark.cudaq
     @pytest.mark.parametrize("n", _BOUNDARY_SIZES)
     @pytest.mark.parametrize("pattern", ["all_zero", "all_one"])
     def test_cudaq(self, n: int, pattern: str) -> None:
+        """CUDA-Q leg; ``-m cudaq`` sessions only (see tests/_cudaq_isolation.py)."""
         bits = [0] * n if pattern == "all_zero" else [1] * n
         shots = 32
         results = _sample_compile_time(_cudaq_transpiler(), n, bits, shots)

--- a/tests/circuit/algorithm/state_preparation/test_mottonen_amplitude_encoding.py
+++ b/tests/circuit/algorithm/state_preparation/test_mottonen_amplitude_encoding.py
@@ -13,6 +13,11 @@ from qamomile.circuit.algorithm.state_preparation import (
     amplitude_encoding_from_angles,
 )
 from qamomile.circuit.ir.operation.composite_gate import CompositeGateType
+from qamomile.circuit.ir.operation.gate import GateOperation
+from qamomile.circuit.ir.operation.operation import QInitOperation
+from qamomile.circuit.ir.value import resolve_root_qubit_address
+from qamomile.circuit.transpiler.passes.emit_support import ResourceAllocator
+from qamomile.circuit.transpiler.segments import QuantumStep
 from qamomile.linalg import (
     compute_mottonen_amplitude_encoding_ry_angles,
     compute_mottonen_amplitude_encoding_rz_angles,
@@ -49,6 +54,7 @@ _FIXED_COMPLEX_AMPLITUDES: list[tuple[str, list[complex]]] = [
 
 _SEEDS = [901, 902, 903, 904, 905]
 _QUBIT_COUNTS = [1, 2, 3, 4]
+_WRAPPER_QUBIT_COUNTS = [1, 2, 3]
 
 # Sampling tolerance: 5 sigma binomial bound at the test shot count, matching
 # the convention used elsewhere in the suite (e.g. test_trotter.py's
@@ -87,6 +93,43 @@ _EXPVAL_CASES: list[tuple[str, list[float] | list[complex], str, int, float]] = 
     # <Z_1> = p_0 + p_1 - p_2 - p_3 = (1 + 2 - 2 - 4) / 9 = -1/3.
     ("2q-mixed-Z0", [1 + 0j, 1 + 1j, 1 - 1j, 0 + 2j], "Z", 0, -1.0 / 3.0),
     ("2q-mixed-Z1", [1 + 0j, 1 + 1j, 1 - 1j, 0 + 2j], "Z", 1, -1.0 / 3.0),
+]
+
+
+def _random_real_amplitudes(n_qubits: int, seed: int) -> list[float]:
+    """Return a deterministic non-zero random real amplitude vector.
+
+    Args:
+        n_qubits (int): Number of qubits represented by the vector.
+        seed (int): Seed for ``np.random.default_rng``.
+
+    Returns:
+        list[float]: Real amplitude vector of length ``2**n_qubits``.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(2**n_qubits).tolist()
+
+
+_WRAPPER_AMPLITUDE_CASES: list[pytest.ParameterSet] = [
+    pytest.param([1.0, 0.0], id="boundary-1q-zero"),
+    pytest.param([1.0, 2.0, 3.0, 4.0], id="fixed-2q-asymmetric"),
+    pytest.param([1.0 + 0j, 0.0 + 1j], id="complex-1q-plus-y"),
+    pytest.param(
+        [1.0 + 0j, 1.0 + 1j, 1.0 - 1j, 0.0 + 2j],
+        id="complex-2q-mixed",
+    ),
+    pytest.param(
+        [1.0, 2.0, 3.0, -4.0, 5.0, -6.0, 7.0, 8.0],
+        id="fixed-3q-signed",
+    ),
+    *[
+        pytest.param(
+            _random_real_amplitudes(n_qubits, seed),
+            id=f"random-{n_qubits}q-seed{seed}",
+        )
+        for n_qubits in _WRAPPER_QUBIT_COUNTS
+        for seed in [0, 1, 2, 42]
+    ],
 ]
 
 
@@ -756,6 +799,201 @@ def _build_expval_kernel(
     return kernel
 
 
+def _build_wrapper_measure_kernel(
+    amplitudes: list[float] | list[complex],
+) -> qmc.QKernel:
+    """Build a wrapper-kernel amplitude-encoding sampler.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector of length ``2**n``.
+
+    Returns:
+        qmc.QKernel: Kernel that calls an inner qkernel wrapper around
+            ``amplitude_encoding`` before measuring the register.
+    """
+    n_qubits = int(round(np.log2(len(amplitudes))))
+
+    @qmc.qkernel
+    def layer(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Apply Möttönen encoding through a qkernel wrapper."""
+        q = amplitude_encoding(q, amplitudes)
+        return q
+
+    @qmc.qkernel
+    def kernel() -> qmc.Vector[qmc.Bit]:
+        q = qmc.qubit_array(n_qubits, "q")
+        q = layer(q)
+        return qmc.measure(q)
+
+    return kernel
+
+
+def _build_wrapper_expval_kernel(
+    amplitudes: list[float] | list[complex],
+) -> qmc.QKernel:
+    """Build a wrapper-kernel amplitude-encoding expval circuit.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector of length ``2**n``.
+
+    Returns:
+        qmc.QKernel: Kernel that calls an inner qkernel wrapper around
+            ``amplitude_encoding`` before computing ``<H>``.
+    """
+    n_qubits = int(round(np.log2(len(amplitudes))))
+
+    @qmc.qkernel
+    def layer(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Apply Möttönen encoding through a qkernel wrapper."""
+        q = amplitude_encoding(q, amplitudes)
+        return q
+
+    @qmc.qkernel
+    def kernel(H: qmc.Observable) -> qmc.Float:
+        q = qmc.qubit_array(n_qubits, "q")
+        q = layer(q)
+        return qmc.expval(q, H)
+
+    return kernel
+
+
+def _build_nested_wrapper_measure_kernel(
+    amplitudes: list[float] | list[complex],
+) -> qmc.QKernel:
+    """Build a two-level wrapper-kernel amplitude-encoding sampler.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector of length ``2**n``.
+
+    Returns:
+        qmc.QKernel: Kernel whose outer wrapper calls another wrapper
+            around ``amplitude_encoding``.
+    """
+    n_qubits = int(round(np.log2(len(amplitudes))))
+
+    @qmc.qkernel
+    def inner(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Apply Möttönen encoding inside the innermost wrapper."""
+        q = amplitude_encoding(q, amplitudes)
+        return q
+
+    @qmc.qkernel
+    def outer(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Forward to the inner Möttönen wrapper."""
+        q = inner(q)
+        return q
+
+    @qmc.qkernel
+    def kernel() -> qmc.Vector[qmc.Bit]:
+        q = qmc.qubit_array(n_qubits, "q")
+        q = outer(q)
+        return qmc.measure(q)
+
+    return kernel
+
+
+def _build_nested_wrapper_expval_kernel(
+    amplitudes: list[float] | list[complex],
+) -> qmc.QKernel:
+    """Build a two-level wrapper-kernel amplitude-encoding expval circuit.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector of length ``2**n``.
+
+    Returns:
+        qmc.QKernel: Kernel whose outer wrapper calls another wrapper
+            around ``amplitude_encoding`` before computing ``<H>``.
+    """
+    n_qubits = int(round(np.log2(len(amplitudes))))
+
+    @qmc.qkernel
+    def inner(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Apply Möttönen encoding inside the innermost wrapper."""
+        q = amplitude_encoding(q, amplitudes)
+        return q
+
+    @qmc.qkernel
+    def outer(q: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Qubit]:
+        """Forward to the inner Möttönen wrapper."""
+        q = inner(q)
+        return q
+
+    @qmc.qkernel
+    def kernel(H: qmc.Observable) -> qmc.Float:
+        q = qmc.qubit_array(n_qubits, "q")
+        q = outer(q)
+        return qmc.expval(q, H)
+
+    return kernel
+
+
+def _expected_z0(amplitudes: list[float] | list[complex]) -> float:
+    """Return the little-endian ``<Z0>`` expectation for *amplitudes*.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector.
+
+    Returns:
+        float: Analytic expectation where basis-index bit 0 corresponds
+            to qubit 0.
+    """
+    probabilities = np.abs(_normalize(amplitudes)) ** 2
+    return float(
+        sum(prob if (idx & 1) == 0 else -prob for idx, prob in enumerate(probabilities))
+    )
+
+
+def _expected_single_pauli(
+    amplitudes: list[float] | list[complex],
+    pauli: str,
+    qubit: int,
+) -> float:
+    """Return the little-endian single-Pauli expectation for *amplitudes*.
+
+    Args:
+        amplitudes (list[float] | list[complex]): Real or complex
+            amplitude vector.
+        pauli (str): One of ``"X"``, ``"Y"``, ``"Z"``.
+        qubit (int): Qubit index in little-endian basis order.
+
+    Returns:
+        float: Analytic expectation for the selected single-qubit Pauli.
+
+    Raises:
+        ValueError: If *pauli* is not one of ``"X"``, ``"Y"``, or ``"Z"``.
+    """
+    state = _normalize(amplitudes).astype(complex)
+    mask = 1 << qubit
+
+    if pauli == "Z":
+        return float(
+            sum(
+                (1.0 if (idx & mask) == 0 else -1.0) * abs(amplitude) ** 2
+                for idx, amplitude in enumerate(state)
+            )
+        )
+
+    if pauli not in {"X", "Y"}:
+        raise ValueError(f"Unknown Pauli label: {pauli}")
+
+    total = 0.0 + 0.0j
+    for idx, amplitude in enumerate(state):
+        paired_idx = idx ^ mask
+        if pauli == "X":
+            coefficient = 1.0
+        elif (idx & mask) == 0:
+            coefficient = 1.0j
+        else:
+            coefficient = -1.0j
+        total += np.conjugate(state[paired_idx]) * coefficient * amplitude
+    return float(np.real_if_close(total))
+
+
 def _bits_to_index(bits: tuple[int, ...] | int) -> int:
     """Convert a measurement outcome to a flat basis-state index.
 
@@ -790,6 +1028,169 @@ def _shot_noise_tolerance(p: float, shots: int) -> float:
             still admit a non-zero (but small) tolerance.
     """
     return _STD_TOLERANCE * float(np.sqrt(max(p * (1.0 - p), 1e-12) / shots))
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-kernel regressions for custom-composite inlining
+# ---------------------------------------------------------------------------
+
+
+class TestAmplitudeEncodingWrapperInlining:
+    """Regression tests for amplitude_encoding inside qkernel wrappers."""
+
+    @pytest.mark.parametrize(
+        "amplitudes",
+        [
+            pytest.param(
+                [1.0, 2.0, 3.0, -4.0, 5.0, -6.0, 7.0, 8.0],
+                id="real-3q",
+            ),
+            pytest.param(
+                [1.0 + 0j, 1.0 + 1j, 1.0 - 1j, 0.0 + 2j],
+                id="complex-2q",
+            ),
+        ],
+    )
+    def test_inline_rewrites_composite_element_parents(
+        self, amplitudes: list[float] | list[complex]
+    ) -> None:
+        """Inlined Möttönen gate operands must resolve to the caller array."""
+        pytest.importorskip("qiskit")
+        from qamomile.qiskit import QiskitTranspiler
+
+        transpiler = QiskitTranspiler()
+        kernel = _build_wrapper_measure_kernel(amplitudes)
+
+        block = transpiler.to_block(kernel)
+        block = transpiler.substitute(block)
+        block = transpiler.resolve_parameter_shapes(block, None)
+        affine = transpiler.inline(block)
+
+        qinit_arrays = [
+            op.results[0] for op in affine.operations if isinstance(op, QInitOperation)
+        ]
+        assert qinit_arrays
+        qinit_uuid = qinit_arrays[0].uuid
+
+        root_addresses: list[tuple[str, int]] = []
+        for op in affine.operations:
+            if isinstance(op, GateOperation):
+                for operand in op.qubit_operands:
+                    if operand.parent_array is None:
+                        continue
+                    root_addr = resolve_root_qubit_address(operand)
+                    assert root_addr is not None
+                    root_addresses.append(root_addr)
+
+        assert root_addresses
+        assert {root_uuid for root_uuid, _ in root_addresses} == {qinit_uuid}
+
+        affine = transpiler.unroll_recursion(affine, None)
+        validated = transpiler.affine_validate(affine)
+        partially_evaluated = transpiler.partial_eval(validated, None)
+        partially_evaluated = transpiler.slice_borrow_check(partially_evaluated)
+        partially_evaluated = transpiler.strip_slice_ops(partially_evaluated)
+        analyzed = transpiler.analyze(partially_evaluated)
+        analyzed = transpiler.classical_lowering(analyzed)
+        analyzed = transpiler.validate_symbolic_shapes(analyzed)
+        plan = transpiler.plan(analyzed)
+        quantum_segment = next(
+            step.segment for step in plan.steps if isinstance(step, QuantumStep)
+        )
+
+        ResourceAllocator().allocate(quantum_segment.operations, bindings={})
+
+    @pytest.mark.parametrize("amplitudes", _WRAPPER_AMPLITUDE_CASES)
+    def test_forward_wrapper_sampler(self, sdk_transpiler, amplitudes) -> None:
+        """Wrapped amplitude_encoding samples the encoded distribution."""
+        kernel = _build_wrapper_measure_kernel(amplitudes)
+        exe = sdk_transpiler.transpiler.transpile(kernel)
+        results = (
+            exe.sample(sdk_transpiler.transpiler.executor(), shots=_SHOTS)
+            .result()
+            .results
+        )
+
+        expected_probs = np.abs(_normalize(amplitudes)) ** 2
+        observed_probs = np.zeros_like(expected_probs)
+        total = 0
+        for bits, count in results:
+            observed_probs[_bits_to_index(bits)] = count / _SHOTS
+            total += count
+        assert total == _SHOTS
+
+        for i, p_exp in enumerate(expected_probs):
+            assert abs(observed_probs[i] - p_exp) < _shot_noise_tolerance(
+                p_exp, _SHOTS
+            ), (
+                f"{sdk_transpiler.backend_name} bin {i}: "
+                f"got {observed_probs[i]:.4f}, expected {p_exp:.4f} "
+                f"(amplitudes={amplitudes})"
+            )
+
+    @pytest.mark.parametrize("amplitudes", _WRAPPER_AMPLITUDE_CASES)
+    def test_forward_wrapper_expval(self, sdk_transpiler, amplitudes) -> None:
+        """Wrapped amplitude_encoding gives the analytic little-endian <Z0>."""
+        n_qubits = int(round(np.log2(len(amplitudes))))
+        H = _pad_observable(n_qubits, _make_pauli("Z", 0))
+        exe = sdk_transpiler.transpiler.transpile(
+            _build_wrapper_expval_kernel(amplitudes), bindings={"H": H}
+        )
+        result = exe.run(sdk_transpiler.transpiler.executor()).result()
+        assert float(result) == pytest.approx(_expected_z0(amplitudes), abs=1e-8)
+
+    def test_forward_wrapper_phase_expval(self, sdk_transpiler) -> None:
+        """Wrapped complex amplitude_encoding preserves phase-sensitive <Y0>."""
+        amplitudes = [1.0 + 0j, 0.0 + 1j]
+        H = _make_pauli("Y", 0)
+        exe = sdk_transpiler.transpiler.transpile(
+            _build_wrapper_expval_kernel(amplitudes), bindings={"H": H}
+        )
+        result = exe.run(sdk_transpiler.transpiler.executor()).result()
+        assert float(result) == pytest.approx(
+            _expected_single_pauli(amplitudes, "Y", 0), abs=1e-8
+        )
+
+    def test_nested_wrapper_sampler(self, sdk_transpiler) -> None:
+        """Nested wrapper amplitude_encoding samples the encoded distribution."""
+        amplitudes = [1.0, 2.0, 3.0, -4.0, 5.0, -6.0, 7.0, 8.0]
+        exe = sdk_transpiler.transpiler.transpile(
+            _build_nested_wrapper_measure_kernel(amplitudes)
+        )
+        results = (
+            exe.sample(sdk_transpiler.transpiler.executor(), shots=_SHOTS)
+            .result()
+            .results
+        )
+
+        expected_probs = np.abs(_normalize(amplitudes)) ** 2
+        observed_probs = np.zeros_like(expected_probs)
+        total = 0
+        for bits, count in results:
+            observed_probs[_bits_to_index(bits)] = count / _SHOTS
+            total += count
+        assert total == _SHOTS
+
+        for i, p_exp in enumerate(expected_probs):
+            assert abs(observed_probs[i] - p_exp) < _shot_noise_tolerance(
+                p_exp, _SHOTS
+            ), (
+                f"{sdk_transpiler.backend_name} bin {i}: "
+                f"got {observed_probs[i]:.4f}, expected {p_exp:.4f}"
+            )
+
+    def test_nested_wrapper_expval(self, sdk_transpiler) -> None:
+        """Nested wrapper complex amplitude_encoding preserves phase-sensitive <Y0>."""
+        amplitudes = [1.0 + 0j, 0.0 + 1j, 0.0 + 0j, 0.0 + 0j]
+        n_qubits = int(round(np.log2(len(amplitudes))))
+        H = _pad_observable(n_qubits, _make_pauli("Y", 0))
+        exe = sdk_transpiler.transpiler.transpile(
+            _build_nested_wrapper_expval_kernel(amplitudes), bindings={"H": H}
+        )
+        result = exe.run(sdk_transpiler.transpiler.executor()).result()
+        assert float(result) == pytest.approx(
+            _expected_single_pauli(amplitudes, "Y", 0), abs=1e-8
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/circuit/algorithm/test_trotter.py
+++ b/tests/circuit/algorithm/test_trotter.py
@@ -480,6 +480,34 @@ def _cudaq_transpiler():
     return CudaqTranspiler()
 
 
+def _statevector_no_aer(circuit) -> np.ndarray:
+    """Strip measurements, unroll for_loops, and simulate without qiskit-aer.
+
+    The cudaq-marked cross-backend tests must not execute qiskit-aer in
+    the same process as cudaq (multiple OpenMP runtimes — see
+    tests/_cudaq_isolation.py), so their Qiskit reference statevector is
+    computed with the pure-Python ``qiskit.quantum_info.Statevector``
+    after ``UnrollForLoops`` removes the runtime-loop instructions that
+    ``Statevector`` cannot simulate.
+
+    Args:
+        circuit: Compiled Qiskit circuit (may contain ``for_loop`` ops).
+
+    Returns:
+        np.ndarray: Complex amplitudes of the unitary core.
+    """
+    from qiskit.quantum_info import Statevector
+    from qiskit.transpiler import PassManager
+    from qiskit.transpiler.passes import UnrollForLoops
+
+    stripped = QuantumCircuit(*circuit.qregs)
+    for instr in circuit.data:
+        if instr.operation.name not in ("measure", "save_statevector"):
+            stripped.append(instr)
+    unrolled = PassManager([UnrollForLoops()]).run(stripped)
+    return np.asarray(Statevector(unrolled).data)
+
+
 def _cudaq_statevector(cudaq_circuit) -> np.ndarray:
     """Simulate a fully-bound CUDA-Q STATIC artifact via ``cudaq.get_state``."""
     import cudaq
@@ -558,9 +586,14 @@ class TestCrossBackendCompilation:
         assert qp_circuit.qubit_count == 1
         assert _rz_count_quri_parts(qp_circuit) == self._EXPECTED_RZ_PER_STEP[order]
 
+    @pytest.mark.cudaq
     @pytest.mark.parametrize("order", [1, 2, 4])
     def test_cudaq_rz_count_matches_qiskit(self, order: int) -> None:
-        """CUDA-Q emits the same per-step RZ count as Qiskit / QURI Parts."""
+        """CUDA-Q emits the same per-step RZ count as Qiskit / QURI Parts.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py.
+        """
         tr = _cudaq_transpiler()
         exe = tr.transpile(
             _rabi_trotter,
@@ -642,7 +675,10 @@ class TestCrossBackendStatevector:
         overlap = abs(np.vdot(sv_qiskit, sv_quri_parts))
         assert overlap > 1.0 - 1e-10
 
+    @pytest.mark.cudaq
     def test_cudaq_matches_exact_propagator(self) -> None:
+        """CUDA-Q reproduces the exact propagator; ``-m cudaq`` sessions
+        only (see tests/_cudaq_isolation.py)."""
         tr = _cudaq_transpiler()
         exe = tr.transpile(
             _rabi_trotter,
@@ -657,8 +693,14 @@ class TestCrossBackendStatevector:
         overlap = abs(np.vdot(_exact_state(), sv))
         assert overlap > 1.0 - self._TOLERANCE
 
+    @pytest.mark.cudaq
     def test_cudaq_statevector_matches_qiskit(self) -> None:
-        """Same kernel + same bindings → same state on both backends."""
+        """Same kernel + same bindings → same state on both backends.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py. The Qiskit
+        reference therefore uses the Aer-free ``_statevector_no_aer``.
+        """
         cudaq_tr = _cudaq_transpiler()
         bindings = {
             "order": 4,
@@ -666,7 +708,7 @@ class TestCrossBackendStatevector:
             "gamma": T_EVOLVE,
             "step": self._STEP,
         }
-        sv_qiskit = _statevector(
+        sv_qiskit = _statevector_no_aer(
             QiskitTranspiler()
             .transpile(_rabi_trotter, bindings=bindings)
             .compiled_quantum[0]
@@ -760,7 +802,10 @@ class TestCrossBackendDistribution:
         n0, n1 = self._sample(_quri_parts_transpiler())
         self._assert_matches_exact(n0, n1)
 
+    @pytest.mark.cudaq
     def test_cudaq(self) -> None:
+        """CUDA-Q sampling matches the Born probabilities; ``-m cudaq``
+        sessions only (see tests/_cudaq_isolation.py)."""
         n0, n1 = self._sample(_cudaq_transpiler())
         self._assert_matches_exact(n0, n1)
 
@@ -903,8 +948,14 @@ class TestRandomHamiltonianConvergence:
         overlap = abs(np.vdot(sv_qk, sv_qp))
         assert overlap > 1.0 - 1e-10, f"cross-backend overlap {overlap:.15f}"
 
+    @pytest.mark.cudaq
     def test_cudaq_matches_qiskit(self) -> None:
-        """Same Hamiltonian + order 4 + step 16 → matching states."""
+        """Same Hamiltonian + order 4 + step 16 → matching states.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py. The Qiskit
+        reference therefore uses the Aer-free ``_statevector_no_aer``.
+        """
         cudaq_tr = _cudaq_transpiler()
         hs, _ = _random_two_part_hamiltonian()
         bindings = {
@@ -916,7 +967,7 @@ class TestRandomHamiltonianConvergence:
 
         # Both backends use the same little-endian basis-index ordering,
         # so the raw statevectors are directly comparable up to a phase.
-        sv_qk = _statevector(
+        sv_qk = _statevector_no_aer(
             QiskitTranspiler()
             .transpile(_rabi_trotter_2q, bindings=bindings)
             .compiled_quantum[0]

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -1068,7 +1068,12 @@ _BUILTIN_BACKENDS = [
     pytest.param(
         _cudaq_transpiler_factory,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 
@@ -1081,7 +1086,12 @@ _QISKIT_CUDAQ_BACKENDS = [
     pytest.param(
         _cudaq_transpiler_factory,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 

--- a/tests/circuit/test_controlled.py
+++ b/tests/circuit/test_controlled.py
@@ -1026,8 +1026,9 @@ except ImportError:  # pragma: no cover
 
 _HAS_CUDAQ = True
 try:  # pragma: no cover - presence check
-    import cudaq  # noqa: F401
-
+    # The lazy accessor raises ImportError when cudaq is missing, without
+    # loading the cudaq runtime at collection time when it is installed
+    # (see tests/_cudaq_isolation.py).
     from qamomile.cudaq import CudaqTranspiler as _CudaqTranspilerCheck  # noqa: F401
 except ImportError:  # pragma: no cover
     _HAS_CUDAQ = False

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -58,8 +58,9 @@ except ImportError:  # pragma: no cover - covered when quri_parts is absent
 
 _HAS_CUDAQ = True
 try:  # pragma: no cover - presence check, not behaviour
-    import cudaq  # noqa: F401
-
+    # The lazy accessor raises ImportError when cudaq is missing, without
+    # loading the cudaq runtime at collection time when it is installed
+    # (see tests/_cudaq_isolation.py).
     from qamomile.cudaq import CudaqTranspiler
 except ImportError:  # pragma: no cover - covered when cudaq is absent
     _HAS_CUDAQ = False

--- a/tests/circuit/test_float_neg.py
+++ b/tests/circuit/test_float_neg.py
@@ -82,7 +82,12 @@ BACKENDS = [
     pytest.param(
         CudaqTranspiler,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 

--- a/tests/circuit/test_gate_broadcast.py
+++ b/tests/circuit/test_gate_broadcast.py
@@ -144,8 +144,9 @@ except ImportError:  # pragma: no cover - covered when quri_parts is absent
 
 _HAS_CUDAQ = True
 try:  # pragma: no cover - presence check, not behaviour
-    import cudaq  # noqa: F401
-
+    # The lazy accessor raises ImportError when cudaq is missing, without
+    # loading the cudaq runtime at collection time when it is installed
+    # (see tests/_cudaq_isolation.py).
     from qamomile.cudaq import CudaqTranspiler
 except ImportError:  # pragma: no cover - covered when cudaq is absent
     _HAS_CUDAQ = False

--- a/tests/circuit/test_gate_broadcast.py
+++ b/tests/circuit/test_gate_broadcast.py
@@ -175,7 +175,12 @@ BACKENDS = [
     pytest.param(
         CudaqTranspiler,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 

--- a/tests/circuit/test_inverse.py
+++ b/tests/circuit/test_inverse.py
@@ -3157,12 +3157,8 @@ def _computational_basis_state_roundtrip_kernels() -> tuple[qmc.QKernel, qmc.QKe
 def _amplitude_encoding_roundtrip_kernels() -> tuple[qmc.QKernel, qmc.QKernel]:
     """Build state-preparation amplitude_encoding inverse roundtrip kernels.
 
-    The inverse leg goes through a register-parameterized qkernel wrapper,
-    exercising Mottonen composite-gate inversion. The forward leg applies
-    `amplitude_encoding` directly inside the entry kernel: routing the
-    forward call through the same wrapper currently trips a pre-existing
-    transpiler qubit-map assertion (QInit ordering for nested composite
-    emission, unrelated to inverse), so only the inverse leg is wrapped.
+    Both legs go through a register-parameterized qkernel wrapper,
+    exercising Möttönen custom-composite inlining and inversion.
 
     Returns:
         tuple[qmc.QKernel, qmc.QKernel]: Sampling kernel that measures
@@ -3180,14 +3176,14 @@ def _amplitude_encoding_roundtrip_kernels() -> tuple[qmc.QKernel, qmc.QKernel]:
     @qmc.qkernel
     def sample_circuit() -> qmc.Vector[qmc.Bit]:
         qs = qmc.qubit_array(2, "qs")
-        qs = amplitude_encoding(qs, amplitudes)
+        qs = amplitude_layer(qs)
         qs = qmc.inverse(amplitude_layer)(qs)
         return qmc.measure(qs)
 
     @qmc.qkernel
     def expval_circuit(observable: qmc.Observable) -> qmc.Float:
         qs = qmc.qubit_array(2, "qs")
-        qs = amplitude_encoding(qs, amplitudes)
+        qs = amplitude_layer(qs)
         qs = qmc.inverse(amplitude_layer)(qs)
         return qmc.expval(qs, observable)
 
@@ -3200,10 +3196,9 @@ def _amplitude_encoding_from_angles_roundtrip_kernels() -> tuple[
     """Build state-preparation amplitude_encoding_from_angles roundtrip kernels.
 
     The parametric companion to `amplitude_encoding`: pre-computed Mottonen
-    Ry angles flow through the same composite gate, so the case mirrors the
-    amplitude_encoding one, including the direct forward leg (the nested
-    forward call trips the same pre-existing transpiler qubit-map
-    assertion, unrelated to inverse).
+    Ry angles are emitted as elementary gates rather than through a custom
+    composite operation. The wrapper path is included for symmetry with
+    `amplitude_encoding`, but it does not exercise `_inline_composite`.
 
     Returns:
         tuple[qmc.QKernel, qmc.QKernel]: Sampling kernel that measures
@@ -3224,14 +3219,14 @@ def _amplitude_encoding_from_angles_roundtrip_kernels() -> tuple[
     @qmc.qkernel
     def sample_circuit() -> qmc.Vector[qmc.Bit]:
         qs = qmc.qubit_array(2, "qs")
-        qs = amplitude_encoding_from_angles(qs, ry_angles)
+        qs = amplitude_angles_layer(qs)
         qs = qmc.inverse(amplitude_angles_layer)(qs)
         return qmc.measure(qs)
 
     @qmc.qkernel
     def expval_circuit(observable: qmc.Observable) -> qmc.Float:
         qs = qmc.qubit_array(2, "qs")
-        qs = amplitude_encoding_from_angles(qs, ry_angles)
+        qs = amplitude_angles_layer(qs)
         qs = qmc.inverse(amplitude_angles_layer)(qs)
         return qmc.expval(qs, observable)
 

--- a/tests/circuit/test_inverse.py
+++ b/tests/circuit/test_inverse.py
@@ -115,7 +115,12 @@ BACKENDS = [
     pytest.param(
         CudaqTranspiler,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 
@@ -2073,8 +2078,13 @@ def test_inverse_vector_qkernel_prefers_quri_parts_backend_inverse(monkeypatch) 
     ]
 
 
+@pytest.mark.cudaq
 def test_inverse_qkernel_prefers_cudaq_backend_adjoint() -> None:
-    """inverse(qkernel) uses CUDA-Q cudaq.adjoint when available."""
+    """inverse(qkernel) uses CUDA-Q cudaq.adjoint when available.
+
+    Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+    session is unsafe — see tests/_cudaq_isolation.py.
+    """
     cudaq = pytest.importorskip("cudaq")
 
     from qamomile.cudaq import CudaqTranspiler
@@ -2108,8 +2118,13 @@ def test_inverse_qkernel_prefers_cudaq_backend_adjoint() -> None:
     assert np.allclose(statevector, expected, atol=1e-8)
 
 
+@pytest.mark.cudaq
 def test_inverse_vector_qkernel_prefers_cudaq_backend_adjoint() -> None:
-    """inverse(qkernel) keeps Vector inputs atomic for CUDA-Q adjoint."""
+    """inverse(qkernel) keeps Vector inputs atomic for CUDA-Q adjoint.
+
+    Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+    session is unsafe — see tests/_cudaq_isolation.py.
+    """
     cudaq = pytest.importorskip("cudaq")
 
     from qamomile.cudaq import CudaqTranspiler
@@ -2146,8 +2161,13 @@ def test_inverse_vector_qkernel_prefers_cudaq_backend_adjoint() -> None:
     assert np.allclose(statevector, expected, atol=1e-8)
 
 
+@pytest.mark.cudaq
 def test_inverse_of_inverse_cudaq_falls_back_without_nested_adjoint() -> None:
-    """CUDA-Q inverse-of-inverse falls back before nested adjoint emission."""
+    """CUDA-Q inverse-of-inverse falls back before nested adjoint emission.
+
+    Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+    session is unsafe — see tests/_cudaq_isolation.py.
+    """
     cudaq = pytest.importorskip("cudaq")
 
     from qamomile.cudaq import CudaqTranspiler
@@ -2211,8 +2231,13 @@ def _inverse_runtime_call_then_gate_layer(
     return q
 
 
+@pytest.mark.cudaq
 def test_inverse_cudaq_adjoint_inlines_nested_source_block() -> None:
-    """CUDA-Q adjoint helpers include nested qkernel call bodies."""
+    """CUDA-Q adjoint helpers include nested qkernel call bodies.
+
+    Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+    session is unsafe — see tests/_cudaq_isolation.py.
+    """
     pytest.importorskip("cudaq")
 
     from qamomile.cudaq import CudaqTranspiler

--- a/tests/circuit/test_inverse.py
+++ b/tests/circuit/test_inverse.py
@@ -89,8 +89,9 @@ except ImportError:  # pragma: no cover - covered when quri_parts is absent.
 
 _HAS_CUDAQ = True
 try:  # pragma: no cover - dependency-presence guard.
-    import cudaq  # noqa: F401
-
+    # The lazy accessor raises ImportError when cudaq is missing, without
+    # loading the cudaq runtime at collection time when it is installed
+    # (see tests/_cudaq_isolation.py).
     from qamomile.cudaq import CudaqTranspiler
 except ImportError:  # pragma: no cover - covered when cudaq is absent.
     _HAS_CUDAQ = False

--- a/tests/circuit/test_qft.py
+++ b/tests/circuit/test_qft.py
@@ -773,11 +773,14 @@ class TestNestedShapeDependentStdlib:
 
     @pytest.mark.parametrize("seed", [0, 1, 7])
     @pytest.mark.parametrize("n", [1, 2, 3])
-    def test_392_cross_backend_sampling(self, n, seed):
+    def test_392_cross_backend_sampling(self, sdk_transpiler, n, seed):
         """Cross-backend sampling: ``IQFT|+...+>`` collapses to ``|0...0>``.
 
         Verifies that the nested-call IQFT fix produces identical
-        behavior on every quantum SDK backend Qamomile ships with.
+        behavior on every quantum SDK backend Qamomile ships with,
+        parametrized via ``sdk_transpiler`` so each backend leg runs in
+        the matching ``-m`` session (the cudaq leg must never load
+        cudaq into a default session — see tests/_cudaq_isolation.py).
 
         The kernel prepares ``H^{⊗n}|0...0> = |+...+>`` inside an inner
         ``prepare`` kernel that *also* applies IQFT, then measures
@@ -788,14 +791,13 @@ class TestNestedShapeDependentStdlib:
         protects both the IR-level fix and each backend's emit pass.
 
         Args:
+            sdk_transpiler (SdkTranspilerCase): Backend label plus
+                transpiler instance from the shared fixture.
             n (int): Register size, parametrized with both 1 and small
                 multi-qubit cases.
-            seed (int): RNG seed for sampler reproducibility.
+            seed (int): RNG seed for sampler reproducibility (used by
+                the seedable Qiskit simulator leg).
         """
-        pytest.importorskip("qiskit")
-        from qiskit.providers.basic_provider import BasicSimulator
-
-        from qamomile.qiskit import QiskitTranspiler
 
         @qkernel
         def prepare(m: qmc.UInt) -> Vector[Qubit]:
@@ -810,64 +812,49 @@ class TestNestedShapeDependentStdlib:
             qs = prepare(m)
             return qmc.measure(qs)
 
-        results: dict[str, dict[tuple, int]] = {}
+        transpiler = sdk_transpiler.transpiler
+        if sdk_transpiler.backend_name == "qiskit":
+            from qiskit.providers.basic_provider import BasicSimulator
 
-        # Qiskit
-        qiskit_tr = QiskitTranspiler()
-        backend = BasicSimulator()
-        backend.set_options(seed_simulator=seed)
-        exe = qiskit_tr.transpile(measure_top, bindings={"m": n})
-        job = exe.sample(qiskit_tr.executor(backend=backend), shots=512)
-        results["qiskit"] = {bits: cnt for bits, cnt in job.result().results}
+            backend = BasicSimulator()
+            backend.set_options(seed_simulator=seed)
+            executor = transpiler.executor(backend=backend)
+        else:
+            executor = transpiler.executor()
 
-        # QuriParts (state-vector sampler)
-        quri_parts = pytest.importorskip("quri_parts")  # noqa: F841
-        from qamomile.quri_parts import QuriPartsTranspiler
-
-        qp_tr = QuriPartsTranspiler()
-        exe = qp_tr.transpile(measure_top, bindings={"m": n})
-        job = exe.sample(qp_tr.executor(), shots=512)
-        results["quri_parts"] = {bits: cnt for bits, cnt in job.result().results}
-
-        # CUDA-Q (optional — many CI envs lack the simulator).
-        try:
-            cudaq = pytest.importorskip("cudaq")  # noqa: F841
-            from qamomile.cudaq import CudaqTranspiler
-
-            cudaq_tr = CudaqTranspiler()
-            exe = cudaq_tr.transpile(measure_top, bindings={"m": n})
-            job = exe.sample(cudaq_tr.executor(), shots=512)
-            results["cudaq"] = {bits: cnt for bits, cnt in job.result().results}
-        except (pytest.skip.Exception, ImportError, RuntimeError):
-            pass
+        exe = transpiler.transpile(measure_top, bindings={"m": n})
+        job = exe.sample(executor, shots=512)
+        counts = {bits: cnt for bits, cnt in job.result().results}
 
         # IQFT followed by sampling a uniform superposition must yield
         # only the all-zero bitstring on every backend.
         expected_bits = tuple(0 for _ in range(n))
-        for backend_name, counts in results.items():
-            assert set(counts) == {expected_bits}, (
-                f"{backend_name}: expected {{({expected_bits})}}, got {set(counts)}"
-            )
+        assert set(counts) == {expected_bits}, (
+            f"{sdk_transpiler.backend_name}: "
+            f"expected {{({expected_bits})}}, got {set(counts)}"
+        )
 
     @pytest.mark.parametrize("seed", [0, 5])
     @pytest.mark.parametrize("n", [1, 2, 3])
-    def test_392_cross_backend_expval(self, n, seed):
+    def test_392_cross_backend_expval(self, sdk_transpiler, n, seed):
         """Cross-backend expval: ``<+...+|IQFT^† Z_0 IQFT|+...+> = 1``.
 
         Pairs with :meth:`test_392_cross_backend_sampling` to exercise
         the estimator pipeline of every backend (sampler and estimator
-        regress independently). ``IQFT|+...+> = |0...0>`` so
-        ``<Z_0> = 1`` exactly under noiseless simulation.
+        regress independently), parametrized via ``sdk_transpiler`` so
+        each backend leg runs in the matching ``-m`` session (see
+        tests/_cudaq_isolation.py for the cudaq constraint).
+        ``IQFT|+...+> = |0...0>`` so ``<Z_0> = 1`` exactly under
+        noiseless simulation.
 
         Args:
+            sdk_transpiler (SdkTranspilerCase): Backend label plus
+                transpiler instance from the shared fixture.
             n (int): Register size.
             seed (int): RNG seed; included so an accidental dependence
                 on a fixed initial state would be caught.
         """
         import qamomile.observable as qm_o
-
-        pytest.importorskip("qiskit")
-        from qamomile.qiskit import QiskitTranspiler
 
         @qkernel
         def prepare(m: qmc.UInt) -> Vector[Qubit]:
@@ -886,41 +873,14 @@ class TestNestedShapeDependentStdlib:
         rng = np.random.default_rng(seed)
         _ = rng.random()  # mix the seed into the RNG state for symmetry with sampling
 
-        # Qiskit
-        qiskit_tr = QiskitTranspiler()
-        exe = qiskit_tr.transpile(expval_top, bindings={"m": n, "obs": H})
-        val_q = exe.run(qiskit_tr.executor()).result()
-        assert np.isclose(val_q, 1.0, atol=1e-8), (
-            f"qiskit n={n} seed={seed}: expected <Z_0>=1, got {val_q}"
+        transpiler = sdk_transpiler.transpiler
+        exe = transpiler.transpile(expval_top, bindings={"m": n, "obs": H})
+        val = exe.run(transpiler.executor()).result()
+        atol = 1e-6 if sdk_transpiler.backend_name == "cudaq" else 1e-8
+        assert np.isclose(val, 1.0, atol=atol), (
+            f"{sdk_transpiler.backend_name} n={n} seed={seed}: "
+            f"expected <Z_0>=1, got {val}"
         )
-
-        # QuriParts
-        try:
-            pytest.importorskip("quri_parts")
-            from qamomile.quri_parts import QuriPartsTranspiler
-
-            qp_tr = QuriPartsTranspiler()
-            exe = qp_tr.transpile(expval_top, bindings={"m": n, "obs": H})
-            val_qp = exe.run(qp_tr.executor()).result()
-            assert np.isclose(val_qp, 1.0, atol=1e-8), (
-                f"quri_parts n={n} seed={seed}: expected <Z_0>=1, got {val_qp}"
-            )
-        except pytest.skip.Exception:
-            pass
-
-        # CUDA-Q (optional)
-        try:
-            pytest.importorskip("cudaq")
-            from qamomile.cudaq import CudaqTranspiler
-
-            cudaq_tr = CudaqTranspiler()
-            exe = cudaq_tr.transpile(expval_top, bindings={"m": n, "obs": H})
-            val_c = exe.run(cudaq_tr.executor()).result()
-            assert np.isclose(val_c, 1.0, atol=1e-6), (
-                f"cudaq n={n} seed={seed}: expected <Z_0>=1, got {val_c}"
-            )
-        except (pytest.skip.Exception, ImportError, RuntimeError):
-            pass
 
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_392_reproducer_iqft_visible_after_inline(self, qiskit_transpiler, n):

--- a/tests/circuit/test_qkernel_literal_promotion.py
+++ b/tests/circuit/test_qkernel_literal_promotion.py
@@ -60,8 +60,9 @@ except ImportError:  # pragma: no cover - covered when quri_parts is absent
 
 _HAS_CUDAQ = True
 try:  # pragma: no cover - presence check, not behaviour
-    import cudaq  # noqa: F401
-
+    # The lazy accessor raises ImportError when cudaq is missing, without
+    # loading the cudaq runtime at collection time when it is installed
+    # (see tests/_cudaq_isolation.py).
     from qamomile.cudaq import CudaqTranspiler
 except ImportError:  # pragma: no cover - covered when cudaq is absent
     _HAS_CUDAQ = False

--- a/tests/circuit/test_qkernel_literal_promotion.py
+++ b/tests/circuit/test_qkernel_literal_promotion.py
@@ -84,7 +84,12 @@ BACKENDS = [
     pytest.param(
         CudaqTranspiler,
         id="cudaq",
-        marks=pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+        # The cudaq mark keeps this leg out of default sessions, where
+        # loading cudaq is unsafe (see tests/_cudaq_isolation.py).
+        marks=[
+            pytest.mark.skipif(not _HAS_CUDAQ, reason="cudaq not installed"),
+            pytest.mark.cudaq,
+        ],
     ),
 ]
 

--- a/tests/circuit/test_qpe.py
+++ b/tests/circuit/test_qpe.py
@@ -315,8 +315,13 @@ class TestQPEFallbackVectorViewPhase:
 
         _assert_fallback_qpe_vector_view_phase(QuriPartsTranspiler())
 
+    @pytest.mark.cudaq
     def test_cudaq_executes_vector_view_phase(self):
-        """CUDA-Q executes fallback QPE with a VectorView phase element."""
+        """CUDA-Q executes fallback QPE with a VectorView phase element.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py.
+        """
         pytest.importorskip("cudaq")
         from qamomile.cudaq import CudaqTranspiler
 
@@ -337,8 +342,13 @@ class TestQPEBuiltinVectorViewPhase:
 
         _assert_builtin_qpe_vector_view_phase(QuriPartsTranspiler())
 
+    @pytest.mark.cudaq
     def test_cudaq_executes_vector_view_phase(self):
-        """CUDA-Q executes public QPE with a VectorView phase element."""
+        """CUDA-Q executes public QPE with a VectorView phase element.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py.
+        """
         pytest.importorskip("cudaq")
         from qamomile.cudaq import CudaqTranspiler
 

--- a/tests/circuit/test_slice_gate_correctness.py
+++ b/tests/circuit/test_slice_gate_correctness.py
@@ -983,21 +983,52 @@ def _random_slice_lo_step(rng: np.random.Generator):
 _PROPERTY_SEEDS = [0, 1, 7, 11, 42, 123, 999, 2024]
 
 
+_SV_BACKEND_HELPERS = {
+    "qiskit": _qiskit_statevector,
+    "quri_parts": _quri_parts_statevector,
+    "cudaq": _cudaq_statevector,
+}
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("qiskit", id="qiskit"),
+        pytest.param("quri_parts", marks=pytest.mark.quri_parts, id="quri_parts"),
+        pytest.param("cudaq", marks=pytest.mark.cudaq, id="cudaq"),
+    ]
+)
+def sv_backend(request):
+    """Backend name for single-backend statevector assertions.
+
+    The quri_parts / cudaq params carry their markers so each leg only
+    runs in the matching ``-m`` session; in particular the cudaq leg
+    must never load cudaq into a default session (see
+    tests/_cudaq_isolation.py). The SDK import itself happens lazily
+    inside the per-backend statevector helper.
+
+    Args:
+        request (pytest.FixtureRequest): Parametrization carrier.
+
+    Returns:
+        str: One of ``"qiskit"``, ``"quri_parts"``, ``"cudaq"``.
+    """
+    return request.param
+
+
 def _run_property_case(
+    backend: str,
     kern,
     bindings: dict,
     expected_sv: Statevector,
     case_label: str,
 ):
-    """Run the kernel on every available backend and assert SV match.
-
-    The Qiskit backend is mandatory; QuriParts and CUDA-Q are guarded
-    by ``pytest.importorskip`` inside their helpers and skip cleanly
-    when the corresponding SDK is not installed.
+    """Run the kernel on one backend and assert the statevector matches.
 
     Args:
+        backend (str): Backend name supplied by the ``sv_backend``
+            fixture.
         kern: Compiled qkernel.
-        bindings (dict): Bindings to pass to every backend's
+        bindings (dict): Bindings to pass to the backend's
             ``transpile``.
         expected_sv (Statevector): Reference statevector.
         case_label (str): Human-readable label describing the random
@@ -1006,24 +1037,10 @@ def _run_property_case(
     """
     expected_data = np.array(expected_sv.data)
 
-    actual_qiskit = _qiskit_statevector(kern, bindings)
-    assert statevectors_equal(actual_qiskit, expected_data), (
-        f"[qiskit] statevector mismatch for {case_label}.\n"
-        f"  actual:   {actual_qiskit}\n"
-        f"  expected: {expected_data}"
-    )
-
-    actual_quri_parts = _quri_parts_statevector(kern, bindings)
-    assert statevectors_equal(actual_quri_parts, expected_data), (
-        f"[quri_parts] statevector mismatch for {case_label}.\n"
-        f"  actual:   {actual_quri_parts}\n"
-        f"  expected: {expected_data}"
-    )
-
-    actual_cudaq = _cudaq_statevector(kern, bindings)
-    assert statevectors_equal(actual_cudaq, expected_data), (
-        f"[cudaq] statevector mismatch for {case_label}.\n"
-        f"  actual:   {actual_cudaq}\n"
+    actual = _SV_BACKEND_HELPERS[backend](kern, bindings)
+    assert statevectors_equal(actual, expected_data), (
+        f"[{backend}] statevector mismatch for {case_label}.\n"
+        f"  actual:   {actual}\n"
         f"  expected: {expected_data}"
     )
 
@@ -1031,7 +1048,7 @@ def _run_property_case(
 class TestPropertyBasedSliceCrossBackend:
     """Property-style: random register size, random slice, random gates
     must produce the same statevector on Qiskit, QuriParts, and CUDA-Q
-    as the per-qubit Qiskit reference.
+    (parametrized via ``sv_backend``) as the per-qubit Qiskit reference.
 
     The seed drives:
       1. ``n_qubits`` in ``[4, 10]``.
@@ -1046,7 +1063,7 @@ class TestPropertyBasedSliceCrossBackend:
     """
 
     @pytest.mark.parametrize("seed", _PROPERTY_SEEDS)
-    def test_random_slice_lo_hi_step(self, seed: int):
+    def test_random_slice_lo_hi_step(self, sv_backend, seed: int):
         """``q[lo:hi:step]`` with random ``(n_qubits, lo, hi, step)``.
 
         Exercises the most general slice form: all three of ``start``,
@@ -1075,6 +1092,7 @@ class TestPropertyBasedSliceCrossBackend:
         expected_sv = _theoretical_statevector(n_qubits, slice_qubits, gate_seq)
 
         _run_property_case(
+            sv_backend,
             kern,
             bindings,
             expected_sv,
@@ -1085,7 +1103,7 @@ class TestPropertyBasedSliceCrossBackend:
         )
 
     @pytest.mark.parametrize("seed", _PROPERTY_SEEDS)
-    def test_random_slice_lo_hi(self, seed: int):
+    def test_random_slice_lo_hi(self, sv_backend, seed: int):
         """``q[lo:hi]`` (step omitted → 1) with random ``(n_qubits, lo, hi)``.
 
         Exercises the no-step form to ensure the default-step branch
@@ -1114,6 +1132,7 @@ class TestPropertyBasedSliceCrossBackend:
         expected_sv = _theoretical_statevector(n_qubits, slice_qubits, gate_seq)
 
         _run_property_case(
+            sv_backend,
             kern,
             bindings,
             expected_sv,
@@ -1124,7 +1143,7 @@ class TestPropertyBasedSliceCrossBackend:
         )
 
     @pytest.mark.parametrize("seed", _PROPERTY_SEEDS)
-    def test_random_slice_lo_step(self, seed: int):
+    def test_random_slice_lo_step(self, sv_backend, seed: int):
         """``q[lo::step]`` (no ``hi`` → end of parent) with random
         ``(n_qubits, lo, step)``.
 
@@ -1155,6 +1174,7 @@ class TestPropertyBasedSliceCrossBackend:
         expected_sv = _theoretical_statevector(n_qubits, slice_qubits, gate_seq)
 
         _run_property_case(
+            sv_backend,
             kern,
             bindings,
             expected_sv,

--- a/tests/circuit/test_slice_pattern_correctness.py
+++ b/tests/circuit/test_slice_pattern_correctness.py
@@ -10,10 +10,11 @@ to write slicing code — evens / odds Bell-pair loop, ``qft`` on a
 slice, ``cast`` to ``QFixed``, in-line ``q[a:b] = h(q[a:b])`` broadcast,
 top-level slice with a body loop, Python-style auto-truncation, and
 passing a view as a sub-kernel argument.  Each kernel is transpiled
-on every supported SDK (Qiskit / QuriParts / CUDA-Q via
-``importorskip``), the result statevector compared to an analytical
-Qiskit reference (or ``run()`` for the QFixed Float-return kernel),
-and ``estimate_resources`` pinned to the expected qubit / gate counts.
+on every supported SDK (Qiskit / QuriParts / CUDA-Q, parametrized via
+the ``sv_backend`` fixture whose quri_parts / cudaq params carry their
+markers), the result statevector compared to an analytical Qiskit
+reference (or ``run()`` for the QFixed Float-return kernel), and
+``estimate_resources`` pinned to the expected qubit / gate counts.
 A backend-agnostic IR-level resource estimator is intentionally
 re-asserted here so the per-pattern claim stays auditable.
 
@@ -145,36 +146,54 @@ def _cudaq_statevector(kern, bindings: dict) -> np.ndarray:
     return np.array(cudaq.get_state(cudaq_circuit.kernel_func))
 
 
-def _assert_cross_backend_matches(kern, bindings: dict, expected_sv: np.ndarray):
-    """Assert that every available backend matches the reference statevector.
+_SV_BACKEND_HELPERS = {
+    "qiskit": _qiskit_statevector,
+    "quri_parts": _quri_parts_statevector,
+    "cudaq": _cudaq_statevector,
+}
 
-    Backends that are not installed are silently skipped via
-    ``pytest.importorskip`` inside the per-backend helpers; the Qiskit
-    branch is always exercised.
+
+@pytest.fixture(
+    params=[
+        pytest.param("qiskit", id="qiskit"),
+        pytest.param("quri_parts", marks=pytest.mark.quri_parts, id="quri_parts"),
+        pytest.param("cudaq", marks=pytest.mark.cudaq, id="cudaq"),
+    ]
+)
+def sv_backend(request):
+    """Backend name for single-backend statevector assertions.
+
+    The quri_parts / cudaq params carry their markers so each leg only
+    runs in the matching ``-m`` session; in particular the cudaq leg
+    must never load cudaq into a default session (see
+    tests/_cudaq_isolation.py). The SDK import itself happens lazily
+    inside the per-backend statevector helper.
 
     Args:
+        request (pytest.FixtureRequest): Parametrization carrier.
+
+    Returns:
+        str: One of ``"qiskit"``, ``"quri_parts"``, ``"cudaq"``.
+    """
+    return request.param
+
+
+def _assert_backend_matches(
+    backend: str, kern, bindings: dict, expected_sv: np.ndarray
+):
+    """Assert that one backend's statevector matches the reference.
+
+    Args:
+        backend (str): Backend name supplied by the ``sv_backend``
+            fixture.
         kern: Compiled qkernel.
         bindings (dict): Compile-time bindings.
         expected_sv (np.ndarray): Reference unitary statevector.
     """
-    actual_qiskit = _qiskit_statevector(kern, bindings)
-    assert statevectors_equal(actual_qiskit, expected_sv), (
-        f"[qiskit] statevector mismatch.\n"
-        f"  actual:   {actual_qiskit}\n"
-        f"  expected: {expected_sv}"
-    )
-
-    actual_quri = _quri_parts_statevector(kern, bindings)
-    assert statevectors_equal(actual_quri, expected_sv), (
-        f"[quri_parts] statevector mismatch.\n"
-        f"  actual:   {actual_quri}\n"
-        f"  expected: {expected_sv}"
-    )
-
-    actual_cudaq = _cudaq_statevector(kern, bindings)
-    assert statevectors_equal(actual_cudaq, expected_sv), (
-        f"[cudaq] statevector mismatch.\n"
-        f"  actual:   {actual_cudaq}\n"
+    actual = _SV_BACKEND_HELPERS[backend](kern, bindings)
+    assert statevectors_equal(actual, expected_sv), (
+        f"[{backend}] statevector mismatch.\n"
+        f"  actual:   {actual}\n"
         f"  expected: {expected_sv}"
     )
 
@@ -218,7 +237,7 @@ class TestEvensOddsCxPattern:
         return qmc.measure(q)
 
     @pytest.mark.parametrize("n", [4, 6])
-    def test_transpile_and_statevector_match(self, n: int):
+    def test_transpile_and_statevector_match(self, sv_backend, n: int):
         """Cross-backend statevector matches ``H_evens then CX(evens, odds)``."""
         bindings = {"n": n}
         ref_qc = QuantumCircuit(n)
@@ -228,7 +247,7 @@ class TestEvensOddsCxPattern:
         for i in range(n_pairs):
             ref_qc.cx(2 * i, 2 * i + 1)
         expected_sv = np.array(Statevector(ref_qc).data)
-        _assert_cross_backend_matches(self._kern, bindings, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, bindings, expected_sv)
 
     @pytest.mark.parametrize(
         "n, exp_qubits, exp_single, exp_two",
@@ -257,7 +276,7 @@ class TestQftOnView:
         q[lo:hi] = view
         return qmc.measure(q)
 
-    def test_transpile_and_statevector_match(self):
+    def test_transpile_and_statevector_match(self, sv_backend):
         """``qft(|000>) = |+++>``; the rest of the register stays |0>."""
         bindings = {"lo": 1, "hi": 4}
         # ``qft(|000>) = (1/sqrt(8)) * sum_k |k>`` for a 3-qubit register,
@@ -272,7 +291,7 @@ class TestQftOnView:
             # Qiskit indexes qubit 0 as the least-significant bit.
             idx = (k & 0b1) << 1 | ((k >> 1) & 0b1) << 2 | ((k >> 2) & 0b1) << 3
             expected_sv[idx] = amp
-        _assert_cross_backend_matches(self._kern, bindings, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, bindings, expected_sv)
 
     def test_resource_estimate(self):
         """``qft`` is wrapped as a composite gate; the top-level block reports 0 leaf gates.
@@ -322,8 +341,13 @@ class TestCastSliceToQFixed:
         got = exe.run(transpiler.executor()).result()
         assert float(got) == pytest.approx(0.0, abs=1e-9)
 
+    @pytest.mark.cudaq
     def test_cudaq_run_returns_zero(self):
-        """Cross-backend: CUDA-Q ``run`` also returns 0.0."""
+        """Cross-backend: CUDA-Q ``run`` also returns 0.0.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py.
+        """
         pytest.importorskip("cudaq")
         from qamomile.cudaq import CudaqTranspiler
 
@@ -353,10 +377,10 @@ class TestInlineSliceAssignBroadcast:
         q[1 : n - 2] = qmc.h(q[1 : n - 2])
         return qmc.measure(q)
 
-    def test_transpile_and_statevector_match(self):
+    def test_transpile_and_statevector_match(self, sv_backend):
         bindings = {"n": 6}
         expected_sv = _reference_statevector(6, [1, 2, 3])
-        _assert_cross_backend_matches(self._kern, bindings, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, bindings, expected_sv)
 
     def test_resource_estimate(self):
         est = estimate_resources(self._kern.block, bindings={"n": 6})
@@ -652,10 +676,10 @@ class TestInlineCallSliceBroadcast:
         qs = _slice_broadcast_inner(qs)
         return qmc.measure(qs)
 
-    def test_concrete_transpile_and_statevector_match(self):
+    def test_concrete_transpile_and_statevector_match(self, sv_backend):
         """The inlined ``qs[0:2] = qmc.h(qs[0:2])`` applies H to qs[0]/qs[1] only."""
         expected_sv = _reference_statevector(3, [0, 1])
-        _assert_cross_backend_matches(self._kern_concrete, {}, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern_concrete, {}, expected_sv)
 
     @qmc.qkernel
     def _kern_symbolic(n: qmc.UInt) -> qmc.Vector[qmc.Bit]:
@@ -665,10 +689,10 @@ class TestInlineCallSliceBroadcast:
         return qmc.measure(qs)
 
     @pytest.mark.parametrize("n", [3, 5, 7])
-    def test_symbolic_transpile_and_statevector_match(self, n: int):
+    def test_symbolic_transpile_and_statevector_match(self, sv_backend, n: int):
         """``qs[0:n-1]`` covers every qubit except the last across multiple sizes."""
         expected_sv = _reference_statevector(n, list(range(n - 1)))
-        _assert_cross_backend_matches(self._kern_symbolic, {"n": n}, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern_symbolic, {"n": n}, expected_sv)
 
     @qmc.qkernel
     def _kern_nested_slice() -> qmc.Vector[qmc.Bit]:
@@ -677,10 +701,10 @@ class TestInlineCallSliceBroadcast:
         qs = _nested_slice_inner(qs)
         return qmc.measure(qs)
 
-    def test_nested_slice_transpile_and_statevector_match(self):
+    def test_nested_slice_transpile_and_statevector_match(self, sv_backend):
         """``s1 = qs[0:4]; s1[0:2] = h(s1[0:2])`` applies H to qs[0]/qs[1]."""
         expected_sv = _reference_statevector(6, [0, 1])
-        _assert_cross_backend_matches(self._kern_nested_slice, {}, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern_nested_slice, {}, expected_sv)
 
     @qmc.qkernel
     def _kern_multi_slice() -> qmc.Vector[qmc.Bit]:
@@ -689,10 +713,10 @@ class TestInlineCallSliceBroadcast:
         qs = _multi_slice_inner(qs)
         return qmc.measure(qs)
 
-    def test_multi_slice_transpile_and_statevector_match(self):
+    def test_multi_slice_transpile_and_statevector_match(self, sv_backend):
         """Both ``qs[0:2]`` and ``qs[2:4]`` broadcasts survive inlining."""
         expected_sv = _reference_statevector(4, [0, 1, 2, 3])
-        _assert_cross_backend_matches(self._kern_multi_slice, {}, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern_multi_slice, {}, expected_sv)
 
     @qmc.qkernel
     def _kern_slice_and_scalar() -> qmc.Vector[qmc.Bit]:
@@ -701,10 +725,12 @@ class TestInlineCallSliceBroadcast:
         qs = _slice_and_scalar_inner(qs)
         return qmc.measure(qs)
 
-    def test_slice_and_scalar_transpile_and_statevector_match(self):
+    def test_slice_and_scalar_transpile_and_statevector_match(self, sv_backend):
         """Mixing slice and scalar element gates in one inlined sub-kernel works."""
         expected_sv = _reference_statevector(3, [0, 1, 2])
-        _assert_cross_backend_matches(self._kern_slice_and_scalar, {}, expected_sv)
+        _assert_backend_matches(
+            sv_backend, self._kern_slice_and_scalar, {}, expected_sv
+        )
 
     @qmc.qkernel
     def _kern_two_level_inline() -> qmc.Vector[qmc.Bit]:
@@ -713,10 +739,12 @@ class TestInlineCallSliceBroadcast:
         qs = _slice_mid_for_two_level(qs)
         return qmc.measure(qs)
 
-    def test_two_level_inline_transpile_and_statevector_match(self):
+    def test_two_level_inline_transpile_and_statevector_match(self, sv_backend):
         """Slice metadata survives two levels of inlining."""
         expected_sv = _reference_statevector(3, [0, 1])
-        _assert_cross_backend_matches(self._kern_two_level_inline, {}, expected_sv)
+        _assert_backend_matches(
+            sv_backend, self._kern_two_level_inline, {}, expected_sv
+        )
 
     @qmc.qkernel
     def _kern_view_arg_inner_slice(num: qmc.UInt) -> qmc.Vector[qmc.Bit]:
@@ -727,13 +755,13 @@ class TestInlineCallSliceBroadcast:
         q[0::2] = evens
         return qmc.measure(q)
 
-    def test_view_arg_inner_slice_transpile_and_statevector_match(self):
+    def test_view_arg_inner_slice_transpile_and_statevector_match(self, sv_backend):
         """Slice chain ``q[0::2][0:2]`` resolves to root qubits q[0] / q[2]."""
         # num=6: evens = q[0::2] = {q[0], q[2], q[4]}.  The sub-kernel
         # applies H to view[0:2] = {evens[0], evens[1]} = {q[0], q[2]}.
         expected_sv = _reference_statevector(6, [0, 2])
-        _assert_cross_backend_matches(
-            self._kern_view_arg_inner_slice, {"num": 6}, expected_sv
+        _assert_backend_matches(
+            sv_backend, self._kern_view_arg_inner_slice, {"num": 6}, expected_sv
         )
 
     @qmc.qkernel
@@ -751,10 +779,12 @@ class TestInlineCallSliceBroadcast:
         qs = _deep_chain_l3(qs)
         return qmc.measure(qs)
 
-    def test_four_level_inline_transpile_and_statevector_match(self):
+    def test_four_level_inline_transpile_and_statevector_match(self, sv_backend):
         """Slice metadata survives four levels of inlining."""
         expected_sv = _reference_statevector(3, [0, 1])
-        _assert_cross_backend_matches(self._kern_four_level_inline, {}, expected_sv)
+        _assert_backend_matches(
+            sv_backend, self._kern_four_level_inline, {}, expected_sv
+        )
 
     @qmc.qkernel
     def _kern_nested_slice_two_level_inline() -> qmc.Vector[qmc.Bit]:
@@ -763,11 +793,13 @@ class TestInlineCallSliceBroadcast:
         qs = _nested_slice_mid(qs)
         return qmc.measure(qs)
 
-    def test_nested_slice_two_level_inline_transpile_and_statevector_match(self):
+    def test_nested_slice_two_level_inline_transpile_and_statevector_match(
+        self, sv_backend
+    ):
         """Slice-of-slice broadcast through two levels of inlining."""
         expected_sv = _reference_statevector(6, [0, 1])
-        _assert_cross_backend_matches(
-            self._kern_nested_slice_two_level_inline, {}, expected_sv
+        _assert_backend_matches(
+            sv_backend, self._kern_nested_slice_two_level_inline, {}, expected_sv
         )
 
 
@@ -784,10 +816,10 @@ class TestTopLevelSliceWithBodyLoop:
         q[0::2] = evens
         return qmc.measure(q)
 
-    def test_transpile_and_statevector_match(self):
+    def test_transpile_and_statevector_match(self, sv_backend):
         bindings = {"n": 4}
         expected_sv = _reference_statevector(4, [0, 2])
-        _assert_cross_backend_matches(self._kern, bindings, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, bindings, expected_sv)
 
     def test_resource_estimate(self):
         est = estimate_resources(self._kern.block, bindings={"n": 4})
@@ -807,11 +839,11 @@ class TestAutoTruncatedSlice:
         q[3:10] = qmc.h(q[3:10])
         return qmc.measure(q)
 
-    def test_transpile_and_statevector_match(self):
+    def test_transpile_and_statevector_match(self, sv_backend):
         # q[3:10] on a length-4 array is truncated to q[3:4]; only q[3]
         # gets H.
         expected_sv = _reference_statevector(4, [3])
-        _assert_cross_backend_matches(self._kern, {}, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, {}, expected_sv)
 
     def test_resource_estimate(self):
         est = estimate_resources(self._kern.block)
@@ -849,10 +881,10 @@ class TestViewPassedToSubKernel:
         q[0::2] = evens
         return qmc.measure(q)
 
-    def test_transpile_and_statevector_match(self):
+    def test_transpile_and_statevector_match(self, sv_backend):
         bindings = {"num": 6}
         expected_sv = _reference_statevector(6, [0, 2, 4])
-        _assert_cross_backend_matches(self._kern, bindings, expected_sv)
+        _assert_backend_matches(sv_backend, self._kern, bindings, expected_sv)
 
     def test_resource_estimate(self):
         est = estimate_resources(self._kern.block, bindings={"num": 6})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Repo-wide pytest configuration.
+
+Its single current job is native-library isolation: prevent the CUDA-Q
+runtime (which drags in torch and a third copy of the OpenMP runtime,
+alongside the copies bundled by torch and qiskit-aer) from being imported
+during collection in runs whose marker expression cannot select any
+cudaq-marked test. See ``tests/_cudaq_isolation.py`` for the full
+background and ``tests/test_cudaq_import_isolation.py`` for the guard
+that keeps the module table in sync.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._cudaq_isolation import (
+    CUDAQ_MODULE_LEVEL_IMPORTERS,
+    markexpr_can_select_cudaq,
+)
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    """Skip collecting module-level cudaq importers in cudaq-less runs.
+
+    Args:
+        collection_path (Path): Candidate path pytest is about to collect.
+        config (pytest.Config): The active pytest configuration, used for
+            the rootdir and the ``-m`` marker expression.
+
+    Returns:
+        bool | None: True to skip the path (a registered cudaq module
+            while every cudaq-marked test is deselected); None to leave
+            the decision to other plugins.
+    """
+    try:
+        relative = collection_path.relative_to(config.rootpath).as_posix()
+    except ValueError:
+        return None
+    if relative not in CUDAQ_MODULE_LEVEL_IMPORTERS:
+        return None
+    if markexpr_can_select_cudaq(config.getoption("markexpr") or ""):
+        return None
+    return True

--- a/tests/optimization/test_pce.py
+++ b/tests/optimization/test_pce.py
@@ -2,6 +2,7 @@
 
 import itertools
 import math
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -706,13 +707,19 @@ class TestPCEEndToEnd:
 
         self._check_transpile_runs(QuriPartsTranspiler())
 
+    @pytest.mark.cudaq
     def test_transpile_with_cudaq(self):
-        """The PCE ansatz produces a runnable executable on CUDA-Q."""
+        """The PCE ansatz produces a runnable executable on CUDA-Q.
+
+        Runs in ``-m cudaq`` sessions only: loading cudaq into a default
+        session is unsafe — see tests/_cudaq_isolation.py.
+        """
         pytest.importorskip("cudaq")
         from qamomile.cudaq import CudaqTranspiler
 
         self._check_transpile_runs(CudaqTranspiler())
 
+    @pytest.mark.cudaq
     def test_cross_backend_expval_consistency(self):
         """The same ansatz/observable produces matching ⟨P⟩ across backends.
 
@@ -721,6 +728,11 @@ class TestPCEEndToEnd:
         expectation values to within numerical tolerance. Backends that are
         not installed are silently skipped; if fewer than two backends are
         available, the test itself is skipped.
+
+        Marked ``cudaq`` because the CUDA-Q leg imports cudaq whenever it is
+        installed, which is unsafe in default sessions (see
+        tests/_cudaq_isolation.py). In the dedicated ``-m cudaq`` CI jobs
+        this cross-checks Qiskit against CUDA-Q.
         """
         _, n, observables, ansatz = self._build_pce_setup()
 
@@ -735,19 +747,36 @@ class TestPCEEndToEnd:
         # around ``from qamomile.<backend> import ...`` does not catch a
         # missing SDK — the ImportError fires later, mid-test. Use
         # ``find_spec`` to check existence without importing.
-        backends: list[tuple[str, Transpiler]] = []
+        backends: list[tuple[str, Transpiler, Any]] = []
         if importlib.util.find_spec("qiskit") is not None:
+            from qiskit.providers.basic_provider import BasicSimulator
+
             from qamomile.qiskit import QiskitTranspiler
 
-            backends.append(("qiskit", QiskitTranspiler()))
+            # An explicit BasicSimulator keeps qiskit-aer out of this
+            # cudaq-marked test's process (see tests/_cudaq_isolation.py);
+            # the expval path uses the pure StatevectorEstimator and never
+            # runs the sampling backend anyway.
+            qiskit_transpiler = QiskitTranspiler()
+            backends.append(
+                (
+                    "qiskit",
+                    qiskit_transpiler,
+                    qiskit_transpiler.executor(backend=BasicSimulator()),
+                )
+            )
         if importlib.util.find_spec("quri_parts") is not None:
             from qamomile.quri_parts import QuriPartsTranspiler
 
-            backends.append(("quri_parts", QuriPartsTranspiler()))
+            quri_parts_transpiler = QuriPartsTranspiler()
+            backends.append(
+                ("quri_parts", quri_parts_transpiler, quri_parts_transpiler.executor())
+            )
         if importlib.util.find_spec("cudaq") is not None:
             from qamomile.cudaq import CudaqTranspiler
 
-            backends.append(("cudaq", CudaqTranspiler()))
+            cudaq_transpiler = CudaqTranspiler()
+            backends.append(("cudaq", cudaq_transpiler, cudaq_transpiler.executor()))
 
         if len(backends) < 2:
             pytest.skip("Need at least two installed backends to cross-check.")
@@ -756,8 +785,7 @@ class TestPCEEndToEnd:
         # same physical expectation value.
         thetas = [0.3, 0.7]
         per_backend: dict[str, list[float]] = {}
-        for name, transpiler in backends:
-            executor = transpiler.executor()
+        for name, transpiler, executor in backends:
             results: list[float] = []
             for P_i in observables:
                 executable = transpiler.transpile(

--- a/tests/test_cudaq_import_isolation.py
+++ b/tests/test_cudaq_import_isolation.py
@@ -1,0 +1,143 @@
+"""Guard the CUDA-Q collection-isolation policy.
+
+Verifies that every test module importing ``cudaq`` at module scope is
+registered in ``CUDAQ_MODULE_LEVEL_IMPORTERS`` (so default ``-m "not
+cudaq"`` runs never load cudaq during collection) and carries the
+``cudaq`` pytestmark (so skipping collection never hides tests a default
+run would have executed), that no conftest imports cudaq at module scope
+(conftests are always imported), and that ``markexpr_can_select_cudaq``
+decides the marker expressions the suite relies on. Background:
+tests/_cudaq_isolation.py — mixing the cudaq/torch OpenMP runtimes with
+qiskit-aer in one process segfaults.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests._cudaq_isolation import (
+    CUDAQ_MODULE_LEVEL_IMPORTERS,
+    markexpr_can_select_cudaq,
+)
+
+TESTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_DIR.parent
+
+
+def _iter_module_level_nodes(tree: ast.Module) -> Iterator[ast.AST]:
+    """Yield AST nodes that execute when the module is imported.
+
+    Descends into every construct except function bodies (class bodies do
+    execute at import time, so they are included).
+    """
+    stack: list[ast.AST] = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        yield node
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _is_cudaq_import(node: ast.AST) -> bool:
+    """Return True when the node imports cudaq (directly or via skip)."""
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name == "cudaq" or alias.name.startswith("cudaq.")
+            for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        # ``from qamomile.cudaq import X`` is fine: the package resolves
+        # its public symbols through a lazy ``__getattr__`` that does not
+        # load the cudaq runtime (pinned by test_cudaq_import_ux.py).
+        module = node.module or ""
+        return module == "cudaq" or module.startswith("cudaq.")
+    if isinstance(node, ast.Call):
+        func = node.func
+        is_importorskip = (
+            isinstance(func, ast.Attribute) and func.attr == "importorskip"
+        ) or (isinstance(func, ast.Name) and func.id == "importorskip")
+        return (
+            is_importorskip
+            and bool(node.args)
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "cudaq"
+        )
+    return False
+
+
+def _imports_cudaq_at_module_level(path: Path) -> bool:
+    """Return True when the file loads cudaq as a side effect of import."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return any(_is_cudaq_import(node) for node in _iter_module_level_nodes(tree))
+
+
+def test_module_level_cudaq_importers_are_registered():
+    """Module-level cudaq importers stay in sync with the ignore table."""
+    found = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in sorted(TESTS_DIR.rglob("test_*.py"))
+        if _imports_cudaq_at_module_level(path)
+    }
+    assert found == set(CUDAQ_MODULE_LEVEL_IMPORTERS), (
+        "Test modules importing cudaq at module scope must match "
+        "tests._cudaq_isolation.CUDAQ_MODULE_LEVEL_IMPORTERS, so that "
+        "default (-m 'not cudaq') runs never load cudaq during collection. "
+        f"Found in sources: {sorted(found)}; registered: "
+        f"{sorted(CUDAQ_MODULE_LEVEL_IMPORTERS)}. Either register the new "
+        "module (and give it `pytestmark = pytest.mark.cudaq`) or move the "
+        "cudaq import into the tests."
+    )
+
+
+def test_registered_modules_exist_and_carry_cudaq_pytestmark():
+    """Every registered module exists and is cudaq-marked at module level."""
+    for relative in sorted(CUDAQ_MODULE_LEVEL_IMPORTERS):
+        path = REPO_ROOT / relative
+        assert path.is_file(), f"{relative} is registered but does not exist"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        has_cudaq_pytestmark = any(
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "pytestmark"
+                for target in node.targets
+            )
+            and "cudaq" in ast.dump(node.value)
+            for node in tree.body
+        )
+        assert has_cudaq_pytestmark, (
+            f"{relative} must set `pytestmark = pytest.mark.cudaq`: the "
+            "collection-ignore in tests/conftest.py assumes every test in "
+            "the module is deselected by `-m 'not cudaq'` anyway."
+        )
+
+
+def test_conftests_do_not_import_cudaq_at_module_level():
+    """Conftests must not import cudaq: they load in every session."""
+    for path in sorted(TESTS_DIR.rglob("conftest.py")):
+        assert not _imports_cudaq_at_module_level(path), (
+            f"{path.relative_to(REPO_ROOT)} imports cudaq at module scope; "
+            "conftest modules are imported unconditionally, which would "
+            "defeat the cudaq isolation."
+        )
+
+
+@pytest.mark.parametrize(
+    ("markexpr", "expected"),
+    [
+        ("not docs and not quri_parts and not cudaq", False),
+        ("not cudaq", False),
+        ("", True),
+        ("   ", True),
+        ("cudaq", True),
+        ("cudaq and two_qubit", True),
+        ("not docs", True),
+    ],
+)
+def test_markexpr_can_select_cudaq(markexpr: str, expected: bool):
+    """Pins the selection decisions the collection-ignore relies on."""
+    assert markexpr_can_select_cudaq(markexpr) is expected

--- a/tests/transpiler/backends/test_cudaq.py
+++ b/tests/transpiler/backends/test_cudaq.py
@@ -11,6 +11,11 @@ from typing import Any
 import numpy as np
 import pytest
 
+from qamomile.circuit.ir.operation.control_flow import ForOperation
+from qamomile.circuit.ir.operation.gate import GateOperation, GateOperationType
+from qamomile.circuit.ir.types.primitives import QubitType, UIntType
+from qamomile.circuit.ir.value import ArrayValue, Value
+
 pytestmark = pytest.mark.cudaq
 
 cudaq = pytest.importorskip("cudaq")
@@ -21,6 +26,116 @@ from tests.transpiler.backends._cudaq_source_assertions import (  # noqa: E402
     assert_inspect_source_matches_artifact,
 )
 from tests.transpiler.base_test import TranspilerTestSuite  # noqa: E402
+
+
+def _uint(name: str, const: int | None = None) -> Value:
+    """Create a UInt value for CUDA-Q controlled fallback tests.
+
+    Args:
+        name (str): Display name assigned to the IR value.
+        const (int | None): Optional constant payload for the value.
+
+    Returns:
+        Value: UInt IR value, constant when ``const`` is provided.
+    """
+    value = Value(type=UIntType(), name=name)
+    return value.with_const(const) if const is not None else value
+
+
+def _qubit_array(name: str, size: int) -> ArrayValue:
+    """Create a Vector[Qubit] IR value with a constant length.
+
+    Args:
+        name (str): Display name assigned to the vector.
+        size (int): Constant vector length.
+
+    Returns:
+        ArrayValue: Vector[Qubit] IR value with one constant shape dimension.
+    """
+    return ArrayValue(type=QubitType(), name=name, shape=(_uint(f"{name}_dim0", size),))
+
+
+def _qubit_element(parent: ArrayValue, index: Value | int, name: str) -> Value:
+    """Create a Vector[Qubit] element IR value.
+
+    Args:
+        parent (ArrayValue): Parent vector or slice view.
+        index (Value | int): Element index as an IR value or Python integer.
+        name (str): Display name assigned to the element.
+
+    Returns:
+        Value: Qubit element value referencing ``parent[index]``.
+    """
+    index_value = _uint(f"{name}_idx", index) if isinstance(index, int) else index
+    return Value(
+        type=QubitType(),
+        name=name,
+        parent_array=parent,
+        element_indices=(index_value,),
+    )
+
+
+def _x_gate_on(qubit: Value) -> GateOperation:
+    """Create an X gate on one IR qubit value.
+
+    Args:
+        qubit (Value): Qubit operand for the gate.
+
+    Returns:
+        GateOperation: Fixed X gate with a next-version qubit result.
+    """
+    return GateOperation.fixed(
+        gate_type=GateOperationType.X,
+        qubits=[qubit],
+        results=[qubit.next_version()],
+    )
+
+
+def _emit_controlled_ops_and_record_targets(
+    transpiler: Any,
+    operations: list[Any],
+    vector_slots: dict[str, list[int]],
+) -> list[list[int]]:
+    """Run CUDA-Q controlled fallback emission and record gate targets.
+
+    Args:
+        transpiler (Any): CUDA-Q transpiler used to create an emit pass.
+        operations (list[Any]): Controlled block operations to emit.
+        vector_slots (dict[str, list[int]]): Initial vector UUID to physical
+            qubit slots map.
+
+    Returns:
+        list[list[int]]: Gate target indices selected for each emitted gate.
+    """
+    emit_pass = transpiler._create_emit_pass()
+    qubit_map: dict[Any, int] = {}
+    calls: list[list[int]] = []
+
+    def record_gate(
+        circuit: Any,
+        op: GateOperation,
+        emitter: Any,
+        control_indices: list[int],
+        gate_target_indices: list[int],
+        bindings: dict[str, Any],
+    ) -> None:
+        """Record the target indices selected by the controlled fallback."""
+        del circuit, op, emitter, control_indices, bindings
+        calls.append(list(gate_target_indices))
+
+    emit_pass._emit_cudaq_multi_controlled_gate = record_gate
+    emit_pass._emit_cudaq_controlled_ops(
+        object(),
+        operations,
+        num_controls=1,
+        control_indices=[0],
+        target_indices=[10, 11, 12, 13],
+        qubit_map=qubit_map,
+        vector_slots=vector_slots,
+        emitter=object(),
+        bindings={},
+    )
+    return calls
 
 
 class TestCudaqTranspiler(TranspilerTestSuite):
@@ -143,6 +258,84 @@ class TestCudaqRuntimeControlFlow:
         exe = transpiler.transpile(circuit_with_while)
         circuit = exe.compiled_quantum[0].circuit
         assert circuit.execution_mode == ExecutionMode.RUNNABLE
+
+
+class TestCudaqControlledSliceElementFallback:
+    """Regression tests for CUDA-Q controlled fallback element resolution."""
+
+    def test_controlled_fallback_resolves_fixed_slice_element(self) -> None:
+        """Controlled fallback should resolve scalar elements of slice views."""
+        root = _qubit_array("q", 4)
+        view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_uint("q_view_dim0", 2),),
+            slice_of=root,
+            slice_start=_uint("slice_start", 1),
+            slice_step=_uint("slice_step", 2),
+        )
+        element = _qubit_element(view, 1, "q_view[1]")
+        transpiler = CudaqTranspiler()
+
+        calls = _emit_controlled_ops_and_record_targets(
+            transpiler,
+            [_x_gate_on(element)],
+            {root.uuid: [10, 11, 12, 13]},
+        )
+
+        assert calls == [[13]]
+
+    def test_controlled_fallback_recomputes_loop_dependent_slice_slots(
+        self,
+    ) -> None:
+        """Loop-dependent slice bounds should not reuse stale slice slots."""
+        root = _qubit_array("q", 4)
+        loop_var = _uint("i")
+        view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_uint("q_view_dim0", 2),),
+            slice_of=root,
+            slice_start=loop_var,
+            slice_step=_uint("slice_step", 2),
+        )
+        element = _qubit_element(view, 0, "q_view[0]")
+        loop = ForOperation(
+            operands=[_uint("start", 0), _uint("stop", 2), _uint("step", 1)],
+            loop_var="i",
+            loop_var_value=loop_var,
+            operations=[_x_gate_on(element)],
+        )
+        transpiler = CudaqTranspiler()
+
+        calls = _emit_controlled_ops_and_record_targets(
+            transpiler,
+            [loop],
+            {root.uuid: [10, 11, 12, 13]},
+        )
+
+        assert calls == [[10], [11]]
+
+    def test_controlled_fallback_reseeds_symbolic_vector_element(self) -> None:
+        """Loop-indexed root-vector elements should reseed on each iteration."""
+        root = _qubit_array("q", 4)
+        loop_var = _uint("i")
+        element = _qubit_element(root, loop_var, "q[i]")
+        loop = ForOperation(
+            operands=[_uint("start", 0), _uint("stop", 2), _uint("step", 1)],
+            loop_var="i",
+            loop_var_value=loop_var,
+            operations=[_x_gate_on(element)],
+        )
+        transpiler = CudaqTranspiler()
+
+        calls = _emit_controlled_ops_and_record_targets(
+            transpiler,
+            [loop],
+            {root.uuid: [10, 11, 12, 13]},
+        )
+
+        assert calls == [[10], [11]]
 
 
 class TestCudaqSourceInspectRegression:

--- a/tests/transpiler/test_classical_lowering.py
+++ b/tests/transpiler/test_classical_lowering.py
@@ -537,6 +537,7 @@ class TestVectorBitElementProvenance:
             "RuntimeClassicalExpr(AND)."
         )
 
+    @pytest.mark.cudaq
     def test_flat_if_on_measured_vector_element_cudaq(self):
         """The same ``if s[i]:`` pattern compiles on the CUDA-Q backend.
 
@@ -545,7 +546,10 @@ class TestVectorBitElementProvenance:
         lookup) and the CUDA-Q-specific ``_collect_loop_carried_clbits``
         pre-scan (which also walks ``parent_array``). Exercising this
         end-to-end on CUDA-Q ensures both call sites stay consistent with
-        the Qiskit-side coverage. Skipped when CUDA-Q is not installed.
+        the Qiskit-side coverage. Runs in ``-m cudaq`` sessions only:
+        loading cudaq (and the torch/OpenMP runtimes it brings) into a
+        default session that also executes qiskit-aer can segfault — see
+        tests/_cudaq_isolation.py.
         """
         pytest.importorskip("cudaq")
         from qamomile.cudaq import CudaqTranspiler

--- a/tests/transpiler/test_emit_base.py
+++ b/tests/transpiler/test_emit_base.py
@@ -56,6 +56,7 @@ from qamomile.circuit.transpiler.passes.emit_support import (
     QubitAddress,
     ResourceAllocator,
     map_phi_outputs,
+    resolve_qubit_key,
 )
 
 # ---------------------------------------------------------------------------
@@ -82,6 +83,32 @@ def _make_array_value(
 ) -> ArrayValue:
     """Create an ArrayValue with the given shape dimension Values."""
     return ArrayValue(type=type_cls(), name=name, shape=shape_vals)
+
+
+def _make_array_element(
+    parent: ArrayValue,
+    index: int,
+    name: str,
+    type_cls: type = QubitType,
+) -> Value:
+    """Create a constant-index element Value for an ArrayValue.
+
+    Args:
+        parent (ArrayValue): Parent vector or slice view.
+        index (int): Constant element index.
+        name (str): Display name assigned to the element.
+        type_cls (type): Element type class. Defaults to QubitType.
+
+    Returns:
+        Value: Element value referencing ``parent[index]``.
+    """
+    idx_value = _make_const_value(f"{name}_idx", index)
+    return Value(
+        type=type_cls(),
+        name=name,
+        parent_array=parent,
+        element_indices=(idx_value,),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +178,97 @@ def _make_gate(
 
 class TestPhiOpsAllocation:
     """Tests that ResourceAllocator processes phi_ops for IfOperation."""
+
+    def test_resolve_qubit_key_uses_root_for_nested_slice_element(self) -> None:
+        """Constant nested slice elements resolve to the root qubit address."""
+        root_size = _make_const_value("q_dim0", 5)
+        q_array = _make_array_value("q", shape_vals=(root_size,))
+        first_view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_make_const_value("q_view_dim0", 2),),
+            slice_of=q_array,
+            slice_start=_make_const_value("start_1", 1),
+            slice_step=_make_const_value("step_2", 2),
+        )
+        nested_view = ArrayValue(
+            type=QubitType(),
+            name="q_nested_view",
+            shape=(_make_const_value("q_nested_view_dim0", 2),),
+            slice_of=first_view,
+            slice_start=_make_const_value("nested_start_0", 0),
+            slice_step=_make_const_value("nested_step_1", 1),
+        )
+        element = _make_array_element(nested_view, 1, "q_nested_view[1]")
+
+        key, is_array = resolve_qubit_key(element)
+
+        assert is_array
+        assert key == QubitAddress(q_array.uuid, 3)
+
+    def test_resolve_qubit_key_defers_symbolic_slice_bounds(self) -> None:
+        """Symbolic slice bounds defer instead of using the slice UUID."""
+        root_size = _make_const_value("q_dim0", 4)
+        q_array = _make_array_value("q", shape_vals=(root_size,))
+        view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_make_const_value("q_view_dim0", 2),),
+            slice_of=q_array,
+            slice_start=_make_value("offset", UIntType),
+            slice_step=_make_const_value("step_1", 1),
+        )
+        element = _make_array_element(view, 0, "q_view[0]")
+
+        key, is_array = resolve_qubit_key(element)
+
+        assert is_array
+        assert key is None
+
+    def test_scalar_phi_merges_root_and_slice_element_aliases(self) -> None:
+        """Scalar qubit PhiOp should recognize root and slice element aliases."""
+        q_array = _make_array_value("q", shape_vals=(_make_const_value("q_dim0", 3),))
+        view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_make_const_value("q_view_dim0", 2),),
+            slice_of=q_array,
+            slice_start=_make_const_value("start_1", 1),
+            slice_step=_make_const_value("step_1", 1),
+        )
+        cond = _make_value("cond", BitType)
+        root_element = _make_array_element(q_array, 1, "q[1]")
+        view_element = _make_array_element(view, 0, "q_view[0]")
+        phi_output = _make_value("q_phi", QubitType)
+        phi = PhiOp(operands=[cond, root_element, view_element], results=[phi_output])
+        qubit_map = {QubitAddress(q_array.uuid, i): i for i in range(3)}
+
+        map_phi_outputs([phi], qubit_map, {})
+
+        assert qubit_map[QubitAddress(phi_output.uuid)] == 1
+        assert QubitAddress(view.uuid, 0) not in qubit_map
+
+    def test_scalar_phi_defers_unresolved_symbolic_slice_element(self) -> None:
+        """Unresolved symbolic slice elements must not create slice-address aliases."""
+        q_array = _make_array_value("q", shape_vals=(_make_const_value("q_dim0", 3),))
+        view = ArrayValue(
+            type=QubitType(),
+            name="q_view",
+            shape=(_make_const_value("q_view_dim0", 2),),
+            slice_of=q_array,
+            slice_start=_make_value("offset", UIntType),
+            slice_step=_make_const_value("step_1", 1),
+        )
+        cond = _make_value("cond", BitType)
+        view_element = _make_array_element(view, 0, "q_view[0]")
+        phi_output = _make_value("q_phi", QubitType)
+        phi = PhiOp(operands=[cond, view_element, view_element], results=[phi_output])
+        qubit_map = {QubitAddress(q_array.uuid, i): i for i in range(3)}
+
+        map_phi_outputs([phi], qubit_map, {})
+
+        assert QubitAddress(phi_output.uuid) not in qubit_map
+        assert QubitAddress(view.uuid, 0) not in qubit_map
 
     def test_phi_output_qubit_is_allocated(self) -> None:
         """Phi output for a qubit type should be registered in qubit_map."""

--- a/tests/transpiler/test_pauli_evolve_vector_observable.py
+++ b/tests/transpiler/test_pauli_evolve_vector_observable.py
@@ -220,7 +220,10 @@ class TestTrotterBackendPortability:
         gate_names = [type(g).__name__ for g in getattr(circuit, "gates", ())]
         assert gate_names, "QuriParts circuit should contain gates"
 
+    @pytest.mark.cudaq
     def test_cudaq(self):
+        """Transpiles on CUDA-Q; ``-m cudaq`` sessions only (see
+        tests/_cudaq_isolation.py for why default runs must not load cudaq)."""
         pytest.importorskip("cudaq")
         from qamomile.cudaq.transpiler import CudaqTranspiler  # noqa: I001
 


### PR DESCRIPTION
## Summary

- Fix custom-composite inlining so Möttönen amplitude encoding inside qkernel wrappers keeps array-element qubit operands scoped to the caller root array.
- Normalize resolvable slice-element qubit addresses through the emit-support path and update CUDA-Q controlled fallback slot resolution for sliced and loop-indexed vector elements.
- Add wrapper sampler/expval regressions, inverse roundtrip coverage, and CUDA-Q import isolation follow-up needed by all-extras test runs.

## Testing

- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`

## Local Review

- `/local-review` mechanical checks passed; no blocking findings found in the reviewed branch diff.
