### PR TITLE
Add OpenFermion bridge for FTQC Hamiltonian summaries

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -24,10 +24,10 @@
    "id": "f3976de9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:10.974922Z",
-     "iopub.status.busy": "2026-06-22T10:46:10.974791Z",
-     "iopub.status.idle": "2026-06-22T10:46:10.980772Z",
-     "shell.execute_reply": "2026-06-22T10:46:10.979665Z"
+     "iopub.execute_input": "2026-06-22T10:57:16.269174Z",
+     "iopub.status.busy": "2026-06-22T10:57:16.269119Z",
+     "iopub.status.idle": "2026-06-22T10:57:16.271086Z",
+     "shell.execute_reply": "2026-06-22T10:57:16.270741Z"
     }
    },
    "outputs": [],
@@ -42,15 +42,16 @@
    "id": "817a2c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:10.984915Z",
-     "iopub.status.busy": "2026-06-22T10:46:10.984778Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.583619Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.583103Z"
+     "iopub.execute_input": "2026-06-22T10:57:16.272049Z",
+     "iopub.status.busy": "2026-06-22T10:57:16.271988Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.472773Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.472196Z"
     }
    },
    "outputs": [],
    "source": [
     "import sympy as sp\n",
+    "from openfermion import QubitOperator\n",
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
@@ -59,6 +60,7 @@
     "    FTQCCostModel,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
    ]
@@ -113,10 +115,10 @@
    "id": "3558f415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:11.585101Z",
-     "iopub.status.busy": "2026-06-22T10:46:11.584995Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.587379Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.587107Z"
+     "iopub.execute_input": "2026-06-22T10:57:17.474748Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.474544Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.476810Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.476433Z"
     }
    },
    "outputs": [],
@@ -150,10 +152,10 @@
    "id": "62975046",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:11.590470Z",
-     "iopub.status.busy": "2026-06-22T10:46:11.590082Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.597663Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.597093Z"
+     "iopub.execute_input": "2026-06-22T10:57:17.477950Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.477869Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.480676Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.480342Z"
     }
    },
    "outputs": [],
@@ -172,6 +174,47 @@
     "assert toy_summary.n_pauli_terms == 2\n",
     "assert toy_summary.constant == sp.Float(\"0.125\")\n",
     "assert sp.simplify(scaled_summary.lambda_norm - sp.Float(\"2.0e5\")) == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f5854e3",
