### PR TITLE
Add FTQC resource comparison helpers

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -24,10 +24,10 @@
    "id": "f3976de9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:31.354288Z",
-     "iopub.status.busy": "2026-06-22T11:13:31.354232Z",
-     "iopub.status.idle": "2026-06-22T11:13:31.356342Z",
-     "shell.execute_reply": "2026-06-22T11:13:31.355890Z"
+     "iopub.execute_input": "2026-06-22T11:29:49.773604Z",
+     "iopub.status.busy": "2026-06-22T11:29:49.773532Z",
+     "iopub.status.idle": "2026-06-22T11:29:49.775826Z",
+     "shell.execute_reply": "2026-06-22T11:29:49.775448Z"
     }
    },
    "outputs": [],
@@ -42,10 +42,10 @@
    "id": "817a2c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:31.357311Z",
-     "iopub.status.busy": "2026-06-22T11:13:31.357257Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.600167Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.599748Z"
+     "iopub.execute_input": "2026-06-22T11:29:49.776843Z",
+     "iopub.status.busy": "2026-06-22T11:29:49.776777Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.056497Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.055861Z"
     }
    },
    "outputs": [],
@@ -58,6 +58,7 @@
     "    ChemistryQPEModel,\n",
     "    ChemistryQPEMethod,\n",
     "    FTQCCostModel,\n",
+    "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
@@ -116,10 +117,10 @@
    "id": "3558f415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.602074Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.601883Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.604103Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.603797Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.058324Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.058110Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.060458Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.060016Z"
     }
    },
    "outputs": [],
@@ -154,10 +155,10 @@
    "id": "a1b1b77d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.605352Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.605270Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.607729Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.607304Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.061588Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.061498Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.063915Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.063636Z"
     }
    },
    "outputs": [
@@ -223,10 +224,10 @@
    "id": "62975046",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.609026Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.608949Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.611833Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.611476Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.065280Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.065203Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.067926Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.067529Z"
     }
    },
    "outputs": [],
@@ -264,10 +265,10 @@
    "id": "2743baac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.613060Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.612980Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.615136Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.614764Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.068967Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.068894Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.070860Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.070567Z"
     }
    },
    "outputs": [],
@@ -315,10 +316,10 @@
    "id": "85d64a19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.616346Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.616274Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.620918Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.620548Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.071923Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.071867Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.090594Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.089972Z"
     }
    },
    "outputs": [
@@ -332,7 +333,10 @@
       "SCDF-style logical qubits: 120\n",
       "Physical qubits 116000 physical qubits\n",
       "Toffoli gates 275000000000.000 Toffoli gates\n",
-      "QPE iterations 62500000.0000000 iterations\n"
+      "QPE iterations 62500000.0000000 iterations\n",
+      "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
+      "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
+      "Physical qubits ratio: 2.231 reduction: -1.231\n"
      ]
     }
    ],
@@ -375,7 +379,25 @@
     "\n",
     "for row in scdf.to_quantity_table():\n",
     "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
-    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])"
+    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])\n",
+    "\n",
+    "qubitized_savings = compare_ftqc_resource_estimates(\n",
+    "    thc,\n",
+    "    scdf,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "for row in qubitized_savings:\n",
+    "    print(\n",
+    "        row.label,\n",
+    "        \"ratio:\",\n",
+    "        sp.N(row.ratio, 4),\n",
+    "        \"reduction:\",\n",
+    "        sp.N(row.reduction, 4),\n",
+    "    )\n",
+    "\n",
+    "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
+    "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
+    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")"
    ]
   },
   {
@@ -398,10 +420,10 @@
    "id": "2e4159a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.622045Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.621982Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.626374Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.626085Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.091907Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.091832Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.096717Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.096291Z"
     }
    },
    "outputs": [
@@ -411,7 +433,9 @@
      "text": [
       "Plain Trotter QPE depth proxy: 2.560e+11\n",
       "UWC-style Trotter QPE depth proxy: 1.280e+10\n",
-      "UWC-style T gates: 3.840e+10\n"
+      "UWC-style T gates: 3.840e+10\n",
+      "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n"
      ]
     }
    ],
