### PR TITLE
Relift FTQC estimates across architectures

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "cac83f3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:22.490957Z",
-     "iopub.status.busy": "2026-06-22T12:05:22.490890Z",
-     "iopub.status.idle": "2026-06-22T12:05:22.493044Z",
-     "shell.execute_reply": "2026-06-22T12:05:22.492612Z"
+     "iopub.execute_input": "2026-06-22T12:20:24.595960Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.595889Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.598739Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.598164Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "42e0ebc1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:22.494036Z",
-     "iopub.status.busy": "2026-06-22T12:05:22.493980Z",
-     "iopub.status.idle": "2026-06-22T12:05:22.742358Z",
-     "shell.execute_reply": "2026-06-22T12:05:22.741799Z"
+     "iopub.execute_input": "2026-06-22T12:20:24.600017Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.599950Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.831075Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.830613Z"
     }
    },
    "outputs": [],
@@ -125,10 +125,10 @@
    "id": "c63164f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:22.743877Z",
-     "iopub.status.busy": "2026-06-22T12:05:22.743776Z",
-     "iopub.status.idle": "2026-06-22T12:05:22.747032Z",
-     "shell.execute_reply": "2026-06-22T12:05:22.746341Z"
+     "iopub.execute_input": "2026-06-22T12:20:24.832542Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.832444Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.835426Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.835087Z"
     }
    },
    "outputs": [
@@ -212,10 +212,10 @@
    "id": "bf3c7567",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:22.748141Z",
-     "iopub.status.busy": "2026-06-22T12:05:22.748082Z",
-     "iopub.status.idle": "2026-06-22T12:05:22.766774Z",
-     "shell.execute_reply": "2026-06-22T12:05:22.766362Z"
+     "iopub.execute_input": "2026-06-22T12:20:24.836542Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.836487Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.855051Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.854528Z"
     }
    },
    "outputs": [
@@ -301,6 +301,69 @@
   },
   {
    "cell_type": "markdown",
+   "id": "afadbd4d",
+   "metadata": {},
+   "source": [
+    "## Architecture Sensitivity\n",
+    "\n",
+    "Once an estimate exists, relift it with a different architecture model to\n",
+    "study hardware assumptions without rebuilding the algorithm model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2c30d506",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:20:24.856194Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.856128Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.859943Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.859498Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Physical qubits ratio: 0.5385\n",
+      "Runtime ratio: 0.5000\n"
+     ]
+    }
+   ],
+   "source": [
+    "faster_architecture = SurfaceCodeCostModel(\n",
+    "    code_distance=10,\n",
+    "    physical_cycle_time_seconds=sp.Float(\"5e-8\"),\n",
+    "    physical_qubits_per_logical_factor=2,\n",
+    "    logical_cycle_factor=1,\n",
+    "    factory_count=8,\n",
+    "    physical_qubits_per_factory=2500,\n",
+    "    factory_cycles_per_toffoli=2,\n",
+    ")\n",
+    "relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())\n",
+    "\n",
+    "architecture_comparison = compare_ftqc_resource_estimates(\n",
+    "    baseline,\n",
+    "    relifted_baseline,\n",
+    "    quantities=(\"physical_qubits\", \"runtime_seconds\"),\n",
+    ")\n",
+    "\n",
+    "for row in architecture_comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4))\n",
+    "\n",
+    "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
+    "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
+    "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(7, 13)) == 0\n",
+    "assert (\n",
+    "    sp.Abs(architecture_comparison[1].ratio - sp.Float(\"0.5\"))\n",
+    "    < sp.Float(\"1e-12\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b88d81f1",
    "metadata": {},
    "source": [
@@ -312,14 +375,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "04da2cd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:22.768374Z",
-     "iopub.status.busy": "2026-06-22T12:05:22.768290Z",
-     "iopub.status.idle": "2026-06-22T12:05:22.772671Z",
-     "shell.execute_reply": "2026-06-22T12:05:22.772316Z"
+     "iopub.execute_input": "2026-06-22T12:20:24.860928Z",
+     "iopub.status.busy": "2026-06-22T12:20:24.860871Z",
+     "iopub.status.idle": "2026-06-22T12:20:24.864882Z",
+     "shell.execute_reply": "2026-06-22T12:20:24.864528Z"
     }
    },
    "outputs": [
@@ -406,6 +469,8 @@
     "  remains backend-neutral.\n",
     "- Surface-code assumptions can be modeled separately and converted into the\n",
     "  cost model consumed by chemistry estimators.\n",
+    "- Existing logical estimates can be relifted under new architecture\n",
+    "  assumptions without rebuilding the algorithm estimate.\n",
     "- `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable\n",
     "  savings tables without hard-coding a particular chemistry factorization."
    ]

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -190,6 +190,41 @@ assert comparison[0].ratio == sp.Float("0.5")
 assert comparison[1].ratio == sp.Float("0.55")
 
 # %% [markdown]
