### PR TITLE
Summarize FTQC resource comparison drivers

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "cac83f3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.513264Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.513070Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.519833Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.518731Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.645320Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.644952Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.649992Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.649308Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "42e0ebc1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.522589Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.522384Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.852093Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.851707Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.653252Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.653050Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.965795Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.965476Z"
     }
    },
    "outputs": [],
@@ -125,10 +125,10 @@
    "id": "c63164f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.853537Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.853437Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.856308Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.855979Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.967361Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.967275Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.970148Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.969757Z"
     }
    },
    "outputs": [
@@ -212,10 +212,10 @@
    "id": "bf3c7567",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.857262Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.857211Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.876063Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.875641Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.971161Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.971110Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.990302Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.989929Z"
     }
    },
    "outputs": [
@@ -318,10 +318,10 @@
    "id": "40a8d601",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.876990Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.876938Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.879022Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.878669Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.991409Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.991351Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.993478Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.993145Z"
     }
    },
    "outputs": [
@@ -362,10 +362,10 @@
    "id": "2c30d506",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.879894Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.879844Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.883126Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.882776Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.994506Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.994455Z",
+     "iopub.status.idle": "2026-06-22T14:15:22.997705Z",
+     "shell.execute_reply": "2026-06-22T14:15:22.997391Z"
     }
    },
    "outputs": [
@@ -425,10 +425,10 @@
    "id": "04da2cd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:23.884125Z",
-     "iopub.status.busy": "2026-06-22T13:27:23.884073Z",
-     "iopub.status.idle": "2026-06-22T13:27:23.887986Z",
-     "shell.execute_reply": "2026-06-22T13:27:23.887591Z"
+     "iopub.execute_input": "2026-06-22T14:15:22.998642Z",
+     "iopub.status.busy": "2026-06-22T14:15:22.998592Z",
+     "iopub.status.idle": "2026-06-22T14:15:23.002229Z",
+     "shell.execute_reply": "2026-06-22T14:15:23.001966Z"
     }
    },
    "outputs": [

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -42,6 +42,7 @@ from qamomile.circuit.estimator.algorithmic import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
 )
 
@@ -183,6 +184,27 @@ assert comparison[0].ratio == sp.Float("0.5")
 assert comparison[1].ratio == sp.Float("0.55")
 
 # %% [markdown]
+# For design reviews, the summary helper groups the same rows by whether the
+# candidate is smaller, larger, unchanged, or still symbolic under the current
+# assumptions. The first `smaller` rows are the largest numeric reductions.
+
+# %%
+comparison_summary = summarize_ftqc_resource_comparison(
+    baseline,
+    compressed,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+for row in comparison_summary.smaller:
+    print("smaller:", row.label, "by", sp.N(row.reduction, 4))
+for row in comparison_summary.larger:
+    print("larger:", row.label, "by", sp.N(-row.reduction, 4))
+
+assert comparison_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert comparison_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS
+assert comparison_summary.symbolic == ()
+
+# %% [markdown]
 # ## Reference Provenance
 #
 # Estimates also carry method-level research references. This is intentionally
@@ -306,3 +328,5 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   assumptions without rebuilding the algorithm estimate.
 # - `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable
 #   savings tables without hard-coding a particular chemistry factorization.
+# - `summarize_ftqc_resource_comparison` groups those rows into smaller,
+#   larger, unchanged, and symbolic changes for design review.

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "44b0dd0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.752625Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.752515Z",
-     "iopub.status.idle": "2026-06-22T13:27:24.755817Z",
-     "shell.execute_reply": "2026-06-22T13:27:24.754987Z"
+     "iopub.execute_input": "2026-06-22T14:15:23.838774Z",
+     "iopub.status.busy": "2026-06-22T14:15:23.838580Z",
+     "iopub.status.idle": "2026-06-22T14:15:23.843962Z",
+     "shell.execute_reply": "2026-06-22T14:15:23.842855Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "6c336198",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.757991Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.757858Z",
-     "iopub.status.idle": "2026-06-22T13:27:24.970591Z",
-     "shell.execute_reply": "2026-06-22T13:27:24.970203Z"
+     "iopub.execute_input": "2026-06-22T14:15:23.846760Z",
+     "iopub.status.busy": "2026-06-22T14:15:23.846561Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.081963Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.081572Z"
     }
    },
    "outputs": [],
@@ -113,10 +113,10 @@
    "id": "ffd12e61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.972199Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.972112Z",
