### PR TITLE
Add block-encoding FTQC resource estimates

### DIFF
--- a/docs/en/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/en/usage/block_encoding_resource_estimation.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6921a98f",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [usage, resource-estimation, primitive]\n",
+    "---\n",
+    "\n",
+    "# Block-Encoding Resource Estimates\n",
+    "\n",
+    "Block-encoding is the interface between a Hamiltonian representation and\n",
+    "qubitized FTQC algorithms. This notebook shows how to model PREPARE, SELECT,\n",
+    "reflection, and QPE readout costs separately before committing to any backend\n",
+    "circuit decomposition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f60e69e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:02.355059Z",
+     "iopub.status.busy": "2026-06-22T13:45:02.354913Z",
+     "iopub.status.idle": "2026-06-22T13:45:02.358878Z",
+     "shell.execute_reply": "2026-06-22T13:45:02.358076Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ccc5ad1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:02.360856Z",
+     "iopub.status.busy": "2026-06-22T13:45:02.360744Z",
+     "iopub.status.idle": "2026-06-22T13:45:02.663220Z",
+     "shell.execute_reply": "2026-06-22T13:45:02.662790Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    BlockEncodingResource,\n",
+    "    FTQCCostModel,\n",
+    "    FTQCResourceQuantity,\n",
+    "    compare_ftqc_resource_estimates,\n",
+    "    estimate_qubitized_qpe_from_block_encoding,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1838f900",
+   "metadata": {},
+   "source": [
+    "## Workflow\n",
+    "\n",
+    "A qubitized walk is usually built from reusable subroutines:\n",
+    "\n",
+    "- PREPARE loads amplitudes or coefficients into an index register.\n",
+    "- SELECT applies the indexed unitary or oracle.\n",
+    "- A reflection completes the walk operator.\n",
+    "\n",
+    "Qamomile keeps these as resource-model fields. The circuit IR does not need a\n",
+    "special block-encoding operation just to compare algorithmic costs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fee091c",
+   "metadata": {},
+   "source": [
+    "## Minimal Example\n",
+    "\n",
+    "The numbers below are synthetic. They show the accounting pattern:\n",
+    "one qubitized walk costs two PREPARE calls, one SELECT call, and one\n",
+    "reflection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4583206c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:02.664483Z",
+     "iopub.status.busy": "2026-06-22T13:45:02.664403Z",
+     "iopub.status.idle": "2026-06-22T13:45:02.666873Z",
+     "shell.execute_reply": "2026-06-22T13:45:02.666525Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'toy_lcu', 'system_qubits': '12', 'normalization': '240', 'select_cost_toffoli': '120', 'prepare_cost_toffoli': '30', 'reflection_cost_toffoli': '8', 'ancilla_qubits': '5', 'logical_qubits': '17', 'walk_cost_toffoli': '188', 'references': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "block = BlockEncodingResource(\n",
+    "    system_qubits=12,\n",
+    "    normalization=sp.Integer(240),\n",
+    "    prepare_cost_toffoli=30,\n",
+    "    select_cost_toffoli=120,\n",
+    "    reflection_cost_toffoli=8,\n",
+    "    ancilla_qubits=5,\n",
+    "    name=\"toy_lcu\",\n",
+    ")\n",
+    "\n",
+    "print(block.to_dict())\n",
+    "\n",
+    "assert block.logical_qubits == 17\n",
+    "assert block.walk_cost_toffoli == 188\n",
+    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8aebd95f",
+   "metadata": {},
+   "source": [
+    "## Qubitized QPE\n",
+    "\n",
+    "QPE repeatedly calls the qubitized walk. For energy precision\n",
+    "$\\epsilon$, the symbolic call proxy is $\\alpha / \\epsilon$, where\n",
+    "$\\alpha$ is the block-encoding normalization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aaa9d778",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:02.667790Z",
+     "iopub.status.busy": "2026-06-22T13:45:02.667739Z",
+     "iopub.status.idle": "2026-06-22T13:45:02.671422Z",
+     "shell.execute_reply": "2026-06-22T13:45:02.671129Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iterations: 80\n",
+      "Toffoli gates: 15040\n",
+      "logical qubits: 23\n"
+     ]
+    }
+   ],
+   "source": [
+    "architecture = FTQCCostModel(\n",
+    "    physical_qubits_per_logical=100,\n",
+    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
+    "    factory_qubits=2000,\n",
+    "    toffoli_throughput_per_second=sp.Float(\"5e5\"),\n",
+    ")\n",
+    "\n",
+    "estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    block,\n",
+    "    precision=sp.Integer(3),\n",
+    "    qpe_register_qubits=6,\n",
+    "    cost_model=architecture,\n",
+    ")\n",
+    "\n",
+    "print(\"iterations:\", estimate.qpe_iterations)\n",
+    "print(\"Toffoli gates:\", estimate.toffoli_gates)\n",
+    "print(\"logical qubits:\", estimate.logical_qubits)\n",
+    "\n",
+    "assert estimate.qpe_iterations == 80\n",
+    "assert estimate.toffoli_gates == 15040\n",
+    "assert estimate.logical_qubits == 23\n",
+    "assert estimate.physical_qubits == 4300\n",
+    "assert estimate.assumptions[\"block_encoding\"] == \"toy_lcu\"\n",
+    "assert any(reference.key == \"arXiv:1610.06546\" for reference in estimate.references)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "958b6ce0",
+   "metadata": {},
+   "source": [
+    "## Compare Representations\n",
+    "\n",
+    "A new factorization or symmetry shift can reduce the normalization while\n",
+    "increasing SELECT/PREPARE cost. Keeping the fields separate makes that\n",
+    "trade-off visible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a65abbbf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:02.672390Z",
+     "iopub.status.busy": "2026-06-22T13:45:02.672339Z",
+     "iopub.status.idle": "2026-06-22T13:45:02.675611Z",
+     "shell.execute_reply": "2026-06-22T13:45:02.675234Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.5000\n",
+      "Toffoli gates ratio: 0.5957\n",
+      "Logical qubits ratio: 1.087\n"
+     ]
+    }
+   ],
+   "source": [
+    "compressed_block = BlockEncodingResource(\n",
+    "    system_qubits=12,\n",
+    "    normalization=sp.Integer(120),\n",
+    "    prepare_cost_toffoli=36,\n",
+    "    select_cost_toffoli=144,\n",
+    "    reflection_cost_toffoli=8,\n",
+    "    ancilla_qubits=7,\n",
+    "    name=\"compressed_toy_lcu\",\n",
+    ")\n",
+    "\n",
+    "compressed_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    compressed_block,\n",
+    "    precision=sp.Integer(3),\n",
+    "    qpe_register_qubits=6,\n",
+    "    cost_model=architecture,\n",
+    ")\n",
+    "\n",
+    "comparison = compare_ftqc_resource_estimates(\n",
+    "    estimate,\n",
+    "    compressed_estimate,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"logical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "for row in comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4))\n",
+    "\n",
+    "assert comparison[0].ratio == sp.Rational(1, 2)\n",
+    "assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0\n",
+    "assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a44fb5a6",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    ":::{note}\n",
+    "Treat `BlockEncodingResource` as a symbolic contract for algorithm design.\n",
+    "It records what the estimator consumes; it does not claim that a particular\n",
+    "PREPARE or SELECT circuit has already been synthesized for a backend.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e775b7e",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we learned:\n",
+    "\n",
+    "- Block-encoding estimates separate normalization, PREPARE, SELECT,\n",
+    "  reflection, ancilla, and QPE readout costs.\n",
+    "- Qubitized QPE composes the block-encoding walk cost with\n",
+    "  normalization-over-precision iterations.\n",
+    "- Representation trade-offs can reduce total Toffoli count even when one\n",
+    "  subroutine becomes more expensive."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/en/usage/block_encoding_resource_estimation.py
+++ b/docs/en/usage/block_encoding_resource_estimation.py
@@ -1,0 +1,168 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [usage, resource-estimation, primitive]
+# ---
+#
+# # Block-Encoding Resource Estimates
+#
+# Block-encoding is the interface between a Hamiltonian representation and
+# qubitized FTQC algorithms. This notebook shows how to model PREPARE, SELECT,
+# reflection, and QPE readout costs separately before committing to any backend
+# circuit decomposition.
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import sympy as sp
+
+from qamomile.circuit.estimator.algorithmic import (
+    BlockEncodingResource,
+    FTQCCostModel,
+    FTQCResourceQuantity,
+    compare_ftqc_resource_estimates,
+    estimate_qubitized_qpe_from_block_encoding,
+)
+
+# %% [markdown]
+# ## Workflow
+#
+# A qubitized walk is usually built from reusable subroutines:
+#
+# - PREPARE loads amplitudes or coefficients into an index register.
+# - SELECT applies the indexed unitary or oracle.
+# - A reflection completes the walk operator.
+#
+# Qamomile keeps these as resource-model fields. The circuit IR does not need a
+# special block-encoding operation just to compare algorithmic costs.
+
+# %% [markdown]
+# ## Minimal Example
+#
+# The numbers below are synthetic. They show the accounting pattern:
+# one qubitized walk costs two PREPARE calls, one SELECT call, and one
+# reflection.
+
+# %%
+block = BlockEncodingResource(
+    system_qubits=12,
+    normalization=sp.Integer(240),
+    prepare_cost_toffoli=30,
+    select_cost_toffoli=120,
+    reflection_cost_toffoli=8,
+    ancilla_qubits=5,
+    name="toy_lcu",
+)
+
+print(block.to_dict())
+
+assert block.logical_qubits == 17
+assert block.walk_cost_toffoli == 188
+assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188
+
+# %% [markdown]
+# ## Qubitized QPE
+#
+# QPE repeatedly calls the qubitized walk. For energy precision
+# $\epsilon$, the symbolic call proxy is $\alpha / \epsilon$, where
+# $\alpha$ is the block-encoding normalization.
+
+# %%
+architecture = FTQCCostModel(
+    physical_qubits_per_logical=100,
+    logical_cycle_time_seconds=sp.Float("1e-6"),
+    factory_qubits=2000,
+    toffoli_throughput_per_second=sp.Float("5e5"),
+)
+
+estimate = estimate_qubitized_qpe_from_block_encoding(
+    block,
+    precision=sp.Integer(3),
+    qpe_register_qubits=6,
+    cost_model=architecture,
+)
+
+print("iterations:", estimate.qpe_iterations)
+print("Toffoli gates:", estimate.toffoli_gates)
+print("logical qubits:", estimate.logical_qubits)
+
+assert estimate.qpe_iterations == 80
+assert estimate.toffoli_gates == 15040
+assert estimate.logical_qubits == 23
+assert estimate.physical_qubits == 4300
+assert estimate.assumptions["block_encoding"] == "toy_lcu"
+assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
+
+# %% [markdown]
+# ## Compare Representations
+#
+# A new factorization or symmetry shift can reduce the normalization while
+# increasing SELECT/PREPARE cost. Keeping the fields separate makes that
+# trade-off visible.
+
+# %%
+compressed_block = BlockEncodingResource(
+    system_qubits=12,
+    normalization=sp.Integer(120),
+    prepare_cost_toffoli=36,
+    select_cost_toffoli=144,
+    reflection_cost_toffoli=8,
+    ancilla_qubits=7,
+    name="compressed_toy_lcu",
+)
+
+compressed_estimate = estimate_qubitized_qpe_from_block_encoding(
+    compressed_block,
+    precision=sp.Integer(3),
+    qpe_register_qubits=6,
+    cost_model=architecture,
+)
+
+comparison = compare_ftqc_resource_estimates(
+    estimate,
+    compressed_estimate,
+    quantities=("qpe_iterations", "toffoli_gates", "logical_qubits"),
+)
+
+for row in comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4))
+
+assert comparison[0].ratio == sp.Rational(1, 2)
+assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0
+assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
+
+# %% [markdown]
+# ## Notes
+#
+# :::{note}
+# Treat `BlockEncodingResource` as a symbolic contract for algorithm design.
+# It records what the estimator consumes; it does not claim that a particular
+# PREPARE or SELECT circuit has already been synthesized for a backend.
+# :::
+
+# %% [markdown]
+# ## Summary
+#
+# In this notebook, we learned:
+#
+# - Block-encoding estimates separate normalization, PREPARE, SELECT,
+#   reflection, ancilla, and QPE readout costs.
+# - Qubitized QPE composes the block-encoding walk cost with
+#   normalization-over-precision iterations.
+# - Representation trade-offs can reduce total Toffoli count even when one
+#   subroutine becomes more expensive.

