### PR TITLE
Add FTQC resource quantity catalog

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -24,10 +24,10 @@
    "id": "f3976de9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:16.269174Z",
-     "iopub.status.busy": "2026-06-22T10:57:16.269119Z",
-     "iopub.status.idle": "2026-06-22T10:57:16.271086Z",
-     "shell.execute_reply": "2026-06-22T10:57:16.270741Z"
+     "iopub.execute_input": "2026-06-22T11:13:31.354288Z",
+     "iopub.status.busy": "2026-06-22T11:13:31.354232Z",
+     "iopub.status.idle": "2026-06-22T11:13:31.356342Z",
+     "shell.execute_reply": "2026-06-22T11:13:31.355890Z"
     }
    },
    "outputs": [],
@@ -42,10 +42,10 @@
    "id": "817a2c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:16.272049Z",
-     "iopub.status.busy": "2026-06-22T10:57:16.271988Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.472773Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.472196Z"
+     "iopub.execute_input": "2026-06-22T11:13:31.357311Z",
+     "iopub.status.busy": "2026-06-22T11:13:31.357257Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.600167Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.599748Z"
     }
    },
    "outputs": [],
@@ -60,6 +60,7 @@
     "    FTQCCostModel,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -115,10 +116,10 @@
    "id": "3558f415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.474748Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.474544Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.476810Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.476433Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.602074Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.601883Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.604103Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.603797Z"
     }
    },
    "outputs": [],
@@ -136,6 +137,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ea59af89",
+   "metadata": {},
+   "source": [
+    "## Resource Quantities\n",
+    "\n",
+    "Symbolic FTQC estimates should keep problem quantities, logical work, and\n",
+    "physical assumptions separate. Qamomile exposes the canonical quantity\n",
+    "catalog so downstream reports can use stable keys while still showing\n",
+    "reader-facing labels, units, and modeling layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a1b1b77d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:13:32.605352Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.605270Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.607729Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.607304Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lambda_norm energy problem\n",
+      "qpe_iterations iterations algorithm\n",
+      "logical_qubits logical qubits logical\n",
+      "toffoli_gates Toffoli gates logical\n",
+      "t_gates T gates logical\n",
+      "physical_qubits physical qubits physical\n",
+      "runtime_seconds seconds physical\n"
+     ]
+    }
+   ],
+   "source": [
+    "quantity_catalog = [\n",
+    "    spec.to_dict()\n",
+    "    for spec in iter_ftqc_resource_quantity_specs()\n",
+    "    if spec.quantity.value\n",
+    "    in {\n",
+    "        \"lambda_norm\",\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"t_gates\",\n",
+    "        \"logical_qubits\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"runtime_seconds\",\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "for row in quantity_catalog:\n",
+    "    print(row[\"quantity\"], row[\"unit\"], row[\"category\"])\n",
+    "\n",
+    "assert {row[\"quantity\"] for row in quantity_catalog} == {\n",
+    "    \"lambda_norm\",\n",
+    "    \"qpe_iterations\",\n",
+    "    \"toffoli_gates\",\n",
+    "    \"t_gates\",\n",
+    "    \"logical_qubits\",\n",
+    "    \"physical_qubits\",\n",
+    "    \"runtime_seconds\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "82a660e5",
    "metadata": {},
    "source": [
@@ -148,14 +219,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "62975046",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.477950Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.477869Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.480676Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.480342Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.609026Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.608949Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.611833Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.611476Z"
     }
    },
    "outputs": [],
@@ -189,14 +260,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "2743baac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.481834Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.481756Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.483798Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.483495Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.613060Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.612980Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.615136Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.614764Z"
     }
    },
    "outputs": [],
@@ -240,14 +311,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "85d64a19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.484918Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.484852Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.488994Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.488606Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.616346Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.616274Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.620918Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.620548Z"
     }
    },
    "outputs": [
@@ -258,7 +329,10 @@
       "THC Toffoli gates: 5.000e+11\n",
       "SCDF-style Toffoli gates: 2.750e+11\n",
       "Toy Pauli terms: 2\n",
-      "SCDF-style logical qubits: 120\n"
+      "SCDF-style logical qubits: 120\n",
+      "Physical qubits 116000 physical qubits\n",
+      "Toffoli gates 275000000000.000 Toffoli gates\n",
+      "QPE iterations 62500000.0000000 iterations\n"
      ]
     }
    ],