-     "iopub.status.idle": "2026-06-22T13:27:24.974964Z",
-     "shell.execute_reply": "2026-06-22T13:27:24.974595Z"
+     "iopub.execute_input": "2026-06-22T14:15:24.083637Z",
+     "iopub.status.busy": "2026-06-22T14:15:24.083541Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.086486Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.086170Z"
     }
    },
    "outputs": [
@@ -198,10 +198,10 @@
    "id": "ad469f4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.976225Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.976166Z",
-     "iopub.status.idle": "2026-06-22T13:27:24.994416Z",
-     "shell.execute_reply": "2026-06-22T13:27:24.994073Z"
+     "iopub.execute_input": "2026-06-22T14:15:24.087901Z",
+     "iopub.status.busy": "2026-06-22T14:15:24.087821Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.106076Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.105718Z"
     }
    },
    "outputs": [
@@ -301,10 +301,10 @@
    "id": "f7981ba5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.995622Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.995559Z",
-     "iopub.status.idle": "2026-06-22T13:27:24.997561Z",
-     "shell.execute_reply": "2026-06-22T13:27:24.997260Z"
+     "iopub.execute_input": "2026-06-22T14:15:24.107327Z",
+     "iopub.status.busy": "2026-06-22T14:15:24.107262Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.109480Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.109134Z"
     }
    },
    "outputs": [
@@ -344,10 +344,10 @@
    "id": "01f5685b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:24.998705Z",
-     "iopub.status.busy": "2026-06-22T13:27:24.998647Z",
-     "iopub.status.idle": "2026-06-22T13:27:25.002034Z",
-     "shell.execute_reply": "2026-06-22T13:27:25.001609Z"
+     "iopub.execute_input": "2026-06-22T14:15:24.110722Z",
+     "iopub.status.busy": "2026-06-22T14:15:24.110663Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.114262Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.113897Z"
     }
    },
    "outputs": [
@@ -406,10 +406,10 @@
    "id": "9e38e20d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T13:27:25.003080Z",
-     "iopub.status.busy": "2026-06-22T13:27:25.003019Z",
-     "iopub.status.idle": "2026-06-22T13:27:25.006849Z",
-     "shell.execute_reply": "2026-06-22T13:27:25.006522Z"
+     "iopub.execute_input": "2026-06-22T14:15:24.115292Z",
+     "iopub.status.busy": "2026-06-22T14:15:24.115238Z",
+     "iopub.status.idle": "2026-06-22T14:15:24.119114Z",
+     "shell.execute_reply": "2026-06-22T14:15:24.118759Z"
     }
    },
    "outputs": [

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -39,6 +39,7 @@ from qamomile.circuit.estimator.algorithmic import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
 )
 
@@ -169,6 +170,25 @@ assert comparison[0].ratio == sp.Float("0.5")
 assert comparison[1].ratio == sp.Float("0.55")
 
 # %% [markdown]