@@ -440,7 +464,24 @@
     "\n",
     "print(\"Plain Trotter QPE depth proxy:\", sp.N(plain_trotter.logical_depth, 4))\n",
     "print(\"UWC-style Trotter QPE depth proxy:\", sp.N(uwc_trotter.logical_depth, 4))\n",
-    "print(\"UWC-style T gates:\", sp.N(uwc_trotter.t_gates, 4))"
+    "print(\"UWC-style T gates:\", sp.N(uwc_trotter.t_gates, 4))\n",
+    "\n",
+    "trotter_savings = compare_ftqc_resource_estimates(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\"),\n",
+    ")\n",
+    "for row in trotter_savings:\n",
+    "    print(\n",
+    "        row.label,\n",
+    "        \"ratio:\",\n",
+    "        sp.N(row.ratio, 4),\n",
+    "        \"reduction:\",\n",
+    "        sp.N(row.reduction, 4),\n",
+    "    )\n",
+    "\n",
+    "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
+    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")"
    ]
   },
   {
@@ -462,10 +503,10 @@
    "id": "8e7db21d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:32.627585Z",
-     "iopub.status.busy": "2026-06-22T11:13:32.627483Z",
-     "iopub.status.idle": "2026-06-22T11:13:32.630303Z",
-     "shell.execute_reply": "2026-06-22T11:13:32.629949Z"
+     "iopub.execute_input": "2026-06-22T11:29:51.097800Z",
+     "iopub.status.busy": "2026-06-22T11:29:51.097724Z",
+     "iopub.status.idle": "2026-06-22T11:29:51.100304Z",
+     "shell.execute_reply": "2026-06-22T11:29:51.100012Z"
     }
    },
    "outputs": [

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -38,6 +38,7 @@ from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEModel,
     ChemistryQPEMethod,
     FTQCCostModel,
+    compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
@@ -229,6 +230,24 @@ for row in scdf.to_quantity_table():
     if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
         print(row["label"], row["value"], row["unit"])
 
+qubitized_savings = compare_ftqc_resource_estimates(
+    thc,
+    scdf,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+for row in qubitized_savings:
+    print(
+        row.label,
+        "ratio:",
+        sp.N(row.ratio, 4),
+        "reduction:",
+        sp.N(row.reduction, 4),
+    )
+
+assert qubitized_savings[0].quantity.value == "qpe_iterations"
+assert qubitized_savings[0].ratio == sp.Float("0.5")
+assert qubitized_savings[1].ratio == sp.Float("0.55")
+
 # %% [markdown]
 # ## Early-FTQC Trotter QPE
 #
@@ -264,6 +283,23 @@ assert uwc_trotter.logical_depth < plain_trotter.logical_depth
 print("Plain Trotter QPE depth proxy:", sp.N(plain_trotter.logical_depth, 4))
 print("UWC-style Trotter QPE depth proxy:", sp.N(uwc_trotter.logical_depth, 4))
 print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
+
+trotter_savings = compare_ftqc_resource_estimates(
+    plain_trotter,
+    uwc_trotter,
+    quantities=("qpe_iterations", "logical_depth"),
+)
+for row in trotter_savings:
+    print(
+        row.label,
+        "ratio:",
+        sp.N(row.ratio, 4),
+        "reduction:",
+        sp.N(row.reduction, 4),
+    )
+
+assert trotter_savings[0].ratio == sp.Float("0.1")
+assert trotter_savings[1].ratio == sp.Float("0.05")
 
 # %% [markdown]
 # ## Result

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "9e792fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:33.828464Z",
-     "iopub.status.busy": "2026-06-22T11:13:33.828305Z",
-     "iopub.status.idle": "2026-06-22T11:13:33.831948Z",
-     "shell.execute_reply": "2026-06-22T11:13:33.830935Z"
+     "iopub.execute_input": "2026-06-22T11:29:52.295333Z",
+     "iopub.status.busy": "2026-06-22T11:29:52.295266Z",
+     "iopub.status.idle": "2026-06-22T11:29:52.297545Z",
+     "shell.execute_reply": "2026-06-22T11:29:52.297181Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "d7d66478",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:33.834760Z",
-     "iopub.status.busy": "2026-06-22T11:13:33.834572Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.933596Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.933058Z"
+     "iopub.execute_input": "2026-06-22T11:29:52.298641Z",
+     "iopub.status.busy": "2026-06-22T11:29:52.298578Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.380669Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.380140Z"
     }
    },
    "outputs": [],