@@ -297,7 +371,11 @@
     "print(\"THC Toffoli gates:\", sp.N(thc.toffoli_gates, 4))\n",
     "print(\"SCDF-style Toffoli gates:\", sp.N(scdf.toffoli_gates, 4))\n",
     "print(\"Toy Pauli terms:\", toy_summary.n_pauli_terms)\n",
-    "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)"
+    "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)\n",
+    "\n",
+    "for row in scdf.to_quantity_table():\n",
+    "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
+    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])"
    ]
   },
   {
@@ -316,14 +394,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2e4159a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.490267Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.490203Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.493606Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.493276Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.622045Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.621982Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.626374Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.626085Z"
     }
    },
    "outputs": [
@@ -380,14 +458,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8e7db21d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:17.494638Z",
-     "iopub.status.busy": "2026-06-22T10:57:17.494574Z",
-     "iopub.status.idle": "2026-06-22T10:57:17.497223Z",
-     "shell.execute_reply": "2026-06-22T10:57:17.496896Z"
+     "iopub.execute_input": "2026-06-22T11:13:32.627585Z",
+     "iopub.status.busy": "2026-06-22T11:13:32.627483Z",
+     "iopub.status.idle": "2026-06-22T11:13:32.630303Z",
+     "shell.execute_reply": "2026-06-22T11:13:32.629949Z"
     }
    },
    "outputs": [

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -40,6 +40,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_resource_quantity_specs,
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
@@ -88,6 +89,43 @@ cost_model = FTQCCostModel(
     factory_qubits=20000,
     toffoli_throughput_per_second=sp.Float("2e6"),
 )
+
+# %% [markdown]
+# ## Resource Quantities
+#
+# Symbolic FTQC estimates should keep problem quantities, logical work, and
+# physical assumptions separate. Qamomile exposes the canonical quantity
+# catalog so downstream reports can use stable keys while still showing
+# reader-facing labels, units, and modeling layers.
+
+# %%
+quantity_catalog = [
+    spec.to_dict()
+    for spec in iter_ftqc_resource_quantity_specs()
+    if spec.quantity.value
+    in {
+        "lambda_norm",
+        "qpe_iterations",
+        "toffoli_gates",
+        "t_gates",
+        "logical_qubits",
+        "physical_qubits",
+        "runtime_seconds",
+    }
+]
+
+for row in quantity_catalog:
+    print(row["quantity"], row["unit"], row["category"])
+
+assert {row["quantity"] for row in quantity_catalog} == {
+    "lambda_norm",
+    "qpe_iterations",
+    "toffoli_gates",
+    "t_gates",
+    "logical_qubits",
+    "physical_qubits",
+    "runtime_seconds",
+}
 
 # %% [markdown]
 # We start from a small Qamomile observable so the workflow has the same shape
@@ -186,6 +224,10 @@ print("THC Toffoli gates:", sp.N(thc.toffoli_gates, 4))
 print("SCDF-style Toffoli gates:", sp.N(scdf.toffoli_gates, 4))
 print("Toy Pauli terms:", toy_summary.n_pauli_terms)
 print("SCDF-style logical qubits:", scdf.logical_qubits)
+
+for row in scdf.to_quantity_table():
+    if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
+        print(row["label"], row["value"], row["unit"])
 
 # %% [markdown]
 # ## Early-FTQC Trotter QPE

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "9e792fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:18.692821Z",
-     "iopub.status.busy": "2026-06-22T10:57:18.692562Z",
-     "iopub.status.idle": "2026-06-22T10:57:18.696640Z",
-     "shell.execute_reply": "2026-06-22T10:57:18.695590Z"
+     "iopub.execute_input": "2026-06-22T11:13:33.828464Z",
+     "iopub.status.busy": "2026-06-22T11:13:33.828305Z",
+     "iopub.status.idle": "2026-06-22T11:13:33.831948Z",
+     "shell.execute_reply": "2026-06-22T11:13:33.830935Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "d7d66478",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:18.699376Z",
-     "iopub.status.busy": "2026-06-22T10:57:18.699284Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.767255Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.766911Z"
+     "iopub.execute_input": "2026-06-22T11:13:33.834760Z",
+     "iopub.status.busy": "2026-06-22T11:13:33.834572Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.933596Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.933058Z"
     }
    },
    "outputs": [],