+   "metadata": {},
+   "source": [
+    "If your chemistry preprocessing already produces an OpenFermion\n",
+    "`QubitOperator`, summarize it through the same boundary. This keeps the\n",
+    "electronic-structure toolchain outside Qamomile's compiler IR while preserving\n",
+    "the cost-driving Hamiltonian metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2743baac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T10:57:17.481834Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.481756Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.483798Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.483495Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "openfermion_hamiltonian = (\n",
+    "    QubitOperator(\"Z0\", 0.5)\n",
+    "    + QubitOperator(\"X1 X2\", 0.25)\n",
+    "    + QubitOperator((), 0.125)\n",
+    ")\n",
+    "openfermion_summary = summarize_openfermion_qubit_operator(\n",
+    "    openfermion_hamiltonian,\n",
+    "    n_spin_orbitals=n_spin_orbitals,\n",
+    "    source=\"openfermion_toy_pauli_lcu\",\n",
+    ")\n",
+    "\n",
+    "assert openfermion_summary.n_pauli_terms == toy_summary.n_pauli_terms\n",
+    "assert openfermion_summary.lambda_norm == toy_summary.lambda_norm\n",
+    "assert openfermion_summary.constant == toy_summary.constant"
    ]
   },
   {
@@ -197,14 +240,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "85d64a19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:11.599187Z",
-     "iopub.status.busy": "2026-06-22T10:46:11.599043Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.604482Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.604189Z"
+     "iopub.execute_input": "2026-06-22T10:57:17.484918Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.484852Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.488994Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.488606Z"
     }
    },
    "outputs": [
@@ -273,14 +316,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "2e4159a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:11.605739Z",
-     "iopub.status.busy": "2026-06-22T10:46:11.605673Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.610333Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.609956Z"
+     "iopub.execute_input": "2026-06-22T10:57:17.490267Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.490203Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.493606Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.493276Z"
     }
    },
    "outputs": [
@@ -337,14 +380,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "8e7db21d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:11.612272Z",
-     "iopub.status.busy": "2026-06-22T10:46:11.612180Z",
-     "iopub.status.idle": "2026-06-22T10:46:11.615261Z",
-     "shell.execute_reply": "2026-06-22T10:46:11.614949Z"
+     "iopub.execute_input": "2026-06-22T10:57:17.494638Z",
+     "iopub.status.busy": "2026-06-22T10:57:17.494574Z",
+     "iopub.status.idle": "2026-06-22T10:57:17.497223Z",
+     "shell.execute_reply": "2026-06-22T10:57:17.496896Z"
     }
    },
    "outputs": [

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -31,6 +31,7 @@
 
 # %%
 import sympy as sp
+from openfermion import QubitOperator
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
@@ -39,6 +40,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
 
@@ -109,6 +111,28 @@ scaled_summary = toy_summary.with_lambda_scale(
 assert toy_summary.n_pauli_terms == 2
 assert toy_summary.constant == sp.Float("0.125")
 assert sp.simplify(scaled_summary.lambda_norm - sp.Float("2.0e5")) == 0
+
+# %% [markdown]
+# If your chemistry preprocessing already produces an OpenFermion
+# `QubitOperator`, summarize it through the same boundary. This keeps the
+# electronic-structure toolchain outside Qamomile's compiler IR while preserving
+# the cost-driving Hamiltonian metadata.
+
+# %%
+openfermion_hamiltonian = (
+    QubitOperator("Z0", 0.5)
+    + QubitOperator("X1 X2", 0.25)
+    + QubitOperator((), 0.125)
+)
+openfermion_summary = summarize_openfermion_qubit_operator(
+    openfermion_hamiltonian,
+    n_spin_orbitals=n_spin_orbitals,
+    source="openfermion_toy_pauli_lcu",
+)
+
+assert openfermion_summary.n_pauli_terms == toy_summary.n_pauli_terms
+assert openfermion_summary.lambda_norm == toy_summary.lambda_norm
+assert openfermion_summary.constant == toy_summary.constant
 
 # %% [markdown]
 # ## Qubitized QPE Comparison

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "9e792fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:12.653232Z",
-     "iopub.status.busy": "2026-06-22T10:46:12.653065Z",
-     "iopub.status.idle": "2026-06-22T10:46:12.658024Z",
-     "shell.execute_reply": "2026-06-22T10:46:12.656659Z"
+     "iopub.execute_input": "2026-06-22T10:57:18.692821Z",
+     "iopub.status.busy": "2026-06-22T10:57:18.692562Z",
+     "iopub.status.idle": "2026-06-22T10:57:18.696640Z",
+     "shell.execute_reply": "2026-06-22T10:57:18.695590Z"
     }
    },
    "outputs": [],
@@ -38,15 +38,16 @@
    "id": "d7d66478",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:12.659803Z",
-     "iopub.status.busy": "2026-06-22T10:46:12.659703Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.294076Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.285998Z"
+     "iopub.execute_input": "2026-06-22T10:57:18.699376Z",
+     "iopub.status.busy": "2026-06-22T10:57:18.699284Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.767255Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.766911Z"
     }
    },
    "outputs": [],
    "source": [
     "import sympy as sp\n",
+    "from openfermion import QubitOperator\n",
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
@@ -55,6 +56,7 @@
     "    FTQCCostModel,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
    ]
@@ -93,10 +95,10 @@
    "id": "994771ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:13.310461Z",
-     "iopub.status.busy": "2026-06-22T10:46:13.310314Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.317534Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.316426Z"
+     "iopub.execute_input": "2026-06-22T10:57:19.768885Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.768732Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.770880Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.770605Z"
     }
    },
    "outputs": [],
@@ -126,10 +128,10 @@
    "id": "0d80f51c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:13.318982Z",
-     "iopub.status.busy": "2026-06-22T10:46:13.318907Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.324314Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.323001Z"
+     "iopub.execute_input": "2026-06-22T10:57:19.772037Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.771976Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.774871Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.774470Z"
     }
    },
    "outputs": [],