+# ## Architecture Sensitivity
+#
+# Once an estimate exists, relift it with a different architecture model to
+# study hardware assumptions without rebuilding the algorithm model.
+
+# %%
+faster_architecture = SurfaceCodeCostModel(
+    code_distance=10,
+    physical_cycle_time_seconds=sp.Float("5e-8"),
+    physical_qubits_per_logical_factor=2,
+    logical_cycle_factor=1,
+    factory_count=8,
+    physical_qubits_per_factory=2500,
+    factory_cycles_per_toffoli=2,
+)
+relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())
+
+architecture_comparison = compare_ftqc_resource_estimates(
+    baseline,
+    relifted_baseline,
+    quantities=("physical_qubits", "runtime_seconds"),
+)
+
+for row in architecture_comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4))
+
+assert relifted_baseline.logical_qubits == baseline.logical_qubits
+assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
+assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(7, 13)) == 0
+assert (
+    sp.Abs(architecture_comparison[1].ratio - sp.Float("0.5"))
+    < sp.Float("1e-12")
+)
+
+# %% [markdown]
 # ## Early-FTQC Pattern
 #
 # Early-FTQC estimates may not be Toffoli-native. The same comparison API works
@@ -258,5 +293,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   remains backend-neutral.
 # - Surface-code assumptions can be modeled separately and converted into the
 #   cost model consumed by chemistry estimators.
+# - Existing logical estimates can be relifted under new architecture
+#   assumptions without rebuilding the algorithm estimate.
 # - `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable
 #   savings tables without hard-coding a particular chemistry factorization.

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "44b0dd0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:23.670312Z",
-     "iopub.status.busy": "2026-06-22T12:05:23.670245Z",
-     "iopub.status.idle": "2026-06-22T12:05:23.672833Z",
-     "shell.execute_reply": "2026-06-22T12:05:23.672441Z"
+     "iopub.execute_input": "2026-06-22T12:20:25.806875Z",
+     "iopub.status.busy": "2026-06-22T12:20:25.806777Z",
+     "iopub.status.idle": "2026-06-22T12:20:25.809176Z",
+     "shell.execute_reply": "2026-06-22T12:20:25.808771Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "6c336198",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:23.674030Z",
-     "iopub.status.busy": "2026-06-22T12:05:23.673969Z",
-     "iopub.status.idle": "2026-06-22T12:05:23.872524Z",
-     "shell.execute_reply": "2026-06-22T12:05:23.872049Z"
+     "iopub.execute_input": "2026-06-22T12:20:25.810283Z",
+     "iopub.status.busy": "2026-06-22T12:20:25.810226Z",
+     "iopub.status.idle": "2026-06-22T12:20:26.057279Z",
+     "shell.execute_reply": "2026-06-22T12:20:26.056862Z"
     }
    },
    "outputs": [],
@@ -113,10 +113,10 @@
    "id": "ffd12e61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:23.873921Z",