@@ -56,6 +56,7 @@
     "    FTQCCostModel,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -95,10 +96,10 @@
    "id": "994771ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.768885Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.768732Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.770880Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.770605Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.935309Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.935113Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.937674Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.937205Z"
     }
    },
    "outputs": [],
@@ -116,6 +117,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "764de2e1",
+   "metadata": {},
+   "source": [
+    "## Resource Quantities\n",
+    "\n",
+    "symbolicなFTQC estimatesでは、problem quantities、logical work、physical\n",
+    "assumptionsを分けて扱うべきです。Qamomileはcanonical quantity catalogを公開\n",
+    "しているので、downstream reportsは安定したkeyを使いつつ、読者向けのlabel、\n",
+    "unit、modeling layerも表示できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1f897449",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:13:34.938991Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.938897Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.941569Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.941173Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lambda_norm energy problem\n",
+      "qpe_iterations iterations algorithm\n",
+      "logical_qubits logical qubits logical\n",
+      "toffoli_gates Toffoli gates logical\n",
+      "t_gates T gates logical\n",
+      "physical_qubits physical qubits physical\n",
+      "runtime_seconds seconds physical\n"
+     ]
+    }
+   ],
+   "source": [
+    "quantity_catalog = [\n",
+    "    spec.to_dict()\n",
+    "    for spec in iter_ftqc_resource_quantity_specs()\n",
+    "    if spec.quantity.value\n",
+    "    in {\n",
+    "        \"lambda_norm\",\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"t_gates\",\n",
+    "        \"logical_qubits\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"runtime_seconds\",\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "for row in quantity_catalog:\n",
+    "    print(row[\"quantity\"], row[\"unit\"], row[\"category\"])\n",
+    "\n",
+    "assert {row[\"quantity\"] for row in quantity_catalog} == {\n",
+    "    \"lambda_norm\",\n",
+    "    \"qpe_iterations\",\n",
+    "    \"toffoli_gates\",\n",
+    "    \"t_gates\",\n",
+    "    \"logical_qubits\",\n",
+    "    \"physical_qubits\",\n",
+    "    \"runtime_seconds\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "accee93f",
    "metadata": {},
    "source": [
@@ -124,14 +195,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "0d80f51c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.772037Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.771976Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.774871Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.774470Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.942858Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.942781Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.945897Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.945571Z"
     }
    },
    "outputs": [],
@@ -165,14 +236,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "741d901e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.775893Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.775834Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.778062Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.777643Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.947214Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.947140Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.949460Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.949020Z"
     }
    },
    "outputs": [],
@@ -212,14 +283,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "adb08eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.778959Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.778901Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.782784Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.782399Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.950521Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.950462Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.955492Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.955133Z"
     }
    },
    "outputs": [
@@ -230,7 +301,10 @@
       "THC Toffoli gates: 5.000e+11\n",
       "SCDF-style Toffoli gates: 2.750e+11\n",
       "Toy Pauli terms: 2\n",
-      "SCDF-style logical qubits: 120\n"
+      "SCDF-style logical qubits: 120\n",
+      "Physical qubits 116000 physical qubits\n",
+      "Toffoli gates 275000000000.000 Toffoli gates\n",
+      "QPE iterations 62500000.0000000 iterations\n"
      ]
     }
    ],
@@ -269,7 +343,11 @@
     "print(\"THC Toffoli gates:\", sp.N(thc.toffoli_gates, 4))\n",
     "print(\"SCDF-style Toffoli gates:\", sp.N(scdf.toffoli_gates, 4))\n",
     "print(\"Toy Pauli terms:\", toy_summary.n_pauli_terms)\n",