@@ -54,6 +54,7 @@
     "    ChemistryQPEModel,\n",
     "    ChemistryQPEMethod,\n",
     "    FTQCCostModel,\n",
+    "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
@@ -96,10 +97,10 @@
    "id": "994771ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.935309Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.935113Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.937674Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.937205Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.382118Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.381967Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.384304Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.383939Z"
     }
    },
    "outputs": [],
@@ -134,10 +135,10 @@
    "id": "1f897449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.938991Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.938897Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.941569Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.941173Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.385387Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.385328Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.387632Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.387358Z"
     }
    },
    "outputs": [
@@ -199,10 +200,10 @@
    "id": "0d80f51c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.942858Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.942781Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.945897Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.945571Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.388878Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.388805Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.391499Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.391165Z"
     }
    },
    "outputs": [],
@@ -240,10 +241,10 @@
    "id": "741d901e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.947214Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.947140Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.949460Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.949020Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.392534Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.392477Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.394642Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.394205Z"
     }
    },
    "outputs": [],
@@ -287,10 +288,10 @@
    "id": "adb08eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.950521Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.950462Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.955492Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.955133Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.395636Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.395575Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.412290Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.411941Z"
     }
    },
    "outputs": [
@@ -304,7 +305,10 @@
       "SCDF-style logical qubits: 120\n",
       "Physical qubits 116000 physical qubits\n",
       "Toffoli gates 275000000000.000 Toffoli gates\n",
-      "QPE iterations 62500000.0000000 iterations\n"
+      "QPE iterations 62500000.0000000 iterations\n",
+      "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
+      "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
+      "Physical qubits ratio: 2.231 reduction: -1.231\n"
      ]
     }
    ],
@@ -347,7 +351,25 @@
     "\n",
     "for row in scdf.to_quantity_table():\n",
     "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
-    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])"
+    "        print(row[\"label\"], row[\"value\"], row[\"unit\"])\n",
+    "\n",
+    "qubitized_savings = compare_ftqc_resource_estimates(\n",
+    "    thc,\n",
+    "    scdf,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "for row in qubitized_savings:\n",
+    "    print(\n",
+    "        row.label,\n",
+    "        \"ratio:\",\n",
+    "        sp.N(row.ratio, 4),\n",
+    "        \"reduction:\",\n",
+    "        sp.N(row.reduction, 4),\n",
+    "    )\n",
+    "\n",
+    "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
+    "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
+    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")"
    ]
   },
   {
@@ -366,10 +388,10 @@
    "id": "513362ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.956809Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.956739Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.960801Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.960436Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.413348Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.413283Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.417548Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.417165Z"
     }
    },
    "outputs": [
@@ -379,7 +401,9 @@
      "text": [
       "Plain Trotter QPE depth proxy: 2.560e+11\n",
       "UWC-style Trotter QPE depth proxy: 1.280e+10\n",
-      "UWC-style T gates: 3.840e+10\n"
+      "UWC-style T gates: 3.840e+10\n",
+      "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n"
      ]
     }
    ],
@@ -408,7 +432,24 @@
     "\n",
     "print(\"Plain Trotter QPE depth proxy:\", sp.N(plain_trotter.logical_depth, 4))\n",
     "print(\"UWC-style Trotter QPE depth proxy:\", sp.N(uwc_trotter.logical_depth, 4))\n",