-     "iopub.status.busy": "2026-06-22T12:05:23.873833Z",
-     "iopub.status.idle": "2026-06-22T12:05:23.876699Z",
-     "shell.execute_reply": "2026-06-22T12:05:23.876314Z"
+     "iopub.execute_input": "2026-06-22T12:20:26.058972Z",
+     "iopub.status.busy": "2026-06-22T12:20:26.058877Z",
+     "iopub.status.idle": "2026-06-22T12:20:26.061721Z",
+     "shell.execute_reply": "2026-06-22T12:20:26.061351Z"
     }
    },
    "outputs": [
@@ -198,10 +198,10 @@
    "id": "ad469f4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:23.877763Z",
-     "iopub.status.busy": "2026-06-22T12:05:23.877707Z",
-     "iopub.status.idle": "2026-06-22T12:05:23.894721Z",
-     "shell.execute_reply": "2026-06-22T12:05:23.894370Z"
+     "iopub.execute_input": "2026-06-22T12:20:26.062909Z",
+     "iopub.status.busy": "2026-06-22T12:20:26.062833Z",
+     "iopub.status.idle": "2026-06-22T12:20:26.080661Z",
+     "shell.execute_reply": "2026-06-22T12:20:26.080268Z"
     }
    },
    "outputs": [
@@ -287,6 +287,68 @@
   },
   {
    "cell_type": "markdown",
+   "id": "05a2ee55",
+   "metadata": {},
+   "source": [
+    "## Architecture感度\n",
+    "\n",
+    "estimateを作った後で別のarchitecture modelへreliftすると、algorithm modelを作り直さずにhardware仮定を調べられます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "01f5685b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:20:26.082002Z",
+     "iopub.status.busy": "2026-06-22T12:20:26.081938Z",
+     "iopub.status.idle": "2026-06-22T12:20:26.085578Z",
+     "shell.execute_reply": "2026-06-22T12:20:26.085168Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Physical qubits ratio: 0.5385\n",
+      "Runtime ratio: 0.5000\n"
+     ]
+    }
+   ],
+   "source": [
+    "faster_architecture = SurfaceCodeCostModel(\n",
+    "    code_distance=10,\n",
+    "    physical_cycle_time_seconds=sp.Float(\"5e-8\"),\n",
+    "    physical_qubits_per_logical_factor=2,\n",
+    "    logical_cycle_factor=1,\n",
+    "    factory_count=8,\n",
+    "    physical_qubits_per_factory=2500,\n",
+    "    factory_cycles_per_toffoli=2,\n",
+    ")\n",
+    "relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())\n",
+    "\n",
+    "architecture_comparison = compare_ftqc_resource_estimates(\n",
+    "    baseline,\n",
+    "    relifted_baseline,\n",
+    "    quantities=(\"physical_qubits\", \"runtime_seconds\"),\n",
+    ")\n",
+    "\n",
+    "for row in architecture_comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4))\n",
+    "\n",
+    "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
+    "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
+    "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(7, 13)) == 0\n",
+    "assert (\n",
+    "    sp.Abs(architecture_comparison[1].ratio - sp.Float(\"0.5\"))\n",
+    "    < sp.Float(\"1e-12\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "83f9ac6d",
    "metadata": {},
    "source": [
@@ -297,14 +359,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "9e38e20d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:05:23.895829Z",
-     "iopub.status.busy": "2026-06-22T12:05:23.895771Z",
-     "iopub.status.idle": "2026-06-22T12:05:23.899744Z",
-     "shell.execute_reply": "2026-06-22T12:05:23.899321Z"
+     "iopub.execute_input": "2026-06-22T12:20:26.086699Z",
+     "iopub.status.busy": "2026-06-22T12:20:26.086642Z",
+     "iopub.status.idle": "2026-06-22T12:20:26.090963Z",
+     "shell.execute_reply": "2026-06-22T12:20:26.090563Z"
     }
    },
    "outputs": [
@@ -381,6 +443,7 @@
     "- 近年のFTQC化学計算研究から、Hamiltonian normalization、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。\n",
+    "- 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。\n",
     "- `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。"
    ]
   }

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -176,6 +176,40 @@ assert comparison[0].ratio == sp.Float("0.5")
 assert comparison[1].ratio == sp.Float("0.55")
 
 # %% [markdown]