-    "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)"
+    "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)\n",
+    "\n",
+    "for row in scdf.to_quantity_table():\n",
+    "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
+    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])"
    ]
   },
   {
@@ -284,14 +362,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "513362ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.783908Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.783854Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.787056Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.786681Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.956809Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.956739Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.960801Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.960436Z"
     }
    },
    "outputs": [
@@ -345,14 +423,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "ee8f8d92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T10:57:19.788077Z",
-     "iopub.status.busy": "2026-06-22T10:57:19.788020Z",
-     "iopub.status.idle": "2026-06-22T10:57:19.790830Z",
-     "shell.execute_reply": "2026-06-22T10:57:19.790429Z"
+     "iopub.execute_input": "2026-06-22T11:13:34.962048Z",
+     "iopub.status.busy": "2026-06-22T11:13:34.961979Z",
+     "iopub.status.idle": "2026-06-22T11:13:34.965111Z",
+     "shell.execute_reply": "2026-06-22T11:13:34.964680Z"
     }
    },
    "outputs": [

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -36,6 +36,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_resource_quantity_specs,
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
@@ -68,6 +69,43 @@ cost_model = FTQCCostModel(
     factory_qubits=20000,
     toffoli_throughput_per_second=sp.Float("2e6"),
 )
+
+# %% [markdown]
+# ## Resource Quantities
+#
+# symbolicなFTQC estimatesでは、problem quantities、logical work、physical
+# assumptionsを分けて扱うべきです。Qamomileはcanonical quantity catalogを公開
+# しているので、downstream reportsは安定したkeyを使いつつ、読者向けのlabel、
+# unit、modeling layerも表示できます。
+
+# %%
+quantity_catalog = [
+    spec.to_dict()
+    for spec in iter_ftqc_resource_quantity_specs()
+    if spec.quantity.value
+    in {
+        "lambda_norm",
+        "qpe_iterations",
+        "toffoli_gates",
+        "t_gates",
+        "logical_qubits",
+        "physical_qubits",
+        "runtime_seconds",
+    }
+]
+
+for row in quantity_catalog:
+    print(row["quantity"], row["unit"], row["category"])
+
+assert {row["quantity"] for row in quantity_catalog} == {
+    "lambda_norm",
+    "qpe_iterations",
+    "toffoli_gates",
+    "t_gates",
+    "logical_qubits",
+    "physical_qubits",
+    "runtime_seconds",
+}
 
 # %% [markdown]
 # 小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。
@@ -158,6 +196,10 @@ print("THC Toffoli gates:", sp.N(thc.toffoli_gates, 4))
 print("SCDF-style Toffoli gates:", sp.N(scdf.toffoli_gates, 4))
 print("Toy Pauli terms:", toy_summary.n_pauli_terms)
 print("SCDF-style logical qubits:", scdf.logical_qubits)
+
+for row in scdf.to_quantity_table():
+    if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
+        print(row["label"], row["value"], row["unit"])
 
 # %% [markdown]
 # ## Early-FTQC Trotter QPE

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -25,6 +25,13 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
+from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
+    FTQCResourceCategory,
+    FTQCResourceQuantity,
+    FTQCResourceQuantitySpec,
+    describe_ftqc_resource_quantity,
+    iter_ftqc_resource_quantity_specs,
+)
 from qamomile.circuit.estimator.algorithmic.hamiltonian_simulation import (
     estimate_qdrift,
     estimate_qsvt,
@@ -36,9 +43,13 @@ from qamomile.circuit.estimator.algorithmic.qpe import estimate_qpe
 __all__ = [
     "ChemistryQPEMethod",
     "ChemistryQPEModel",
+    "FTQCResourceCategory",
     "FTQCCostModel",
     "FTQCResourceEstimate",
+    "FTQCResourceQuantity",
+    "FTQCResourceQuantitySpec",
     "PauliHamiltonianResource",
+    "describe_ftqc_resource_quantity",
     "estimate_qaoa",
     "estimate_qpe",
     "estimate_qubitized_chemistry_qpe",
@@ -46,6 +57,7 @@ __all__ = [
     "estimate_single_ancilla_trotter_qpe",
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",
     "hamiltonian_from_openfermion_qubit_operator",
+    "iter_ftqc_resource_quantity_specs",
     "summarize_openfermion_qubit_operator",
     "summarize_pauli_hamiltonian",
     "estimate_trotter",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -9,6 +9,11 @@ from typing import TYPE_CHECKING, Any
 
 import sympy as sp
 
+from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
+    FTQCResourceQuantity,
+    describe_ftqc_resource_quantity,
+)
+
 if TYPE_CHECKING:
     import qamomile.observable as qm_o
 
@@ -120,6 +125,31 @@ class FTQCCostModel:
             "toffoli_throughput_per_second",
         )
 
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return architecture knobs keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Architecture-model values.
+        """
+        return {
+            FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL: _as_expr(
+                self.physical_qubits_per_logical,
+                "physical_qubits_per_logical",
+            ),
+            FTQCResourceQuantity.LOGICAL_CYCLE_TIME_SECONDS: _as_expr(
+                self.logical_cycle_time_seconds,
+                "logical_cycle_time_seconds",
+            ),
+            FTQCResourceQuantity.FACTORY_QUBITS: _as_expr(
+                self.factory_qubits,
+                "factory_qubits",
+            ),
+            FTQCResourceQuantity.TOFFOLI_THROUGHPUT_PER_SECOND: _as_expr(
+                self.toffoli_throughput_per_second,
+                "toffoli_throughput_per_second",
+            ),
+        }
+
 
 @dataclass(frozen=True)
 class FTQCResourceEstimate:
@@ -209,6 +239,39 @@ class FTQCResourceEstimate:
             },
             "assumptions": dict(self.assumptions),
         }
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return estimate values keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Resource values for logical
+                and physical output quantities.
+        """
+        return {
+            FTQCResourceQuantity.LOGICAL_QUBITS: self.logical_qubits,
+            FTQCResourceQuantity.PHYSICAL_QUBITS: self.physical_qubits,
+            FTQCResourceQuantity.TOFFOLI_GATES: self.toffoli_gates,
+            FTQCResourceQuantity.T_GATES: self.t_gates,
+            FTQCResourceQuantity.CLIFFORD_GATES: self.clifford_gates,
+            FTQCResourceQuantity.QPE_ITERATIONS: self.qpe_iterations,
+            FTQCResourceQuantity.LOGICAL_DEPTH: self.logical_depth,
+            FTQCResourceQuantity.RUNTIME_SECONDS: self.runtime_seconds,
+        }
+
+    def to_quantity_table(self) -> list[dict[str, str]]:
+        """Serialize estimate values with quantity metadata.
+
+        Returns:
+            list[dict[str, str]]: Rows containing ``quantity``, ``label``,
+                ``category``, ``unit``, ``value``, and ``description``.
+        """
+        rows = []
+        for quantity, value in self.resource_values().items():
+            spec = describe_ftqc_resource_quantity(quantity)
+            row = spec.to_dict()
+            row["value"] = str(value)
+            rows.append(row)
+        return rows
 
     def _map_exprs(self, fn: Callable[[sp.Expr], sp.Expr]) -> FTQCResourceEstimate:
         """Apply a function to each symbolic resource field.
@@ -334,6 +397,20 @@ class PauliHamiltonianResource:
             "constant": str(self.constant),
             "constant_included": self.constant_included,
             "source": self.source,
+        }
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return Hamiltonian metadata keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Problem-level Hamiltonian
+                quantities that feed algorithmic FTQC estimates.
+        """
+        return {
+            FTQCResourceQuantity.N_SPIN_ORBITALS: self.n_spin_orbitals,
+            FTQCResourceQuantity.N_PAULI_TERMS: self.n_pauli_terms,
+            FTQCResourceQuantity.LAMBDA_NORM: self.lambda_norm,
+            FTQCResourceQuantity.MAX_LOCALITY: self.max_locality,
         }
 
 
@@ -467,6 +544,20 @@ class ChemistryQPEModel:
             ),
             "description": self.description,
         }
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return model inputs keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Hamiltonian metadata plus
+                the representation-level walk cost.
+        """
+        values = self.hamiltonian.resource_values()
+        values[FTQCResourceQuantity.WALK_COST_TOFFOLI] = _as_expr(
+            self.walk_cost_toffoli,
+            "walk_cost_toffoli",
+        )
+        return values
 
 
 def summarize_pauli_hamiltonian(

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -1,0 +1,274 @@
+"""Define canonical FTQC resource quantities for symbolic estimators."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class FTQCResourceCategory(enum.StrEnum):
+    """Group FTQC resource quantities by modeling layer.
+
+    Attributes:
+        PROBLEM: Input problem and Hamiltonian representation quantities.
+        ALGORITHM: Algorithm-control quantities such as QPE iteration counts.
+        LOGICAL: Logical-circuit quantities before hardware lifting.
+        PHYSICAL: Physical-device quantities after architecture assumptions.
+        ARCHITECTURE: Hardware-model knobs that map logical work to physical
+            resources.
+
+    Example:
+        >>> FTQCResourceCategory("logical")
+        <FTQCResourceCategory.LOGICAL: 'logical'>
+    """
+
+    PROBLEM = "problem"
+    ALGORITHM = "algorithm"
+    LOGICAL = "logical"
+    PHYSICAL = "physical"
+    ARCHITECTURE = "architecture"
+
+
+class FTQCResourceQuantity(enum.StrEnum):
+    """Name canonical FTQC resource quantities.
+
+    Attributes:
+        N_SPIN_ORBITALS: Encoded active-space size or qubit-register size.
+        N_PAULI_TERMS: Number of non-identity Pauli terms in an LCU model.
+        LAMBDA_NORM: Hamiltonian normalization driving QPE walk calls.
+        MAX_LOCALITY: Maximum Pauli-string locality.
+        WALK_COST_TOFFOLI: Toffoli cost of one qubitized walk.
+        QPE_ITERATIONS: Number of phase-estimation walk or time-evolution
+            calls.
+        LOGICAL_QUBITS: Logical qubits required by an algorithm.
+        LOGICAL_DEPTH: Logical-depth proxy.
+        TOFFOLI_GATES: Toffoli or Toffoli-equivalent non-Clifford count.
+        T_GATES: T-gate or T-equivalent count.
+        CLIFFORD_GATES: Clifford gate count.
+        PHYSICAL_QUBITS: Physical qubits under an architecture model.
+        RUNTIME_SECONDS: Runtime proxy in seconds.
+        PHYSICAL_QUBITS_PER_LOGICAL: Physical overhead per logical qubit.
+        LOGICAL_CYCLE_TIME_SECONDS: Logical layer or cycle time.
+        FACTORY_QUBITS: Physical qubits reserved for factories.
+        TOFFOLI_THROUGHPUT_PER_SECOND: Sustainable non-Clifford throughput.
+
+    Example:
+        >>> FTQCResourceQuantity("lambda_norm")
+        <FTQCResourceQuantity.LAMBDA_NORM: 'lambda_norm'>
+    """
+
+    N_SPIN_ORBITALS = "n_spin_orbitals"
+    N_PAULI_TERMS = "n_pauli_terms"
+    LAMBDA_NORM = "lambda_norm"
+    MAX_LOCALITY = "max_locality"
+    WALK_COST_TOFFOLI = "walk_cost_toffoli"
+    QPE_ITERATIONS = "qpe_iterations"
+    LOGICAL_QUBITS = "logical_qubits"
+    LOGICAL_DEPTH = "logical_depth"
+    TOFFOLI_GATES = "toffoli_gates"
+    T_GATES = "t_gates"
+    CLIFFORD_GATES = "clifford_gates"
+    PHYSICAL_QUBITS = "physical_qubits"
+    RUNTIME_SECONDS = "runtime_seconds"
+    PHYSICAL_QUBITS_PER_LOGICAL = "physical_qubits_per_logical"
+    LOGICAL_CYCLE_TIME_SECONDS = "logical_cycle_time_seconds"
+    FACTORY_QUBITS = "factory_qubits"
+    TOFFOLI_THROUGHPUT_PER_SECOND = "toffoli_throughput_per_second"
+
+
+@dataclass(frozen=True)
+class FTQCResourceQuantitySpec:
+    """Describe one canonical FTQC resource quantity.
+
+    Attributes:
+        quantity (FTQCResourceQuantity): Machine-readable quantity key.
+        label (str): Reader-facing label.
+        unit (str): Unit or dimension of the quantity.
+        category (FTQCResourceCategory): Modeling layer that owns the
+            quantity.
+        description (str): Short description of what the quantity measures.
+
+    Example:
+        >>> spec = describe_ftqc_resource_quantity("logical_qubits")
+        >>> spec.unit
+        'logical qubits'
+    """
+
+    quantity: FTQCResourceQuantity
+    label: str
+    unit: str
+    category: FTQCResourceCategory
+    description: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the quantity specification.
+
+        Returns:
+            dict[str, str]: JSON-friendly quantity metadata.
+        """
+        return {
+            "quantity": self.quantity.value,
+            "label": self.label,
+            "unit": self.unit,
+            "category": self.category.value,
+            "description": self.description,
+        }
+
+
+FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.N_SPIN_ORBITALS,
+        "Spin orbitals",
+        "spin orbitals",
+        FTQCResourceCategory.PROBLEM,
+        "Encoded active-space size, often equal to the qubit-register size.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.N_PAULI_TERMS,
+        "Pauli terms",
+        "terms",
+        FTQCResourceCategory.PROBLEM,
+        "Number of non-identity Pauli strings in the Hamiltonian model.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.LAMBDA_NORM,
+        "Hamiltonian normalization",
+        "energy",
+        FTQCResourceCategory.PROBLEM,
+        "LCU normalization that controls QPE walk or evolution calls.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.MAX_LOCALITY,
+        "Maximum locality",
+        "Pauli factors",
+        FTQCResourceCategory.PROBLEM,
+        "Maximum number of non-identity Pauli factors in one term.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.WALK_COST_TOFFOLI,
+        "Walk cost",
+        "Toffoli gates per walk",
+        FTQCResourceCategory.ALGORITHM,
+        "Toffoli cost of one qubitized walk operator call.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        "QPE iterations",
+        "iterations",
+        FTQCResourceCategory.ALGORITHM,
+        "Number of QPE walk or time-evolution calls.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.LOGICAL_QUBITS,
+        "Logical qubits",
+        "logical qubits",
+        FTQCResourceCategory.LOGICAL,
+        "Logical data, ancilla, and algorithm workspace qubits.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.LOGICAL_DEPTH,
+        "Logical depth",
+        "logical layers",
+        FTQCResourceCategory.LOGICAL,
+        "Logical circuit-depth proxy after algorithmic repetition factors.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.TOFFOLI_GATES,
+        "Toffoli gates",
+        "Toffoli gates",
+        FTQCResourceCategory.LOGICAL,
+        "Toffoli or Toffoli-equivalent non-Clifford gate count.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.T_GATES,
+        "T gates",
+        "T gates",
+        FTQCResourceCategory.LOGICAL,
+        "T-gate or T-equivalent count when it differs from Toffoli count.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.CLIFFORD_GATES,
+        "Clifford gates",
+        "Clifford gates",
+        FTQCResourceCategory.LOGICAL,
+        "Clifford gate count when an estimator has a reliable model for it.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.PHYSICAL_QUBITS,
+        "Physical qubits",
+        "physical qubits",
+        FTQCResourceCategory.PHYSICAL,
+        "Physical qubits after logical-qubit overhead and factory allocation.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.RUNTIME_SECONDS,
+        "Runtime",
+        "seconds",
+        FTQCResourceCategory.PHYSICAL,
+        "Wall-clock runtime proxy under the selected architecture model.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL,
+        "Physical qubits per logical qubit",
+        "physical qubits / logical qubit",
+        FTQCResourceCategory.ARCHITECTURE,
+        "Physical overhead used to lift logical qubits to hardware qubits.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.LOGICAL_CYCLE_TIME_SECONDS,
+        "Logical cycle time",
+        "seconds",
+        FTQCResourceCategory.ARCHITECTURE,
+        "Duration of one logical layer or logical error-correction cycle.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.FACTORY_QUBITS,
+        "Factory qubits",
+        "physical qubits",
+        FTQCResourceCategory.ARCHITECTURE,
+        "Physical qubits reserved for magic-state factories or equivalents.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.TOFFOLI_THROUGHPUT_PER_SECOND,
+        "Toffoli throughput",
+        "Toffoli gates / second",
+        FTQCResourceCategory.ARCHITECTURE,
+        "Sustainable non-Clifford throughput from factories or hardware.",
+    ),
+)
+
+_SPECS_BY_QUANTITY = {spec.quantity: spec for spec in FTQC_RESOURCE_QUANTITY_SPECS}
+
+
+def iter_ftqc_resource_quantity_specs() -> tuple[FTQCResourceQuantitySpec, ...]:
+    """Return the canonical FTQC resource quantity specifications.
+
+    Returns:
+        tuple[FTQCResourceQuantitySpec, ...]: Quantity specifications in a
+            reader-friendly order from problem inputs to physical outputs.
+    """
+    return FTQC_RESOURCE_QUANTITY_SPECS
+
+
+def describe_ftqc_resource_quantity(
+    quantity: str | FTQCResourceQuantity,
+) -> FTQCResourceQuantitySpec:
+    """Return metadata for one FTQC resource quantity.
+
+    Args:
+        quantity (str | FTQCResourceQuantity): Quantity key or enum value.
+
+    Returns:
+        FTQCResourceQuantitySpec: Metadata describing the quantity.
+
+    Raises:
+        ValueError: If ``quantity`` is not a known FTQC resource quantity.
+    """
+    try:
+        normalized = FTQCResourceQuantity(quantity)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in FTQCResourceQuantity)
+        raise ValueError(
+            f"Unknown FTQC resource quantity {quantity!r}; valid: {valid}."
+        ) from exc
+    return _SPECS_BY_QUANTITY[normalized]

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1,0 +1,89 @@
+"""Tests for canonical FTQC resource quantity metadata."""
+
+from __future__ import annotations
+
+import pytest
+import sympy as sp
+
+import qamomile.observable as qm_o
+from qamomile.circuit.estimator.algorithmic import (
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
+    FTQCCostModel,
+    FTQCResourceCategory,
+    FTQCResourceQuantity,
+    describe_ftqc_resource_quantity,
+    estimate_qubitized_chemistry_qpe_from_model,
+    iter_ftqc_resource_quantity_specs,
+    summarize_pauli_hamiltonian,
+)
+
+
+def test_ftqc_quantity_specs_cover_core_resource_layers():
+    """The FTQC quantity catalog covers problem, logical, and physical layers."""
+    specs = iter_ftqc_resource_quantity_specs()
+    quantities = {spec.quantity for spec in specs}
+    categories = {spec.category for spec in specs}
+
+    assert FTQCResourceQuantity.LAMBDA_NORM in quantities
+    assert FTQCResourceQuantity.TOFFOLI_GATES in quantities
+    assert FTQCResourceQuantity.PHYSICAL_QUBITS in quantities
+    assert {
+        FTQCResourceCategory.PROBLEM,
+        FTQCResourceCategory.ALGORITHM,
+        FTQCResourceCategory.LOGICAL,
+        FTQCResourceCategory.PHYSICAL,
+        FTQCResourceCategory.ARCHITECTURE,
+    }.issubset(categories)
+    assert len(quantities) == len(specs)
+
+
+def test_describe_ftqc_resource_quantity_normalizes_strings():
+    """String quantity keys resolve to metadata with stable units."""
+    spec = describe_ftqc_resource_quantity("lambda_norm")
+
+    assert spec.quantity == FTQCResourceQuantity.LAMBDA_NORM
+    assert spec.category == FTQCResourceCategory.PROBLEM
+    assert spec.unit == "energy"
+
+
+def test_describe_ftqc_resource_quantity_rejects_unknown_key():
+    """Unknown quantity keys fail with a finite-set validation error."""
+    with pytest.raises(ValueError, match="Unknown FTQC resource quantity"):
+        describe_ftqc_resource_quantity("not-a-resource")
+
+
+def test_ftqc_models_expose_canonical_resource_values():
+    """Hamiltonian, model, cost, and estimate values share canonical keys."""
+    summary = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    model = ChemistryQPEModel(
+        hamiltonian=summary,
+        method=ChemistryQPEMethod.SPARSE,
+        walk_cost_toffoli=11,
+    )
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e5"),
+    )
+
+    estimate = estimate_qubitized_chemistry_qpe_from_model(
+        model,
+        precision=1,
+        cost_model=cost,
+    )
+
+    assert (
+        sp.simplify(summary.resource_values()[FTQCResourceQuantity.LAMBDA_NORM] - 5)
+        == 0
+    )
+    assert model.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 11
+    assert (
+        cost.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL] == 100
+    )
+    assert (
+        sp.simplify(estimate.resource_values()[FTQCResourceQuantity.TOFFOLI_GATES] - 55)
+        == 0
+    )
+    assert estimate.to_quantity_table()[0]["quantity"] == "logical_qubits"


### PR DESCRIPTION
## Summary
- Add canonical FTQC resource quantity and category enums with metadata specs for problem, algorithm, logical, physical, and architecture layers.
- Add resource-value accessors for FTQC cost models, Hamiltonian summaries, chemistry QPE models, and resource estimates.
- Add quantity-table serialization for FTQC estimates so reports can display stable keys with labels, units, and descriptions.
- Update the EN/JA FTQC chemistry resource-estimation tutorial to show the quantity catalog and table output.

## Validation
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run pytest tests/circuit/estimator -q`
- `uv run pytest -m docs tests/docs/test_tag_whitelist.py -q`
- `uv run pytest -m docs 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[en/algorithm/ftqc_chemistry_resource_estimation]' 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[ja/algorithm/ftqc_chemistry_resource_estimation]' -q`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`