### PR TITLE
Add QPE FTQC building-block tutorial

### DIFF
--- a/docs/en/algorithm/index.md
+++ b/docs/en/algorithm/index.md
@@ -11,6 +11,7 @@ Concrete quantum algorithm examples built with Qamomile.
 - [QAOA for MaxCut](qaoa_maxcut) — Build a QAOA circuit from scratch to solve MaxCut, then compare with the built-in `qaoa_state`
 - [QAOA for Graph Partitioning](qaoa_graph_partition) — End-to-end optimization example using OMMX, JijModeling, and `QAOAConverter`
 - [VQE for the Hydrogen Molecule](vqe_for_hydrogen) — Build a molecular Hamiltonian with OpenFermion and find the ground state energy via VQE
+- [Quantum Phase Estimation as an FTQC Building Block](phase_estimation) — Build a minimal QPE kernel, verify the decoded phase, and connect precision to symbolic resources
 - [FTQC Chemistry Resource Estimation](ftqc_chemistry_resource_estimation) — Compare qubitized QPE and early-FTQC Trotter QPE cost drivers for chemistry workloads
 - [Hamiltonian Simulation with Suzuki–Trotter](hamiltonian_simulation) — Trotter–Suzuki product formulas on the Rabi model with empirical convergence orders
 - [Introduction to Quantum Error Correction](quantum_error_correction) — 3-qubit bit-flip/phase-flip codes, Shor's 9-qubit code, and stabilizers

--- a/docs/en/algorithm/phase_estimation.ipynb
+++ b/docs/en/algorithm/phase_estimation.ipynb
@@ -24,10 +24,10 @@
    "id": "4b525afc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.170585Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.170395Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.174558Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.173664Z"
+     "iopub.execute_input": "2026-06-22T12:41:34.802919Z",
+     "iopub.status.busy": "2026-06-22T12:41:34.802771Z",
+     "iopub.status.idle": "2026-06-22T12:41:34.806268Z",
+     "shell.execute_reply": "2026-06-22T12:41:34.805613Z"
     }
    },
    "outputs": [],
@@ -42,10 +42,10 @@
    "id": "ceb80131",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.177011Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.176856Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.542980Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.542554Z"
+     "iopub.execute_input": "2026-06-22T12:41:34.807998Z",
+     "iopub.status.busy": "2026-06-22T12:41:34.807874Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.175249Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.174818Z"
     }
    },
    "outputs": [],
@@ -86,20 +86,20 @@
    "id": "361d6a04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.546393Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.546253Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.548423Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.547872Z"
+     "iopub.execute_input": "2026-06-22T12:41:35.176601Z",
+     "iopub.status.busy": "2026-06-22T12:41:35.176510Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.178300Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.177987Z"
     },
     "lines_to_next_cell": 1
    },
    "outputs": [],
    "source": [
     "theta = math.pi / 2\n",
-    "expected_phase = theta / (2 * math.pi)\n",
+    "expected_phase = sp.Rational(1, 4)\n",
     "counting_qubits = 3\n",
     "\n",
-    "assert expected_phase == 0.25"
+    "assert expected_phase == sp.Rational(1, 4)"
    ]
   },
   {
@@ -121,10 +121,10 @@
    "id": "948c4a2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.549853Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.549773Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.552989Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.552628Z"
+     "iopub.execute_input": "2026-06-22T12:41:35.179234Z",
+     "iopub.status.busy": "2026-06-22T12:41:35.179185Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.182396Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.181924Z"
     },
     "lines_to_next_cell": 1
    },
@@ -152,10 +152,10 @@
    "id": "4856c1d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.553888Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.553835Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.557263Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.556755Z"
