### PR TITLE
Bridge chemistry models to block-encoding resources

### DIFF
--- a/docs/en/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/en/usage/block_encoding_resource_estimation.ipynb
@@ -23,10 +23,10 @@
    "id": "f60e69e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:02.355059Z",
-     "iopub.status.busy": "2026-06-22T13:45:02.354913Z",
-     "iopub.status.idle": "2026-06-22T13:45:02.358878Z",
-     "shell.execute_reply": "2026-06-22T13:45:02.358076Z"
+     "iopub.execute_input": "2026-06-22T14:02:42.233574Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.232298Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.241745Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.240832Z"
     }
    },
    "outputs": [],
@@ -41,22 +41,27 @@
    "id": "ccc5ad1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:02.360856Z",
-     "iopub.status.busy": "2026-06-22T13:45:02.360744Z",
-     "iopub.status.idle": "2026-06-22T13:45:02.663220Z",
-     "shell.execute_reply": "2026-06-22T13:45:02.662790Z"
+     "iopub.execute_input": "2026-06-22T14:02:42.248493Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.248179Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.636847Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.636358Z"
     }
    },
    "outputs": [],
    "source": [
     "import sympy as sp\n",
     "\n",
+    "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    BlockEncodingResource,\n",
+    "    ChemistryQPEMethod,\n",
+    "    ChemistryQPEModel,\n",
     "    FTQCCostModel,\n",
     "    FTQCResourceQuantity,\n",
+    "    block_encoding_from_chemistry_model,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
+    "    summarize_pauli_hamiltonian,\n",
     ")"
    ]
   },
@@ -95,10 +100,10 @@
    "id": "4583206c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:02.664483Z",