-    "print(\"UWC-style T gates:\", sp.N(uwc_trotter.t_gates, 4))"
+    "print(\"UWC-style T gates:\", sp.N(uwc_trotter.t_gates, 4))\n",
+    "\n",
+    "trotter_savings = compare_ftqc_resource_estimates(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\"),\n",
+    ")\n",
+    "for row in trotter_savings:\n",
+    "    print(\n",
+    "        row.label,\n",
+    "        \"ratio:\",\n",
+    "        sp.N(row.ratio, 4),\n",
+    "        \"reduction:\",\n",
+    "        sp.N(row.reduction, 4),\n",
+    "    )\n",
+    "\n",
+    "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
+    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")"
    ]
   },
   {
@@ -427,10 +468,10 @@
    "id": "ee8f8d92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:13:34.962048Z",
-     "iopub.status.busy": "2026-06-22T11:13:34.961979Z",
-     "iopub.status.idle": "2026-06-22T11:13:34.965111Z",
-     "shell.execute_reply": "2026-06-22T11:13:34.964680Z"
+     "iopub.execute_input": "2026-06-22T11:29:53.418581Z",
+     "iopub.status.busy": "2026-06-22T11:29:53.418526Z",
+     "iopub.status.idle": "2026-06-22T11:29:53.421068Z",
+     "shell.execute_reply": "2026-06-22T11:29:53.420687Z"
     }
    },
    "outputs": [

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -34,6 +34,7 @@ from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEModel,
     ChemistryQPEMethod,
     FTQCCostModel,
+    compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
@@ -201,6 +202,24 @@ for row in scdf.to_quantity_table():
     if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
         print(row["label"], row["value"], row["unit"])
 
+qubitized_savings = compare_ftqc_resource_estimates(
+    thc,
+    scdf,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+for row in qubitized_savings:
+    print(
+        row.label,
+        "ratio:",
+        sp.N(row.ratio, 4),
+        "reduction:",
+        sp.N(row.reduction, 4),
+    )
+
+assert qubitized_savings[0].quantity.value == "qpe_iterations"
+assert qubitized_savings[0].ratio == sp.Float("0.5")
+assert qubitized_savings[1].ratio == sp.Float("0.55")
+
 # %% [markdown]
 # ## Early-FTQC Trotter QPE
 #
@@ -232,6 +251,23 @@ assert uwc_trotter.logical_depth < plain_trotter.logical_depth
 print("Plain Trotter QPE depth proxy:", sp.N(plain_trotter.logical_depth, 4))
 print("UWC-style Trotter QPE depth proxy:", sp.N(uwc_trotter.logical_depth, 4))
 print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
+
+trotter_savings = compare_ftqc_resource_estimates(
+    plain_trotter,
+    uwc_trotter,
+    quantities=("qpe_iterations", "logical_depth"),
+)
+for row in trotter_savings:
+    print(
+        row.label,
+        "ratio:",
+        sp.N(row.ratio, 4),
+        "reduction:",
+        sp.N(row.reduction, 4),
+    )
+
+assert trotter_savings[0].ratio == sp.Float("0.1")
+assert trotter_savings[1].ratio == sp.Float("0.05")
 
 # %% [markdown]
 # ## Result

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -27,8 +27,11 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceCategory,
+    FTQCResourceComparisonRow,
     FTQCResourceQuantity,
     FTQCResourceQuantitySpec,
+    SupportsFTQCResourceValues,
+    compare_ftqc_resource_estimates,
     describe_ftqc_resource_quantity,
     iter_ftqc_resource_quantity_specs,
 )
@@ -44,11 +47,14 @@ __all__ = [
     "ChemistryQPEMethod",
     "ChemistryQPEModel",
     "FTQCResourceCategory",
+    "FTQCResourceComparisonRow",
     "FTQCCostModel",
     "FTQCResourceEstimate",
     "FTQCResourceQuantity",
     "FTQCResourceQuantitySpec",
     "PauliHamiltonianResource",
+    "SupportsFTQCResourceValues",
+    "compare_ftqc_resource_estimates",
     "describe_ftqc_resource_quantity",
     "estimate_qaoa",
     "estimate_qpe",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
+from typing import Protocol
+
+import sympy as sp
 
 
 class FTQCResourceCategory(enum.StrEnum):
@@ -76,6 +79,23 @@ class FTQCResourceQuantity(enum.StrEnum):
     TOFFOLI_THROUGHPUT_PER_SECOND = "toffoli_throughput_per_second"
 
 
+class SupportsFTQCResourceValues(Protocol):
+    """Represent objects that expose canonical FTQC resource values.
+
+    Example:
+        >>> hasattr(object(), "resource_values")
+        False
+    """
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return resource values keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Resource values.
+        """
+        ...
+
+
 @dataclass(frozen=True)
 class FTQCResourceQuantitySpec:
     """Describe one canonical FTQC resource quantity.
@@ -112,6 +132,63 @@ class FTQCResourceQuantitySpec:
             "unit": self.unit,
             "category": self.category.value,
             "description": self.description,
+        }
+
+
+@dataclass(frozen=True)
+class FTQCResourceComparisonRow:
+    """Compare one FTQC resource quantity between two estimates.
+
+    Attributes:
+        quantity (FTQCResourceQuantity): Compared resource quantity.
+        baseline (sp.Expr): Baseline estimate value.
+        candidate (sp.Expr): Candidate estimate value.
+        ratio (sp.Expr): Candidate divided by baseline.
+        reduction (sp.Expr): Fractional reduction, equal to
+            ``1 - candidate / baseline``.
+        label (str): Reader-facing quantity label.
+        unit (str): Resource unit.
+        category (FTQCResourceCategory): Modeling layer for the quantity.
+
+    Example:
+        >>> row = FTQCResourceComparisonRow(
+        ...     quantity=FTQCResourceQuantity.TOFFOLI_GATES,
+        ...     baseline=10,
+        ...     candidate=4,
+        ...     ratio=sp.Rational(2, 5),
+        ...     reduction=sp.Rational(3, 5),
+        ...     label="Toffoli gates",
+        ...     unit="Toffoli gates",
+        ...     category=FTQCResourceCategory.LOGICAL,
+        ... )
+        >>> row.to_dict()["ratio"]
+        '2/5'
+    """
+
+    quantity: FTQCResourceQuantity
+    baseline: sp.Expr
+    candidate: sp.Expr
+    ratio: sp.Expr
+    reduction: sp.Expr
+    label: str
+    unit: str
+    category: FTQCResourceCategory
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the comparison row.
+
+        Returns:
+            dict[str, str]: JSON-friendly comparison metadata and values.
+        """
+        return {
+            "quantity": self.quantity.value,
+            "label": self.label,
+            "unit": self.unit,
+            "category": self.category.value,
+            "baseline": str(self.baseline),
+            "candidate": str(self.candidate),
+            "ratio": str(self.ratio),
+            "reduction": str(self.reduction),
         }
 
 
@@ -264,11 +341,134 @@ def describe_ftqc_resource_quantity(
     Raises:
         ValueError: If ``quantity`` is not a known FTQC resource quantity.
     """
+    normalized = _normalize_resource_quantity(quantity)
+    return _SPECS_BY_QUANTITY[normalized]
+
+
+def compare_ftqc_resource_estimates(
+    baseline: SupportsFTQCResourceValues,
+    candidate: SupportsFTQCResourceValues,
+    *,
+    quantities: tuple[str | FTQCResourceQuantity, ...] | None = None,
+) -> tuple[FTQCResourceComparisonRow, ...]:
+    """Compare canonical FTQC quantities between two estimates.
+
+    Args:
+        baseline (SupportsFTQCResourceValues): Reference estimate, model, or
+            summary exposing ``resource_values()``.
+        candidate (SupportsFTQCResourceValues): Candidate estimate, model, or
+            summary exposing ``resource_values()``.
+        quantities (tuple[str | FTQCResourceQuantity, ...] | None): Quantities
+            to compare. Defaults to the intersection of quantities exposed by
+            both inputs, ordered by the canonical quantity catalog.
+
+    Returns:
+        tuple[FTQCResourceComparisonRow, ...]: Comparison rows containing
+            baseline values, candidate values, ratios, and fractional
+            reductions.
+
+    Raises:
+        ValueError: If a requested quantity is missing from either input or if
+            a baseline value is exactly zero.
+    """
+    baseline_values = baseline.resource_values()
+    candidate_values = candidate.resource_values()
+    selected = _normalize_comparison_quantities(
+        baseline_values,
+        candidate_values,
+        quantities,
+    )
+
+    rows = []
+    for quantity in selected:
+        baseline_value = sp.sympify(baseline_values[quantity])
+        candidate_value = sp.sympify(candidate_values[quantity])
+        if baseline_value.equals(0):
+            raise ValueError(
+                f"Cannot compare {quantity.value!r} against a zero baseline."
+            )
+        ratio = sp.simplify(candidate_value / baseline_value)
+        reduction = sp.simplify(1 - ratio)
+        spec = describe_ftqc_resource_quantity(quantity)
+        rows.append(
+            FTQCResourceComparisonRow(
+                quantity=quantity,
+                baseline=baseline_value,
+                candidate=candidate_value,
+                ratio=ratio,
+                reduction=reduction,
+                label=spec.label,
+                unit=spec.unit,
+                category=spec.category,
+            )
+        )
+    return tuple(rows)
+
+
+def _normalize_comparison_quantities(
+    baseline_values: dict[FTQCResourceQuantity, sp.Expr],
+    candidate_values: dict[FTQCResourceQuantity, sp.Expr],
+    quantities: tuple[str | FTQCResourceQuantity, ...] | None,
+) -> tuple[FTQCResourceQuantity, ...]:
+    """Normalize comparison quantity selection.
+
+    Args:
+        baseline_values (dict[FTQCResourceQuantity, sp.Expr]): Baseline
+            resource values.
+        candidate_values (dict[FTQCResourceQuantity, sp.Expr]): Candidate
+            resource values.
+        quantities (tuple[str | FTQCResourceQuantity, ...] | None): Requested
+            quantities or None for the canonical intersection.
+
+    Returns:
+        tuple[FTQCResourceQuantity, ...]: Normalized quantities.
+
+    Raises:
+        ValueError: If a requested quantity is absent from either value map.
+    """
+    if quantities is None:
+        common = set(baseline_values) & set(candidate_values)
+        return tuple(
+            spec.quantity
+            for spec in FTQC_RESOURCE_QUANTITY_SPECS
+            if spec.quantity in common
+        )
+
+    normalized = tuple(
+        _normalize_resource_quantity(quantity) for quantity in quantities
+    )
+    missing = [
+        quantity.value
+        for quantity in normalized
+        if quantity not in baseline_values or quantity not in candidate_values
+    ]
+    if missing:
+        raise ValueError(
+            "Requested FTQC resource quantities are missing from the inputs: "
+            + ", ".join(missing)
+            + "."
+        )
+    return normalized
+
+
+def _normalize_resource_quantity(
+    quantity: str | FTQCResourceQuantity,
+) -> FTQCResourceQuantity:
+    """Normalize one resource quantity key.
+
+    Args:
+        quantity (str | FTQCResourceQuantity): Resource quantity key.
+
+    Returns:
+        FTQCResourceQuantity: Normalized quantity enum.
+
+    Raises:
+        ValueError: If ``quantity`` is not a known FTQC resource quantity.
+    """
     try:
-        normalized = FTQCResourceQuantity(quantity)
+        return FTQCResourceQuantity(quantity)
     except ValueError as exc:
         valid = ", ".join(item.value for item in FTQCResourceQuantity)
         raise ValueError(
             f"Unknown FTQC resource quantity {quantity!r}; valid: {valid}."
         ) from exc
-    return _SPECS_BY_QUANTITY[normalized]

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -12,6 +12,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     FTQCResourceCategory,
     FTQCResourceQuantity,
+    compare_ftqc_resource_estimates,
     describe_ftqc_resource_quantity,
     estimate_qubitized_chemistry_qpe_from_model,
     iter_ftqc_resource_quantity_specs,
@@ -87,3 +88,85 @@ def test_ftqc_models_expose_canonical_resource_values():
         == 0
     )
     assert estimate.to_quantity_table()[0]["quantity"] == "logical_qubits"
