### PR TITLE
Add modulo (%) operator for UInt in qamomile.circuit

### DIFF
--- a/qamomile/circuit/estimator/_utils.py
+++ b/qamomile/circuit/estimator/_utils.py
@@ -38,6 +38,7 @@ BINOP_TO_SYMPY = {
     BinOpKind.MUL: lambda lhs, r: lhs * r,
     BinOpKind.DIV: lambda lhs, r: lhs / r,
     BinOpKind.FLOORDIV: _smart_floordiv,
+    BinOpKind.MOD: lambda lhs, r: sp.Mod(lhs, r),
     BinOpKind.POW: lambda lhs, r: lhs**r,
 }
 

--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -228,6 +228,54 @@ class UInt(ArithmeticMixin, Handle):
         _emit_binop(coerced.value, self.value, result, BinOpKind.FLOORDIV)
         return result
 
+    # UInt-specific modulo
+    def __mod__(self, other: "int | UInt") -> "UInt":
+        """Take this UInt modulo an integer-like operand.
+
+        Mirrors the other ``UInt`` arithmetic operators by emitting a
+        ``BinOp(MOD)`` whose result is a fresh ``UInt`` handle. When both
+        operands are compile-time constants the result is folded eagerly
+        (``_emit_binop``), so ``i % k`` is a valid index/loop-bound
+        expression and ``i % k == 0`` is a valid compile-time ``if``
+        predicate once the enclosing loop is unrolled.
+
+        Args:
+            other (int | UInt): The divisor. A Python ``int`` is coerced
+                to a constant ``UInt`` operand.
+
+        Returns:
+            UInt: A new ``UInt`` handle holding ``self % other``.
+
+        Example:
+            >>> import qamomile.circuit as qmc
+            >>> @qmc.qkernel
+            ... def circuit() -> qmc.Vector[qmc.Qubit]:
+            ...     q = qmc.qubit_array(4, "q")
+            ...     for i in qmc.range(4):
+            ...         if i % 2 == 0:
+            ...             q[i] = qmc.x(q[i])
+            ...     return q
+        """
+        coerced = self._coerce(other)
+        result = self._make_result()
+        _emit_binop(self.value, coerced.value, result, BinOpKind.MOD)
+        return result
+
+    def __rmod__(self, other: "int | UInt") -> "UInt":
+        """Take an integer-like operand modulo this UInt.
+
+        Args:
+            other (int | UInt): The dividend. A Python ``int`` is coerced
+                to a constant ``UInt`` operand.
+
+        Returns:
+            UInt: A new ``UInt`` handle holding ``other % self``.
+        """
+        coerced = self._coerce(other)
+        result = self._make_result()
+        _emit_binop(coerced.value, self.value, result, BinOpKind.MOD)
+        return result
+
     # UInt-specific power operation
     def __pow__(self, other: "int | UInt") -> "UInt":
         coerced = self._coerce(other)

--- a/qamomile/circuit/frontend/handle/primitives.py
+++ b/qamomile/circuit/frontend/handle/primitives.py
@@ -239,6 +239,11 @@ class UInt(ArithmeticMixin, Handle):
         expression and ``i % k == 0`` is a valid compile-time ``if``
         predicate once the enclosing loop is unrolled.
 
+        Like the sibling integer operators (``__floordiv__`` / ``__pow__``),
+        the ``int | UInt`` operand contract is enforced statically by the
+        type checker; passing a non-integral operand (e.g. a Python
+        ``float``) is a type error rather than a runtime branch here.
+
         Args:
             other (int | UInt): The divisor. A Python ``int`` is coerced
                 to a constant ``UInt`` operand.

--- a/qamomile/circuit/ir/operation/arithmetic_operations.py
+++ b/qamomile/circuit/ir/operation/arithmetic_operations.py
@@ -54,13 +54,14 @@ class BinOpKind(enum.Enum):
     MUL = enum.auto()
     DIV = enum.auto()
     FLOORDIV = enum.auto()
+    MOD = enum.auto()
     POW = enum.auto()
     MIN = enum.auto()
 
 
 @dataclasses.dataclass
 class BinOp(BinaryOperationBase):
-    """Binary arithmetic operation (ADD, SUB, MUL, DIV, FLOORDIV, POW)."""
+    """Binary arithmetic operation (ADD, SUB, MUL, DIV, FLOORDIV, MOD, POW)."""
 
     kind: BinOpKind | None = None
 