-     "iopub.status.busy": "2026-06-22T13:45:02.664403Z",
-     "iopub.status.idle": "2026-06-22T13:45:02.666873Z",
-     "shell.execute_reply": "2026-06-22T13:45:02.666525Z"
+     "iopub.execute_input": "2026-06-22T14:02:42.640471Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.640339Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.643245Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.642835Z"
     }
    },
    "outputs": [
@@ -146,10 +151,10 @@
    "id": "aaa9d778",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:02.667790Z",
-     "iopub.status.busy": "2026-06-22T13:45:02.667739Z",
-     "iopub.status.idle": "2026-06-22T13:45:02.671422Z",
-     "shell.execute_reply": "2026-06-22T13:45:02.671129Z"
+     "iopub.execute_input": "2026-06-22T14:02:42.644442Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.644369Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.650122Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.649727Z"
     }
    },
    "outputs": [
@@ -208,10 +213,10 @@
    "id": "a65abbbf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:02.672390Z",
-     "iopub.status.busy": "2026-06-22T13:45:02.672339Z",
-     "iopub.status.idle": "2026-06-22T13:45:02.675611Z",
-     "shell.execute_reply": "2026-06-22T13:45:02.675234Z"
+     "iopub.execute_input": "2026-06-22T14:02:42.651147Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.651079Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.654676Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.654375Z"
     }
    },
    "outputs": [
@@ -259,6 +264,71 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7c0f0409",
+   "metadata": {},
+   "source": [
+    "## Bridge from Chemistry Models\n",
+    "\n",
+    "Chemistry estimators often start from a Hamiltonian summary and a\n",
+    "representation-level walk cost. The bridge below turns that model into the\n",
+    "same block-encoding contract, so reports can compare chemistry-specific and\n",
+    "block-encoding views without duplicating inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "79a89877",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T14:02:42.655692Z",
+     "iopub.status.busy": "2026-06-22T14:02:42.655634Z",
+     "iopub.status.idle": "2026-06-22T14:02:42.784799Z",
+     "shell.execute_reply": "2026-06-22T14:02:42.784328Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'compressed chemistry toy', 'system_qubits': '8', 'normalization': '2.50000000000000', 'select_cost_toffoli': '100', 'prepare_cost_toffoli': '0', 'reflection_cost_toffoli': '0', 'ancilla_qubits': '8', 'logical_qubits': '16', 'walk_cost_toffoli': '100', 'references': [{'key': 'arXiv:1902.02134', 'title': 'Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization', 'url': 'https://arxiv.org/abs/1902.02134', 'note': 'Provides sparse and low-rank qubitized chemistry cost models that motivate representation-specific logical-resource scaling.'}, {'key': 'arXiv:2403.03502', 'title': 'Reducing the runtime of fault-tolerant quantum simulations in chemistry through symmetry-compressed double factorization', 'url': 'https://arxiv.org/abs/2403.03502', 'note': 'Introduces symmetry-compressed double factorization and reports Hamiltonian 1-norm and Toffoli-count reductions.'}, {'key': 'arXiv:2412.01338', 'title': 'Simultaneously optimizing symmetry shifts and tensor factorizations for cost-efficient Fault-Tolerant Quantum Simulations of electronic Hamiltonians', 'url': 'https://arxiv.org/abs/2412.01338', 'note': 'Optimizes symmetry shifts together with tensor factorizations to reduce block-encoding normalization.'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "toy_chemistry = summarize_pauli_hamiltonian(\n",
+    "    2 * qm_o.Z(0) + 3 * qm_o.X(1),\n",
+    "    n_spin_orbitals=8,\n",
+    "    source=\"toy_chemistry\",\n",
+    ")\n",
+    "chemistry_model = ChemistryQPEModel(\n",
+    "    hamiltonian=toy_chemistry.with_lambda_scale(sp.Rational(1, 2)),\n",
+    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "    walk_cost_toffoli=100,\n",
+    "    second_factor_rank=4,\n",
+    "    description=\"compressed chemistry toy\",\n",
+    ")\n",
+    "\n",
+    "chemistry_block = block_encoding_from_chemistry_model(chemistry_model)\n",
+    "chemistry_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    chemistry_block,\n",
+    "    precision=1,\n",
+    ")\n",
+    "\n",
+    "print(chemistry_block.to_dict())\n",
+    "\n",
+    "assert chemistry_model.logical_qubit_count == 16\n",
+    "assert chemistry_block.logical_qubits == 16\n",
+    "assert sp.Abs(chemistry_estimate.qpe_iterations - 2.5) < sp.Float(\"1e-12\")\n",
+    "assert sp.Abs(chemistry_estimate.toffoli_gates - 250) < sp.Float(\"1e-12\")\n",
+    "assert any(\n",
+    "    reference.key == \"arXiv:2403.03502\" for reference in chemistry_block.references\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a44fb5a6",
    "metadata": {},
    "source": [
@@ -284,6 +354,8 @@
     "  reflection, ancilla, and QPE readout costs.\n",
     "- Qubitized QPE composes the block-encoding walk cost with\n",
     "  normalization-over-precision iterations.\n",
+    "- Chemistry QPE models can be converted into the same block-encoding\n",
+    "  contract for cross-view comparisons.\n",
     "- Representation trade-offs can reduce total Toffoli count even when one\n",
     "  subroutine becomes more expensive."
    ]

--- a/docs/en/usage/block_encoding_resource_estimation.py
+++ b/docs/en/usage/block_encoding_resource_estimation.py
@@ -31,12 +31,17 @@
 # %%
 import sympy as sp
 
+import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     BlockEncodingResource,
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
     FTQCCostModel,
     FTQCResourceQuantity,
+    block_encoding_from_chemistry_model,
     compare_ftqc_resource_estimates,
     estimate_qubitized_qpe_from_block_encoding,
+    summarize_pauli_hamiltonian,
 )
 
 # %% [markdown]
@@ -147,6 +152,44 @@ assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0
 assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
 
 # %% [markdown]
+# ## Bridge from Chemistry Models
+#
+# Chemistry estimators often start from a Hamiltonian summary and a
+# representation-level walk cost. The bridge below turns that model into the
+# same block-encoding contract, so reports can compare chemistry-specific and
+# block-encoding views without duplicating inputs.
+
+# %%
+toy_chemistry = summarize_pauli_hamiltonian(
+    2 * qm_o.Z(0) + 3 * qm_o.X(1),
+    n_spin_orbitals=8,
+    source="toy_chemistry",
+)
+chemistry_model = ChemistryQPEModel(
+    hamiltonian=toy_chemistry.with_lambda_scale(sp.Rational(1, 2)),
+    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+    walk_cost_toffoli=100,
+    second_factor_rank=4,
+    description="compressed chemistry toy",
+)
+
+chemistry_block = block_encoding_from_chemistry_model(chemistry_model)
+chemistry_estimate = estimate_qubitized_qpe_from_block_encoding(
+    chemistry_block,
+    precision=1,
+)
+
+print(chemistry_block.to_dict())
+
+assert chemistry_model.logical_qubit_count == 16
+assert chemistry_block.logical_qubits == 16
+assert sp.Abs(chemistry_estimate.qpe_iterations - 2.5) < sp.Float("1e-12")
+assert sp.Abs(chemistry_estimate.toffoli_gates - 250) < sp.Float("1e-12")
+assert any(
+    reference.key == "arXiv:2403.03502" for reference in chemistry_block.references
+)
+
+# %% [markdown]
 # ## Notes
 #
 # :::{note}
@@ -164,5 +207,7 @@ assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
 #   reflection, ancilla, and QPE readout costs.
 # - Qubitized QPE composes the block-encoding walk cost with
 #   normalization-over-precision iterations.
+# - Chemistry QPE models can be converted into the same block-encoding
+#   contract for cross-view comparisons.
 # - Representation trade-offs can reduce total Toffoli count even when one
 #   subroutine becomes more expensive.

--- a/docs/ja/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/ja/usage/block_encoding_resource_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "5e639b65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:03.533020Z",
-     "iopub.status.busy": "2026-06-22T13:45:03.532835Z",
-     "iopub.status.idle": "2026-06-22T13:45:03.537918Z",
-     "shell.execute_reply": "2026-06-22T13:45:03.537169Z"
+     "iopub.execute_input": "2026-06-22T14:02:44.957070Z",
+     "iopub.status.busy": "2026-06-22T14:02:44.956751Z",
+     "iopub.status.idle": "2026-06-22T14:02:45.162478Z",
+     "shell.execute_reply": "2026-06-22T14:02:45.161584Z"
     }
    },
    "outputs": [],