+# ## Architecture感度
+#
+# estimateを作った後で別のarchitecture modelへreliftすると、algorithm modelを作り直さずにhardware仮定を調べられます。
+
+# %%
+faster_architecture = SurfaceCodeCostModel(
+    code_distance=10,
+    physical_cycle_time_seconds=sp.Float("5e-8"),
+    physical_qubits_per_logical_factor=2,
+    logical_cycle_factor=1,
+    factory_count=8,
+    physical_qubits_per_factory=2500,
+    factory_cycles_per_toffoli=2,
+)
+relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())
+
+architecture_comparison = compare_ftqc_resource_estimates(
+    baseline,
+    relifted_baseline,
+    quantities=("physical_qubits", "runtime_seconds"),
+)
+
+for row in architecture_comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4))
+
+assert relifted_baseline.logical_qubits == baseline.logical_qubits
+assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
+assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(7, 13)) == 0
+assert (
+    sp.Abs(architecture_comparison[1].ratio - sp.Float("0.5"))
+    < sp.Float("1e-12")
+)
+
+# %% [markdown]
 # ## Early-FTQCのパターン
 #
 # Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。
@@ -233,4 +267,5 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # - 近年のFTQC化学計算研究から、Hamiltonian normalization、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。
+# - 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。
 # - `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -150,6 +150,85 @@ class FTQCCostModel:
             ),
         }
 
+    def physical_qubits_for(self, logical_qubits: _SympyLike) -> sp.Expr:
+        """Lift logical-qubit count to physical qubits.
+
+        Args:
+            logical_qubits (sp.Expr | int | float): Logical qubit count to
+                lift with this architecture model.
+
+        Returns:
+            sp.Expr: Physical qubits including data patches and factories.
+
+        Raises:
+            ValueError: If ``logical_qubits`` is negative.
+        """
+        logical_expr = _as_expr(logical_qubits, "logical_qubits")
+        _validate_nonnegative(logical_expr, "logical_qubits")
+        return sp.simplify(
+            logical_expr
+            * _as_expr(
+                self.physical_qubits_per_logical,
+                "physical_qubits_per_logical",
+            )
+            + _as_expr(self.factory_qubits, "factory_qubits")
+        )
+
+    def runtime_seconds_for(
+        self,
+        logical_depth: _SympyLike,
+        non_clifford_gates: _SympyLike,
+    ) -> sp.Expr:
+        """Lift logical work to a wall-clock runtime proxy.
+
+        Args:
+            logical_depth (sp.Expr | int | float): Logical-depth proxy.
+            non_clifford_gates (sp.Expr | int | float): Toffoli-equivalent or
+                T-equivalent non-Clifford gate count served by factories.
+
+        Returns:
+            sp.Expr: Runtime proxy in seconds, as the maximum of logical-cycle
+                time and factory-throughput time.
+
+        Raises:
+            ValueError: If either input is negative.
+        """
+        depth_expr = _as_expr(logical_depth, "logical_depth")
+        non_clifford_expr = _as_expr(non_clifford_gates, "non_clifford_gates")
+        _validate_nonnegative(depth_expr, "logical_depth")
+        _validate_nonnegative(non_clifford_expr, "non_clifford_gates")
+        return sp.simplify(
+            sp.Max(
+                depth_expr
+                * _as_expr(
+                    self.logical_cycle_time_seconds,
+                    "logical_cycle_time_seconds",
+                ),
+                non_clifford_expr
+                / _as_expr(
+                    self.toffoli_throughput_per_second,
+                    "toffoli_throughput_per_second",
+                ),
+            )
+        )
+
+    def lift_estimate(
+        self,
+        estimate: FTQCResourceEstimate,
+    ) -> FTQCResourceEstimate:
+        """Recompute physical resources for an existing logical estimate.
+
+        Args:
+            estimate (FTQCResourceEstimate): Estimate whose logical qubits,
+                logical depth, and non-Clifford counts should be preserved
+                while replacing physical architecture assumptions.
+
+        Returns:
+            FTQCResourceEstimate: Copy of ``estimate`` with new
+                ``physical_qubits`` and ``runtime_seconds`` fields.
+        """
+        return estimate.with_cost_model(self)
+
 
 @dataclass(frozen=True)
 class SurfaceCodeCostModel:
@@ -546,6 +625,44 @@ class FTQCResourceEstimate:
             row["value"] = str(value)
             rows.append(row)
         return rows
+
+    def with_cost_model(self, cost_model: FTQCCostModel) -> FTQCResourceEstimate:
+        """Relift physical resources with a different architecture model.
+
+        The logical algorithm quantities are preserved. Physical qubits and
+        runtime are recomputed from ``cost_model`` using ``logical_qubits``,
+        ``logical_depth``, and the sum of Toffoli and T counts as the
+        non-Clifford throughput demand.
+
+        Args:
+            cost_model (FTQCCostModel): Architecture model used for the new
+                physical-qubit and runtime estimates.
+
+        Returns:
+            FTQCResourceEstimate: Estimate with identical logical resources
+                and updated physical resources.
+        """
+        assumptions = dict(self.assumptions)
+        assumptions["architecture_relift"] = (
+            "physical_qubits and runtime_seconds were recomputed from an "
+            "existing logical estimate with a replacement FTQCCostModel."
+        )
+        non_clifford_gates = sp.simplify(self.toffoli_gates + self.t_gates)
+        return _build_estimate(
+            algorithm=self.algorithm,
+            logical_qubits=self.logical_qubits,
+            physical_qubits=cost_model.physical_qubits_for(self.logical_qubits),
+            toffoli_gates=self.toffoli_gates,
+            t_gates=self.t_gates,
+            clifford_gates=self.clifford_gates,
+            qpe_iterations=self.qpe_iterations,
+            logical_depth=self.logical_depth,
+            runtime_seconds=cost_model.runtime_seconds_for(
+                self.logical_depth,
+                non_clifford_gates,
+            ),
+            assumptions=assumptions,
+        )
 
     def _map_exprs(self, fn: Callable[[sp.Expr], sp.Expr]) -> FTQCResourceEstimate:
         """Apply a function to each symbolic resource field.
@@ -1069,15 +1186,8 @@ def estimate_qubitized_chemistry_qpe(
     qpe_iterations = sp.simplify(lambda_expr / precision_expr)
     toffoli_gates = sp.simplify(qpe_iterations * walk_expr)
     logical_depth = toffoli_gates
-    physical_qubits = sp.simplify(
-        logical_expr * model.physical_qubits_per_logical + model.factory_qubits
-    )
-    runtime_seconds = sp.simplify(
-        sp.Max(
-            logical_depth * model.logical_cycle_time_seconds,
-            toffoli_gates / model.toffoli_throughput_per_second,
-        )
-    )
+    physical_qubits = model.physical_qubits_for(logical_expr)
+    runtime_seconds = model.runtime_seconds_for(logical_depth, toffoli_gates)
     assumptions = {
         "qpe_iterations": "Uses lambda_norm / precision as the walk-call proxy.",
         "method": method_enum.value,
@@ -1259,15 +1369,8 @@ def estimate_single_ancilla_trotter_qpe(
     t_gates = sp.simplify(logical_depth * rotation_t)
     toffoli_gates = sp.Integer(0)
     model = cost_model or FTQCCostModel()
-    physical_qubits = sp.simplify(
-        logical_expr * model.physical_qubits_per_logical + model.factory_qubits
-    )
-    runtime_seconds = sp.simplify(
-        sp.Max(
-            logical_depth * model.logical_cycle_time_seconds,
-            t_gates / model.toffoli_throughput_per_second,
-        )
-    )
+    physical_qubits = model.physical_qubits_for(logical_expr)
+    runtime_seconds = model.runtime_seconds_for(logical_depth, t_gates)
     assumptions = {
         "effective_lambda": "lambda_norm * unitary_weight_factor.",
         "qpe_style": "Single-ancilla Hadamard-test QPE with product-formula evolution.",

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -130,6 +130,74 @@ def test_surface_code_cost_model_derives_architecture_knobs():
     assert sp.Abs(estimate.runtime_seconds - sp.Float("5e-4")) < sp.Float("1e-12")
 
 
+def test_cost_model_relifts_existing_estimate_without_changing_logical_work():
+    """Architecture relifting updates physical fields while preserving logical work."""
+    original_cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e6"),
+    )
+    replacement_cost = FTQCCostModel(
+        physical_qubits_per_logical=200,
+        logical_cycle_time_seconds=sp.Float("5e-7"),
+        factory_qubits=20,
+        toffoli_throughput_per_second=sp.Float("2e6"),
+    )
+    estimate = estimate_qubitized_chemistry_qpe(
+        n_spin_orbitals=4,
+        lambda_norm=8,
+        precision=2,
+        walk_cost_toffoli=10,
+        logical_qubits=7,
+        cost_model=original_cost,
+    )
+
+    relifted = estimate.with_cost_model(replacement_cost)
+    relifted_via_model = replacement_cost.lift_estimate(estimate)
+
+    assert relifted.logical_qubits == estimate.logical_qubits
+    assert relifted.toffoli_gates == estimate.toffoli_gates
+    assert relifted.t_gates == estimate.t_gates
+    assert relifted.logical_depth == estimate.logical_depth
+    assert relifted.physical_qubits == 1420
+    assert sp.Abs(relifted.runtime_seconds - sp.Float("2e-5")) < sp.Float("1e-12")
+    assert relifted_via_model.physical_qubits == relifted.physical_qubits
+    assert relifted.assumptions["architecture_relift"].startswith("physical_qubits")
+
+
+def test_cost_model_relifts_t_gate_estimates_with_t_throughput_demand():
+    """Architecture relifting uses T counts when a model is not Toffoli-native."""
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e6"),
+    )
+    replacement = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-9"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e3"),
+    )
+    estimate = estimate_single_ancilla_trotter_qpe(
+        n_spin_orbitals=2,
+        n_pauli_terms=3,
+        lambda_norm=4,
+        precision=1,
+        trotter_steps_per_sample=2,
+        samples=5,
+        rotation_synthesis_t_gates=7,
+        cost_model=cost,
+    )
+
+    relifted = estimate.with_cost_model(replacement)
+
+    assert estimate.toffoli_gates == 0
+    assert estimate.t_gates == 840
+    assert sp.Abs(relifted.runtime_seconds - sp.Float("0.84")) < sp.Float("1e-12")
+
+
 def test_single_ancilla_trotter_qpe_models_unitary_weight_reduction():
     """Unitary-weight concentration reduces the lambda-driven QPE iterations."""
     baseline = estimate_single_ancilla_trotter_qpe(
@@ -168,6 +236,23 @@ def test_cost_model_rejects_zero_non_clifford_throughput():
             factory_qubits=0,
             toffoli_throughput_per_second=0,
         )
+
+
+def test_cost_model_rejects_negative_relift_inputs():
+    """Cost-model lifting rejects negative logical work before producing resources."""
+    model = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=1,
+        factory_qubits=0,
+        toffoli_throughput_per_second=1,
+    )
+
+    with pytest.raises(ValueError, match="logical_qubits"):
+        model.physical_qubits_for(-1)
+    with pytest.raises(ValueError, match="logical_depth"):
+        model.runtime_seconds_for(-1, 0)
+    with pytest.raises(ValueError, match="non_clifford_gates"):
+        model.runtime_seconds_for(0, -1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add cost-model helpers for lifting logical qubits and logical work into physical qubits and runtime
- add `FTQCResourceEstimate.with_cost_model(...)` and `FTQCCostModel.lift_estimate(...)` so logical estimates can be reused under replacement architecture assumptions
- update EN/JA FTQC resource-estimation design docs with an architecture-sensitivity example

## Validation
- uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_resources.py -q
- uv run pytest tests/circuit/estimator -q
- uv run jupytext --to ipynb --update docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb docs/ja/usage/ftqc_resource_estimation_design.ipynb
- uv run pytest -m docs tests/docs/test_tag_whitelist.py -q
- uv run pytest -m docs tests/docs/test_tutorials.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/