+     "iopub.execute_input": "2026-06-22T12:41:35.183308Z",
+     "iopub.status.busy": "2026-06-22T12:41:35.183257Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.186480Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.186054Z"
     }
    },
    "outputs": [
@@ -196,10 +196,10 @@
    "id": "353501e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.558346Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.558281Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.923097Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.922724Z"
+     "iopub.execute_input": "2026-06-22T12:41:35.187421Z",
+     "iopub.status.busy": "2026-06-22T12:41:35.187367Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.578512Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.578084Z"
     }
    },
    "outputs": [
@@ -242,10 +242,10 @@
    "id": "4f3f5ce0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:29.924279Z",
-     "iopub.status.busy": "2026-06-22T12:35:29.924192Z",
-     "iopub.status.idle": "2026-06-22T12:35:29.927678Z",
-     "shell.execute_reply": "2026-06-22T12:35:29.927390Z"
+     "iopub.execute_input": "2026-06-22T12:41:35.579715Z",
+     "iopub.status.busy": "2026-06-22T12:41:35.579628Z",
+     "iopub.status.idle": "2026-06-22T12:41:35.583362Z",
+     "shell.execute_reply": "2026-06-22T12:41:35.583045Z"
     }
    },
    "outputs": [

--- a/docs/en/algorithm/phase_estimation.ipynb
+++ b/docs/en/algorithm/phase_estimation.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "db6092dc",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [algorithm, primitive, resource-estimation]\n",
+    "---\n",
+    "\n",
+    "# Quantum Phase Estimation as an FTQC Building Block\n",
+    "\n",
+    "Quantum phase estimation (QPE) is the control-flow pattern behind many\n",
+    "fault-tolerant algorithms: prepare an eigenstate, apply controlled powers of\n",
+    "a unitary, and decode the phase with an inverse QFT. This notebook shows the\n",
+    "smallest useful Qamomile implementation, checks the measured phase, and links\n",
+    "the same precision choice to a symbolic resource estimate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4b525afc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.170585Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.170395Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.174558Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.173664Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ceb80131",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.177011Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.176856Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.542980Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.542554Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import sympy as sp\n",
+    "\n",
+    "import qamomile.circuit as qmc\n",
+    "from qamomile.circuit.estimator.algorithmic import estimate_qpe\n",
+    "from qamomile.circuit.ir.operation.composite_gate import (\n",
+    "    CompositeGateOperation,\n",
+    "    CompositeGateType,\n",
+    ")\n",
+    "from qamomile.qiskit import QiskitTranspiler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccbdc89a",
+   "metadata": {},
+   "source": [
+    "## Background\n",
+    "\n",
+    "If $U|\\psi\\rangle = e^{2\\pi i \\phi}|\\psi\\rangle$, QPE estimates the binary\n",
+    "digits of $\\phi$. The example below uses the one-qubit phase gate\n",
+    "$P(\\theta)|1\\rangle = e^{i\\theta}|1\\rangle$. Setting $\\theta=\\pi/2$ gives\n",
+    "$\\phi=\\theta/(2\\pi)=1/4$, exactly representable with three fractional bits.\n",
+    "\n",
+    "The target qubit is prepared in $|1\\rangle$, an eigenstate of the phase gate.\n",
+    "The counting register is measured as a `QFixed` value, so Qamomile decodes\n",
+    "the measured bit string into a `Float`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "361d6a04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.546393Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.546253Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.548423Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.547872Z"
+    },
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "theta = math.pi / 2\n",
+    "expected_phase = theta / (2 * math.pi)\n",
+    "counting_qubits = 3\n",
+    "\n",
+    "assert expected_phase == 0.25"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b7eb1be",
+   "metadata": {},
+   "source": [
+    "## Implementation\n",
+    "\n",
+    "`qmc.qpe` takes the target eigenstate, a counting register, and a Qamomile\n",
+    "unitary kernel. The controlled powers are generated inside the standard\n",
+    "library helper. Qamomile keeps the inverse QFT as a composite operation so\n",
+    "backends can emit it natively or decompose it later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "948c4a2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.549853Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.549773Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.552989Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.552628Z"
+    },
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "@qmc.qkernel\n",
+    "def phase_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:\n",
+    "    q = qmc.p(q, theta)\n",
+    "    return q\n",
+    "\n",
+    "\n",
+    "@qmc.qkernel\n",
+    "def estimate_phase(theta: qmc.Float) -> qmc.Float:\n",
+    "    counting = qmc.qubit_array(counting_qubits, name=\"counting\")\n",
+    "    target = qmc.qubit(name=\"target\")\n",
+    "    target = qmc.x(target)\n",
+    "\n",
+    "    phase = qmc.qpe(target, counting, phase_gate, theta=theta)\n",
+    "    return qmc.measure(phase)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4856c1d2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.553888Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.553835Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.557263Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.556755Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['iqft']\n"
+     ]
+    }
+   ],
+   "source": [
+    "block = estimate_phase.build(theta=theta)\n",
+    "composite_types = [\n",
+    "    op.gate_type\n",
+    "    for op in block.operations\n",
+    "    if isinstance(op, CompositeGateOperation)\n",
+    "]\n",
+    "\n",
+    "print([gate_type.value for gate_type in composite_types])\n",
+    "assert CompositeGateType.IQFT in composite_types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be654c58",
+   "metadata": {},
+   "source": [
+    "## Result\n",
+    "\n",
+    "The phase is exactly representable by the three-qubit counting register, so\n",
+    "the simulator returns one decoded value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "353501e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.558346Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.558281Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.923097Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.922724Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(0.25, 256)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "transpiler = QiskitTranspiler()\n",
+    "executable = transpiler.transpile(estimate_phase, bindings={\"theta\": theta})\n",
+    "result = executable.sample(transpiler.executor(), shots=256).result()\n",
+    "\n",
+    "print(result.results)\n",
+    "assert len(result.results) == 1\n",
+    "measured_phase, count = result.results[0]\n",
+    "assert measured_phase == sp.Float(expected_phase)\n",
+    "assert count == 256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65cbc0d2",
+   "metadata": {},
+   "source": [
+    "## Resource Estimate\n",
+    "\n",
+    "Circuit execution shows the small exact example. For FTQC planning, the more\n",
+    "important question is how the cost scales with system size and precision.\n",
+    "`estimate_qpe` records that relationship symbolically, without committing to\n",
+    "a backend circuit decomposition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4f3f5ce0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:29.924279Z",
+     "iopub.status.busy": "2026-06-22T12:35:29.924192Z",
+     "iopub.status.idle": "2026-06-22T12:35:29.927678Z",
+     "shell.execute_reply": "2026-06-22T12:35:29.927390Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qubits: 4\n",
+      "total gates: 8.00000000000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "resource_estimate = estimate_qpe(\n",
+    "    n_system=1,\n",
+    "    precision=counting_qubits,\n",
+    "    hamiltonian_norm=1,\n",
+    "    method=\"qubitization\",\n",
+    ")\n",
+    "\n",
+    "print(\"qubits:\", resource_estimate.qubits)\n",
+    "print(\"total gates:\", resource_estimate.gates.total)\n",
+    "\n",
+    "assert resource_estimate.qubits == 4\n",
+    "assert sp.simplify(resource_estimate.gates.total - 8) == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "319b625e",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we:\n",
+    "\n",
+    "- Built a minimal QPE kernel with `qmc.qpe` and measured a `QFixed` phase.\n",
+    "- Verified that the inverse QFT stays as an abstract composite operation in\n",
+    "  the IR before backend emission.\n",
+    "- Connected the same precision parameter to a symbolic QPE resource estimate."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/en/algorithm/phase_estimation.py
+++ b/docs/en/algorithm/phase_estimation.py
@@ -56,10 +56,10 @@ from qamomile.qiskit import QiskitTranspiler
 
 # %%
 theta = math.pi / 2
-expected_phase = theta / (2 * math.pi)
+expected_phase = sp.Rational(1, 4)
 counting_qubits = 3
 
-assert expected_phase == 0.25
+assert expected_phase == sp.Rational(1, 4)
 
 # %% [markdown]
 # ## Implementation

--- a/docs/en/algorithm/phase_estimation.py
+++ b/docs/en/algorithm/phase_estimation.py
@@ -1,0 +1,146 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [algorithm, primitive, resource-estimation]
+# ---
+#
+# # Quantum Phase Estimation as an FTQC Building Block
+#
+# Quantum phase estimation (QPE) is the control-flow pattern behind many
+# fault-tolerant algorithms: prepare an eigenstate, apply controlled powers of
+# a unitary, and decode the phase with an inverse QFT. This notebook shows the
+# smallest useful Qamomile implementation, checks the measured phase, and links
+# the same precision choice to a symbolic resource estimate.
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import math
+
+import sympy as sp
+
+import qamomile.circuit as qmc
+from qamomile.circuit.estimator.algorithmic import estimate_qpe
+from qamomile.circuit.ir.operation.composite_gate import (
+    CompositeGateOperation,
+    CompositeGateType,
+)
+from qamomile.qiskit import QiskitTranspiler
+
+# %% [markdown]
+# ## Background
+#
+# If $U|\psi\rangle = e^{2\pi i \phi}|\psi\rangle$, QPE estimates the binary
+# digits of $\phi$. The example below uses the one-qubit phase gate
+# $P(\theta)|1\rangle = e^{i\theta}|1\rangle$. Setting $\theta=\pi/2$ gives
+# $\phi=\theta/(2\pi)=1/4$, exactly representable with three fractional bits.
+#
+# The target qubit is prepared in $|1\rangle$, an eigenstate of the phase gate.
+# The counting register is measured as a `QFixed` value, so Qamomile decodes
+# the measured bit string into a `Float`.
+
+# %%
+theta = math.pi / 2
+expected_phase = theta / (2 * math.pi)
+counting_qubits = 3
+
+assert expected_phase == 0.25
+
+# %% [markdown]
+# ## Implementation
+#
+# `qmc.qpe` takes the target eigenstate, a counting register, and a Qamomile
+# unitary kernel. The controlled powers are generated inside the standard
+# library helper. Qamomile keeps the inverse QFT as a composite operation so
+# backends can emit it natively or decompose it later.
+
+# %%
+@qmc.qkernel
+def phase_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    q = qmc.p(q, theta)
+    return q
+
+
+@qmc.qkernel
+def estimate_phase(theta: qmc.Float) -> qmc.Float:
+    counting = qmc.qubit_array(counting_qubits, name="counting")
+    target = qmc.qubit(name="target")
+    target = qmc.x(target)
+
+    phase = qmc.qpe(target, counting, phase_gate, theta=theta)
+    return qmc.measure(phase)
+
+# %%
+block = estimate_phase.build(theta=theta)
+composite_types = [
+    op.gate_type
+    for op in block.operations
+    if isinstance(op, CompositeGateOperation)
+]
+
+print([gate_type.value for gate_type in composite_types])
+assert CompositeGateType.IQFT in composite_types
+
+# %% [markdown]
+# ## Result
+#
+# The phase is exactly representable by the three-qubit counting register, so
+# the simulator returns one decoded value.
+
+# %%
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(estimate_phase, bindings={"theta": theta})
+result = executable.sample(transpiler.executor(), shots=256).result()
+
+print(result.results)
+assert len(result.results) == 1
+measured_phase, count = result.results[0]
+assert measured_phase == sp.Float(expected_phase)
+assert count == 256
+
+# %% [markdown]
+# ## Resource Estimate
+#
+# Circuit execution shows the small exact example. For FTQC planning, the more
+# important question is how the cost scales with system size and precision.
+# `estimate_qpe` records that relationship symbolically, without committing to
+# a backend circuit decomposition.
+
+# %%
+resource_estimate = estimate_qpe(
+    n_system=1,
+    precision=counting_qubits,
+    hamiltonian_norm=1,
+    method="qubitization",
+)
+
+print("qubits:", resource_estimate.qubits)
+print("total gates:", resource_estimate.gates.total)
+
+assert resource_estimate.qubits == 4
+assert sp.simplify(resource_estimate.gates.total - 8) == 0
+
+# %% [markdown]
+# ## Summary
+#
+# In this notebook, we:
+#
+# - Built a minimal QPE kernel with `qmc.qpe` and measured a `QFixed` phase.
+# - Verified that the inverse QFT stays as an abstract composite operation in
+#   the IR before backend emission.
+# - Connected the same precision parameter to a symbolic QPE resource estimate.

--- a/docs/ja/algorithm/index.md
+++ b/docs/ja/algorithm/index.md
@@ -11,6 +11,7 @@ Qamomileで実装した具体的な量子アルゴリズム例です。
 - [QAOAでMaxCutを解く](qaoa_maxcut) — QAOA回路をゼロから構築してMaxCutを解き、組み込みの`qaoa_state`と比較する
 - [QAOAによるグラフ分割](qaoa_graph_partition) — OMMX・JijModeling・`QAOAConverter`を使ったend-to-endの最適化例
 - [水素分子のためのVQE](vqe_for_hydrogen) — OpenFermionで分子ハミルトニアンを構築し、VQEで基底状態エネルギーを求める
+- [FTQCのbuilding blockとしての量子位相推定](phase_estimation) — 最小のQPE量子カーネルを構築し、decodeされたphaseを確認してprecisionをsymbolic resourceへ接続する
 - [FTQC化学計算のリソース推定](ftqc_chemistry_resource_estimation) — 化学計算workloadについて、qubitized QPEとearly-FTQC Trotter QPEのcost driverを比較する
 - [Suzuki–Trotterによるハミルトニアンシミュレーション](hamiltonian_simulation) — RabiモデルでのTrotter–Suzuki積公式と収束次数の実験
 - [量子誤り訂正入門](quantum_error_correction) — 3量子ビットbit-flip/phase-flip符号からShor 9量子ビット符号、スタビライザー形式まで

--- a/docs/ja/algorithm/phase_estimation.ipynb
+++ b/docs/ja/algorithm/phase_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "b87819f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:30.784963Z",
-     "iopub.status.busy": "2026-06-22T12:35:30.784688Z",
-     "iopub.status.idle": "2026-06-22T12:35:30.790236Z",
-     "shell.execute_reply": "2026-06-22T12:35:30.789148Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.438183Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.438095Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.440477Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.440026Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "0a3f6293",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:30.794007Z",
-     "iopub.status.busy": "2026-06-22T12:35:30.793793Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.067015Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.066536Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.441638Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.441556Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.666081Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.665680Z"
     }
    },
    "outputs": [],
@@ -77,20 +77,20 @@
    "id": "a297f25e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:31.068372Z",
-     "iopub.status.busy": "2026-06-22T12:35:31.068280Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.070015Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.069701Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.667608Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.667518Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.669363Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.668975Z"
     },
     "lines_to_next_cell": 1
    },
    "outputs": [],
    "source": [
     "theta = math.pi / 2\n",
-    "expected_phase = theta / (2 * math.pi)\n",
+    "expected_phase = sp.Rational(1, 4)\n",
     "counting_qubits = 3\n",
     "\n",
-    "assert expected_phase == 0.25"
+    "assert expected_phase == sp.Rational(1, 4)"
    ]
   },
   {
@@ -109,10 +109,10 @@
    "id": "7152b648",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:31.071144Z",
-     "iopub.status.busy": "2026-06-22T12:35:31.071086Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.074182Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.073795Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.670585Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.670527Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.673707Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.673314Z"
     },
     "lines_to_next_cell": 1
    },