@@ -152,6 +154,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "79aa15fe",
+   "metadata": {},
+   "source": [
+    "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
+    "同じ境界でsummaryを作れます。これにより、electronic-structure toolchainは\n",
+    "Qamomileのcompiler IRの外側に保ちながら、コストを支配するHamiltonian\n",
+    "metadataを保持できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "741d901e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T10:57:19.775893Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.775834Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.778062Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.777643Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "openfermion_hamiltonian = (\n",
+    "    QubitOperator(\"Z0\", 0.5)\n",
+    "    + QubitOperator(\"X1 X2\", 0.25)\n",
+    "    + QubitOperator((), 0.125)\n",
+    ")\n",
+    "openfermion_summary = summarize_openfermion_qubit_operator(\n",
+    "    openfermion_hamiltonian,\n",
+    "    n_spin_orbitals=n_spin_orbitals,\n",
+    "    source=\"openfermion_toy_pauli_lcu\",\n",
+    ")\n",
+    "\n",
+    "assert openfermion_summary.n_pauli_terms == toy_summary.n_pauli_terms\n",
+    "assert openfermion_summary.lambda_norm == toy_summary.lambda_norm\n",
+    "assert openfermion_summary.constant == toy_summary.constant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bccb9f45",
    "metadata": {},
    "source": [
@@ -169,14 +212,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "adb08eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:13.325588Z",
-     "iopub.status.busy": "2026-06-22T10:46:13.325508Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.334364Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.333220Z"
+     "iopub.execute_input": "2026-06-22T10:57:19.778959Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.778901Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.782784Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.782399Z"
     }
    },
    "outputs": [
@@ -241,14 +284,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "513362ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:13.336328Z",
-     "iopub.status.busy": "2026-06-22T10:46:13.336184Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.341816Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.341342Z"
+     "iopub.execute_input": "2026-06-22T10:57:19.783908Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.783854Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.787056Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.786681Z"
     }
    },
    "outputs": [
@@ -302,14 +345,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ee8f8d92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:46:13.343044Z",
-     "iopub.status.busy": "2026-06-22T10:46:13.342947Z",
-     "iopub.status.idle": "2026-06-22T10:46:13.346530Z",
-     "shell.execute_reply": "2026-06-22T10:46:13.346053Z"
+     "iopub.execute_input": "2026-06-22T10:57:19.788077Z",
+     "iopub.status.busy": "2026-06-22T10:57:19.788020Z",
+     "iopub.status.idle": "2026-06-22T10:57:19.790830Z",
+     "shell.execute_reply": "2026-06-22T10:57:19.790429Z"
     }
    },
    "outputs": [

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -27,6 +27,7 @@
 
 # %%
 import sympy as sp
+from openfermion import QubitOperator
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
@@ -35,6 +36,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
 
@@ -85,6 +87,28 @@ scaled_summary = toy_summary.with_lambda_scale(
 assert toy_summary.n_pauli_terms == 2
 assert toy_summary.constant == sp.Float("0.125")
 assert sp.simplify(scaled_summary.lambda_norm - sp.Float("2.0e5")) == 0
+
+# %% [markdown]
+# chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、
+# 同じ境界でsummaryを作れます。これにより、electronic-structure toolchainは
+# Qamomileのcompiler IRの外側に保ちながら、コストを支配するHamiltonian
+# metadataを保持できます。
+
+# %%
+openfermion_hamiltonian = (
+    QubitOperator("Z0", 0.5)
+    + QubitOperator("X1 X2", 0.25)
+    + QubitOperator((), 0.125)
+)
+openfermion_summary = summarize_openfermion_qubit_operator(
+    openfermion_hamiltonian,
+    n_spin_orbitals=n_spin_orbitals,
+    source="openfermion_toy_pauli_lcu",
+)
+
+assert openfermion_summary.n_pauli_terms == toy_summary.n_pauli_terms
+assert openfermion_summary.lambda_norm == toy_summary.lambda_norm
+assert openfermion_summary.constant == toy_summary.constant
 
 # %% [markdown]
 # ## Qubitized QPE Comparison

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -21,6 +21,8 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    hamiltonian_from_openfermion_qubit_operator,
+    summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
 from qamomile.circuit.estimator.algorithmic.hamiltonian_simulation import (
@@ -43,6 +45,8 @@ __all__ = [
     "estimate_qubitized_chemistry_qpe_from_model",
     "estimate_single_ancilla_trotter_qpe",
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",
+    "hamiltonian_from_openfermion_qubit_operator",
+    "summarize_openfermion_qubit_operator",
     "summarize_pauli_hamiltonian",
     "estimate_trotter",
     "estimate_qsvt",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import enum
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sympy as sp
 
+if TYPE_CHECKING:
+    import qamomile.observable as qm_o
+
 _SympyLike = sp.Expr | int | float
 _CoefficientLike = _SympyLike | complex
+_OPENFERMION_PAULI_LABELS = {"X": "X", "Y": "Y", "Z": "Z"}
 
 
 class ChemistryQPEMethod(enum.StrEnum):
@@ -520,6 +524,110 @@ def summarize_pauli_hamiltonian(
         max_locality=sp.Integer(max_locality),
         constant=constant,
         constant_included=include_constant,
+        source=source,
+    )
+
+
+def hamiltonian_from_openfermion_qubit_operator(
+    openfermion_operator: Any,
+    *,
+    num_qubits: int | None = None,
+) -> qm_o.Hamiltonian:
+    """Convert an OpenFermion qubit operator into a Qamomile Hamiltonian.
+
+    Args:
+        openfermion_operator (Any): OpenFermion ``QubitOperator``-like
+            object exposing a ``terms`` mapping from Pauli-string tuples to
+            numeric coefficients.
+        num_qubits (int | None): Optional encoded register size to store on
+            the returned Hamiltonian. Defaults to inferring the size from the
+            largest Pauli index.
+
+    Returns:
+        qamomile.observable.Hamiltonian: Equivalent Qamomile Hamiltonian with
+            identity terms stored as ``constant``.
+
+    Raises:
+        TypeError: If ``openfermion_operator`` does not expose a terms
+            mapping or a term is malformed.
+        ValueError: If a Pauli label is not one of ``X``, ``Y``, or ``Z``.
+    """
+    import qamomile.observable as qm_o
+
+    terms = getattr(openfermion_operator, "terms", None)
+    if not isinstance(terms, dict):
+        raise TypeError(
+            "openfermion_operator must expose an OpenFermion-style terms mapping."
+        )
+
+    paulis = {
+        "X": qm_o.Pauli.X,
+        "Y": qm_o.Pauli.Y,
+        "Z": qm_o.Pauli.Z,
+    }
+    hamiltonian = qm_o.Hamiltonian(num_qubits=num_qubits)
+    for term, coefficient in terms.items():
+        if term == ():
+            hamiltonian.constant += coefficient
+            continue
+        if not isinstance(term, tuple):
+            raise TypeError("OpenFermion Pauli terms must be tuples.")
+
+        operators = []
+        for factor in term:
+            if (
+                not isinstance(factor, tuple)
+                or len(factor) != 2
+                or not isinstance(factor[0], int)
+                or not isinstance(factor[1], str)
+            ):
+                raise TypeError("OpenFermion Pauli factors must be (int, str) tuples.")
+            qubit, label = factor
+            if label not in _OPENFERMION_PAULI_LABELS:
+                valid = ", ".join(sorted(_OPENFERMION_PAULI_LABELS))
+                raise ValueError(
+                    f"Unsupported OpenFermion Pauli label {label!r}; "
+                    f"valid labels: {valid}."
+                )
+            operators.append(qm_o.PauliOperator(paulis[label], qubit))
+        hamiltonian.add_term(tuple(operators), coefficient)
+    return hamiltonian
+
+
+def summarize_openfermion_qubit_operator(
+    openfermion_operator: Any,
+    *,
+    n_spin_orbitals: _SympyLike | None = None,
+    include_constant: bool = False,
+    source: str = "openfermion_qubit_operator",
+) -> PauliHamiltonianResource:
+    """Summarize an OpenFermion qubit operator for FTQC estimates.
+
+    Args:
+        openfermion_operator (Any): OpenFermion ``QubitOperator``-like
+            object exposing a ``terms`` mapping.
+        n_spin_orbitals (sp.Expr | int | float | None): Override for the
+            encoded active-space size. Defaults to the inferred Qamomile
+            Hamiltonian qubit count.
+        include_constant (bool): Whether to include the constant term in
+            ``lambda_norm``. Defaults to False.
+        source (str): Human-readable source label for the summary.
+
+    Returns:
+        PauliHamiltonianResource: Hamiltonian summary containing term count,
+            lambda norm, constant, and max locality.
+
+    Raises:
+        TypeError: If the OpenFermion object is malformed.
+        ValueError: If a Pauli label or derived resource quantity is invalid.
+    """
+    hamiltonian = hamiltonian_from_openfermion_qubit_operator(
+        openfermion_operator,
+    )
+    return summarize_pauli_hamiltonian(
+        hamiltonian,
+        n_spin_orbitals=n_spin_orbitals,
+        include_constant=include_constant,
         source=source,
     )
 

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -14,6 +14,8 @@ from qamomile.circuit.estimator.algorithmic import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    hamiltonian_from_openfermion_qubit_operator,
+    summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
 
@@ -267,3 +269,71 @@ def test_chemistry_qpe_model_rejects_negative_truncation_error():
             walk_cost_toffoli=1,
             truncation_error=-1,
         )
+
+
+def test_openfermion_qubit_operator_conversion_preserves_terms():
+    """OpenFermion qubit operators convert into Qamomile Hamiltonians."""
+    openfermion = pytest.importorskip("openfermion")
+
+    operator = (
+        openfermion.QubitOperator("Z0", 0.5)
+        + openfermion.QubitOperator("X1 Y2", -1.25j)
+        + openfermion.QubitOperator((), 0.75)
+    )
+
+    hamiltonian = hamiltonian_from_openfermion_qubit_operator(
+        operator,
+        num_qubits=5,
+    )
+
+    assert hamiltonian.num_qubits == 5
+    assert sp.sympify(hamiltonian.constant) == sp.Float("0.75")
+    assert len(hamiltonian) == 2
+    assert hamiltonian.terms[(qm_o.PauliOperator(qm_o.Pauli.Z, 0),)] == 0.5
+    assert (
+        hamiltonian.terms[
+            (
+                qm_o.PauliOperator(qm_o.Pauli.X, 1),
+                qm_o.PauliOperator(qm_o.Pauli.Y, 2),
+            )
+        ]
+        == -1.25j
+    )
+
+
+def test_openfermion_qubit_operator_summary_extracts_lcu_metadata():
+    """OpenFermion summaries feed the FTQC Hamiltonian-resource model."""
+    openfermion = pytest.importorskip("openfermion")
+    operator = (
+        openfermion.QubitOperator("Z0", 0.5)
+        + openfermion.QubitOperator("X1 Y2", -1.25j)
+        + openfermion.QubitOperator((), 0.75)
+    )
+
+    summary = summarize_openfermion_qubit_operator(
+        operator,
+        n_spin_orbitals=8,
+        include_constant=True,
+        source="h2_jordan_wigner",
+    )
+
+    assert summary.source == "h2_jordan_wigner"
+    assert summary.n_spin_orbitals == 8
+    assert summary.n_pauli_terms == 2
+    assert summary.max_locality == 2
+    assert sp.simplify(summary.lambda_norm - sp.Float("2.5")) == 0
+    assert summary.constant_included is True
+
+
+def test_openfermion_qubit_operator_conversion_rejects_malformed_input():
+    """Malformed OpenFermion-style inputs fail before resource estimation."""
+    with pytest.raises(TypeError, match="terms mapping"):
+        hamiltonian_from_openfermion_qubit_operator(object())
+
+    class BadOperator:
+        """Hold malformed OpenFermion-like terms for validation tests."""
+
+        terms = {((0, "A"),): 1.0}
+
+    with pytest.raises(ValueError, match="Unsupported OpenFermion Pauli label"):
+        hamiltonian_from_openfermion_qubit_operator(BadOperator())


### PR DESCRIPTION
## Summary
- Add a converter from OpenFermion-style qubit operators to Qamomile Hamiltonians.
- Add a direct summary helper that feeds OpenFermion qubit operators into FTQC Hamiltonian resource metadata.
- Cover conversion, LCU summary extraction, and malformed-input validation in estimator tests.
- Show OpenFermion `QubitOperator` input in the EN/JA FTQC chemistry resource-estimation tutorial.

## Validation
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run pytest tests/circuit/estimator -q`
- `uv run pytest -m docs tests/docs/test_tag_whitelist.py -q`
- `uv run pytest -m docs 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[en/algorithm/ftqc_chemistry_resource_estimation]' 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[ja/algorithm/ftqc_chemistry_resource_estimation]' -q`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`