+# 設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。
+
+# %%
+comparison_summary = summarize_ftqc_resource_comparison(
+    baseline,
+    compressed,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+for row in comparison_summary.smaller:
+    print("smaller:", row.label, "by", sp.N(row.reduction, 4))
+for row in comparison_summary.larger:
+    print("larger:", row.label, "by", sp.N(-row.reduction, 4))
+
+assert comparison_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert comparison_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS
+assert comparison_summary.symbolic == ()
+
+# %% [markdown]
 # ## Reference provenance
 #
 # estimateはmethod-levelの研究referenceも保持します。これは数式とは意図的に分けています。reportは、上のsynthetic exampleを特定分子の再現とみなさずに、どの論文がmodelの動機になったかを示せます。
@@ -274,3 +294,4 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # - estimateに研究referenceを保持し、どの論文がsymbolic modelの根拠になったかをreportでauditできるようにします。
 # - 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。
 # - `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。
+# - `summarize_ftqc_resource_comparison`を使うと、その行を小さい、大きい、変わらない、symbolicな変化へ分けて設計レビューできます。

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -35,13 +35,16 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceCategory,
+    FTQCResourceChangeDirection,
     FTQCResourceComparisonRow,
+    FTQCResourceComparisonSummary,
     FTQCResourceQuantity,
     FTQCResourceQuantitySpec,
     SupportsFTQCResourceValues,
     compare_ftqc_resource_estimates,
     describe_ftqc_resource_quantity,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
 )
 from qamomile.circuit.estimator.algorithmic.hamiltonian_simulation import (
     estimate_qdrift,
@@ -55,8 +58,10 @@ __all__ = [
     "ChemistryQPEMethod",
     "ChemistryQPEModel",
     "BlockEncodingResource",
+    "FTQCResourceChangeDirection",
     "FTQCResourceCategory",
     "FTQCResourceComparisonRow",
+    "FTQCResourceComparisonSummary",
     "FTQCCostModel",
     "FTQCReference",
     "FTQCResourceEstimate",
@@ -80,6 +85,7 @@ __all__ = [
     "iter_ftqc_resource_quantity_specs",
     "summarize_openfermion_qubit_operator",
     "summarize_pauli_hamiltonian",
+    "summarize_ftqc_resource_comparison",
     "estimate_trotter",
     "estimate_qsvt",
     "estimate_qdrift",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -95,6 +95,27 @@ class FTQCResourceQuantity(enum.StrEnum):
     FACTORY_CYCLES_PER_TOFFOLI = "factory_cycles_per_toffoli"
 
 
+class FTQCResourceChangeDirection(enum.StrEnum):
+    """Classify how a candidate FTQC quantity changed versus baseline.
+
+    Attributes:
+        SMALLER: Candidate value is provably smaller than the baseline.
+        LARGER: Candidate value is provably larger than the baseline.
+        UNCHANGED: Candidate value is provably equal to the baseline.
+        SYMBOLIC: The sign of the symbolic change is not decidable from the
+            available assumptions.
+
+    Example:
+        >>> FTQCResourceChangeDirection("smaller")
+        <FTQCResourceChangeDirection.SMALLER: 'smaller'>
+    """
+
+    SMALLER = "smaller"
+    LARGER = "larger"
+    UNCHANGED = "unchanged"
+    SYMBOLIC = "symbolic"
+
+
 class SupportsFTQCResourceValues(Protocol):
     """Represent objects that expose canonical FTQC resource values.
 
@@ -205,6 +226,98 @@ class FTQCResourceComparisonRow:
             "candidate": str(self.candidate),
             "ratio": str(self.ratio),
             "reduction": str(self.reduction),
+        }
+
+
+@dataclass(frozen=True)
+class FTQCResourceComparisonSummary:
+    """Group FTQC comparison rows by the sign of their resource change.
+
+    Attributes:
+        rows (tuple[FTQCResourceComparisonRow, ...]): All comparison rows in
+            the order returned by ``compare_ftqc_resource_estimates``.
+        smaller (tuple[FTQCResourceComparisonRow, ...]): Rows where the
+            candidate is provably smaller than the baseline. Rows are sorted by
+            descending fractional reduction when the reduction is numeric.
+        larger (tuple[FTQCResourceComparisonRow, ...]): Rows where the
+            candidate is provably larger than the baseline. Rows are sorted by
+            descending fractional increase when the increase is numeric.
+        unchanged (tuple[FTQCResourceComparisonRow, ...]): Rows where the
+            candidate and baseline are provably equal.
+        symbolic (tuple[FTQCResourceComparisonRow, ...]): Rows whose change
+            sign cannot be proven from the symbolic expression alone.
+
+    Example:
+        >>> row = FTQCResourceComparisonRow(
+        ...     quantity=FTQCResourceQuantity.TOFFOLI_GATES,
+        ...     baseline=10,
+        ...     candidate=4,
+        ...     ratio=sp.Rational(2, 5),
+        ...     reduction=sp.Rational(3, 5),
+        ...     label="Toffoli gates",
+        ...     unit="Toffoli gates",
+        ...     category=FTQCResourceCategory.LOGICAL,
+        ... )
+        >>> FTQCResourceComparisonSummary.from_rows((row,)).smaller[0].quantity
+        <FTQCResourceQuantity.TOFFOLI_GATES: 'toffoli_gates'>
+    """
+
+    rows: tuple[FTQCResourceComparisonRow, ...]
+    smaller: tuple[FTQCResourceComparisonRow, ...]
+    larger: tuple[FTQCResourceComparisonRow, ...]
+    unchanged: tuple[FTQCResourceComparisonRow, ...]
+    symbolic: tuple[FTQCResourceComparisonRow, ...]
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: tuple[FTQCResourceComparisonRow, ...],
+    ) -> FTQCResourceComparisonSummary:
+        """Build a grouped summary from comparison rows.
+
+        Args:
+            rows (tuple[FTQCResourceComparisonRow, ...]): Comparison rows to
+                classify by the sign of ``reduction``.
+
+        Returns:
+            FTQCResourceComparisonSummary: Grouped comparison summary.
+        """
+        grouped: dict[FTQCResourceChangeDirection, list[FTQCResourceComparisonRow]] = {
+            FTQCResourceChangeDirection.SMALLER: [],
+            FTQCResourceChangeDirection.LARGER: [],
+            FTQCResourceChangeDirection.UNCHANGED: [],
+            FTQCResourceChangeDirection.SYMBOLIC: [],
+        }
+        for row in rows:
+            grouped[_classify_change(row.reduction)].append(row)
+
+        return cls(
+            rows=rows,
+            smaller=_sort_rows_by_change(grouped[FTQCResourceChangeDirection.SMALLER]),
+            larger=_sort_rows_by_change(grouped[FTQCResourceChangeDirection.LARGER]),
+            unchanged=tuple(grouped[FTQCResourceChangeDirection.UNCHANGED]),
+            symbolic=tuple(grouped[FTQCResourceChangeDirection.SYMBOLIC]),
+        )
+
+    def to_dict(self) -> dict[str, list[dict[str, str]] | dict[str, int]]:
+        """Serialize grouped comparison rows.
+
+        Returns:
+            dict[str, list[dict[str, str]] | dict[str, int]]: JSON-friendly
+                summary containing all rows, grouped rows, and group counts.
+        """
+        return {
+            "rows": [row.to_dict() for row in self.rows],
+            "smaller": [row.to_dict() for row in self.smaller],
+            "larger": [row.to_dict() for row in self.larger],
+            "unchanged": [row.to_dict() for row in self.unchanged],
+            "symbolic": [row.to_dict() for row in self.symbolic],
+            "counts": {
+                "smaller": len(self.smaller),
+                "larger": len(self.larger),
+                "unchanged": len(self.unchanged),
+                "symbolic": len(self.symbolic),
+            },
         }
 
 
@@ -470,6 +583,43 @@ def compare_ftqc_resource_estimates(
     return tuple(rows)
 
 
+def summarize_ftqc_resource_comparison(
+    baseline: SupportsFTQCResourceValues,
+    candidate: SupportsFTQCResourceValues,
+    *,
+    quantities: tuple[str | FTQCResourceQuantity, ...] | None = None,
+) -> FTQCResourceComparisonSummary:
+    """Summarize FTQC resource changes between two estimates.
+
+    This is a convenience wrapper over ``compare_ftqc_resource_estimates`` for
+    reviews and reports that need to distinguish reductions, regressions,
+    unchanged quantities, and symbolic quantities whose sign is undecidable.
+
+    Args:
+        baseline (SupportsFTQCResourceValues): Reference estimate, model, or
+            summary exposing ``resource_values()``.
+        candidate (SupportsFTQCResourceValues): Candidate estimate, model, or
+            summary exposing ``resource_values()``.
+        quantities (tuple[str | FTQCResourceQuantity, ...] | None): Quantities
+            to compare. Defaults to the intersection of quantities exposed by
+            both inputs, ordered by the canonical quantity catalog.
+
+    Returns:
+        FTQCResourceComparisonSummary: Grouped comparison rows.
+
+    Raises:
+        ValueError: If a requested quantity is missing from either input or if
+            a baseline value is exactly zero.
+    """
+    return FTQCResourceComparisonSummary.from_rows(
+        compare_ftqc_resource_estimates(
+            baseline,
+            candidate,
+            quantities=quantities,
+        )
+    )
+
+
 def _normalize_comparison_quantities(
     baseline_values: dict[FTQCResourceQuantity, sp.Expr],
     candidate_values: dict[FTQCResourceQuantity, sp.Expr],
@@ -537,3 +687,47 @@ def _normalize_resource_quantity(
         raise ValueError(
             f"Unknown FTQC resource quantity {quantity!r}; valid: {valid}."
         ) from exc
+
+
+def _classify_change(reduction: sp.Expr) -> FTQCResourceChangeDirection:
+    """Classify a fractional reduction expression by sign.
+
+    Args:
+        reduction (sp.Expr): Fractional reduction, where positive means the
+            candidate is smaller than the baseline.
+
+    Returns:
+        FTQCResourceChangeDirection: Sign classification for the change.
+    """
+    simplified = sp.simplify(reduction)
+    if simplified.equals(0):
+        return FTQCResourceChangeDirection.UNCHANGED
+    if simplified.is_positive:
+        return FTQCResourceChangeDirection.SMALLER
+    if simplified.is_negative:
+        return FTQCResourceChangeDirection.LARGER
+    return FTQCResourceChangeDirection.SYMBOLIC
+
+
+def _sort_rows_by_change(
+    rows: list[FTQCResourceComparisonRow],
+) -> tuple[FTQCResourceComparisonRow, ...]:
+    """Sort rows by descending numeric fractional change when available.
+
+    Args:
+        rows (list[FTQCResourceComparisonRow]): Rows to sort.
+
+    Returns:
+        tuple[FTQCResourceComparisonRow, ...]: Rows with numerically comparable
+            changes first and symbolic ties left in their input order.
+    """
+    indexed_rows = list(enumerate(rows))
+
+    def key(item: tuple[int, FTQCResourceComparisonRow]) -> tuple[int, float, int]:
+        index, row = item
+        magnitude = sp.Abs(sp.simplify(row.reduction))
+        if magnitude.is_number:
+            return (0, -float(sp.N(magnitude)), index)
+        return (1, 0.0, index)
+
+    return tuple(row for _, row in sorted(indexed_rows, key=key))

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -11,12 +11,15 @@ from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEModel,
     FTQCCostModel,
     FTQCResourceCategory,
+    FTQCResourceComparisonRow,
+    FTQCResourceComparisonSummary,
     FTQCResourceQuantity,
     SurfaceCodeCostModel,
     compare_ftqc_resource_estimates,
     describe_ftqc_resource_quantity,
     estimate_qubitized_chemistry_qpe_from_model,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
 )
 
@@ -196,3 +199,82 @@ def test_compare_ftqc_resource_estimates_rejects_missing_or_zero_baseline():
             summary,
             quantities=(FTQCResourceQuantity.LAMBDA_NORM,),
         )
+
+
+def test_summarize_ftqc_resource_comparison_groups_review_drivers():
+    """Comparison summaries group improvements, regressions, and ties."""
+    baseline = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    candidate = baseline.with_lambda_scale(sp.Rational(1, 2), source="compressed")
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e5"),
+    )
+    baseline_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=baseline,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=10,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+    candidate_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=candidate,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=30,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+
+    summary = summarize_ftqc_resource_comparison(
+        baseline_estimate,
+        candidate_estimate,
+        quantities=(
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.TOFFOLI_GATES,
+            FTQCResourceQuantity.LOGICAL_QUBITS,
+        ),
+    )
+
+    assert [row.quantity for row in summary.smaller] == [
+        FTQCResourceQuantity.QPE_ITERATIONS
+    ]
+    assert [row.quantity for row in summary.larger] == [
+        FTQCResourceQuantity.TOFFOLI_GATES
+    ]
+    assert [row.quantity for row in summary.unchanged] == [
+        FTQCResourceQuantity.LOGICAL_QUBITS
+    ]
+    assert summary.symbolic == ()
+    assert summary.to_dict()["counts"] == {
+        "smaller": 1,
+        "larger": 1,
+        "unchanged": 1,
+        "symbolic": 0,
+    }
+
+
+def test_comparison_summary_keeps_undecidable_symbolic_changes_separate():
+    """Symbolic comparison signs remain undecided until assumptions are added."""
+    x = sp.Symbol("x")
+    row = FTQCResourceComparisonRow(
+        quantity=FTQCResourceQuantity.TOFFOLI_GATES,
+        baseline=1,
+        candidate=x,
+        ratio=x,
+        reduction=1 - x,
+        label="Toffoli gates",
+        unit="Toffoli gates",
+        category=FTQCResourceCategory.LOGICAL,
+    )
+
+    summary = FTQCResourceComparisonSummary.from_rows((row,))
+
+    assert summary.smaller == ()
+    assert summary.larger == ()
+    assert summary.unchanged == ()
+    assert summary.symbolic == (row,)


### PR DESCRIPTION
## Summary
- add `FTQCResourceComparisonSummary` and `summarize_ftqc_resource_comparison` to group comparison rows into smaller, larger, unchanged, and symbolic changes
- expose the new comparison-summary API from the algorithmic estimator package
- document the summary helper in the FTQC resource-estimation design guide with updated executed notebooks

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run pytest tests/circuit/estimator -q`
- `uv run pytest -m docs tests/docs/test_tag_whitelist.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `git diff --check`