+
+
+def test_compare_ftqc_resource_estimates_reports_ratios_and_reductions():
+    """Comparison rows quantify savings for a lower-cost FTQC candidate."""
+    baseline = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    candidate = baseline.with_lambda_scale(sp.Rational(1, 2), source="compressed")
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e5"),
+    )
+    baseline_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=baseline,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=10,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+    candidate_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=candidate,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=11,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+
+    rows = compare_ftqc_resource_estimates(
+        baseline_estimate,
+        candidate_estimate,
+        quantities=(
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.TOFFOLI_GATES,
+        ),
+    )
+
+    assert rows[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+    assert sp.simplify(rows[0].ratio - sp.Rational(1, 2)) == 0
+    assert sp.simplify(rows[0].reduction - sp.Rational(1, 2)) == 0
+    assert sp.simplify(rows[1].ratio - sp.Rational(11, 20)) == 0
+    assert rows[1].to_dict()["unit"] == "Toffoli gates"
+
+
+def test_compare_ftqc_resource_estimates_defaults_to_common_quantities():
+    """Default comparison uses the canonical intersection of exposed values."""
+    summary = summarize_pauli_hamiltonian(qm_o.Z(0) + qm_o.X(1))
+    rows = compare_ftqc_resource_estimates(
+        summary,
+        summary.with_lambda_scale(sp.Rational(1, 2)),
+    )
+
+    assert [row.quantity for row in rows] == [
+        FTQCResourceQuantity.N_SPIN_ORBITALS,
+        FTQCResourceQuantity.N_PAULI_TERMS,
+        FTQCResourceQuantity.LAMBDA_NORM,
+        FTQCResourceQuantity.MAX_LOCALITY,
+    ]
+    lambda_row = rows[2]
+    assert sp.simplify(lambda_row.ratio - sp.Rational(1, 2)) == 0
+
+
+def test_compare_ftqc_resource_estimates_rejects_missing_or_zero_baseline():
+    """Invalid comparison requests fail before returning misleading ratios."""
+    summary = summarize_pauli_hamiltonian(qm_o.Z(0))
+
+    with pytest.raises(ValueError, match="missing"):
+        compare_ftqc_resource_estimates(
+            summary,
+            summary,
+            quantities=(FTQCResourceQuantity.TOFFOLI_GATES,),
+        )
+
+    with pytest.raises(ValueError, match="zero baseline"):
+        compare_ftqc_resource_estimates(
+            summary.with_lambda_scale(0),
+            summary,
+            quantities=(FTQCResourceQuantity.LAMBDA_NORM,),
+        )


### PR DESCRIPTION
## Summary
- Add protocol-based FTQC resource comparison helpers over canonical resource quantities.
- Add comparison rows with baseline, candidate, ratio, and fractional reduction fields.
- Cover savings, default common-quantity selection, missing quantity requests, and zero-baseline rejection in estimator tests.
- Update the EN/JA FTQC chemistry resource-estimation tutorial to report SCDF-style and UWC-style savings through the comparison API.

## Validation
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run pytest tests/circuit/estimator -q`
- `uv run pytest -m docs tests/docs/test_tag_whitelist.py -q`
- `uv run pytest -m docs 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[en/algorithm/ftqc_chemistry_resource_estimation]' 'tests/docs/test_tutorials.py::test_tutorial_executes_without_error[ja/algorithm/ftqc_chemistry_resource_estimation]' -q`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`