@@ -178,6 +179,7 @@ class RuntimeOpKind(enum.Enum):
     MUL = enum.auto()
     DIV = enum.auto()
     FLOORDIV = enum.auto()
+    MOD = enum.auto()
     POW = enum.auto()
 
 
@@ -193,7 +195,7 @@ class RuntimeClassicalExpr(Operation):
     (e.g. ``qiskit.circuit.classical.expr.Expr``).
 
     Operand convention:
-    - Binary kinds (EQ/NEQ/LT/LE/GT/GE/AND/OR/ADD/SUB/MUL/DIV/FLOORDIV/POW):
+    - Binary kinds (EQ/NEQ/LT/LE/GT/GE/AND/OR/ADD/SUB/MUL/DIV/FLOORDIV/MOD/POW):
       ``operands = [lhs, rhs]``.
     - Unary kind (NOT): ``operands = [val]``.
     - Result: ``results = [output_value]``.
@@ -240,6 +242,7 @@ _BINOP_KIND_TO_RUNTIME: dict[BinOpKind, RuntimeOpKind] = {
     BinOpKind.MUL: RuntimeOpKind.MUL,
     BinOpKind.DIV: RuntimeOpKind.DIV,
     BinOpKind.FLOORDIV: RuntimeOpKind.FLOORDIV,
+    BinOpKind.MOD: RuntimeOpKind.MOD,
     BinOpKind.POW: RuntimeOpKind.POW,
 }
 

--- a/qamomile/circuit/ir/operation/arithmetic_operations.py
+++ b/qamomile/circuit/ir/operation/arithmetic_operations.py
@@ -61,7 +61,7 @@ class BinOpKind(enum.Enum):
 
 @dataclasses.dataclass
 class BinOp(BinaryOperationBase):
-    """Binary arithmetic operation (ADD, SUB, MUL, DIV, FLOORDIV, MOD, POW)."""
+    """Binary arithmetic operation (ADD, SUB, MUL, DIV, FLOORDIV, MOD, POW, MIN)."""
 
     kind: BinOpKind | None = None
 

--- a/qamomile/circuit/ir/printer.py
+++ b/qamomile/circuit/ir/printer.py
@@ -283,6 +283,7 @@ def _init_op_symbols() -> None:
             BinOpKind.MUL: "*",
             BinOpKind.DIV: "/",
             BinOpKind.FLOORDIV: "//",
+            BinOpKind.MOD: "%",
             BinOpKind.POW: "**",
         }
     )

