### PR TITLE
Document FTQC resource estimation design

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -1,0 +1,405 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9dece688",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [usage, chemistry, resource-estimation]\n",
+    "---\n",
+    "\n",
+    "# FTQC Resource Estimation Design\n",
+    "\n",
+    "This notebook explains the resource-estimation quantities Qamomile tracks for\n",
+    "fault-tolerant quantum chemistry. It focuses on how to separate problem\n",
+    "metadata, algorithmic work, logical resources, and architecture assumptions\n",
+    "before lowering anything into backend-specific circuits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cac83f3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:11.269415Z",
+     "iopub.status.busy": "2026-06-22T11:48:11.269188Z",
+     "iopub.status.idle": "2026-06-22T11:48:11.273872Z",
+     "shell.execute_reply": "2026-06-22T11:48:11.272995Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "42e0ebc1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:11.275935Z",
+     "iopub.status.busy": "2026-06-22T11:48:11.275767Z",
+     "iopub.status.idle": "2026-06-22T11:48:11.638081Z",
+     "shell.execute_reply": "2026-06-22T11:48:11.637641Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "import qamomile.observable as qm_o\n",
+    "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    ChemistryQPEMethod,\n",
+    "    ChemistryQPEModel,\n",
+    "    FTQCCostModel,\n",
+    "    FTQCResourceCategory,\n",
+    "    FTQCResourceQuantity,\n",
+    "    compare_ftqc_resource_estimates,\n",
+    "    estimate_qubitized_chemistry_qpe_from_model,\n",
+    "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_resource_quantity_specs,\n",
+    "    summarize_pauli_hamiltonian,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "142dc915",
+   "metadata": {},
+   "source": [
+    "## Design Boundary\n",
+    "\n",
+    "FTQC chemistry papers often reduce cost by changing the Hamiltonian\n",
+    "representation, not by changing the compiler IR. Qamomile therefore keeps\n",
+    "this layer as algorithmic metadata:\n",
+    "\n",
+    "- Hamiltonian summaries capture representation-level quantities such as\n",
+    "  `lambda_norm` and Pauli term count.\n",
+    "- Algorithm estimators turn those quantities into QPE iterations, Toffoli or\n",
+    "  T counts, logical qubits, logical depth, physical qubits, and runtime\n",
+    "  proxies.\n",
+    "- Backend emitters remain responsible for concrete circuit lowering.\n",
+    "\n",
+    "This matches the compiler rule used elsewhere in Qamomile: keep the IR\n",
+    "abstract and push concretization as late as possible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5fc0e2d",
+   "metadata": {},
+   "source": [
+    "## Research Signals\n",
+    "\n",
+    "The current quantity catalog follows the cost drivers used in recent FTQC\n",
+    "chemistry work:\n",
+    "\n",
+    "| Research direction | Cost signal for Qamomile |\n",
+    "| --- | --- |\n",
+    "| Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |\n",
+    "| Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |\n",
+    "| Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |\n",
+    "\n",
+    "These are modeling quantities. They should be validated against each paper's\n",
+    "assumptions before being used as a molecule-specific resource claim."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13aa8536",
+   "metadata": {},
+   "source": [
+    "## Quantity Catalog\n",
+    "\n",
+    "Qamomile exposes canonical quantity keys so reports and tutorials do not have\n",
+    "to invent ad hoc column names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c63164f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:11.639467Z",
+     "iopub.status.busy": "2026-06-22T11:48:11.639380Z",
+     "iopub.status.idle": "2026-06-22T11:48:11.642454Z",
+     "shell.execute_reply": "2026-06-22T11:48:11.642074Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_spin_orbitals spin orbitals problem\n",
+      "n_pauli_terms terms problem\n",
+      "lambda_norm energy problem\n",
+      "max_locality Pauli factors problem\n",
+      "walk_cost_toffoli Toffoli gates per walk algorithm\n",
+      "qpe_iterations iterations algorithm\n",
+      "logical_qubits logical qubits logical\n",
+      "logical_depth logical layers logical\n",
+      "toffoli_gates Toffoli gates logical\n",
+      "t_gates T gates logical\n",
+      "clifford_gates Clifford gates logical\n",
+      "physical_qubits physical qubits physical\n",
+      "runtime_seconds seconds physical\n"
+     ]
+    }
+   ],
+   "source": [
+    "catalog = [\n",
+    "    spec.to_dict()\n",
+    "    for spec in iter_ftqc_resource_quantity_specs()\n",
+    "    if spec.category\n",
+    "    in {\n",
+    "        FTQCResourceCategory.PROBLEM,\n",
+    "        FTQCResourceCategory.ALGORITHM,\n",
+    "        FTQCResourceCategory.LOGICAL,\n",
+    "        FTQCResourceCategory.PHYSICAL,\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "for row in catalog:\n",
+    "    print(row[\"quantity\"], row[\"unit\"], row[\"category\"])\n",
+    "\n",
+    "assert FTQCResourceQuantity.LAMBDA_NORM.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.TOFFOLI_GATES.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ace2814",
+   "metadata": {},
+   "source": [
+    "## Minimal Example\n",
+    "\n",
+    "Start from a Qamomile observable, summarize it once, then construct two\n",
+    "representation-level models. The example below uses synthetic scaling values\n",
+    "so it demonstrates the workflow without claiming a specific molecule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bf3c7567",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:11.643398Z",
+     "iopub.status.busy": "2026-06-22T11:48:11.643346Z",
+     "iopub.status.idle": "2026-06-22T11:48:11.662423Z",
+     "shell.execute_reply": "2026-06-22T11:48:11.662054Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
+      "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
+      "Physical qubits ratio: 2.231 reduction: -1.231\n"
+     ]
+    }
+   ],
+   "source": [
+    "toy_hamiltonian = 0.5 * qm_o.Z(0) + 0.25 * qm_o.X(1) * qm_o.X(2)\n",
+    "summary = summarize_pauli_hamiltonian(\n",
+    "    toy_hamiltonian,\n",
+    "    n_spin_orbitals=40,\n",
+    "    source=\"toy_pauli_lcu\",\n",
+    ")\n",
+    "scaled_summary = summary.with_lambda_scale(\n",
+    "    sp.Float(\"2.0e5\") / summary.lambda_norm,\n",
+    "    source=\"scaled_toy_pauli_lcu\",\n",
+    ")\n",
+    "\n",
+    "cost_model = FTQCCostModel(\n",
+    "    physical_qubits_per_logical=800,\n",
+    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
+    "    factory_qubits=20000,\n",
+    "    toffoli_throughput_per_second=sp.Float(\"2e6\"),\n",
+    ")\n",
+    "\n",
+    "baseline_model = ChemistryQPEModel(\n",
+    "    hamiltonian=scaled_summary,\n",
+    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "    walk_cost_toffoli=sp.Integer(4_000),\n",
+    ")\n",
+    "compressed_model = ChemistryQPEModel(\n",
+    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "        sp.Float(\"0.5\"),\n",
+    "        source=\"compressed_scaled_toy_pauli_lcu\",\n",
+    "    ),\n",
+    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "    walk_cost_toffoli=sp.Integer(4_400),\n",
+    "    second_factor_rank=9,\n",
+    ")\n",
+    "\n",
+    "baseline = estimate_qubitized_chemistry_qpe_from_model(\n",
+    "    baseline_model,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "compressed = estimate_qubitized_chemistry_qpe_from_model(\n",
+    "    compressed_model,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "comparison = compare_ftqc_resource_estimates(\n",
+    "    baseline,\n",
+    "    compressed,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "for row in comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
+    "\n",
+    "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
+    "assert comparison[1].ratio == sp.Float(\"0.55\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b88d81f1",
+   "metadata": {},
+   "source": [
+    "## Early-FTQC Pattern\n",
+    "\n",
+    "Early-FTQC estimates may not be Toffoli-native. The same comparison API works\n",
+    "for Trotter-style models that primarily report T gates and logical depth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "04da2cd9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:11.663409Z",
+     "iopub.status.busy": "2026-06-22T11:48:11.663356Z",
+     "iopub.status.idle": "2026-06-22T11:48:11.667282Z",
+     "shell.execute_reply": "2026-06-22T11:48:11.666889Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n",
+      "T gates ratio: 0.1500 reduction: 0.8500\n"
+     ]
+    }
+   ],
+   "source": [
+    "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
+    "    scaled_summary,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    trotter_steps_per_sample=8,\n",
+    "    samples=128,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
+    "    scaled_summary,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    trotter_steps_per_sample=8,\n",
+    "    samples=128,\n",
+    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
+    "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
+    "    rotation_synthesis_t_gates=3,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "trotter_comparison = compare_ftqc_resource_estimates(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\", \"t_gates\"),\n",
+    ")\n",
+    "\n",
+    "for row in trotter_comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
+    "\n",
+    "assert trotter_comparison[0].ratio == sp.Float(\"0.1\")\n",
+    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3c087e8",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    ":::{note}\n",
+    "The numbers above are synthetic. They demonstrate how Qamomile separates cost\n",
+    "drivers and compares estimates. A publication-quality molecule study still\n",
+    "needs molecule-specific integrals, factorization ranks, truncation errors,\n",
+    "synthesis assumptions, and architecture calibration.\n",
+    ":::\n",
+    "\n",
+    "Keep these boundaries in mind when adding new FTQC estimators:\n",
+    "\n",
+    "- Add new problem metadata as structured summaries, not as IR operations.\n",
+    "- Add new measured quantities to the canonical catalog before exposing new\n",
+    "  report columns.\n",
+    "- Keep architecture assumptions explicit so physical-qubit and runtime\n",
+    "  estimates can be swapped without changing algorithm metadata."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2793b79d",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we learned:\n",
+    "\n",
+    "- Recent FTQC chemistry work motivates tracking Hamiltonian normalization,\n",
+    "  QPE iterations, non-Clifford counts, logical depth, physical qubits, and\n",
+    "  runtime separately.\n",
+    "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
+    "  remains backend-neutral.\n",
+    "- `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable\n",
+    "  savings tables without hard-coding a particular chemistry factorization."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -1,0 +1,243 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [usage, chemistry, resource-estimation]
+# ---
+#
+# # FTQC Resource Estimation Design
+#
+# This notebook explains the resource-estimation quantities Qamomile tracks for
+# fault-tolerant quantum chemistry. It focuses on how to separate problem
+# metadata, algorithmic work, logical resources, and architecture assumptions
+# before lowering anything into backend-specific circuits.
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import sympy as sp
+
+import qamomile.observable as qm_o
+from qamomile.circuit.estimator.algorithmic import (
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
+    FTQCCostModel,
+    FTQCResourceCategory,
+    FTQCResourceQuantity,
+    compare_ftqc_resource_estimates,
+    estimate_qubitized_chemistry_qpe_from_model,
+    estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_resource_quantity_specs,
+    summarize_pauli_hamiltonian,
+)
+
+# %% [markdown]
+# ## Design Boundary
+#
+# FTQC chemistry papers often reduce cost by changing the Hamiltonian
+# representation, not by changing the compiler IR. Qamomile therefore keeps
+# this layer as algorithmic metadata:
+#
+# - Hamiltonian summaries capture representation-level quantities such as
+#   `lambda_norm` and Pauli term count.
+# - Algorithm estimators turn those quantities into QPE iterations, Toffoli or
+#   T counts, logical qubits, logical depth, physical qubits, and runtime
+#   proxies.
+# - Backend emitters remain responsible for concrete circuit lowering.
+#
+# This matches the compiler rule used elsewhere in Qamomile: keep the IR
+# abstract and push concretization as late as possible.
+
+# %% [markdown]
+# ## Research Signals
+#
+# The current quantity catalog follows the cost drivers used in recent FTQC
+# chemistry work:
+#
+# | Research direction | Cost signal for Qamomile |
+# | --- | --- |
+# | Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |
+# | Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |
+# | Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |
+#
+# These are modeling quantities. They should be validated against each paper's
+# assumptions before being used as a molecule-specific resource claim.
+
+# %% [markdown]
+# ## Quantity Catalog
+#
+# Qamomile exposes canonical quantity keys so reports and tutorials do not have
+# to invent ad hoc column names.
+
+# %%
+catalog = [
+    spec.to_dict()
+    for spec in iter_ftqc_resource_quantity_specs()
+    if spec.category
+    in {
+        FTQCResourceCategory.PROBLEM,
+        FTQCResourceCategory.ALGORITHM,
+        FTQCResourceCategory.LOGICAL,
+        FTQCResourceCategory.PHYSICAL,
+    }
+]
+
+for row in catalog:
+    print(row["quantity"], row["unit"], row["category"])
+
+assert FTQCResourceQuantity.LAMBDA_NORM.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.TOFFOLI_GATES.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {
+    row["quantity"] for row in catalog
+}
+
+# %% [markdown]
+# ## Minimal Example
+#
+# Start from a Qamomile observable, summarize it once, then construct two
+# representation-level models. The example below uses synthetic scaling values
+# so it demonstrates the workflow without claiming a specific molecule.
+
+# %%
+toy_hamiltonian = 0.5 * qm_o.Z(0) + 0.25 * qm_o.X(1) * qm_o.X(2)
+summary = summarize_pauli_hamiltonian(
+    toy_hamiltonian,
+    n_spin_orbitals=40,
+    source="toy_pauli_lcu",
+)
+scaled_summary = summary.with_lambda_scale(
+    sp.Float("2.0e5") / summary.lambda_norm,
+    source="scaled_toy_pauli_lcu",
+)
+
+cost_model = FTQCCostModel(
+    physical_qubits_per_logical=800,
+    logical_cycle_time_seconds=sp.Float("1e-6"),
+    factory_qubits=20000,
+    toffoli_throughput_per_second=sp.Float("2e6"),
+)
+
+baseline_model = ChemistryQPEModel(
+    hamiltonian=scaled_summary,
+    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+    walk_cost_toffoli=sp.Integer(4_000),
+)
+compressed_model = ChemistryQPEModel(
+    hamiltonian=scaled_summary.with_lambda_scale(
+        sp.Float("0.5"),
+        source="compressed_scaled_toy_pauli_lcu",
+    ),
+    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+    walk_cost_toffoli=sp.Integer(4_400),
+    second_factor_rank=9,
+)
+
+baseline = estimate_qubitized_chemistry_qpe_from_model(
+    baseline_model,
+    precision=sp.Float("0.0016"),
+    cost_model=cost_model,
+)
+compressed = estimate_qubitized_chemistry_qpe_from_model(
+    compressed_model,
+    precision=sp.Float("0.0016"),
+    cost_model=cost_model,
+)
+
+comparison = compare_ftqc_resource_estimates(
+    baseline,
+    compressed,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+for row in comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4), "reduction:", sp.N(row.reduction, 4))
+
+assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert comparison[0].ratio == sp.Float("0.5")
+assert comparison[1].ratio == sp.Float("0.55")
+
+# %% [markdown]
+# ## Early-FTQC Pattern
+#
+# Early-FTQC estimates may not be Toffoli-native. The same comparison API works
+# for Trotter-style models that primarily report T gates and logical depth.
+
+# %%
+plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+    scaled_summary,
+    precision=sp.Float("0.0016"),
+    trotter_steps_per_sample=8,
+    samples=128,
+    cost_model=cost_model,
+)
+uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+    scaled_summary,
+    precision=sp.Float("0.0016"),
+    trotter_steps_per_sample=8,
+    samples=128,
+    unitary_weight_factor=sp.Float("0.1"),
+    randomized_compilation_factor=sp.Float("0.5"),
+    rotation_synthesis_t_gates=3,
+    cost_model=cost_model,
+)
+
+trotter_comparison = compare_ftqc_resource_estimates(
+    plain_trotter,
+    uwc_trotter,
+    quantities=("qpe_iterations", "logical_depth", "t_gates"),
+)
+
+for row in trotter_comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4), "reduction:", sp.N(row.reduction, 4))
+
+assert trotter_comparison[0].ratio == sp.Float("0.1")
+assert trotter_comparison[1].ratio == sp.Float("0.05")
+
+# %% [markdown]
+# ## Notes
+#
+# :::{note}
+# The numbers above are synthetic. They demonstrate how Qamomile separates cost
+# drivers and compares estimates. A publication-quality molecule study still
+# needs molecule-specific integrals, factorization ranks, truncation errors,
+# synthesis assumptions, and architecture calibration.
+# :::
+#
+# Keep these boundaries in mind when adding new FTQC estimators:
+#
+# - Add new problem metadata as structured summaries, not as IR operations.
+# - Add new measured quantities to the canonical catalog before exposing new
+#   report columns.
+# - Keep architecture assumptions explicit so physical-qubit and runtime
+#   estimates can be swapped without changing algorithm metadata.
+
+# %% [markdown]
+# ## Summary
+#
+# In this notebook, we learned:
+#
+# - Recent FTQC chemistry work motivates tracking Hamiltonian normalization,
+#   QPE iterations, non-Clifford counts, logical depth, physical qubits, and
+#   runtime separately.
+# - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
+#   remains backend-neutral.
+# - `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable
+#   savings tables without hard-coding a particular chemistry factorization.