@@ -140,10 +140,10 @@
    "id": "4438e459",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:31.075137Z",
-     "iopub.status.busy": "2026-06-22T12:35:31.075080Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.078430Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.078102Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.674730Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.674672Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.677685Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.677353Z"
     }
    },
    "outputs": [
@@ -183,10 +183,10 @@
    "id": "32f3f5de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:31.079506Z",
-     "iopub.status.busy": "2026-06-22T12:35:31.079447Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.277279Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.276798Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.678725Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.678666Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.871475Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.871042Z"
     }
    },
    "outputs": [
@@ -226,10 +226,10 @@
    "id": "6c91d093",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T12:35:31.278540Z",
-     "iopub.status.busy": "2026-06-22T12:35:31.278459Z",
-     "iopub.status.idle": "2026-06-22T12:35:31.281937Z",
-     "shell.execute_reply": "2026-06-22T12:35:31.281467Z"
+     "iopub.execute_input": "2026-06-22T12:41:36.872665Z",
+     "iopub.status.busy": "2026-06-22T12:41:36.872587Z",
+     "iopub.status.idle": "2026-06-22T12:41:36.876014Z",
+     "shell.execute_reply": "2026-06-22T12:41:36.875598Z"
     }
    },
    "outputs": [

--- a/docs/ja/algorithm/phase_estimation.ipynb
+++ b/docs/ja/algorithm/phase_estimation.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "21a1ae34",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [algorithm, primitive, resource-estimation]\n",
+    "---\n",
+    "\n",
+    "# FTQCのbuilding blockとしての量子位相推定\n",
+    "\n",
+    "量子位相推定(QPE)は、多くのfault-tolerantアルゴリズムの背後にあるcontrol-flow patternです。固有状態を準備し、unitaryの制御付き冪を適用し、逆QFTで位相をdecodeします。このnotebookでは、最小のQamomile実装を示し、測定された位相を確認し、同じprecision選択をsymbolicなリソース推定へつなげます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b87819f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:30.784963Z",
+     "iopub.status.busy": "2026-06-22T12:35:30.784688Z",
+     "iopub.status.idle": "2026-06-22T12:35:30.790236Z",
+     "shell.execute_reply": "2026-06-22T12:35:30.789148Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0a3f6293",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:30.794007Z",
+     "iopub.status.busy": "2026-06-22T12:35:30.793793Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.067015Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.066536Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import sympy as sp\n",
+    "\n",
+    "import qamomile.circuit as qmc\n",
+    "from qamomile.circuit.estimator.algorithmic import estimate_qpe\n",
+    "from qamomile.circuit.ir.operation.composite_gate import (\n",
+    "    CompositeGateOperation,\n",
+    "    CompositeGateType,\n",
+    ")\n",
+    "from qamomile.qiskit import QiskitTranspiler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b50429bb",
+   "metadata": {},
+   "source": [
+    "## 背景\n",
+    "\n",
+    "$U|\\psi\\rangle = e^{2\\pi i \\phi}|\\psi\\rangle$のとき、QPEは$\\phi$の2進桁を推定します。下の例では1量子ビットのphase gate $P(\\theta)|1\\rangle = e^{i\\theta}|1\\rangle$を使います。$\\theta=\\pi/2$にすると$\\phi=\\theta/(2\\pi)=1/4$になり、3つの小数bitで正確に表せます。\n",
+    "\n",
+    "target量子ビットはphase gateの固有状態である$|1\\rangle$に準備します。counting registerは`QFixed`値として測定するため、Qamomileは測定bit列を`Float`へdecodeします。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a297f25e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:31.068372Z",
+     "iopub.status.busy": "2026-06-22T12:35:31.068280Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.070015Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.069701Z"
+    },
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "theta = math.pi / 2\n",
+    "expected_phase = theta / (2 * math.pi)\n",
+    "counting_qubits = 3\n",
+    "\n",
+    "assert expected_phase == 0.25"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "305ef575",
+   "metadata": {},
+   "source": [
+    "## 実装\n",
+    "\n",
+    "`qmc.qpe`はtarget固有状態、counting register、Qamomileのunitary量子カーネルを受け取ります。制御付き冪はstandard library helperの中で生成されます。Qamomileは逆QFTをcomposite operationとして保つため、backendはそれをnativeにemitするか、後でdecomposeできます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7152b648",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:31.071144Z",
+     "iopub.status.busy": "2026-06-22T12:35:31.071086Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.074182Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.073795Z"
+    },
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "@qmc.qkernel\n",
+    "def phase_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:\n",
+    "    q = qmc.p(q, theta)\n",
+    "    return q\n",
+    "\n",
+    "\n",
+    "@qmc.qkernel\n",
+    "def estimate_phase(theta: qmc.Float) -> qmc.Float:\n",
+    "    counting = qmc.qubit_array(counting_qubits, name=\"counting\")\n",
+    "    target = qmc.qubit(name=\"target\")\n",
+    "    target = qmc.x(target)\n",
+    "\n",
+    "    phase = qmc.qpe(target, counting, phase_gate, theta=theta)\n",
+    "    return qmc.measure(phase)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4438e459",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:31.075137Z",
+     "iopub.status.busy": "2026-06-22T12:35:31.075080Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.078430Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.078102Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['iqft']\n"
+     ]
+    }
+   ],
+   "source": [
+    "block = estimate_phase.build(theta=theta)\n",
+    "composite_types = [\n",
+    "    op.gate_type\n",
+    "    for op in block.operations\n",
+    "    if isinstance(op, CompositeGateOperation)\n",
+    "]\n",
+    "\n",
+    "print([gate_type.value for gate_type in composite_types])\n",
+    "assert CompositeGateType.IQFT in composite_types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b68d38a",
+   "metadata": {},
+   "source": [
+    "## 結果\n",
+    "\n",
+    "この位相は3量子ビットのcounting registerで正確に表せるため、simulatorは1つのdecode済み値を返します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "32f3f5de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:31.079506Z",
+     "iopub.status.busy": "2026-06-22T12:35:31.079447Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.277279Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.276798Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(0.25, 256)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "transpiler = QiskitTranspiler()\n",
+    "executable = transpiler.transpile(estimate_phase, bindings={\"theta\": theta})\n",
+    "result = executable.sample(transpiler.executor(), shots=256).result()\n",
+    "\n",
+    "print(result.results)\n",
+    "assert len(result.results) == 1\n",
+    "measured_phase, count = result.results[0]\n",
+    "assert measured_phase == sp.Float(expected_phase)\n",
+    "assert count == 256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a88f222c",
+   "metadata": {},
+   "source": [
+    "## リソース推定\n",
+    "\n",
+    "回路実行では小さなexact exampleを確認できます。FTQC planningでより重要なのは、system sizeとprecisionに対してcostがどうscaleするかです。`estimate_qpe`はその関係を、backend circuit decompositionにcommitせずsymbolicに記録します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6c91d093",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T12:35:31.278540Z",
+     "iopub.status.busy": "2026-06-22T12:35:31.278459Z",
+     "iopub.status.idle": "2026-06-22T12:35:31.281937Z",
+     "shell.execute_reply": "2026-06-22T12:35:31.281467Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qubits: 4\n",
+      "total gates: 8.00000000000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "resource_estimate = estimate_qpe(\n",
+    "    n_system=1,\n",
+    "    precision=counting_qubits,\n",
+    "    hamiltonian_norm=1,\n",
+    "    method=\"qubitization\",\n",
+    ")\n",
+    "\n",
+    "print(\"qubits:\", resource_estimate.qubits)\n",
+    "print(\"total gates:\", resource_estimate.gates.total)\n",
+    "\n",
+    "assert resource_estimate.qubits == 4\n",
+    "assert sp.simplify(resource_estimate.gates.total - 8) == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e6c25f5",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "このnotebookでは、次のことを行いました。\n",
+    "\n",
+    "- `qmc.qpe`で最小のQPE量子カーネルを構築し、`QFixed` phaseを測定しました。\n",
+    "- backend emission前のIRで、逆QFTが抽象的なcomposite operationとして残ることを確認しました。\n",
+    "- 同じprecision parameterをsymbolicなQPEリソース推定へ接続しました。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/ja/algorithm/phase_estimation.py
+++ b/docs/ja/algorithm/phase_estimation.py
@@ -1,0 +1,129 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [algorithm, primitive, resource-estimation]
+# ---
+#
+# # FTQCのbuilding blockとしての量子位相推定
+#
+# 量子位相推定(QPE)は、多くのfault-tolerantアルゴリズムの背後にあるcontrol-flow patternです。固有状態を準備し、unitaryの制御付き冪を適用し、逆QFTで位相をdecodeします。このnotebookでは、最小のQamomile実装を示し、測定された位相を確認し、同じprecision選択をsymbolicなリソース推定へつなげます。
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import math
+
+import sympy as sp
+
+import qamomile.circuit as qmc
+from qamomile.circuit.estimator.algorithmic import estimate_qpe
+from qamomile.circuit.ir.operation.composite_gate import (
+    CompositeGateOperation,
+    CompositeGateType,
+)
+from qamomile.qiskit import QiskitTranspiler
+
+# %% [markdown]
+# ## 背景
+#
+# $U|\psi\rangle = e^{2\pi i \phi}|\psi\rangle$のとき、QPEは$\phi$の2進桁を推定します。下の例では1量子ビットのphase gate $P(\theta)|1\rangle = e^{i\theta}|1\rangle$を使います。$\theta=\pi/2$にすると$\phi=\theta/(2\pi)=1/4$になり、3つの小数bitで正確に表せます。
+#
+# target量子ビットはphase gateの固有状態である$|1\rangle$に準備します。counting registerは`QFixed`値として測定するため、Qamomileは測定bit列を`Float`へdecodeします。
+
+# %%
+theta = math.pi / 2
+expected_phase = theta / (2 * math.pi)
+counting_qubits = 3
+
+assert expected_phase == 0.25
+
+# %% [markdown]
+# ## 実装
+#
+# `qmc.qpe`はtarget固有状態、counting register、Qamomileのunitary量子カーネルを受け取ります。制御付き冪はstandard library helperの中で生成されます。Qamomileは逆QFTをcomposite operationとして保つため、backendはそれをnativeにemitするか、後でdecomposeできます。
+
+# %%
+@qmc.qkernel
+def phase_gate(q: qmc.Qubit, theta: qmc.Float) -> qmc.Qubit:
+    q = qmc.p(q, theta)
+    return q
+
+
+@qmc.qkernel
+def estimate_phase(theta: qmc.Float) -> qmc.Float:
+    counting = qmc.qubit_array(counting_qubits, name="counting")
+    target = qmc.qubit(name="target")
+    target = qmc.x(target)
+
+    phase = qmc.qpe(target, counting, phase_gate, theta=theta)
+    return qmc.measure(phase)
+
+# %%
+block = estimate_phase.build(theta=theta)
+composite_types = [
+    op.gate_type
+    for op in block.operations
+    if isinstance(op, CompositeGateOperation)
+]
+
+print([gate_type.value for gate_type in composite_types])
+assert CompositeGateType.IQFT in composite_types
+
+# %% [markdown]
+# ## 結果
+#
+# この位相は3量子ビットのcounting registerで正確に表せるため、simulatorは1つのdecode済み値を返します。
+
+# %%
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(estimate_phase, bindings={"theta": theta})
+result = executable.sample(transpiler.executor(), shots=256).result()
+
+print(result.results)
+assert len(result.results) == 1
+measured_phase, count = result.results[0]
+assert measured_phase == sp.Float(expected_phase)
+assert count == 256
+
+# %% [markdown]
+# ## リソース推定
+#
+# 回路実行では小さなexact exampleを確認できます。FTQC planningでより重要なのは、system sizeとprecisionに対してcostがどうscaleするかです。`estimate_qpe`はその関係を、backend circuit decompositionにcommitせずsymbolicに記録します。
+
+# %%
+resource_estimate = estimate_qpe(
+    n_system=1,
+    precision=counting_qubits,
+    hamiltonian_norm=1,
+    method="qubitization",
+)
+
+print("qubits:", resource_estimate.qubits)
+print("total gates:", resource_estimate.gates.total)
+
+assert resource_estimate.qubits == 4
+assert sp.simplify(resource_estimate.gates.total - 8) == 0
+
+# %% [markdown]
+# ## Summary
+#
+# このnotebookでは、次のことを行いました。
+#
+# - `qmc.qpe`で最小のQPE量子カーネルを構築し、`QFixed` phaseを測定しました。
+# - backend emission前のIRで、逆QFTが抽象的なcomposite operationとして残ることを確認しました。
+# - 同じprecision parameterをsymbolicなQPEリソース推定へ接続しました。

--- a/docs/ja/algorithm/phase_estimation.py
+++ b/docs/ja/algorithm/phase_estimation.py
@@ -47,10 +47,10 @@ from qamomile.qiskit import QiskitTranspiler
 
 # %%
 theta = math.pi / 2
-expected_phase = theta / (2 * math.pi)
+expected_phase = sp.Rational(1, 4)
 counting_qubits = 3
 
-assert expected_phase == 0.25
+assert expected_phase == sp.Rational(1, 4)
 
 # %% [markdown]
 # ## 実装


### PR DESCRIPTION
## Summary
- add an English/Japanese QPE tutorial framed as an FTQC building block
- demonstrate a minimal phase-estimation kernel, composite IQFT inspection, backend sampling, and symbolic resource linkage
- expose the article from both algorithm indexes

## Validation
- uv run ruff check docs/en/algorithm/phase_estimation.py docs/ja/algorithm/phase_estimation.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/phase_estimation.ipynb docs/ja/algorithm/phase_estimation.ipynb
- uv run pytest -m docs tests/docs/test_tag_whitelist.py -q
- uv run pytest -m docs tests/docs/test_tutorials.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- uv run jupytext --to ipynb --test docs/en/algorithm/phase_estimation.py docs/ja/algorithm/phase_estimation.py
- git diff --check