--- a/qamomile/circuit/transpiler/gate_emitter.py
+++ b/qamomile/circuit/transpiler/gate_emitter.py
@@ -529,6 +529,8 @@ def default_combine_symbolic(
             return lhs / rhs if rhs != 0 else 0.0
         case BinOpKind.FLOORDIV:
             return lhs // rhs if rhs != 0 else 0
+        case BinOpKind.MOD:
+            return lhs % rhs if rhs != 0 else 0
         case BinOpKind.POW:
             return lhs**rhs
         case _:

--- a/qamomile/circuit/transpiler/gate_emitter.py
+++ b/qamomile/circuit/transpiler/gate_emitter.py
@@ -530,7 +530,13 @@ def default_combine_symbolic(
         case BinOpKind.FLOORDIV:
             return lhs // rhs if rhs != 0 else 0
         case BinOpKind.MOD:
-            return lhs % rhs if rhs != 0 else 0
+            # Unlike the div-by-zero degenerate convention above (return 0 to
+            # let emission continue), modulo by zero is undefined, and the
+            # compile-time fold path (evaluate_binop_values) treats it as
+            # non-foldable. Do not special-case rhs == 0 here: a concrete zero
+            # divisor raises loudly rather than silently producing a wrong
+            # value, keeping the symbolic path consistent with folding.
+            return lhs % rhs
         case BinOpKind.POW:
             return lhs**rhs
         case _:

--- a/qamomile/circuit/transpiler/passes/eval_utils.py
+++ b/qamomile/circuit/transpiler/passes/eval_utils.py
@@ -188,6 +188,8 @@ def evaluate_binop_values(
                 return left / right if right != 0 else None
             case BinOpKind.FLOORDIV:
                 return left // right if right != 0 else None
+            case BinOpKind.MOD:
+                return left % right if right != 0 else None
             case BinOpKind.POW:
                 return left**right
             case BinOpKind.MIN:

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -2456,6 +2456,8 @@ class CircuitAnalyzer:
                         return lhs_val * rhs_val
                     elif op.kind == BinOpKind.FLOORDIV:
                         return lhs_val // rhs_val if rhs_val != 0 else None
+                    elif op.kind == BinOpKind.MOD:
+                        return lhs_val % rhs_val if rhs_val != 0 else None
                     elif op.kind == BinOpKind.DIV:
                         return lhs_val / rhs_val if rhs_val != 0 else None
                     elif op.kind == BinOpKind.POW:
@@ -2719,6 +2721,7 @@ class CircuitAnalyzer:
         else:
             _extra_ops: dict[BinOpKind, str] = {
                 BinOpKind.FLOORDIV: "//",
+                BinOpKind.MOD: "%",
                 BinOpKind.POW: "**",
             }
             op_sym = _extra_ops.get(binop.kind, "?") if binop.kind is not None else "?"
@@ -4507,6 +4510,7 @@ class CircuitAnalyzer:
                     BinOpKind.SUB: "-",
                     BinOpKind.MUL: "*",
                     BinOpKind.FLOORDIV: "//",
+                    BinOpKind.MOD: "%",
                     BinOpKind.POW: "**",
                 }
                 op_symbol = (

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -378,7 +378,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
 
         Every arm of ``RuntimeOpKind`` (except ``NOT``, which is handled
         upstream) is dispatched here. Kinds without a Qiskit ``expr``
-        equivalent — currently ``FLOORDIV`` and ``POW`` — raise
+        equivalent — currently ``FLOORDIV``, ``MOD`` and ``POW`` — raise
         ``NotImplementedError`` rather than silently returning ``None``,
         so the contract gap is loud at emit time instead of producing a
         misleading "Unsupported kind" error.
@@ -413,7 +413,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
                 return expr.mul(lhs, rhs)
             case RuntimeOpKind.DIV:
                 return expr.div(lhs, rhs)
-            case RuntimeOpKind.FLOORDIV | RuntimeOpKind.POW:
+            case RuntimeOpKind.FLOORDIV | RuntimeOpKind.MOD | RuntimeOpKind.POW:
                 raise NotImplementedError(
                     f"RuntimeOpKind.{kind.name} is not supported by the Qiskit "
                     f"backend (Qiskit's classical expr has no equivalent). "

--- a/qamomile/quri_parts/emitter.py
+++ b/qamomile/quri_parts/emitter.py
@@ -247,7 +247,7 @@ class QuriPartsGateEmitter:
                         "QURI Parts backend: division by zero in symbolic angle."
                     )
                 return _scale_form(lf_lhs, 1.0 / divisor)
-            case BinOpKind.POW | BinOpKind.FLOORDIV:
+            case BinOpKind.POW | BinOpKind.FLOORDIV | BinOpKind.MOD:
                 raise QamomileQuriPartsTranspileError(
                     f"QURI Parts backend supports only linear combinations of "
                     f"parameters; '{kind.name}' is not supported on parametric "

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -1270,9 +1270,11 @@ FRONTEND_EXECUTION_CASES = [
         sample_kernel=uint_mod_alternating_sample,
         run_kernel=uint_mod_alternating_run,
         sample_mode="deterministic",
-        expected_bits=(1, 0, 1, 0),
+        expected_bits=(1, 0, 1, 0),  # sample kernel flips even indices
         expected_support={(1, 0, 1, 0)},
-        expected_expval=0.0,  # Z0+Z1+Z2+Z3 over (1,0,1,0) = -1+1-1+1
+        # run kernel flips ODD indices via RX((i % 2) * pi) -> state (0,1,0,1),
+        # so Z0+Z1+Z2+Z3 = +1-1+1-1 = 0.
+        expected_expval=0.0,
         run_bindings={"obs": qm_o.Z(0) + qm_o.Z(1) + qm_o.Z(2) + qm_o.Z(3)},
     ),
     FrontendExecutionCase(

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -996,10 +996,16 @@ def nested_classical_output_run(
 #
 # Motivating use case for ``UInt.__mod__`` (backlog BACKLOG-8409): a QSVT-style
 # loop that selects between a forward and inverse step on alternating iterations
-# via ``if i % 2 == 0``. Here it flips the even-indexed qubits, giving the
-# deterministic bit pattern ``(1, 0, 1, 0)``. ``i % 2`` folds to a concrete
-# value once the loop is unrolled, so the compile-time ``if`` resolves per
-# iteration and every backend emits the same circuit.
+# via ``i % 2``. ``i % 2`` folds to a concrete value once the loop is unrolled.
+#
+# The sample kernel uses the natural ``if i % 2 == 0`` form (compile-time
+# branch resolved per iteration) to flip the even-indexed qubits, giving the
+# deterministic pattern ``(1, 0, 1, 0)``. The run/expval kernel instead folds
+# ``i % 2`` into an RX angle (``(i % 2) * pi``) rather than an ``if``: CUDA-Q
+# marks any ``if``-containing kernel as RUNNABLE, and ``cudaq.observe()`` (the
+# expval path) rejects RUNNABLE artifacts, so the angle form keeps the kernel
+# STATIC and exercises ``%`` through the estimator on every backend. RX(pi)
+# flips the odd-indexed qubits, so Z0+Z1+Z2+Z3 sums to +1-1+1-1 = 0.
 
 
 @qmc.qkernel
@@ -1014,11 +1020,10 @@ def uint_mod_alternating_sample() -> qmc.Vector[qmc.Bit]:
 
 @qmc.qkernel
 def uint_mod_alternating_run(obs: qmc.Observable) -> qmc.Float:
-    """Run expval after flipping even-indexed qubits via ``i % 2 == 0``."""
+    """Run expval after RX((i % 2) * pi), flipping odd-indexed qubits."""
     q = qmc.qubit_array(4, "q")
     for i in qmc.range(4):
-        if i % 2 == 0:
-            q[i] = qmc.x(q[i])
+        q[i] = qmc.rx(q[i], (i % 2) * math.pi)
     return qmc.expval(q, obs)
 
 

--- a/tests/circuit/test_frontend_cross_backend_execution.py
+++ b/tests/circuit/test_frontend_cross_backend_execution.py
@@ -992,6 +992,36 @@ def nested_classical_output_run(
     return qmc.measure(q), out
 
 
+# --- Modulo operator (UInt.__mod__) on alternating loop indices ---
+#
+# Motivating use case for ``UInt.__mod__`` (backlog BACKLOG-8409): a QSVT-style
+# loop that selects between a forward and inverse step on alternating iterations
+# via ``if i % 2 == 0``. Here it flips the even-indexed qubits, giving the
+# deterministic bit pattern ``(1, 0, 1, 0)``. ``i % 2`` folds to a concrete
+# value once the loop is unrolled, so the compile-time ``if`` resolves per
+# iteration and every backend emits the same circuit.
+
+
+@qmc.qkernel
+def uint_mod_alternating_sample() -> qmc.Vector[qmc.Bit]:
+    """Flip even-indexed qubits using ``i % 2 == 0`` in an unrolled loop."""
+    q = qmc.qubit_array(4, "q")
+    for i in qmc.range(4):
+        if i % 2 == 0:
+            q[i] = qmc.x(q[i])
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def uint_mod_alternating_run(obs: qmc.Observable) -> qmc.Float:
+    """Run expval after flipping even-indexed qubits via ``i % 2 == 0``."""
+    q = qmc.qubit_array(4, "q")
+    for i in qmc.range(4):
+        if i % 2 == 0:
+            q[i] = qmc.x(q[i])
+    return qmc.expval(q, obs)
+
+
 @dataclasses.dataclass(frozen=True)
 class FrontendExecutionCase:
     """Describe one frontend pattern with paired sample and run kernels."""
@@ -1229,6 +1259,16 @@ FRONTEND_EXECUTION_CASES = [
         expected_support={(1, 0, 1)},
         expected_expval=-1.0,
         run_bindings={"obs": qm_o.Z(0) + qm_o.Z(1) + qm_o.Z(2)},
+    ),
+    FrontendExecutionCase(
+        name="uint-mod-alternating",
+        sample_kernel=uint_mod_alternating_sample,
+        run_kernel=uint_mod_alternating_run,
+        sample_mode="deterministic",
+        expected_bits=(1, 0, 1, 0),
+        expected_support={(1, 0, 1, 0)},
+        expected_expval=0.0,  # Z0+Z1+Z2+Z3 over (1,0,1,0) = -1+1-1+1
+        run_bindings={"obs": qm_o.Z(0) + qm_o.Z(1) + qm_o.Z(2) + qm_o.Z(3)},
     ),
     FrontendExecutionCase(
         name="pauli-evolve",

--- a/tests/transpiler/test_emit_base.py
+++ b/tests/transpiler/test_emit_base.py
@@ -16,7 +16,7 @@ Section 2: LoopAnalyzer BinOp dependency detection.
     inside nested control-flow), and theta array-element access
     referencing the loop variable triggers unrolling.
 
-Section 3: Integration tests for UInt BinOp (``//``, ``**``) folding
+Section 3: Integration tests for UInt BinOp (``//``, ``%``, ``**``) folding
     into loop bounds via the constant folding pass.
 """
 
@@ -1152,6 +1152,26 @@ def binop_pow_circuit(n: qmc.UInt, theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
 
 
 @qmc.qkernel
+def binop_mod_circuit(n: qmc.UInt, theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    """Apply RX(theta) to first n % 3 qubits of a 4-qubit register."""
+    q = qmc.qubit_array(4, "q")
+    count = n % 3
+    for i in qmc.range(count):
+        q[i] = qmc.rx(q[i], angle=theta)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def binop_rmod_circuit(n: qmc.UInt, theta: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    """Apply RX(theta) to first 7 % n qubits of a 4-qubit register."""
+    q = qmc.qubit_array(4, "q")
+    count = 7 % n  # exercises UInt.__rmod__
+    for i in qmc.range(count):
+        q[i] = qmc.rx(q[i], angle=theta)
+    return qmc.measure(q)
+
+
+@qmc.qkernel
 def array_element_loop_bound_circuit(
     bounds: qmc.Vector[qmc.UInt], theta: qmc.Float
 ) -> qmc.Vector[qmc.Bit]:
@@ -1271,7 +1291,7 @@ class TestPhiMergeAliasRegression:
 
 
 class TestUIntBinOpFolding:
-    """Tests for UInt BinOp kinds (``//``, ``**``) that affect loop bounds.
+    """Tests for UInt BinOp kinds (``//``, ``%``, ``**``) that affect loop bounds.
 
     At tracing time ``n`` is a symbolic ``UInt`` handle, so ``n // 2``
     emits a ``BinOp(FLOORDIV)`` into the IR.  The constant folding pass
@@ -1323,6 +1343,59 @@ class TestUIntBinOpFolding:
 
         assert len(rx_angles) == expected_rx_count, (
             f"Expected {expected_rx_count} RX gates (n={n}, n**2={n**2}), "
+            f"got {len(rx_angles)}"
+        )
+        for i, angle in enumerate(rx_angles):
+            assert np.isclose(angle, theta), (
+                f"RX[{i}] angle {angle} != expected {theta}"
+            )
+
+    @pytest.mark.parametrize(
+        "n, theta, expected_rx_count",
+        [
+            (4, 0.5, 1),  # 4 % 3 = 1
+            (5, 0.3, 2),  # 5 % 3 = 2
+            (6, 1.0, 0),  # 6 % 3 = 0 (boundary: empty loop)
+            (2, 0.2, 2),  # 2 % 3 = 2
+        ],
+        ids=["4%3=1", "5%3=2", "6%3=0", "2%3=2"],
+    )
+    def test_mod_loop_bound(self, n: int, theta: float, expected_rx_count: int) -> None:
+        """``n % 3`` correctly folded as loop bound; angles verified."""
+        _, qc = _transpile_and_get_circuit(
+            binop_mod_circuit, bindings={"n": n, "theta": theta}
+        )
+        rx_angles = _extract_rx_angles(qc)
+
+        assert len(rx_angles) == expected_rx_count, (
+            f"Expected {expected_rx_count} RX gates (n={n}, n%3={n % 3}), "
+            f"got {len(rx_angles)}"
+        )
+        for i, angle in enumerate(rx_angles):
+            assert np.isclose(angle, theta), (
+                f"RX[{i}] angle {angle} != expected {theta}"
+            )
+
+    @pytest.mark.parametrize(
+        "n, theta, expected_rx_count",
+        [
+            (2, 0.5, 1),  # 7 % 2 = 1
+            (3, 0.3, 1),  # 7 % 3 = 1
+            (4, 1.0, 3),  # 7 % 4 = 3
+        ],
+        ids=["7%2=1", "7%3=1", "7%4=3"],
+    )
+    def test_rmod_loop_bound(
+        self, n: int, theta: float, expected_rx_count: int
+    ) -> None:
+        """``7 % n`` (UInt.__rmod__) correctly folded as loop bound."""
+        _, qc = _transpile_and_get_circuit(
+            binop_rmod_circuit, bindings={"n": n, "theta": theta}
+        )
+        rx_angles = _extract_rx_angles(qc)
+
+        assert len(rx_angles) == expected_rx_count, (
+            f"Expected {expected_rx_count} RX gates (n={n}, 7%n={7 % n}), "
             f"got {len(rx_angles)}"
         )
         for i, angle in enumerate(rx_angles):

--- a/tests/transpiler/test_runtime_op_kinds.py
+++ b/tests/transpiler/test_runtime_op_kinds.py
@@ -20,7 +20,7 @@ These tests pin every cell:
    ``equal``/``less``/... arms, exercising numeric preservation.
 
 3. **NotImplementedError** for kinds without a Qiskit equivalent
-   (``FLOORDIV``, ``POW``).
+   (``FLOORDIV``, ``MOD``, ``POW``).
 """
 
 from __future__ import annotations
@@ -162,9 +162,11 @@ class TestSyntheticBinaryExprDispatch:
         assert hasattr(result, "op"), f"Expected expr.Binary, got {type(result)}"
         assert result.op.name == expected_op_name
 
-    @pytest.mark.parametrize("kind", [RuntimeOpKind.FLOORDIV, RuntimeOpKind.POW])
+    @pytest.mark.parametrize(
+        "kind", [RuntimeOpKind.FLOORDIV, RuntimeOpKind.MOD, RuntimeOpKind.POW]
+    )
     def test_unsupported_kinds_raise_not_implemented(self, kind, expr_module):
-        """FLOORDIV and POW have no qiskit.expr equivalent — raise loudly."""
+        """FLOORDIV, MOD and POW have no qiskit.expr equivalent — raise loudly."""
         from qamomile.qiskit.transpiler import QiskitEmitPass
 
         expr, types = expr_module


### PR DESCRIPTION
## Summary

`UInt` (the compile-time unsigned-integer handle) already implemented `+ - * / // **` but not the modulo operator `%`. As a result, writing natural index arithmetic such as `i % 2` inside a `qmc.range` loop — for example to alternate between a forward block-encoding and its inverse in QSVT — raised `TypeError` at trace time because `UInt` had no `__mod__`.

This PR adds `UInt.__mod__` / `__rmod__`, mirroring the existing `__floordiv__`, and threads a new `BinOpKind.MOD` / `RuntimeOpKind.MOD` through every dispatch site that already handles `FLOORDIV`:

- `UInt.__mod__` / `__rmod__` (`qamomile/circuit/frontend/handle/primitives.py`)
- IR enums + runtime mapping (`arithmetic_operations.py`)
- compile-time constant folding (`eval_utils.evaluate_binop_values`)
- symbolic-angle combination (`gate_emitter.default_combine_symbolic`)
- estimator SymPy mapping (`estimator/_utils.BINOP_TO_SYMPY` → `sp.Mod`)
- IR printer + circuit visualization symbols/eval
- Qiskit backend (`MOD` joins `FLOORDIV`/`POW` as unsupported on runtime classical exprs — fold at compile time) and QURI Parts backend (unsupported on parametric angles)

The IR keeps modulo as a single abstract binary-op node and defers concretization to emit time, matching the existing `//` treatment. The `i % 2` QSVT motivation folds at compile time once the enclosing loop is unrolled, so it works on every backend.

After the loop is unrolled, `i % k` folds to a concrete value, so a kernel like the one below flips only the even-indexed qubits and samples deterministically to `(1, 0, 1, 0)`:

```python
@qmc.qkernel
def alternating() -> qmc.Vector[qmc.Bit]:
    q = qmc.qubit_array(4, "q")
    for i in qmc.range(4):
        if i % 2 == 0:
            q[i] = qmc.x(q[i])
    return qmc.measure(q)
```

Closes BACKLOG-8409.

## Test plan

- `tests/transpiler/test_emit_base.py`: `n % 3` and `7 % n` (`__rmod__`) loop-bound folding, parametrized including the `6 % 3 = 0` empty-loop boundary.
- `tests/circuit/test_frontend_cross_backend_execution.py`: new `uint-mod-alternating` case with paired sample and expval kernels, parametrized across the Qiskit / QURI Parts / CUDA-Q backend matrix (`importorskip`-guarded).
- `tests/transpiler/test_runtime_op_kinds.py`: `RuntimeOpKind.MOD` added to the Qiskit unsupported-runtime-kind `NotImplementedError` test.
- Full local suite: `8317 passed, 387 skipped, 1 xfailed`. `ruff check`, `ruff format --check`, and `zuban check` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZYkUGhT8LmSWZ7LEhaebY)_