--- a/docs/en/usage/index.md
+++ b/docs/en/usage/index.md
@@ -8,5 +8,6 @@ How-to guides for using individual Qamomile modules.
 
 ## All articles
 
+- [Block-Encoding Resource Estimates](block_encoding_resource_estimation) — Model PREPARE, SELECT, reflection, and qubitized QPE costs separately
 - [FTQC Resource Estimation Design](ftqc_resource_estimation_design) — Understand the quantity model behind symbolic FTQC chemistry estimates
 - [How to use BinaryModel](binary_model) — Build unconstrained binary/spin models from BinaryExpr, QUBO/HUBO/Ising, or OMMX

--- a/docs/ja/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/ja/usage/block_encoding_resource_estimation.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5424621c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "tags: [usage, resource-estimation, primitive]\n",
+    "---\n",
+    "\n",
+    "# Block-encodingのリソース推定\n",
+    "\n",
+    "block-encodingは、Hamiltonian表現とqubitized FTQC algorithmをつなぐinterfaceです。このnotebookでは、backend circuit decompositionにcommitする前に、PREPARE、SELECT、reflection、QPE readoutのcostを分けてmodel化する方法を示します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5e639b65",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:03.533020Z",
+     "iopub.status.busy": "2026-06-22T13:45:03.532835Z",
+     "iopub.status.idle": "2026-06-22T13:45:03.537918Z",
+     "shell.execute_reply": "2026-06-22T13:45:03.537169Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Install the latest Qamomile through pip!\n",
+    "# !pip install qamomile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aa6cfc02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:03.540683Z",
+     "iopub.status.busy": "2026-06-22T13:45:03.540493Z",
+     "iopub.status.idle": "2026-06-22T13:45:03.772540Z",
+     "shell.execute_reply": "2026-06-22T13:45:03.772043Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    BlockEncodingResource,\n",
+    "    FTQCCostModel,\n",
+    "    FTQCResourceQuantity,\n",
+    "    compare_ftqc_resource_estimates,\n",
+    "    estimate_qubitized_qpe_from_block_encoding,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0be28c8",
+   "metadata": {},
+   "source": [
+    "## Workflow\n",
+    "\n",
+    "qubitized walkは通常、再利用可能なsubroutineから構成されます。\n",
+    "\n",
+    "- PREPAREはamplitudeや係数をindex registerへloadします。\n",
+    "- SELECTはindexされたunitaryやoracleを適用します。\n",
+    "- reflectionはwalk operatorを完成させます。\n",
+    "\n",
+    "Qamomileはこれらをresource modelのfieldとして保持します。algorithmic costを比較するだけなら、circuit IRに特別なblock-encoding operationを追加する必要はありません。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbba5660",
+   "metadata": {},
+   "source": [
+    "## 最小例\n",
+    "\n",
+    "下の数値はsyntheticです。1回のqubitized walkが2回のPREPARE、1回のSELECT、1回のreflectionでcost計上されることを示します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fe893204",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:03.773975Z",
+     "iopub.status.busy": "2026-06-22T13:45:03.773882Z",
+     "iopub.status.idle": "2026-06-22T13:45:03.776787Z",
+     "shell.execute_reply": "2026-06-22T13:45:03.776384Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'toy_lcu', 'system_qubits': '12', 'normalization': '240', 'select_cost_toffoli': '120', 'prepare_cost_toffoli': '30', 'reflection_cost_toffoli': '8', 'ancilla_qubits': '5', 'logical_qubits': '17', 'walk_cost_toffoli': '188', 'references': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "block = BlockEncodingResource(\n",
+    "    system_qubits=12,\n",
+    "    normalization=sp.Integer(240),\n",
+    "    prepare_cost_toffoli=30,\n",
+    "    select_cost_toffoli=120,\n",
+    "    reflection_cost_toffoli=8,\n",
+    "    ancilla_qubits=5,\n",
+    "    name=\"toy_lcu\",\n",
+    ")\n",
+    "\n",
+    "print(block.to_dict())\n",
+    "\n",
+    "assert block.logical_qubits == 17\n",
+    "assert block.walk_cost_toffoli == 188\n",
+    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84549c5f",
+   "metadata": {},
+   "source": [
+    "## Qubitized QPE\n",
+    "\n",
+    "QPEはqubitized walkを繰り返し呼び出します。energy precisionを$\\epsilon$とすると、symbolicなcall proxyは$\\alpha / \\epsilon$です。ここで$\\alpha$はblock-encoding normalizationです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "90088ec6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:03.777899Z",
+     "iopub.status.busy": "2026-06-22T13:45:03.777843Z",
+     "iopub.status.idle": "2026-06-22T13:45:03.781444Z",
+     "shell.execute_reply": "2026-06-22T13:45:03.781047Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iterations: 80\n",
+      "Toffoli gates: 15040\n",
+      "logical qubits: 23\n"
+     ]
+    }
+   ],
+   "source": [
+    "architecture = FTQCCostModel(\n",
+    "    physical_qubits_per_logical=100,\n",
+    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
+    "    factory_qubits=2000,\n",
+    "    toffoli_throughput_per_second=sp.Float(\"5e5\"),\n",
+    ")\n",
+    "\n",
+    "estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    block,\n",
+    "    precision=sp.Integer(3),\n",
+    "    qpe_register_qubits=6,\n",
+    "    cost_model=architecture,\n",
+    ")\n",
+    "\n",
+    "print(\"iterations:\", estimate.qpe_iterations)\n",
+    "print(\"Toffoli gates:\", estimate.toffoli_gates)\n",
+    "print(\"logical qubits:\", estimate.logical_qubits)\n",
+    "\n",
+    "assert estimate.qpe_iterations == 80\n",
+    "assert estimate.toffoli_gates == 15040\n",
+    "assert estimate.logical_qubits == 23\n",
+    "assert estimate.physical_qubits == 4300\n",
+    "assert estimate.assumptions[\"block_encoding\"] == \"toy_lcu\"\n",
+    "assert any(reference.key == \"arXiv:1610.06546\" for reference in estimate.references)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f1b4b2d",
+   "metadata": {},
+   "source": [
+    "## 表現を比較する\n",
+    "\n",
+    "新しいfactorizationやsymmetry shiftは、SELECT/PREPARE costを増やしながらnormalizationを下げることがあります。fieldを分けておくと、そのtrade-offが見えます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "43570e22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:45:03.782431Z",
+     "iopub.status.busy": "2026-06-22T13:45:03.782374Z",
+     "iopub.status.idle": "2026-06-22T13:45:03.785749Z",
+     "shell.execute_reply": "2026-06-22T13:45:03.785330Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "QPE iterations ratio: 0.5000\n",
+      "Toffoli gates ratio: 0.5957\n",
+      "Logical qubits ratio: 1.087\n"
+     ]
+    }
+   ],
+   "source": [
+    "compressed_block = BlockEncodingResource(\n",
+    "    system_qubits=12,\n",
+    "    normalization=sp.Integer(120),\n",
+    "    prepare_cost_toffoli=36,\n",
+    "    select_cost_toffoli=144,\n",
+    "    reflection_cost_toffoli=8,\n",
+    "    ancilla_qubits=7,\n",
+    "    name=\"compressed_toy_lcu\",\n",
+    ")\n",
+    "\n",
+    "compressed_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    compressed_block,\n",
+    "    precision=sp.Integer(3),\n",
+    "    qpe_register_qubits=6,\n",
+    "    cost_model=architecture,\n",
+    ")\n",
+    "\n",
+    "comparison = compare_ftqc_resource_estimates(\n",
+    "    estimate,\n",
+    "    compressed_estimate,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"logical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "for row in comparison:\n",
+    "    print(row.label, \"ratio:\", sp.N(row.ratio, 4))\n",
+    "\n",
+    "assert comparison[0].ratio == sp.Rational(1, 2)\n",
+    "assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0\n",
+    "assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa283ee6",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    ":::{note}\n",
+    "`BlockEncodingResource`はalgorithm designのためのsymbolic contractとして扱います。これはestimatorが消費する量を記録するものであり、特定backend向けのPREPAREやSELECT circuitがすでにsynthesize済みであるとは主張しません。\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7547959",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "このnotebookでは、次のことを学びました。\n",
+    "\n",
+    "- Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。\n",
+    "- Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。\n",
+    "- あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/ja/usage/block_encoding_resource_estimation.py
+++ b/docs/ja/usage/block_encoding_resource_estimation.py
@@ -1,0 +1,153 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.18.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ---
+# tags: [usage, resource-estimation, primitive]
+# ---
+#
+# # Block-encodingのリソース推定
+#
+# block-encodingは、Hamiltonian表現とqubitized FTQC algorithmをつなぐinterfaceです。このnotebookでは、backend circuit decompositionにcommitする前に、PREPARE、SELECT、reflection、QPE readoutのcostを分けてmodel化する方法を示します。
+
+# %%
+# Install the latest Qamomile through pip!
+# # !pip install qamomile
+
+# %%
+import sympy as sp
+
+from qamomile.circuit.estimator.algorithmic import (
+    BlockEncodingResource,
+    FTQCCostModel,
+    FTQCResourceQuantity,
+    compare_ftqc_resource_estimates,
+    estimate_qubitized_qpe_from_block_encoding,
+)
+
+# %% [markdown]
+# ## Workflow
+#
+# qubitized walkは通常、再利用可能なsubroutineから構成されます。
+#
+# - PREPAREはamplitudeや係数をindex registerへloadします。
+# - SELECTはindexされたunitaryやoracleを適用します。
+# - reflectionはwalk operatorを完成させます。
+#
+# Qamomileはこれらをresource modelのfieldとして保持します。algorithmic costを比較するだけなら、circuit IRに特別なblock-encoding operationを追加する必要はありません。
+
+# %% [markdown]
+# ## 最小例
+#
+# 下の数値はsyntheticです。1回のqubitized walkが2回のPREPARE、1回のSELECT、1回のreflectionでcost計上されることを示します。
+
+# %%
+block = BlockEncodingResource(
+    system_qubits=12,
+    normalization=sp.Integer(240),
+    prepare_cost_toffoli=30,
+    select_cost_toffoli=120,
+    reflection_cost_toffoli=8,
+    ancilla_qubits=5,
+    name="toy_lcu",
+)
+
+print(block.to_dict())
+
+assert block.logical_qubits == 17
+assert block.walk_cost_toffoli == 188
+assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188
+
+# %% [markdown]
+# ## Qubitized QPE
+#
+# QPEはqubitized walkを繰り返し呼び出します。energy precisionを$\epsilon$とすると、symbolicなcall proxyは$\alpha / \epsilon$です。ここで$\alpha$はblock-encoding normalizationです。
+
+# %%
+architecture = FTQCCostModel(
+    physical_qubits_per_logical=100,
+    logical_cycle_time_seconds=sp.Float("1e-6"),
+    factory_qubits=2000,
+    toffoli_throughput_per_second=sp.Float("5e5"),
+)
+
+estimate = estimate_qubitized_qpe_from_block_encoding(
+    block,
+    precision=sp.Integer(3),
+    qpe_register_qubits=6,
+    cost_model=architecture,
+)
+
+print("iterations:", estimate.qpe_iterations)
+print("Toffoli gates:", estimate.toffoli_gates)
+print("logical qubits:", estimate.logical_qubits)
+
+assert estimate.qpe_iterations == 80
+assert estimate.toffoli_gates == 15040
+assert estimate.logical_qubits == 23
+assert estimate.physical_qubits == 4300
+assert estimate.assumptions["block_encoding"] == "toy_lcu"
+assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
+
+# %% [markdown]
+# ## 表現を比較する
+#
+# 新しいfactorizationやsymmetry shiftは、SELECT/PREPARE costを増やしながらnormalizationを下げることがあります。fieldを分けておくと、そのtrade-offが見えます。
+
+# %%
+compressed_block = BlockEncodingResource(
+    system_qubits=12,
+    normalization=sp.Integer(120),
+    prepare_cost_toffoli=36,
+    select_cost_toffoli=144,
+    reflection_cost_toffoli=8,
+    ancilla_qubits=7,
+    name="compressed_toy_lcu",
+)
+
+compressed_estimate = estimate_qubitized_qpe_from_block_encoding(
+    compressed_block,
+    precision=sp.Integer(3),
+    qpe_register_qubits=6,
+    cost_model=architecture,
+)
+
+comparison = compare_ftqc_resource_estimates(
+    estimate,
+    compressed_estimate,
+    quantities=("qpe_iterations", "toffoli_gates", "logical_qubits"),
+)
+
+for row in comparison:
+    print(row.label, "ratio:", sp.N(row.ratio, 4))
+
+assert comparison[0].ratio == sp.Rational(1, 2)
+assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0
+assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
+
+# %% [markdown]
+# ## Notes
+#
+# :::{note}
+# `BlockEncodingResource`はalgorithm designのためのsymbolic contractとして扱います。これはestimatorが消費する量を記録するものであり、特定backend向けのPREPAREやSELECT circuitがすでにsynthesize済みであるとは主張しません。
+# :::
+
+# %% [markdown]
+# ## Summary
+#
+# このnotebookでは、次のことを学びました。
+#
+# - Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。
+# - Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。
+# - あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。

--- a/docs/ja/usage/index.md
+++ b/docs/ja/usage/index.md
@@ -8,5 +8,6 @@ Qamomileの個別モジュールを使うためのHow-toガイドです。
 
 ## すべての記事
 
+- [Block-encodingのリソース推定](block_encoding_resource_estimation) — PREPARE、SELECT、reflection、qubitized QPEのcostを分けてmodel化する
 - [FTQCリソース推定の設計](ftqc_resource_estimation_design) — symbolicなFTQC化学計算推定のquantity modelを理解する
 - [`BinaryModel`の使い方](binary_model) — 制約なしのバイナリ/スピン変数モデルをQUBO/HUBO/IsingあるいはOMMXから構築する

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -11,6 +11,10 @@ these provide theoretical estimates based on algorithm parameters
 without needing the actual circuit implementation.
 """
 
+from qamomile.circuit.estimator.algorithmic.ftqc_block_encoding import (
+    BlockEncodingResource,
+    estimate_qubitized_qpe_from_block_encoding,
+)
 from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
@@ -48,6 +52,7 @@ from qamomile.circuit.estimator.algorithmic.qpe import estimate_qpe
 __all__ = [
     "ChemistryQPEMethod",
     "ChemistryQPEModel",
+    "BlockEncodingResource",
     "FTQCResourceCategory",
     "FTQCResourceComparisonRow",
     "FTQCCostModel",
@@ -63,6 +68,7 @@ __all__ = [
     "estimate_qaoa",
     "estimate_qpe",
     "estimate_qubitized_chemistry_qpe",
+    "estimate_qubitized_qpe_from_block_encoding",
     "estimate_qubitized_chemistry_qpe_from_model",
     "estimate_single_ancilla_trotter_qpe",
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -1,0 +1,377 @@
+"""Symbolic FTQC resource models for block-encoding based algorithms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import sympy as sp
+
+from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
+    FTQCCostModel,
+    FTQCReference,
+    FTQCResourceEstimate,
+)
+from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
+    FTQCResourceQuantity,
+)
+
+_SympyLike = sp.Expr | int | float
+
+
+_QUBITIZATION_REFERENCE = FTQCReference(
+    key="arXiv:1610.06546",
+    title="Hamiltonian Simulation by Qubitization",
+    url="https://arxiv.org/abs/1610.06546",
+    note=(
+        "Introduces qubitized quantum walks built from a block-encoding, "
+        "including PREPARE, SELECT, and reflection-style primitives."
+    ),
+)
+
+
+@dataclass(frozen=True)
+class BlockEncodingResource:
+    """Describe a block-encoding implementation for FTQC estimates.
+
+    The model separates the logical problem size, block-encoding
+    normalization, and the Toffoli cost of the reusable qubitization
+    subroutines. It does not lower those subroutines into IR operations;
+    backend-specific circuit realization remains a later concern.
+
+    Attributes:
+        system_qubits (sp.Expr | int | float): Logical system-register qubits.
+        normalization (sp.Expr | int | float): Block-encoding normalization
+            alpha such that ``H / alpha`` is encoded.
+        select_cost_toffoli (sp.Expr | int | float): Toffoli cost for one
+            SELECT or oracle application.
+        prepare_cost_toffoli (sp.Expr | int | float): Toffoli cost for one
+            PREPARE or PREPARE inverse call. Defaults to zero.
+        reflection_cost_toffoli (sp.Expr | int | float): Toffoli cost for
+            the reflection used by one qubitized walk. Defaults to zero.
+        ancilla_qubits (sp.Expr | int | float): Ancilla/workspace qubits
+            required by the block-encoding, excluding optional QPE readout
+            qubits. Defaults to zero.
+        name (str): Reader-facing label for this block-encoding model.
+        references (tuple[FTQCReference, ...]): Research sources or internal
+            notes that justify the supplied subroutine costs.
+
+    Raises:
+        ValueError: If a positive-valued quantity is non-positive or if a
+            nonnegative-valued quantity is negative.
+
+    Example:
+        >>> block = BlockEncodingResource(
+        ...     system_qubits=10,
+        ...     normalization=100,
+        ...     select_cost_toffoli=50,
+        ...     prepare_cost_toffoli=20,
+        ... )
+        >>> block.walk_cost_toffoli
+        90
+    """
+
+    system_qubits: _SympyLike
+    normalization: _SympyLike
+    select_cost_toffoli: _SympyLike
+    prepare_cost_toffoli: _SympyLike = 0
+    reflection_cost_toffoli: _SympyLike = 0
+    ancilla_qubits: _SympyLike = 0
+    name: str = "block_encoding"
+    references: tuple[FTQCReference, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate block-encoding fields after dataclass construction.
+
+        Raises:
+            ValueError: If a positive-valued quantity is non-positive or if a
+                nonnegative-valued quantity is negative.
+        """
+        _validate_positive(self._system_qubits, "system_qubits")
+        _validate_positive(self._normalization, "normalization")
+        for name, expr in [
+            ("select_cost_toffoli", self._select_cost_toffoli),
+            ("prepare_cost_toffoli", self._prepare_cost_toffoli),
+            ("reflection_cost_toffoli", self._reflection_cost_toffoli),
+            ("ancilla_qubits", self._ancilla_qubits),
+        ]:
+            _validate_nonnegative(expr, name)
+
+    @property
+    def logical_qubits(self) -> sp.Expr:
+        """Return block-encoding logical qubits before QPE readout.
+
+        Returns:
+            sp.Expr: ``system_qubits + ancilla_qubits``.
+        """
+        return sp.simplify(self._system_qubits + self._ancilla_qubits)
+
+    @property
+    def walk_cost_toffoli(self) -> sp.Expr:
+        """Return the Toffoli cost of one qubitized walk operator.
+
+        Returns:
+            sp.Expr: ``2 * prepare_cost_toffoli + select_cost_toffoli +
+            reflection_cost_toffoli``.
+        """
+        return sp.simplify(
+            2 * self._prepare_cost_toffoli
+            + self._select_cost_toffoli
+            + self._reflection_cost_toffoli
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the block-encoding model.
+
+        Returns:
+            dict[str, Any]: JSON-friendly block-encoding metadata.
+        """
+        return {
+            "name": self.name,
+            "system_qubits": str(self._system_qubits),
+            "normalization": str(self._normalization),
+            "select_cost_toffoli": str(self._select_cost_toffoli),
+            "prepare_cost_toffoli": str(self._prepare_cost_toffoli),
+            "reflection_cost_toffoli": str(self._reflection_cost_toffoli),
+            "ancilla_qubits": str(self._ancilla_qubits),
+            "logical_qubits": str(self.logical_qubits),
+            "walk_cost_toffoli": str(self.walk_cost_toffoli),
+            "references": [reference.to_dict() for reference in self.references],
+        }
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return block-encoding values keyed by canonical FTQC quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Problem and algorithm
+            quantities that feed qubitized QPE estimates.
+        """
+        return {
+            FTQCResourceQuantity.LOGICAL_QUBITS: self.logical_qubits,
+            FTQCResourceQuantity.LAMBDA_NORM: self._normalization,
+            FTQCResourceQuantity.WALK_COST_TOFFOLI: self.walk_cost_toffoli,
+        }
+
+    @property
+    def _system_qubits(self) -> sp.Expr:
+        """Return system qubits as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted system-qubit count.
+        """
+        return _as_expr(self.system_qubits, "system_qubits")
+
+    @property
+    def _normalization(self) -> sp.Expr:
+        """Return normalization as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted block-encoding normalization.
+        """
+        return _as_expr(self.normalization, "normalization")
+
+    @property
+    def _select_cost_toffoli(self) -> sp.Expr:
+        """Return SELECT cost as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted SELECT Toffoli cost.
+        """
+        return _as_expr(self.select_cost_toffoli, "select_cost_toffoli")
+
+    @property
+    def _prepare_cost_toffoli(self) -> sp.Expr:
+        """Return PREPARE cost as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted PREPARE Toffoli cost.
+        """
+        return _as_expr(self.prepare_cost_toffoli, "prepare_cost_toffoli")
+
+    @property
+    def _reflection_cost_toffoli(self) -> sp.Expr:
+        """Return reflection cost as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted reflection Toffoli cost.
+        """
+        return _as_expr(self.reflection_cost_toffoli, "reflection_cost_toffoli")
+
+    @property
+    def _ancilla_qubits(self) -> sp.Expr:
+        """Return ancilla qubits as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted ancilla-qubit count.
+        """
+        return _as_expr(self.ancilla_qubits, "ancilla_qubits")
+
+
+def estimate_qubitized_qpe_from_block_encoding(
+    block_encoding: BlockEncodingResource,
+    precision: _SympyLike,
+    *,
+    qpe_register_qubits: _SympyLike = 0,
+    cost_model: FTQCCostModel | None = None,
+    references: tuple[FTQCReference, ...] = (),
+) -> FTQCResourceEstimate:
+    """Estimate qubitized QPE resources from a block-encoding model.
+
+    Args:
+        block_encoding (BlockEncodingResource): Block-encoding subroutine
+            metadata, including normalization and walk-operator cost.
+        precision (sp.Expr | int | float): Target energy precision in the
+            same units as ``block_encoding.normalization``.
+        qpe_register_qubits (sp.Expr | int | float): Optional readout qubits
+            used by an explicit QPE circuit. Defaults to zero so callers can
+            separately decide whether phase-readout qubits are included in
+            the block-encoding workspace.
+        cost_model (FTQCCostModel | None): Architecture model used to lift
+            logical estimates to physical qubits and runtime. Defaults to a
+            symbolic architecture model.
+        references (tuple[FTQCReference, ...]): Additional research sources
+            to attach to the estimate.
+
+    Returns:
+        FTQCResourceEstimate: Symbolic FTQC resource estimate.
+
+    Raises:
+        ValueError: If ``precision`` is non-positive or
+            ``qpe_register_qubits`` is negative.
+    """
+    precision_expr = _as_expr(precision, "precision")
+    qpe_qubits = _as_expr(qpe_register_qubits, "qpe_register_qubits")
+    _validate_positive(precision_expr, "precision")
+    _validate_nonnegative(qpe_qubits, "qpe_register_qubits")
+
+    qpe_iterations = sp.simplify(block_encoding._normalization / precision_expr)
+    toffoli_gates = sp.simplify(qpe_iterations * block_encoding.walk_cost_toffoli)
+    logical_depth = toffoli_gates
+    logical_qubits = sp.simplify(block_encoding.logical_qubits + qpe_qubits)
+    model = cost_model or FTQCCostModel()
+    runtime_seconds = model.runtime_seconds_for(logical_depth, toffoli_gates)
+    physical_qubits = model.physical_qubits_for(logical_qubits)
+    assumptions = {
+        "block_encoding": block_encoding.name,
+        "walk_cost_toffoli": (
+            "Uses 2 * prepare_cost_toffoli + select_cost_toffoli + "
+            "reflection_cost_toffoli for one qubitized walk."
+        ),
+        "qpe_iterations": (
+            "Uses block_encoding.normalization / precision as the walk-call proxy."
+        ),
+        "qpe_register_qubits": str(qpe_qubits),
+    }
+    references_for_estimate = _combine_references(
+        (_QUBITIZATION_REFERENCE,),
+        block_encoding.references,
+        references,
+    )
+    return FTQCResourceEstimate(
+        algorithm=f"qubitized_qpe:block_encoding:{block_encoding.name}",
+        logical_qubits=sp.simplify(logical_qubits),
+        physical_qubits=sp.simplify(physical_qubits),
+        toffoli_gates=sp.simplify(toffoli_gates),
+        t_gates=sp.Integer(0),
+        clifford_gates=sp.Integer(0),
+        qpe_iterations=sp.simplify(qpe_iterations),
+        logical_depth=sp.simplify(logical_depth),
+        runtime_seconds=sp.simplify(runtime_seconds),
+        parameters=_collect_parameters(
+            logical_qubits,
+            physical_qubits,
+            toffoli_gates,
+            qpe_iterations,
+            logical_depth,
+            runtime_seconds,
+        ),
+        assumptions=assumptions,
+        references=references_for_estimate,
+    )
+
+
+def _collect_parameters(*expressions: sp.Expr) -> dict[str, sp.Symbol]:
+    """Collect free symbols from symbolic resource expressions.
+
+    Args:
+        *expressions (sp.Expr): Expressions to inspect.
+
+    Returns:
+        dict[str, sp.Symbol]: Symbols keyed by their display names.
+    """
+    symbols: set[sp.Symbol] = set()
+    for expression in expressions:
+        for symbol in expression.free_symbols:
+            if isinstance(symbol, sp.Symbol):
+                symbols.add(symbol)
+    return {str(symbol): symbol for symbol in sorted(symbols, key=str)}
+
+
+def _combine_references(
+    *groups: tuple[FTQCReference, ...],
+) -> tuple[FTQCReference, ...]:
+    """Merge reference groups while preserving first-seen order.
+
+    Args:
+        *groups (tuple[FTQCReference, ...]): Reference groups to merge.
+
+    Returns:
+        tuple[FTQCReference, ...]: Deduplicated references keyed by
+            ``FTQCReference.key``.
+    """
+    references: list[FTQCReference] = []
+    seen: set[str] = set()
+    for group in groups:
+        for reference in group:
+            if reference.key in seen:
+                continue
+            references.append(reference)
+            seen.add(reference.key)
+    return tuple(references)
+
+
+def _as_expr(value: _SympyLike, name: str) -> sp.Expr:
+    """Convert a numeric or symbolic value to a SymPy expression.
+
+    Args:
+        value (sp.Expr | int | float): Value to convert.
+        name (str): Field name used in error messages.
+
+    Returns:
+        sp.Expr: Converted SymPy expression.
+
+    Raises:
+        TypeError: If ``value`` cannot be sympified.
+    """
+    try:
+        return sp.sympify(value)
+    except (TypeError, sp.SympifyError) as exc:
+        raise TypeError(f"{name} must be a numeric or SymPy expression.") from exc
+
+
+def _validate_positive(expr: sp.Expr, name: str) -> None:
+    """Validate that an expression is positive when decidable.
+
+    Args:
+        expr (sp.Expr): Expression to validate.
+        name (str): Field name used in error messages.
+
+    Raises:
+        ValueError: If SymPy can prove that ``expr`` is not positive.
+    """
+    if expr.is_positive is False:
+        raise ValueError(f"{name} must be positive.")
+
+
+def _validate_nonnegative(expr: sp.Expr, name: str) -> None:
+    """Validate that an expression is nonnegative when decidable.
+
+    Args:
+        expr (sp.Expr): Expression to validate.
+        name (str): Field name used in error messages.
+
+    Raises:
+        ValueError: If SymPy can prove that ``expr`` is negative.
+    """
+    if expr.is_nonnegative is False:
+        raise ValueError(f"{name} must be nonnegative.")

--- a/tests/circuit/estimator/test_ftqc_block_encoding.py
+++ b/tests/circuit/estimator/test_ftqc_block_encoding.py
@@ -1,0 +1,162 @@
+"""Tests for block-encoding based FTQC resource estimators."""
+
+from __future__ import annotations
+
+import pytest
+import sympy as sp
+
+from qamomile.circuit.estimator.algorithmic import (
+    BlockEncodingResource,
+    FTQCCostModel,
+    FTQCReference,
+    FTQCResourceQuantity,
+    estimate_qubitized_qpe_from_block_encoding,
+)
+
+
+def test_block_encoding_resource_separates_prepare_select_and_reflection():
+    """Block-encoding metadata exposes walk cost without circuit lowering."""
+    n, alpha, prep, select, reflect, ancilla = sp.symbols(
+        "n alpha C_P C_S C_R a",
+        positive=True,
+    )
+
+    block = BlockEncodingResource(
+        system_qubits=n,
+        normalization=alpha,
+        prepare_cost_toffoli=prep,
+        select_cost_toffoli=select,
+        reflection_cost_toffoli=reflect,
+        ancilla_qubits=ancilla,
+        name="lcu_oracle",
+    )
+
+    assert block.logical_qubits == n + ancilla
+    assert block.walk_cost_toffoli == 2 * prep + select + reflect
+    assert block.resource_values()[FTQCResourceQuantity.LAMBDA_NORM] == alpha
+    assert (
+        block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI]
+        == 2 * prep + select + reflect
+    )
+    assert block.to_dict()["name"] == "lcu_oracle"
+
+
+def test_qubitized_qpe_from_block_encoding_tracks_walk_calls_and_costs():
+    """Qubitized QPE composes alpha-over-epsilon calls with walk cost."""
+    cost_model = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e6"),
+    )
+    block = BlockEncodingResource(
+        system_qubits=6,
+        normalization=100,
+        prepare_cost_toffoli=20,
+        select_cost_toffoli=50,
+        reflection_cost_toffoli=5,
+        ancilla_qubits=3,
+        name="toy_lcu",
+    )
+
+    estimate = estimate_qubitized_qpe_from_block_encoding(
+        block,
+        precision=2,
+        qpe_register_qubits=4,
+        cost_model=cost_model,
+    )
+
+    assert block.walk_cost_toffoli == 95
+    assert estimate.logical_qubits == 13
+    assert estimate.qpe_iterations == 50
+    assert estimate.toffoli_gates == 4750
+    assert estimate.physical_qubits == 1310
+    assert sp.Abs(estimate.runtime_seconds - sp.Float("0.00475")) < sp.Float("1e-12")
+    assert estimate.assumptions["block_encoding"] == "toy_lcu"
+    assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
+
+
+def test_qubitized_qpe_from_block_encoding_preserves_custom_references():
+    """Block-encoding and estimate references are deduplicated by key."""
+    duplicate = FTQCReference(
+        key="arXiv:1610.06546",
+        title="Duplicate qubitization citation",
+        url="https://example.invalid/duplicate",
+    )
+    custom = FTQCReference(
+        key="internal:block-cost-v1",
+        title="Internal block-encoding cost model",
+        url="https://example.invalid/block-cost-v1",
+    )
+    block = BlockEncodingResource(
+        system_qubits=2,
+        normalization=4,
+        prepare_cost_toffoli=1,
+        select_cost_toffoli=3,
+        references=(duplicate, custom),
+    )
+
+    estimate = estimate_qubitized_qpe_from_block_encoding(
+        block,
+        precision=1,
+        references=(custom,),
+    )
+    keys = [reference.key for reference in estimate.references]
+
+    assert keys.count("arXiv:1610.06546") == 1
+    assert keys.count("internal:block-cost-v1") == 1
+    assert estimate.to_dict()["references"][-1]["key"] == "internal:block-cost-v1"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"system_qubits": 0}, "system_qubits"),
+        ({"normalization": 0}, "normalization"),
+        ({"select_cost_toffoli": -1}, "select_cost_toffoli"),
+        ({"prepare_cost_toffoli": -1}, "prepare_cost_toffoli"),
+        ({"reflection_cost_toffoli": -1}, "reflection_cost_toffoli"),
+        ({"ancilla_qubits": -1}, "ancilla_qubits"),
+    ],
+)
+def test_block_encoding_resource_rejects_invalid_quantities(
+    kwargs: dict[str, object],
+    match: str,
+):
+    """Invalid block-encoding quantities fail before estimate construction."""
+    valid = {
+        "system_qubits": 2,
+        "normalization": 4,
+        "select_cost_toffoli": 3,
+    }
+    valid.update(kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        BlockEncodingResource(**valid)
+
+
+@pytest.mark.parametrize(
+    ("precision", "qpe_register_qubits", "match"),
+    [
+        (0, 0, "precision"),
+        (1, -1, "qpe_register_qubits"),
+    ],
+)
+def test_qubitized_qpe_from_block_encoding_rejects_invalid_inputs(
+    precision: int,
+    qpe_register_qubits: int,
+    match: str,
+):
+    """Invalid QPE precision or readout register sizes fail early."""
+    block = BlockEncodingResource(
+        system_qubits=2,
+        normalization=4,
+        select_cost_toffoli=3,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        estimate_qubitized_qpe_from_block_encoding(
+            block,
+            precision=precision,
+            qpe_register_qubits=qpe_register_qubits,
+        )


### PR DESCRIPTION
## Summary
- add `BlockEncodingResource` for symbolic PREPARE, SELECT, reflection, normalization, and ancilla accounting
- add `estimate_qubitized_qpe_from_block_encoding` to compose block-encoding walk costs with QPE precision and architecture lifting
- add focused estimator tests for symbolic walk costs, QPE totals, validation, and provenance
- add English/Japanese usage docs showing block-encoding trade-offs without introducing a new IR lowering

## Validation
- uv run pytest tests/circuit/estimator/test_ftqc_block_encoding.py -q
- uv run pytest tests/circuit/estimator -q
- uv run pytest -m docs tests/docs/test_tag_whitelist.py -q
- uv run pytest -m docs tests/docs/test_tutorials.py -q
- uv run jupytext --to ipynb --test docs/en/usage/block_encoding_resource_estimation.py docs/ja/usage/block_encoding_resource_estimation.py
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check