--- a/docs/en/usage/index.md
+++ b/docs/en/usage/index.md
@@ -8,4 +8,5 @@ How-to guides for using individual Qamomile modules.
 
 ## All articles
 
+- [FTQC Resource Estimation Design](ftqc_resource_estimation_design) — Understand the quantity model behind symbolic FTQC chemistry estimates
 - [How to use BinaryModel](binary_model) — Build unconstrained binary/spin models from BinaryExpr, QUBO/HUBO/Ising, or OMMX

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dace7874",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [usage, chemistry, resource-estimation]\n",
+    "---\n",
+    "\n",
+    "# FTQCリソース推定の設計\n",
+    "\n",
+    "このnotebookでは、Qamomileがfault-tolerant quantum chemistryのために追跡するリソース推定量を説明します。backend固有の回路へloweringする前に、問題メタデータ、アルゴリズム上の作業量、logicalリソース、architecture仮定をどう分けるかに焦点を当てます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "44b0dd0e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:12.807443Z",
+     "iopub.status.busy": "2026-06-22T11:48:12.807309Z",
+     "iopub.status.idle": "2026-06-22T11:48:12.810951Z",
+     "shell.execute_reply": "2026-06-22T11:48:12.810245Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6c336198",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:12.815482Z",
+     "iopub.status.busy": "2026-06-22T11:48:12.815259Z",
+     "iopub.status.idle": "2026-06-22T11:48:13.036600Z",
+     "shell.execute_reply": "2026-06-22T11:48:13.036201Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "import qamomile.observable as qm_o\n",
+    "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    ChemistryQPEMethod,\n",
+    "    ChemistryQPEModel,\n",
+    "    FTQCCostModel,\n",
+    "    FTQCResourceCategory,\n",
+    "    FTQCResourceQuantity,\n",
+    "    compare_ftqc_resource_estimates,\n",
+    "    estimate_qubitized_chemistry_qpe_from_model,\n",
+    "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_resource_quantity_specs,\n",
+    "    summarize_pauli_hamiltonian,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ad647a",
+   "metadata": {},
+   "source": [
+    "## 設計上の境界\n",
+    "\n",
+    "FTQC化学計算の論文では、compiler IRを変えるのではなく、Hamiltonian表現を変えることでcostを下げることがよくあります。そのためQamomileでは、この層をアルゴリズム上のメタデータとして扱います。\n",
+    "\n",
+    "- Hamiltonian summaryは`lambda_norm`やPauli項数など、表現レベルの量を保持します。\n",
+    "- アルゴリズム推定器はそれらの量をQPE反復回数、ToffoliまたはT count、logical量子ビット、logical depth、physical量子ビット、runtime proxyへ変換します。\n",
+    "- 具体的な回路loweringはbackend emitterが担当します。\n",
+    "\n",
+    "これはQamomileの他の場所で使っているcompiler上の規則と一致します。IRは抽象的に保ち、具体化はできるだけ遅くまで押し下げます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d980dbc",
+   "metadata": {},
+   "source": [
+    "## 研究上のシグナル\n",
+    "\n",
+    "現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。\n",
+    "\n",
+    "| Research direction | Cost signal for Qamomile |\n",
+    "| --- | --- |\n",
+    "| Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |\n",
+    "| Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |\n",
+    "| Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |\n",
+    "\n",
+    "これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff5b682",
+   "metadata": {},
+   "source": [
+    "## Quantity Catalog\n",
+    "\n",
+    "Qamomileはcanonicalなquantity keyを公開しているため、reportやtutorialごとにad hocな列名を作る必要がありません。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ffd12e61",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:13.038160Z",
+     "iopub.status.busy": "2026-06-22T11:48:13.038075Z",
+     "iopub.status.idle": "2026-06-22T11:48:13.041276Z",
+     "shell.execute_reply": "2026-06-22T11:48:13.040904Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_spin_orbitals spin orbitals problem\n",
+      "n_pauli_terms terms problem\n",
+      "lambda_norm energy problem\n",
+      "max_locality Pauli factors problem\n",
+      "walk_cost_toffoli Toffoli gates per walk algorithm\n",
+      "qpe_iterations iterations algorithm\n",
+      "logical_qubits logical qubits logical\n",
+      "logical_depth logical layers logical\n",
+      "toffoli_gates Toffoli gates logical\n",
+      "t_gates T gates logical\n",
+      "clifford_gates Clifford gates logical\n",
+      "physical_qubits physical qubits physical\n",
+      "runtime_seconds seconds physical\n"
+     ]
+    }
+   ],
+   "source": [
+    "catalog = [\n",
+    "    spec.to_dict()\n",
+    "    for spec in iter_ftqc_resource_quantity_specs()\n",
+    "    if spec.category\n",
+    "    in {\n",
+    "        FTQCResourceCategory.PROBLEM,\n",
+    "        FTQCResourceCategory.ALGORITHM,\n",
+    "        FTQCResourceCategory.LOGICAL,\n",
+    "        FTQCResourceCategory.PHYSICAL,\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "for row in catalog:\n",
+    "    print(row[\"quantity\"], row[\"unit\"], row[\"category\"])\n",
+    "\n",
+    "assert FTQCResourceQuantity.LAMBDA_NORM.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.TOFFOLI_GATES.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b462b43",
+   "metadata": {},
+   "source": [
+    "## 最小例\n",
+    "\n",
+    "まずQamomile observableから始め、それを一度summaryにしてから、表現レベルのmodelを2つ構築します。下の例ではsyntheticなscaling値を使うため、特定の分子についての主張ではなくworkflowを示します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ad469f4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:13.042431Z",
+     "iopub.status.busy": "2026-06-22T11:48:13.042365Z",
+     "iopub.status.idle": "2026-06-22T11:48:13.059069Z",
+     "shell.execute_reply": "2026-06-22T11:48:13.058652Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
+      "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
+      "Physical qubits ratio: 2.231 reduction: -1.231\n"
+     ]
+    }
+   ],
+   "source": [
+    "toy_hamiltonian = 0.5 * qm_o.Z(0) + 0.25 * qm_o.X(1) * qm_o.X(2)\n",
+    "summary = summarize_pauli_hamiltonian(\n",
+    "    toy_hamiltonian,\n",
+    "    n_spin_orbitals=40,\n",
+    "    source=\"toy_pauli_lcu\",\n",
+    ")\n",
+    "scaled_summary = summary.with_lambda_scale(\n",
+    "    sp.Float(\"2.0e5\") / summary.lambda_norm,\n",
+    "    source=\"scaled_toy_pauli_lcu\",\n",
+    ")\n",
+    "\n",
+    "cost_model = FTQCCostModel(\n",
+    "    physical_qubits_per_logical=800,\n",
+    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
+    "    factory_qubits=20000,\n",
+    "    toffoli_throughput_per_second=sp.Float(\"2e6\"),\n",
+    ")\n",
+    "\n",
+    "baseline_model = ChemistryQPEModel(\n",
+    "    hamiltonian=scaled_summary,\n",
+    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "    walk_cost_toffoli=sp.Integer(4_000),\n",
+    ")\n",
+    "compressed_model = ChemistryQPEModel(\n",
+    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "        sp.Float(\"0.5\"),\n",
+    "        source=\"compressed_scaled_toy_pauli_lcu\",\n",
+    "    ),\n",
+    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "    walk_cost_toffoli=sp.Integer(4_400),\n",
+    "    second_factor_rank=9,\n",
+    ")\n",
+    "\n",
+    "baseline = estimate_qubitized_chemistry_qpe_from_model(\n",
+    "    baseline_model,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "compressed = estimate_qubitized_chemistry_qpe_from_model(\n",
+    "    compressed_model,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "comparison = compare_ftqc_resource_estimates(\n",
+    "    baseline,\n",
+    "    compressed,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "for row in comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
+    "\n",
+    "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
+    "assert comparison[1].ratio == sp.Float(\"0.55\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83f9ac6d",
+   "metadata": {},
+   "source": [
+    "## Early-FTQCのパターン\n",
+    "\n",
+    "Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9e38e20d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T11:48:13.060194Z",
+     "iopub.status.busy": "2026-06-22T11:48:13.060130Z",
+     "iopub.status.idle": "2026-06-22T11:48:13.064294Z",
+     "shell.execute_reply": "2026-06-22T11:48:13.063865Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n",
+      "T gates ratio: 0.1500 reduction: 0.8500\n"
+     ]
+    }
+   ],
+   "source": [
+    "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
+    "    scaled_summary,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    trotter_steps_per_sample=8,\n",
+    "    samples=128,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
+    "    scaled_summary,\n",
+    "    precision=sp.Float(\"0.0016\"),\n",
+    "    trotter_steps_per_sample=8,\n",
+    "    samples=128,\n",
+    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
+    "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
+    "    rotation_synthesis_t_gates=3,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "trotter_comparison = compare_ftqc_resource_estimates(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\", \"t_gates\"),\n",
+    ")\n",
+    "\n",
+    "for row in trotter_comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
+    "\n",
+    "assert trotter_comparison[0].ratio == sp.Float(\"0.1\")\n",
+    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a8e8344",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    ":::{note}\n",
+    "上の数値はsyntheticです。Qamomileがcost driverを分けて比較する流れを示しています。publication-qualityの分子研究には、分子固有のintegral、factorization rank、truncation error、synthesis仮定、architecture calibrationが必要です。\n",
+    ":::\n",
+    "\n",
+    "新しいFTQC推定器を追加するときは、次の境界を意識してください。\n",
+    "\n",
+    "- 新しい問題メタデータはIR operationではなく、structured summaryとして追加します。\n",
+    "- 新しい測定量を公開するときは、report列として出す前にcanonical catalogへ追加します。\n",
+    "- architecture仮定を明示して、algorithm metadataを変えずにphysical量子ビットとruntime推定を差し替えられるようにします。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db9a9650",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "このnotebookでは、次のことを学びました。\n",
+    "\n",
+    "- 近年のFTQC化学計算研究から、Hamiltonian normalization、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。\n",
+    "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
+    "- `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -1,0 +1,219 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [usage, chemistry, resource-estimation]
+# ---
+#
+# # FTQCリソース推定の設計
+#
+# このnotebookでは、Qamomileがfault-tolerant quantum chemistryのために追跡するリソース推定量を説明します。backend固有の回路へloweringする前に、問題メタデータ、アルゴリズム上の作業量、logicalリソース、architecture仮定をどう分けるかに焦点を当てます。
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import sympy as sp
+
+import qamomile.observable as qm_o
+from qamomile.circuit.estimator.algorithmic import (
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
+    FTQCCostModel,
+    FTQCResourceCategory,
+    FTQCResourceQuantity,
+    compare_ftqc_resource_estimates,
+    estimate_qubitized_chemistry_qpe_from_model,
+    estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_resource_quantity_specs,
+    summarize_pauli_hamiltonian,
+)
+
+# %% [markdown]
+# ## 設計上の境界
+#
+# FTQC化学計算の論文では、compiler IRを変えるのではなく、Hamiltonian表現を変えることでcostを下げることがよくあります。そのためQamomileでは、この層をアルゴリズム上のメタデータとして扱います。
+#
+# - Hamiltonian summaryは`lambda_norm`やPauli項数など、表現レベルの量を保持します。
+# - アルゴリズム推定器はそれらの量をQPE反復回数、ToffoliまたはT count、logical量子ビット、logical depth、physical量子ビット、runtime proxyへ変換します。
+# - 具体的な回路loweringはbackend emitterが担当します。
+#
+# これはQamomileの他の場所で使っているcompiler上の規則と一致します。IRは抽象的に保ち、具体化はできるだけ遅くまで押し下げます。
+
+# %% [markdown]
+# ## 研究上のシグナル
+#
+# 現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。
+#
+# | Research direction | Cost signal for Qamomile |
+# | --- | --- |
+# | Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |
+# | Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |
+# | Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |
+#
+# これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。
+
+# %% [markdown]
+# ## Quantity Catalog
+#
+# Qamomileはcanonicalなquantity keyを公開しているため、reportやtutorialごとにad hocな列名を作る必要がありません。
+
+# %%
+catalog = [
+    spec.to_dict()
+    for spec in iter_ftqc_resource_quantity_specs()
+    if spec.category
+    in {
+        FTQCResourceCategory.PROBLEM,
+        FTQCResourceCategory.ALGORITHM,
+        FTQCResourceCategory.LOGICAL,
+        FTQCResourceCategory.PHYSICAL,
+    }
+]
+
+for row in catalog:
+    print(row["quantity"], row["unit"], row["category"])
+
+assert FTQCResourceQuantity.LAMBDA_NORM.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.TOFFOLI_GATES.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {
+    row["quantity"] for row in catalog
+}
+
+# %% [markdown]
+# ## 最小例
+#
+# まずQamomile observableから始め、それを一度summaryにしてから、表現レベルのmodelを2つ構築します。下の例ではsyntheticなscaling値を使うため、特定の分子についての主張ではなくworkflowを示します。
+
+# %%
+toy_hamiltonian = 0.5 * qm_o.Z(0) + 0.25 * qm_o.X(1) * qm_o.X(2)
+summary = summarize_pauli_hamiltonian(
+    toy_hamiltonian,
+    n_spin_orbitals=40,
+    source="toy_pauli_lcu",
+)
+scaled_summary = summary.with_lambda_scale(
+    sp.Float("2.0e5") / summary.lambda_norm,
+    source="scaled_toy_pauli_lcu",
+)
+
+cost_model = FTQCCostModel(
+    physical_qubits_per_logical=800,
+    logical_cycle_time_seconds=sp.Float("1e-6"),
+    factory_qubits=20000,
+    toffoli_throughput_per_second=sp.Float("2e6"),
+)
+
+baseline_model = ChemistryQPEModel(
+    hamiltonian=scaled_summary,
+    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+    walk_cost_toffoli=sp.Integer(4_000),
+)
+compressed_model = ChemistryQPEModel(
+    hamiltonian=scaled_summary.with_lambda_scale(
+        sp.Float("0.5"),
+        source="compressed_scaled_toy_pauli_lcu",
+    ),
+    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+    walk_cost_toffoli=sp.Integer(4_400),
+    second_factor_rank=9,
+)
+
+baseline = estimate_qubitized_chemistry_qpe_from_model(
+    baseline_model,
+    precision=sp.Float("0.0016"),
+    cost_model=cost_model,
+)
+compressed = estimate_qubitized_chemistry_qpe_from_model(
+    compressed_model,
+    precision=sp.Float("0.0016"),
+    cost_model=cost_model,
+)
+
+comparison = compare_ftqc_resource_estimates(
+    baseline,
+    compressed,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+for row in comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4), "reduction:", sp.N(row.reduction, 4))
+
+assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert comparison[0].ratio == sp.Float("0.5")
+assert comparison[1].ratio == sp.Float("0.55")
+
+# %% [markdown]
+# ## Early-FTQCのパターン
+#
+# Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。
+
+# %%
+plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+    scaled_summary,
+    precision=sp.Float("0.0016"),
+    trotter_steps_per_sample=8,
+    samples=128,
+    cost_model=cost_model,
+)
+uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+    scaled_summary,
+    precision=sp.Float("0.0016"),
+    trotter_steps_per_sample=8,
+    samples=128,
+    unitary_weight_factor=sp.Float("0.1"),
+    randomized_compilation_factor=sp.Float("0.5"),
+    rotation_synthesis_t_gates=3,
+    cost_model=cost_model,
+)
+
+trotter_comparison = compare_ftqc_resource_estimates(
+    plain_trotter,
+    uwc_trotter,
+    quantities=("qpe_iterations", "logical_depth", "t_gates"),
+)
+
+for row in trotter_comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4), "reduction:", sp.N(row.reduction, 4))
+
+assert trotter_comparison[0].ratio == sp.Float("0.1")
+assert trotter_comparison[1].ratio == sp.Float("0.05")
+
+# %% [markdown]
+# ## Notes
+#
+# :::{note}
+# 上の数値はsyntheticです。Qamomileがcost driverを分けて比較する流れを示しています。publication-qualityの分子研究には、分子固有のintegral、factorization rank、truncation error、synthesis仮定、architecture calibrationが必要です。
+# :::
+#
+# 新しいFTQC推定器を追加するときは、次の境界を意識してください。
+#
+# - 新しい問題メタデータはIR operationではなく、structured summaryとして追加します。
+# - 新しい測定量を公開するときは、report列として出す前にcanonical catalogへ追加します。
+# - architecture仮定を明示して、algorithm metadataを変えずにphysical量子ビットとruntime推定を差し替えられるようにします。
+
+# %% [markdown]
+# ## Summary
+#
+# このnotebookでは、次のことを学びました。
+#
+# - 近年のFTQC化学計算研究から、Hamiltonian normalization、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。
+# - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
+# - `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。

--- a/docs/ja/usage/index.md
+++ b/docs/ja/usage/index.md
@@ -8,4 +8,5 @@ Qamomileの個別モジュールを使うためのHow-toガイドです。
 
 ## すべての記事
 
+- [FTQCリソース推定の設計](ftqc_resource_estimation_design) — symbolicなFTQC化学計算推定のquantity modelを理解する
 - [`BinaryModel`の使い方](binary_model) — 制約なしのバイナリ/スピン変数モデルをQUBO/HUBO/IsingあるいはOMMXから構築する


### PR DESCRIPTION
## Summary
- add an EN/JA usage guide that frames FTQC chemistry resource estimation quantities and IR boundaries
- document recent research signals for compressed qubitized QPE and early-FTQC Trotter-style estimates
- include executable examples for the quantity catalog, symbolic estimate comparison, and early-FTQC resource comparisons

## Validation
- uv run jupytext --to ipynb --update docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb docs/ja/usage/ftqc_resource_estimation_design.ipynb
- uv run pytest -m docs tests/docs/test_tag_whitelist.py -q
- uv run pytest -m docs tests/docs/test_tutorials.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/