### PR TITLE
Clarify CUDA-Q static-only expectation-value behavior

### DIFF
--- a/qamomile/cudaq/transpiler.py
+++ b/qamomile/cudaq/transpiler.py
@@ -2252,13 +2252,25 @@ class CudaqEmitPass(StandardEmitPass[CudaqKernelArtifact]):
 class CudaqExecutor(QuantumExecutor[CudaqKernelArtifact]):
     """CUDA-Q quantum executor.
 
-    Supports sampling via ``cudaq.sample`` and expectation value estimation
-    via ``cudaq.observe``.  Dispatches to the appropriate CUDA-Q runtime
-    API based on the artifact's ``execution_mode``.
+    Supports sampling via ``cudaq.sample`` / ``cudaq.run`` and expectation
+    value estimation via ``cudaq.observe``.  Dispatches to the appropriate
+    CUDA-Q runtime API based on the artifact's ``execution_mode``:
+
+    - ``STATIC`` artifacts (no mid-circuit measurement or runtime control
+      flow) support both sampling (``cudaq.sample``) and expectation-value
+      estimation (``cudaq.observe``).
+    - ``RUNNABLE`` artifacts (mid-circuit measurement or measurement-dependent
+      control flow such as ``if bit:`` / ``while bit:``) support sampling only,
+      via ``cudaq.run``.
+
+    Expectation-value estimation is therefore **static-only**: calling
+    :meth:`estimate` on a ``RUNNABLE`` artifact raises ``TypeError`` because
+    ``cudaq.observe`` cannot consume a kernel that requires ``cudaq.run``.
+    See :meth:`estimate` for the full rationale.
 
     Args:
-        target: CUDA-Q target name (e.g., ``"qpp-cpu"``). If None, uses
-            the default CUDA-Q target.
+        target (str | None): CUDA-Q target name (e.g., ``"qpp-cpu"``). If
+            None, uses the default CUDA-Q target.
     """
 
     def __init__(self, target: str | None = None):
@@ -2402,10 +2414,55 @@ class CudaqExecutor(QuantumExecutor[CudaqKernelArtifact]):
         hamiltonian: "qm_o.Hamiltonian",
         params: Sequence[float] | None = None,
     ) -> float:
-        """Estimate expectation value using ``cudaq.observe``.
+        """Estimate an expectation value using ``cudaq.observe``.
 