@@ -38,22 +38,27 @@
    "id": "aa6cfc02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:03.540683Z",
-     "iopub.status.busy": "2026-06-22T13:45:03.540493Z",
-     "iopub.status.idle": "2026-06-22T13:45:03.772540Z",
-     "shell.execute_reply": "2026-06-22T13:45:03.772043Z"
+     "iopub.execute_input": "2026-06-22T14:02:45.408539Z",
+     "iopub.status.busy": "2026-06-22T14:02:45.406585Z",
+     "iopub.status.idle": "2026-06-22T14:02:46.178120Z",
+     "shell.execute_reply": "2026-06-22T14:02:46.177719Z"
     }
    },
    "outputs": [],
    "source": [
     "import sympy as sp\n",
     "\n",
+    "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    BlockEncodingResource,\n",
+    "    ChemistryQPEMethod,\n",
+    "    ChemistryQPEModel,\n",
     "    FTQCCostModel,\n",
     "    FTQCResourceQuantity,\n",
+    "    block_encoding_from_chemistry_model,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
+    "    summarize_pauli_hamiltonian,\n",
     ")"
    ]
   },
@@ -89,10 +94,10 @@
    "id": "fe893204",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:03.773975Z",
-     "iopub.status.busy": "2026-06-22T13:45:03.773882Z",
-     "iopub.status.idle": "2026-06-22T13:45:03.776787Z",
-     "shell.execute_reply": "2026-06-22T13:45:03.776384Z"
+     "iopub.execute_input": "2026-06-22T14:02:46.179994Z",
+     "iopub.status.busy": "2026-06-22T14:02:46.179873Z",
+     "iopub.status.idle": "2026-06-22T14:02:46.183075Z",
+     "shell.execute_reply": "2026-06-22T14:02:46.182072Z"
     }
    },
    "outputs": [
@@ -138,10 +143,10 @@
    "id": "90088ec6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:03.777899Z",
-     "iopub.status.busy": "2026-06-22T13:45:03.777843Z",
-     "iopub.status.idle": "2026-06-22T13:45:03.781444Z",
-     "shell.execute_reply": "2026-06-22T13:45:03.781047Z"
+     "iopub.execute_input": "2026-06-22T14:02:46.186847Z",
+     "iopub.status.busy": "2026-06-22T14:02:46.186675Z",
+     "iopub.status.idle": "2026-06-22T14:02:46.206564Z",
+     "shell.execute_reply": "2026-06-22T14:02:46.201676Z"
     }
    },
    "outputs": [
@@ -198,10 +203,10 @@
    "id": "43570e22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:45:03.782431Z",
-     "iopub.status.busy": "2026-06-22T13:45:03.782374Z",
-     "iopub.status.idle": "2026-06-22T13:45:03.785749Z",
-     "shell.execute_reply": "2026-06-22T13:45:03.785330Z"
+     "iopub.execute_input": "2026-06-22T14:02:46.291196Z",
+     "iopub.status.busy": "2026-06-22T14:02:46.291043Z",
+     "iopub.status.idle": "2026-06-22T14:02:46.334461Z",
+     "shell.execute_reply": "2026-06-22T14:02:46.322942Z"
     }
    },
    "outputs": [
@@ -249,6 +254,68 @@
   },
   {
    "cell_type": "markdown",
+   "id": "618f1826",
+   "metadata": {},
+   "source": [
+    "## Chemistry modelからのbridge\n",
+    "\n",
+    "chemistry estimatorは、Hamiltonian summaryと表現レベルのwalk costから始まることがよくあります。下のbridgeは、そのmodelを同じblock-encoding contractへ変換します。これにより、chemistry-specificなviewとblock-encoding viewを、入力を重複させずに比較できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5ccbc030",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T14:02:46.350409Z",
+     "iopub.status.busy": "2026-06-22T14:02:46.347498Z",
+     "iopub.status.idle": "2026-06-22T14:02:46.577791Z",
+     "shell.execute_reply": "2026-06-22T14:02:46.577317Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'compressed chemistry toy', 'system_qubits': '8', 'normalization': '2.50000000000000', 'select_cost_toffoli': '100', 'prepare_cost_toffoli': '0', 'reflection_cost_toffoli': '0', 'ancilla_qubits': '8', 'logical_qubits': '16', 'walk_cost_toffoli': '100', 'references': [{'key': 'arXiv:1902.02134', 'title': 'Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization', 'url': 'https://arxiv.org/abs/1902.02134', 'note': 'Provides sparse and low-rank qubitized chemistry cost models that motivate representation-specific logical-resource scaling.'}, {'key': 'arXiv:2403.03502', 'title': 'Reducing the runtime of fault-tolerant quantum simulations in chemistry through symmetry-compressed double factorization', 'url': 'https://arxiv.org/abs/2403.03502', 'note': 'Introduces symmetry-compressed double factorization and reports Hamiltonian 1-norm and Toffoli-count reductions.'}, {'key': 'arXiv:2412.01338', 'title': 'Simultaneously optimizing symmetry shifts and tensor factorizations for cost-efficient Fault-Tolerant Quantum Simulations of electronic Hamiltonians', 'url': 'https://arxiv.org/abs/2412.01338', 'note': 'Optimizes symmetry shifts together with tensor factorizations to reduce block-encoding normalization.'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "toy_chemistry = summarize_pauli_hamiltonian(\n",
+    "    2 * qm_o.Z(0) + 3 * qm_o.X(1),\n",
+    "    n_spin_orbitals=8,\n",
+    "    source=\"toy_chemistry\",\n",
+    ")\n",
+    "chemistry_model = ChemistryQPEModel(\n",
+    "    hamiltonian=toy_chemistry.with_lambda_scale(sp.Rational(1, 2)),\n",
+    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "    walk_cost_toffoli=100,\n",
+    "    second_factor_rank=4,\n",
+    "    description=\"compressed chemistry toy\",\n",
+    ")\n",
+    "\n",
+    "chemistry_block = block_encoding_from_chemistry_model(chemistry_model)\n",
+    "chemistry_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    chemistry_block,\n",
+    "    precision=1,\n",
+    ")\n",
+    "\n",
+    "print(chemistry_block.to_dict())\n",
+    "\n",
+    "assert chemistry_model.logical_qubit_count == 16\n",
+    "assert chemistry_block.logical_qubits == 16\n",
+    "assert sp.Abs(chemistry_estimate.qpe_iterations - 2.5) < sp.Float(\"1e-12\")\n",
+    "assert sp.Abs(chemistry_estimate.toffoli_gates - 250) < sp.Float(\"1e-12\")\n",
+    "assert any(\n",
+    "    reference.key == \"arXiv:2403.03502\" for reference in chemistry_block.references\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fa283ee6",
    "metadata": {},
    "source": [
@@ -270,6 +337,7 @@
     "\n",
     "- Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。\n",
     "- Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。\n",
+    "- Chemistry QPE modelは同じblock-encoding contractへ変換でき、複数のviewを比較できます。\n",
     "- あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。"
    ]
   }

--- a/docs/ja/usage/block_encoding_resource_estimation.py
+++ b/docs/ja/usage/block_encoding_resource_estimation.py
@@ -28,12 +28,17 @@
 # %%
 import sympy as sp
 
+import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     BlockEncodingResource,
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
     FTQCCostModel,
     FTQCResourceQuantity,
+    block_encoding_from_chemistry_model,
     compare_ftqc_resource_estimates,
     estimate_qubitized_qpe_from_block_encoding,
+    summarize_pauli_hamiltonian,
 )
 
 # %% [markdown]
@@ -137,6 +142,41 @@ assert sp.simplify(comparison[1].ratio - sp.Rational(28, 47)) == 0
 assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
 
 # %% [markdown]
+# ## Chemistry modelからのbridge
+#
+# chemistry estimatorは、Hamiltonian summaryと表現レベルのwalk costから始まることがよくあります。下のbridgeは、そのmodelを同じblock-encoding contractへ変換します。これにより、chemistry-specificなviewとblock-encoding viewを、入力を重複させずに比較できます。
+
+# %%
+toy_chemistry = summarize_pauli_hamiltonian(
+    2 * qm_o.Z(0) + 3 * qm_o.X(1),
+    n_spin_orbitals=8,
+    source="toy_chemistry",
+)
+chemistry_model = ChemistryQPEModel(
+    hamiltonian=toy_chemistry.with_lambda_scale(sp.Rational(1, 2)),
+    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+    walk_cost_toffoli=100,
+    second_factor_rank=4,
+    description="compressed chemistry toy",
+)
+
+chemistry_block = block_encoding_from_chemistry_model(chemistry_model)
+chemistry_estimate = estimate_qubitized_qpe_from_block_encoding(
+    chemistry_block,
+    precision=1,
+)
+
+print(chemistry_block.to_dict())
+
+assert chemistry_model.logical_qubit_count == 16
+assert chemistry_block.logical_qubits == 16
+assert sp.Abs(chemistry_estimate.qpe_iterations - 2.5) < sp.Float("1e-12")
+assert sp.Abs(chemistry_estimate.toffoli_gates - 250) < sp.Float("1e-12")
+assert any(
+    reference.key == "arXiv:2403.03502" for reference in chemistry_block.references
+)
+
+# %% [markdown]
 # ## Notes
 #
 # :::{note}
@@ -150,4 +190,5 @@ assert sp.simplify(comparison[2].ratio - sp.Rational(25, 23)) == 0
 #
 # - Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。
 # - Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。
+# - Chemistry QPE modelは同じblock-encoding contractへ変換でき、複数のviewを比較できます。
 # - あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -13,6 +13,7 @@ without needing the actual circuit implementation.
 
 from qamomile.circuit.estimator.algorithmic.ftqc_block_encoding import (
     BlockEncodingResource,
+    block_encoding_from_chemistry_model,
     estimate_qubitized_qpe_from_block_encoding,
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
@@ -28,6 +29,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     estimate_single_ancilla_trotter_qpe,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     hamiltonian_from_openfermion_qubit_operator,
+    references_for_chemistry_qpe_method,
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
@@ -63,6 +65,7 @@ __all__ = [
     "PauliHamiltonianResource",
     "SurfaceCodeCostModel",
     "SupportsFTQCResourceValues",
+    "block_encoding_from_chemistry_model",
     "compare_ftqc_resource_estimates",
     "describe_ftqc_resource_quantity",
     "estimate_qaoa",
@@ -73,6 +76,7 @@ __all__ = [
     "estimate_single_ancilla_trotter_qpe",
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",
     "hamiltonian_from_openfermion_qubit_operator",
+    "references_for_chemistry_qpe_method",
     "iter_ftqc_resource_quantity_specs",
     "summarize_openfermion_qubit_operator",
     "summarize_pauli_hamiltonian",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -8,9 +8,11 @@ from typing import Any
 import sympy as sp
 
 from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
+    ChemistryQPEModel,
     FTQCCostModel,
     FTQCReference,
     FTQCResourceEstimate,
+    references_for_chemistry_qpe_method,
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceQuantity,
@@ -287,6 +289,74 @@ def estimate_qubitized_qpe_from_block_encoding(
         ),
         assumptions=assumptions,
         references=references_for_estimate,
+    )
+
+
+def block_encoding_from_chemistry_model(
+    model: ChemistryQPEModel,
+    *,
+    prepare_cost_toffoli: _SympyLike = 0,
+    select_cost_toffoli: _SympyLike | None = None,
+    reflection_cost_toffoli: _SympyLike = 0,
+    ancilla_qubits: _SympyLike | None = None,
+    name: str | None = None,
+    references: tuple[FTQCReference, ...] = (),
+) -> BlockEncodingResource:
+    """Build a block-encoding resource from a chemistry QPE model.
+
+    Args:
+        model (ChemistryQPEModel): Chemistry QPE model to translate into a
+            block-encoding contract.
+        prepare_cost_toffoli (sp.Expr | int | float): Toffoli cost for one
+            PREPARE call. Defaults to zero, preserving the model's existing
+            aggregate walk cost as SELECT cost.
+        select_cost_toffoli (sp.Expr | int | float | None): Toffoli cost for
+            SELECT. Defaults to ``model.walk_cost_toffoli``.
+        reflection_cost_toffoli (sp.Expr | int | float): Toffoli cost for the
+            qubitization reflection. Defaults to zero.
+        ancilla_qubits (sp.Expr | int | float | None): Ancilla qubits used by
+            the block encoding. Defaults to ``model.logical_qubit_count -
+            model.hamiltonian.n_spin_orbitals``.
+        name (str | None): Optional block-encoding label. Defaults to
+            ``model.description`` when set, otherwise the method value.
+        references (tuple[FTQCReference, ...]): Additional references to carry
+            on the block-encoding model.
+
+    Returns:
+        BlockEncodingResource: Block-encoding contract derived from the
+            chemistry model.
+
+    Raises:
+        TypeError: If ``model`` is not a ``ChemistryQPEModel``.
+        ValueError: If any derived or supplied resource quantity is invalid.
+    """
+    if not isinstance(model, ChemistryQPEModel):
+        raise TypeError("model must be a ChemistryQPEModel instance.")
+
+    select_cost = (
+        _as_expr(model.walk_cost_toffoli, "walk_cost_toffoli")
+        if select_cost_toffoli is None
+        else _as_expr(select_cost_toffoli, "select_cost_toffoli")
+    )
+    ancilla = (
+        sp.simplify(model.logical_qubit_count - model.hamiltonian.n_spin_orbitals)
+        if ancilla_qubits is None
+        else _as_expr(ancilla_qubits, "ancilla_qubits")
+    )
+    label = name or model.description or model.normalized_method.value
+    return BlockEncodingResource(
+        system_qubits=model.hamiltonian.n_spin_orbitals,
+        normalization=model.hamiltonian.lambda_norm,
+        prepare_cost_toffoli=prepare_cost_toffoli,
+        select_cost_toffoli=select_cost,
+        reflection_cost_toffoli=reflection_cost_toffoli,
+        ancilla_qubits=ancilla,
+        name=label,
+        references=_combine_references(
+            references_for_chemistry_qpe_method(model.normalized_method),
+            model.references,
+            references,
+        ),
     )
 
 

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -154,6 +154,24 @@ _METHOD_REFERENCES: dict[ChemistryQPEMethod, tuple[FTQCReference, ...]] = {
 }
 
 
+def references_for_chemistry_qpe_method(
+    method: str | ChemistryQPEMethod,
+) -> tuple[FTQCReference, ...]:
+    """Return default research references for a chemistry QPE method.
+
+    Args:
+        method (str | ChemistryQPEMethod): Chemistry QPE method to inspect.
+
+    Returns:
+        tuple[FTQCReference, ...]: Default references associated with the
+            method's symbolic resource model.
+
+    Raises:
+        ValueError: If ``method`` is not a known chemistry QPE method.
+    """
+    return _METHOD_REFERENCES[_normalize_method(method)]
+
+
 @dataclass(frozen=True)
 class FTQCCostModel:
     """Describe an architecture-level FTQC cost model.
@@ -1020,6 +1038,27 @@ class ChemistryQPEModel:
             return self.hamiltonian.n_pauli_terms
         return None
 
+    @property
+    def logical_qubit_count(self) -> sp.Expr:
+        """Return the logical-qubit model used by chemistry QPE estimates.
+
+        Returns:
+            sp.Expr: Explicit logical-qubit count when supplied, otherwise
+            the representation-specific default.
+        """
+        if self.logical_qubits is not None:
+            return _as_expr(self.logical_qubits, "logical_qubits")
+        return _default_logical_qubits(
+            self.normalized_method,
+            self.hamiltonian.n_spin_orbitals,
+            sparsity=self.effective_sparsity,
+            second_factor_rank=(
+                None
+                if self.second_factor_rank is None
+                else _as_expr(self.second_factor_rank, "second_factor_rank")
+            ),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the model to a JSON-friendly dictionary.
 
@@ -1047,6 +1086,7 @@ class ChemistryQPEModel:
                 if self.logical_qubits is None
                 else str(_as_expr(self.logical_qubits, "logical_qubits"))
             ),
+            "logical_qubit_count": str(self.logical_qubit_count),
             "truncation_error": str(
                 _as_expr(self.truncation_error, "truncation_error")
             ),

--- a/tests/circuit/estimator/test_ftqc_block_encoding.py
+++ b/tests/circuit/estimator/test_ftqc_block_encoding.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import pytest
 import sympy as sp
 
+import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     BlockEncodingResource,
+    ChemistryQPEMethod,
+    ChemistryQPEModel,
     FTQCCostModel,
     FTQCReference,
     FTQCResourceQuantity,
+    block_encoding_from_chemistry_model,
     estimate_qubitized_qpe_from_block_encoding,
+    summarize_pauli_hamiltonian,
 )
 
 
@@ -106,6 +111,70 @@ def test_qubitized_qpe_from_block_encoding_preserves_custom_references():
     assert keys.count("arXiv:1610.06546") == 1
     assert keys.count("internal:block-cost-v1") == 1
     assert estimate.to_dict()["references"][-1]["key"] == "internal:block-cost-v1"
+
+
+def test_block_encoding_from_chemistry_model_preserves_qpe_inputs():
+    """Chemistry models translate into block-encoding contracts for QPE."""
+    summary = summarize_pauli_hamiltonian(
+        2 * qm_o.Z(0) + 3 * qm_o.X(1),
+        n_spin_orbitals=8,
+        source="toy_chemistry",
+    )
+    model = ChemistryQPEModel(
+        hamiltonian=summary.with_lambda_scale(sp.Rational(1, 2)),
+        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+        walk_cost_toffoli=100,
+        second_factor_rank=4,
+        description="compressed chemistry toy",
+    )
+
+    block = block_encoding_from_chemistry_model(model)
+    estimate = estimate_qubitized_qpe_from_block_encoding(
+        block,
+        precision=1,
+    )
+
+    assert model.logical_qubit_count == 16
+    assert block.name == "compressed chemistry toy"
+    assert sp.Abs(block.resource_values()[FTQCResourceQuantity.LAMBDA_NORM] - 2.5) < (
+        sp.Float("1e-12")
+    )
+    assert block._select_cost_toffoli == 100
+    assert block._ancilla_qubits == 8
+    assert sp.Abs(estimate.qpe_iterations - 2.5) < sp.Float("1e-12")
+    assert sp.Abs(estimate.toffoli_gates - 250) < sp.Float("1e-12")
+    assert any(reference.key == "arXiv:2403.03502" for reference in block.references)
+
+
+def test_block_encoding_from_chemistry_model_accepts_subroutine_split():
+    """Chemistry walk costs can be re-expressed as PREPARE/SELECT/reflection."""
+    summary = summarize_pauli_hamiltonian(
+        qm_o.Z(0) + qm_o.Z(1),
+        n_spin_orbitals=4,
+    )
+    model = ChemistryQPEModel(
+        hamiltonian=summary,
+        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+        walk_cost_toffoli=100,
+    )
+
+    block = block_encoding_from_chemistry_model(
+        model,
+        prepare_cost_toffoli=10,
+        select_cost_toffoli=70,
+        reflection_cost_toffoli=5,
+        name="split_walk",
+    )
+
+    assert block.name == "split_walk"
+    assert block.logical_qubits == 4
+    assert block.walk_cost_toffoli == 95
+
+
+def test_block_encoding_from_chemistry_model_rejects_non_model():
+    """The chemistry bridge fails early when called with unrelated objects."""
+    with pytest.raises(TypeError, match="ChemistryQPEModel"):
+        block_encoding_from_chemistry_model(object())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- expose method-reference lookup and derived logical-qubit counts on chemistry QPE models
- add `block_encoding_from_chemistry_model` so chemistry resource models can feed block-encoding QPE estimates without duplicating inputs
- extend block-encoding tests for chemistry conversion, subroutine cost splitting, and invalid inputs
- update English/Japanese block-encoding docs with the chemistry-model bridge workflow

## Validation
- uv run pytest tests/circuit/estimator/test_ftqc_block_encoding.py -q
- uv run pytest tests/circuit/estimator -q
- uv run pytest -m docs tests/docs/test_tag_whitelist.py -q
- uv run pytest -m docs tests/docs/test_tutorials.py -q
- uv run jupytext --to ipynb --test docs/en/usage/block_encoding_resource_estimation.py docs/ja/usage/block_encoding_resource_estimation.py
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check