-        Only supported for STATIC-mode artifacts.  RUNNABLE-mode artifacts
-        are not compatible with ``cudaq.observe()`` and raise ``TypeError``.
+        Expectation-value estimation on the CUDA-Q backend is **static-only**.
+        It is supported exclusively for ``STATIC``-mode artifacts, which are
+        evaluated with ``cudaq.observe()``.  ``RUNNABLE``-mode artifacts (a
+        kernel containing mid-circuit measurement or measurement-dependent
+        control flow such as ``if bit:`` / ``while bit:``) are emitted for
+        ``cudaq.run()``, and ``cudaq.observe()`` cannot consume them.  Such
+        artifacts therefore raise ``TypeError`` rather than silently returning
+        a meaningless value.
+
+        This is a CUDA-Q API limitation, not merely a Qamomile gap:
+        ``cudaq.observe()`` evaluates the analytic expectation value of a
+        deterministic state-preparation kernel and has no execution path for a
+        kernel that requires the per-shot ``cudaq.run()`` runtime.  There is no
+        safe alternative that preserves the exact-expectation contract of this
+        method, so the ``TypeError`` path is intentional.  Under the current
+        affine model a single Qamomile kernel also cannot be both ``RUNNABLE``
+        and carry a terminal ``qmc.expval`` (reusing a measured qubit is
+        rejected), so the ``ExecutableProgram.run`` expval path does not reach
+        this guard; it is reached only when ``estimate`` is called directly on
+        a ``RUNNABLE`` artifact.
+
+        Args:
+            circuit (Any): A CUDA-Q artifact (``CudaqKernelArtifact`` or
+                ``BoundCudaqKernelArtifact``).  Must be ``STATIC``-mode;
+                ``RUNNABLE``-mode artifacts are rejected.
+            hamiltonian (qm_o.Hamiltonian): The observable to measure.  A
+                ``qamomile.observable.Hamiltonian`` is converted to a CUDA-Q
+                ``SpinOperator``; an already-converted operator is used as-is.
+            params (Sequence[float] | None): Values for the kernel's runtime
+                ``parameters`` slots, in declared parameter order.  Compile-
+                time-bound parameters are already baked into the artifact and
+                are not included here.  Defaults to None for a non-parametric
+                or already-bound (``BoundCudaqKernelArtifact``) kernel.
+
+        Returns:
+            float: The estimated expectation value ``<psi|H|psi>``.
+
+        Raises:
+            TypeError: If ``circuit`` is a ``RUNNABLE``-mode artifact, since
+                ``cudaq.observe()`` only accepts static state-preparation
+                kernels (see the static-only note above).
+
+        Example:
+            >>> transpiler = CudaqTranspiler()
+            >>> exe = transpiler.transpile(static_ansatz, bindings={"H": H})
+            >>> executor = transpiler.executor()
+            >>> value = executor.estimate(exe.get_first_circuit(), H)
         """
         import cudaq
         import qamomile.observable as qm_o
@@ -2414,8 +2471,17 @@ class CudaqExecutor(QuantumExecutor[CudaqKernelArtifact]):
         mode = getattr(circuit, "execution_mode", ExecutionMode.STATIC)
         if mode == ExecutionMode.RUNNABLE:
             raise TypeError(
-                "cudaq.observe() is not supported for runtime control flow "
-                "circuits. Use sample() or run() instead."
+                "Expectation-value estimation is not available for this CUDA-Q "
+                "circuit. The kernel uses mid-circuit measurement or "
+                "measurement-dependent control flow (e.g. `if bit:` / "
+                "`while bit:`), so it is emitted in RUNNABLE mode and executed "
+                "with `cudaq.run()`. CUDA-Q's expectation-value primitive "
+                "`cudaq.observe()` only accepts static state-preparation "
+                "kernels and cannot consume a RUNNABLE kernel. To estimate an "
+                "expectation value, express the state preparation as a static "
+                "kernel without measurement-dependent control flow; "
+                "expectation values cannot be computed for measurement-"
+                "conditioned circuits on the CUDA-Q backend."
             )
 
         self._ensure_target()  # type: ignore[unreachable]

--- a/tests/transpiler/backends/test_cudaq_frontend.py
+++ b/tests/transpiler/backends/test_cudaq_frontend.py
@@ -1275,6 +1275,131 @@ class TestExpvalCudaqPipeline:
             transpiler.transpile(circuit, bindings={"n": 2})
 
 
+class TestExpvalStaticOnlyCudaq:
+    """Pin down CUDA-Q's static-only expectation-value contract.
+
+    Expectation values on CUDA-Q go through ``cudaq.observe`` and are only
+    available for STATIC artifacts.  RUNNABLE artifacts (mid-circuit
+    measurement / measurement-dependent control flow) must raise a clear
+    ``TypeError`` from ``estimate`` rather than silently mis-evaluating.
+    """
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 42])
+    @pytest.mark.parametrize("theta", [0.0, np.pi / 2, np.pi, 2 * np.pi, None])
+    def test_static_kernel_estimate_matches_analytic(self, seed, theta):
+        """Static-mode ``estimate`` returns ``<Z> = cos(theta)`` exactly.
+
+        ``None`` selects a random angle for the given seed; the listed
+        constants cover the 0/pi/2pi boundaries.
+        """
+        rng = np.random.default_rng(seed)
+        angle = float(rng.uniform(0.0, 2 * np.pi)) if theta is None else float(theta)
+
+        @qmc.qkernel
+        def rx_z(t: qmc.Float, H: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit("q")
+            q = qmc.rx(q, t)
+            return qmc.expval((q,), H)
+
+        H_label = qm_o.Hamiltonian(num_qubits=1)
+        H_label += qm_o.Z(0)
+        transpiler = CudaqTranspiler()
+        exe = transpiler.transpile(rx_z, bindings={"H": H_label}, parameters=["t"])
+        artifact = exe.get_first_circuit()
+        assert artifact.execution_mode == ExecutionMode.STATIC
+
+        executor = transpiler.executor()
+        value = executor.estimate(artifact, H_label, params=[angle])
+        assert np.isclose(value, np.cos(angle), atol=1e-6)
+
+    @pytest.mark.parametrize("seed", [0, 1, 7])
+    def test_static_kernel_estimate_random_observable(self, seed):
+        """Static ``estimate`` on a Bell state matches the analytic value.
+
+        For the Bell state, ``<ZZ> = 1`` and ``<XX> = 1`` while ``<X0> = 0``;
+        a random combination ``a*ZZ + b*X0`` therefore has expectation ``a``.
+        """
+        rng = np.random.default_rng(seed)
+        a = float(rng.uniform(-2.0, 2.0))
+        b = float(rng.uniform(-2.0, 2.0))
+
+        @qmc.qkernel
+        def bell(n: qmc.UInt, H: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit_array(n, "q")
+            q[0] = qmc.h(q[0])
+            q[0], q[1] = qmc.cx(q[0], q[1])
+            return qmc.expval(q, H)
+
+        H_label = a * (qm_o.Z(0) * qm_o.Z(1)) + b * qm_o.X(0)
+        transpiler = CudaqTranspiler()
+        exe = transpiler.transpile(bell, bindings={"H": H_label, "n": 2})
+        artifact = exe.get_first_circuit()
+        assert artifact.execution_mode == ExecutionMode.STATIC
+
+        executor = transpiler.executor()
+        value = executor.estimate(artifact, H_label)
+        assert np.isclose(value, a, atol=1e-6)
+
+    def test_runnable_kernel_estimate_raises_clear_typeerror(self):
+        """``estimate`` on a RUNNABLE artifact raises an explanatory TypeError."""
+
+        @qmc.qkernel
+        def runnable() -> qmc.Bit:
+            q = qmc.qubit("q")
+            q = qmc.h(q)
+            b = qmc.measure(q)
+            if b:
+                q2 = qmc.qubit("q2")
+                q2 = qmc.x(q2)
+            return b
+
+        transpiler = CudaqTranspiler()
+        exe = transpiler.transpile(runnable)
+        artifact = exe.get_first_circuit()
+        assert artifact.execution_mode == ExecutionMode.RUNNABLE
+
+        H_label = qm_o.Hamiltonian(num_qubits=1)
+        H_label += qm_o.Z(0)
+        executor = transpiler.executor()
+        with pytest.raises(TypeError) as excinfo:
+            executor.estimate(artifact, H_label)
+
+        message = str(excinfo.value)
+        # The message must name the cause (RUNNABLE / cudaq.run vs observe) and
+        # the remedy (use a static kernel), not just say "not supported".
+        assert "cudaq.observe" in message
+        assert "cudaq.run" in message
+        assert "static" in message.lower()
+
+    def test_runnable_kernel_cannot_carry_terminal_expval(self):
+        """A RUNNABLE kernel with a terminal ``expval`` is structurally illegal.
+
+        Because the affine model rejects reusing a measured qubit, no single
+        kernel can be both RUNNABLE and produce a terminal expectation value,
+        so the ``ExecutableProgram.run`` expval path never feeds a RUNNABLE
+        artifact into ``estimate``.  The static-only ``TypeError`` guard is
+        reachable only by calling ``estimate`` directly on a RUNNABLE artifact.
+        The match keeps this test pinned to the consumed-qubit rejection rather
+        than any unrelated affine rule.
+        """
+        from qamomile.circuit.transpiler.errors import AffineTypeError
+
+        @qmc.qkernel
+        def runnable_expval(H: qmc.Observable) -> qmc.Float:
+            q = qmc.qubit("q")
+            q = qmc.h(q)
+            b = qmc.measure(q)
+            if b:
+                q = qmc.x(q)
+            return qmc.expval((q,), H)
+
+        H_label = qm_o.Hamiltonian(num_qubits=1)
+        H_label += qm_o.Z(0)
+        transpiler = CudaqTranspiler()
+        with pytest.raises(AffineTypeError, match="already consumed"):
+            transpiler.transpile(runnable_expval, bindings={"H": H_label})
+
+
 # ============================================================================
 # 10. Sub-Kernel Inlining
 # ============================================================================


### PR DESCRIPTION
## Summary

- Expectation-value estimation on the CUDA-Q backend goes through `cudaq.observe`, which only accepts STATIC kernels. RUNNABLE artifacts (mid-circuit measurement or measurement-dependent control flow such as `if bit:` / `while bit:`) are executed with `cudaq.run` and cannot be consumed by `cudaq.observe`.
- `CudaqExecutor.estimate` previously raised a terse `TypeError` that told users to "use sample() or run() instead", neither of which returns an expectation value. This rewrites the message to name the cause (RUNNABLE mode is emitted for `cudaq.run`, which `cudaq.observe` cannot consume) and the remedy (express the state preparation as a static kernel; expectation values are unavailable for measurement-conditioned circuits on CUDA-Q).
- Documents the static-only contract on the `CudaqExecutor` class docstring and the `estimate` method docstring, recording that this is a CUDA-Q API limitation rather than a Qamomile gap, so the `TypeError` path is intentional.
- Investigation outcome: a single Qamomile kernel cannot be both RUNNABLE and carry a terminal `qmc.expval` (the affine model rejects reusing a measured qubit), so the `ExecutableProgram.run` expval path never feeds a RUNNABLE artifact into `estimate`; the guard is reachable only when `estimate` is called directly on a RUNNABLE artifact.

No behavior change to the static path or to the RUNNABLE/STATIC classification — only the error message wording, docstrings, and test coverage.

## Test plan

- New `TestExpvalStaticOnlyCudaq` in `tests/transpiler/backends/test_cudaq_frontend.py`:
  - Static estimate path: `<Z> = cos(theta)` parametrized over seeds and boundary angles (`0`, `pi/2`, `pi`, `2*pi`) plus a random angle per seed, and a Bell-state `a*ZZ + b*X0` -> `a` reference with randomized coefficients.
  - RUNNABLE estimate path raises a `TypeError` whose message names both the cause (`cudaq.run` vs `cudaq.observe`) and the remedy (static kernel).
  - A kernel cannot be both RUNNABLE and carry a terminal expectation value (affine rejection, matched on the consumed-qubit message).
- `uv run pytest -m cudaq tests/transpiler/backends/test_cudaq.py tests/transpiler/backends/test_cudaq_frontend.py` -> 388 passed.
- `uv run pytest tests/` -> 8843 passed, 4 skipped.
- `uv run ruff check qamomile/ tests/`, `uv run ruff format --check qamomile/ tests/`, and `uv run zuban check qamomile/` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtWeu7epEQtqVMDGEPaVBn)_