### PR TITLE
Extend FTQC chemistry resource tutorial workflow

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b741f413",
+   "id": "e68cbaf8",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f3976de9",
+   "id": "7840a4d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:49.773604Z",
-     "iopub.status.busy": "2026-06-22T11:29:49.773532Z",
-     "iopub.status.idle": "2026-06-22T11:29:49.775826Z",
-     "shell.execute_reply": "2026-06-22T11:29:49.775448Z"
+     "iopub.execute_input": "2026-06-22T15:53:25.039745Z",
+     "iopub.status.busy": "2026-06-22T15:53:25.039557Z",
+     "iopub.status.idle": "2026-06-22T15:53:25.044142Z",
+     "shell.execute_reply": "2026-06-22T15:53:25.043293Z"
     }
    },
    "outputs": [],
@@ -39,13 +39,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "817a2c22",
+   "id": "47131420",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:49.776843Z",
-     "iopub.status.busy": "2026-06-22T11:29:49.776777Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.056497Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.055861Z"
+     "iopub.execute_input": "2026-06-22T15:53:25.046178Z",
+     "iopub.status.busy": "2026-06-22T15:53:25.046045Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.707219Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.706757Z"
     }
    },
    "outputs": [],
@@ -55,13 +55,17 @@
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
-    "    ChemistryQPEModel,\n",
     "    ChemistryQPEMethod,\n",
-    "    FTQCCostModel,\n",
+    "    ChemistryQPEModel,\n",
+    "    FTQCResourceQuantity,\n",
+    "    SurfaceCodeDistanceBudget,\n",
+    "    block_encoding_from_chemistry_model,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
+    "    estimate_qubitized_qpe_from_block_encoding,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
+    "    summarize_ftqc_resource_comparison,\n",
     "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -69,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e817c2b",
+   "id": "f7105b94",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -94,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76905534",
+   "id": "802a1c1b",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -114,13 +118,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3558f415",
+   "id": "5f657435",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.058324Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.058110Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.060458Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.060016Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.708832Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.708685Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.712086Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.711779Z"
     }
    },
    "outputs": [],
@@ -128,17 +132,30 @@
     "n_spin_orbitals = 40\n",
     "precision = sp.Float(\"0.0016\")  # about chemical accuracy in Hartree\n",
     "\n",
-    "cost_model = FTQCCostModel(\n",
-    "    physical_qubits_per_logical=800,\n",
-    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
-    "    factory_qubits=20000,\n",
-    "    toffoli_throughput_per_second=sp.Float(\"2e6\"),\n",
-    ")"
+    "distance_budget = SurfaceCodeDistanceBudget(\n",
+    "    physical_error_rate=sp.Float(\"1e-3\"),\n",
+    "    threshold_error_rate=sp.Float(\"1e-2\"),\n",
+    "    target_logical_failure_probability=sp.Float(\"1e-9\"),\n",
+    "    logical_operation_budget=1000,\n",
+    ")\n",
+    "architecture = distance_budget.to_surface_code_cost_model(\n",
+    "    physical_cycle_time_seconds=sp.Float(\"5e-8\"),\n",
+    "    physical_qubits_per_logical_factor=2,\n",
+    "    logical_cycle_factor=1,\n",
+    "    factory_count=4,\n",
+    "    physical_qubits_per_factory=5000,\n",
+    "    factory_cycles_per_toffoli=2,\n",
+    ")\n",
+    "cost_model = architecture.to_cost_model()\n",
+    "\n",
+    "assert distance_budget.code_distance == 21\n",
+    "assert cost_model.physical_qubits_per_logical == 882\n",
+    "assert cost_model.factory_qubits == 20000"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ea59af89",
+   "id": "f96f6245",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -152,13 +169,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a1b1b77d",
+   "id": "2abeb0bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.061588Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.061498Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.063915Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.063636Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.713117Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.713062Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.715523Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.715152Z"
     }
    },
    "outputs": [
@@ -167,12 +184,15 @@
      "output_type": "stream",
      "text": [
       "lambda_norm energy problem\n",
+      "target_precision energy algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "physical_qubits physical qubits physical\n",
-      "runtime_seconds seconds physical\n"
+      "runtime_seconds seconds physical\n",
+      "logical_error_rate probability physical\n",
+      "code_distance distance architecture\n"
      ]
     }
    ],
@@ -183,12 +203,15 @@
     "    if spec.quantity.value\n",
     "    in {\n",
     "        \"lambda_norm\",\n",
+    "        \"target_precision\",\n",
     "        \"qpe_iterations\",\n",
     "        \"toffoli_gates\",\n",
     "        \"t_gates\",\n",
     "        \"logical_qubits\",\n",
     "        \"physical_qubits\",\n",
     "        \"runtime_seconds\",\n",
+    "        \"logical_error_rate\",\n",
+    "        \"code_distance\",\n",
     "    }\n",
     "]\n",
     "\n",
@@ -197,18 +220,21 @@
     "\n",
     "assert {row[\"quantity\"] for row in quantity_catalog} == {\n",
     "    \"lambda_norm\",\n",
+    "    \"target_precision\",\n",
     "    \"qpe_iterations\",\n",
     "    \"toffoli_gates\",\n",
     "    \"t_gates\",\n",
     "    \"logical_qubits\",\n",
     "    \"physical_qubits\",\n",
     "    \"runtime_seconds\",\n",
+    "    \"logical_error_rate\",\n",
+    "    \"code_distance\",\n",
     "}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "82a660e5",
+   "id": "0c25ede9",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -221,13 +247,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "62975046",
+   "id": "11facc9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.065280Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.065203Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.067926Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.067529Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.716769Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.716715Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.719361Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.718998Z"
     }
    },
    "outputs": [],
@@ -250,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f5854e3",
+   "id": "e7ab8218",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -262,13 +288,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2743baac",
+   "id": "1733441c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.068967Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.068894Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.070860Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.070567Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.720455Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.720399Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.722511Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.722168Z"
     }
    },
    "outputs": [],
@@ -291,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17e806e4",
+   "id": "b2dee38f",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -313,13 +339,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "85d64a19",
+   "id": "4328e8e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.071923Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.071867Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.090594Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.089972Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.723542Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.723488Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.747874Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.747346Z"
     }
    },
    "outputs": [
@@ -331,12 +357,12 @@
       "SCDF-style Toffoli gates: 2.750e+11\n",
       "Toy Pauli terms: 2\n",
       "SCDF-style logical qubits: 120\n",
-      "Physical qubits 116000 physical qubits\n",
+      "Physical qubits 125840 physical qubits\n",
       "Toffoli gates 275000000000.000 Toffoli gates\n",
       "QPE iterations 62500000.0000000 iterations\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.231 reduction: -1.231\n"
+      "Physical qubits ratio: 2.276 reduction: -1.276\n"
      ]
     }
    ],
@@ -397,12 +423,73 @@
     "\n",
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
-    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")"
+    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")\n",
+    "\n",
+    "qubitized_summary = summarize_ftqc_resource_comparison(\n",
+    "    thc,\n",
+    "    scdf,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "assert qubitized_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dc55bea9",
+   "id": "78bff46c",
+   "metadata": {},
+   "source": [
+    "The same chemistry model can also be converted into a block-encoding\n",
+    "contract. This is the point where a future loader implementation can split\n",
+    "cost into PREPARE, SELECT, reflection, and workspace pieces without changing\n",
+    "the chemistry summary or the compiler IR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9dd11f3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:53:26.748958Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.748894Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.751762Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.751405Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'scdf_block_contract', 'system_qubits': '40', 'normalization': '100000.000000000', 'select_cost_toffoli': '4400', 'prepare_cost_toffoli': '200', 'reflection_cost_toffoli': '50', 'ancilla_qubits': '80', 'logical_qubits': '120', 'walk_cost_toffoli': '4850', 'references': [{'key': 'arXiv:1902.02134', 'title': 'Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization', 'url': 'https://arxiv.org/abs/1902.02134', 'note': 'Provides sparse and low-rank qubitized chemistry cost models that motivate representation-specific logical-resource scaling.'}, {'key': 'arXiv:2403.03502', 'title': 'Reducing the runtime of fault-tolerant quantum simulations in chemistry through symmetry-compressed double factorization', 'url': 'https://arxiv.org/abs/2403.03502', 'note': 'Introduces symmetry-compressed double factorization and reports Hamiltonian 1-norm and Toffoli-count reductions.'}, {'key': 'arXiv:2412.01338', 'title': 'Simultaneously optimizing symmetry shifts and tensor factorizations for cost-efficient Fault-Tolerant Quantum Simulations of electronic Hamiltonians', 'url': 'https://arxiv.org/abs/2412.01338', 'note': 'Optimizes symmetry shifts together with tensor factorizations to reduce block-encoding normalization.'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "scdf_block = block_encoding_from_chemistry_model(\n",
+    "    scdf_model,\n",
+    "    prepare_cost_toffoli=sp.Integer(200),\n",
+    "    reflection_cost_toffoli=sp.Integer(50),\n",
+    "    name=\"scdf_block_contract\",\n",
+    ")\n",
+    "scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    scdf_block,\n",
+    "    precision=precision,\n",
+    "    qpe_register_qubits=12,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "print(scdf_block.to_dict())\n",
+    "assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450\n",
+    "assert scdf_block_estimate.target_precision == precision\n",
+    "assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64bcd147",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -416,14 +503,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "2e4159a7",
+   "execution_count": 9,
+   "id": "8ed89819",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.091907Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.091832Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.096717Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.096291Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.752765Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.752716Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.756756Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.756398Z"
     }
    },
    "outputs": [
@@ -486,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffc99000",
+   "id": "715c620c",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -499,14 +586,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "8e7db21d",
+   "execution_count": 10,
+   "id": "b5e6097a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:51.097800Z",
-     "iopub.status.busy": "2026-06-22T11:29:51.097724Z",
-     "iopub.status.idle": "2026-06-22T11:29:51.100304Z",
-     "shell.execute_reply": "2026-06-22T11:29:51.100012Z"
+     "iopub.execute_input": "2026-06-22T15:53:26.757822Z",
+     "iopub.status.busy": "2026-06-22T15:53:26.757765Z",
+     "iopub.status.idle": "2026-06-22T15:53:26.760281Z",
+     "shell.execute_reply": "2026-06-22T15:53:26.759894Z"
     }
    },
    "outputs": [
@@ -514,10 +601,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.200e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.000e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.160e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.750e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.280e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.560e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.280e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 1.920e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.250e+5}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.888e+5}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.688e+5}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 2.016e+4}\n"
      ]
     }
    ],
@@ -548,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c388e11",
+   "id": "69f379b0",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -560,6 +647,10 @@
     "  physical qubits, and runtime proxies.\n",
     "- Compared qubitized QPE representations without lowering the Qamomile IR\n",
     "  into backend-specific chemistry loading circuits.\n",
+    "- Selected surface-code distance from an explicit logical failure budget\n",
+    "  before lifting logical resources to physical resources.\n",
+    "- Converted a chemistry QPE model into a block-encoding contract so PREPARE,\n",
+    "  SELECT, reflection, and workspace costs can be reviewed separately.\n",
     "- Demonstrated how a unitary-weight concentration factor can be modeled as a\n",
     "  cost-driver reduction for early-FTQC single-ancilla Trotter QPE."
    ]

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -35,13 +35,17 @@ from openfermion import QubitOperator
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
-    ChemistryQPEModel,
     ChemistryQPEMethod,
-    FTQCCostModel,
+    ChemistryQPEModel,
+    FTQCResourceQuantity,
+    SurfaceCodeDistanceBudget,
+    block_encoding_from_chemistry_model,
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
+    estimate_qubitized_qpe_from_block_encoding,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
@@ -84,12 +88,25 @@ from qamomile.circuit.estimator.algorithmic import (
 n_spin_orbitals = 40
 precision = sp.Float("0.0016")  # about chemical accuracy in Hartree
 
-cost_model = FTQCCostModel(
-    physical_qubits_per_logical=800,
-    logical_cycle_time_seconds=sp.Float("1e-6"),
-    factory_qubits=20000,
-    toffoli_throughput_per_second=sp.Float("2e6"),
+distance_budget = SurfaceCodeDistanceBudget(
+    physical_error_rate=sp.Float("1e-3"),
+    threshold_error_rate=sp.Float("1e-2"),
+    target_logical_failure_probability=sp.Float("1e-9"),
+    logical_operation_budget=1000,
 )
+architecture = distance_budget.to_surface_code_cost_model(
+    physical_cycle_time_seconds=sp.Float("5e-8"),
+    physical_qubits_per_logical_factor=2,
+    logical_cycle_factor=1,
+    factory_count=4,
+    physical_qubits_per_factory=5000,
+    factory_cycles_per_toffoli=2,
+)
+cost_model = architecture.to_cost_model()
+
+assert distance_budget.code_distance == 21
+assert cost_model.physical_qubits_per_logical == 882
+assert cost_model.factory_qubits == 20000
 
 # %% [markdown]
 # ## Resource Quantities
@@ -106,12 +123,15 @@ quantity_catalog = [
     if spec.quantity.value
     in {
         "lambda_norm",
+        "target_precision",
         "qpe_iterations",
         "toffoli_gates",
         "t_gates",
         "logical_qubits",
         "physical_qubits",
         "runtime_seconds",
+        "logical_error_rate",
+        "code_distance",
     }
 ]
 
@@ -120,12 +140,15 @@ for row in quantity_catalog:
 
 assert {row["quantity"] for row in quantity_catalog} == {
     "lambda_norm",
+    "target_precision",
     "qpe_iterations",
     "toffoli_gates",
     "t_gates",
     "logical_qubits",
     "physical_qubits",
     "runtime_seconds",
+    "logical_error_rate",
+    "code_distance",
 }
 
 # %% [markdown]
@@ -248,6 +271,40 @@ assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
 assert qubitized_savings[1].ratio == sp.Float("0.55")
 
+qubitized_summary = summarize_ftqc_resource_comparison(
+    thc,
+    scdf,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert qubitized_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS
+
+# %% [markdown]
+# The same chemistry model can also be converted into a block-encoding
+# contract. This is the point where a future loader implementation can split
+# cost into PREPARE, SELECT, reflection, and workspace pieces without changing
+# the chemistry summary or the compiler IR.
+
+# %%
+scdf_block = block_encoding_from_chemistry_model(
+    scdf_model,
+    prepare_cost_toffoli=sp.Integer(200),
+    reflection_cost_toffoli=sp.Integer(50),
+    name="scdf_block_contract",
+)
+scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(
+    scdf_block,
+    precision=precision,
+    qpe_register_qubits=12,
+    cost_model=cost_model,
+)
+
+print(scdf_block.to_dict())
+assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450
+assert scdf_block_estimate.target_precision == precision
+assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
+
 # %% [markdown]
 # ## Early-FTQC Trotter QPE
 #
@@ -343,5 +400,9 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 #   physical qubits, and runtime proxies.
 # - Compared qubitized QPE representations without lowering the Qamomile IR
 #   into backend-specific chemistry loading circuits.
+# - Selected surface-code distance from an explicit logical failure budget
+#   before lifting logical resources to physical resources.
+# - Converted a chemistry QPE model into a block-encoding contract so PREPARE,
+#   SELECT, reflection, and workspace costs can be reviewed separately.
 # - Demonstrated how a unitary-weight concentration factor can be modeled as a
 #   cost-driver reduction for early-FTQC single-ancilla Trotter QPE.

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f5653c57",
+   "id": "dccc0aaa",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9e792fb7",
+   "id": "d131c015",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:52.295333Z",
-     "iopub.status.busy": "2026-06-22T11:29:52.295266Z",
-     "iopub.status.idle": "2026-06-22T11:29:52.297545Z",
-     "shell.execute_reply": "2026-06-22T11:29:52.297181Z"
+     "iopub.execute_input": "2026-06-22T15:53:27.733925Z",
+     "iopub.status.busy": "2026-06-22T15:53:27.733762Z",
+     "iopub.status.idle": "2026-06-22T15:53:27.737584Z",
+     "shell.execute_reply": "2026-06-22T15:53:27.737023Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d7d66478",
+   "id": "f8f0d10a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:52.298641Z",
-     "iopub.status.busy": "2026-06-22T11:29:52.298578Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.380669Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.380140Z"
+     "iopub.execute_input": "2026-06-22T15:53:27.739267Z",
+     "iopub.status.busy": "2026-06-22T15:53:27.739151Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.732366Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.731847Z"
     }
    },
    "outputs": [],
@@ -51,13 +51,17 @@
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
-    "    ChemistryQPEModel,\n",
     "    ChemistryQPEMethod,\n",
-    "    FTQCCostModel,\n",
+    "    ChemistryQPEModel,\n",
+    "    FTQCResourceQuantity,\n",
+    "    SurfaceCodeDistanceBudget,\n",
+    "    block_encoding_from_chemistry_model,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
+    "    estimate_qubitized_qpe_from_block_encoding,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
+    "    summarize_ftqc_resource_comparison,\n",
     "    summarize_openfermion_qubit_operator,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -65,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "635506e8",
+   "id": "02a48593",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -77,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b7c4854",
+   "id": "427ea219",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -94,13 +98,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "994771ab",
+   "id": "f6771888",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.382118Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.381967Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.384304Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.383939Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.733800Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.733666Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.737193Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.736879Z"
     }
    },
    "outputs": [],
@@ -108,17 +112,30 @@
     "n_spin_orbitals = 40\n",
     "precision = sp.Float(\"0.0016\")  # Hartree単位のおおよそのchemical accuracy\n",
     "\n",
-    "cost_model = FTQCCostModel(\n",
-    "    physical_qubits_per_logical=800,\n",
-    "    logical_cycle_time_seconds=sp.Float(\"1e-6\"),\n",
-    "    factory_qubits=20000,\n",
-    "    toffoli_throughput_per_second=sp.Float(\"2e6\"),\n",
-    ")"
+    "distance_budget = SurfaceCodeDistanceBudget(\n",
+    "    physical_error_rate=sp.Float(\"1e-3\"),\n",
+    "    threshold_error_rate=sp.Float(\"1e-2\"),\n",
+    "    target_logical_failure_probability=sp.Float(\"1e-9\"),\n",
+    "    logical_operation_budget=1000,\n",
+    ")\n",
+    "architecture = distance_budget.to_surface_code_cost_model(\n",
+    "    physical_cycle_time_seconds=sp.Float(\"5e-8\"),\n",
+    "    physical_qubits_per_logical_factor=2,\n",
+    "    logical_cycle_factor=1,\n",
+    "    factory_count=4,\n",
+    "    physical_qubits_per_factory=5000,\n",
+    "    factory_cycles_per_toffoli=2,\n",
+    ")\n",
+    "cost_model = architecture.to_cost_model()\n",
+    "\n",
+    "assert distance_budget.code_distance == 21\n",
+    "assert cost_model.physical_qubits_per_logical == 882\n",
+    "assert cost_model.factory_qubits == 20000"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "764de2e1",
+   "id": "bb0d395f",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -132,13 +149,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1f897449",
+   "id": "f5085044",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.385387Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.385328Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.387632Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.387358Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.738326Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.738271Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.740672Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.740339Z"
     }
    },
    "outputs": [
@@ -147,12 +164,15 @@
      "output_type": "stream",
      "text": [
       "lambda_norm energy problem\n",
+      "target_precision energy algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "physical_qubits physical qubits physical\n",
-      "runtime_seconds seconds physical\n"
+      "runtime_seconds seconds physical\n",
+      "logical_error_rate probability physical\n",
+      "code_distance distance architecture\n"
      ]
     }
    ],
@@ -163,12 +183,15 @@
     "    if spec.quantity.value\n",
     "    in {\n",
     "        \"lambda_norm\",\n",
+    "        \"target_precision\",\n",
     "        \"qpe_iterations\",\n",
     "        \"toffoli_gates\",\n",
     "        \"t_gates\",\n",
     "        \"logical_qubits\",\n",
     "        \"physical_qubits\",\n",
     "        \"runtime_seconds\",\n",
+    "        \"logical_error_rate\",\n",
+    "        \"code_distance\",\n",
     "    }\n",
     "]\n",
     "\n",
@@ -177,18 +200,21 @@
     "\n",
     "assert {row[\"quantity\"] for row in quantity_catalog} == {\n",
     "    \"lambda_norm\",\n",
+    "    \"target_precision\",\n",
     "    \"qpe_iterations\",\n",
     "    \"toffoli_gates\",\n",
     "    \"t_gates\",\n",
     "    \"logical_qubits\",\n",
     "    \"physical_qubits\",\n",
     "    \"runtime_seconds\",\n",
+    "    \"logical_error_rate\",\n",
+    "    \"code_distance\",\n",
     "}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "accee93f",
+   "id": "fcc0ba4a",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -197,13 +223,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0d80f51c",
+   "id": "52709233",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.388878Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.388805Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.391499Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.391165Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.741748Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.741689Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.744403Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.743954Z"
     }
    },
    "outputs": [],
@@ -226,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79aa15fe",
+   "id": "acd8e21d",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -238,13 +264,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "741d901e",
+   "id": "c4fc1b7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.392534Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.392477Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.394642Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.394205Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.745528Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.745466Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.747658Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.747222Z"
     }
    },
    "outputs": [],
@@ -267,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bccb9f45",
+   "id": "129dee6e",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -285,13 +311,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "adb08eeb",
+   "id": "0ce8060c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.395636Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.395575Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.412290Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.411941Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.748683Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.748627Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.764949Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.764601Z"
     }
    },
    "outputs": [
@@ -303,12 +329,12 @@
       "SCDF-style Toffoli gates: 2.750e+11\n",
       "Toy Pauli terms: 2\n",
       "SCDF-style logical qubits: 120\n",
-      "Physical qubits 116000 physical qubits\n",
+      "Physical qubits 125840 physical qubits\n",
       "Toffoli gates 275000000000.000 Toffoli gates\n",
       "QPE iterations 62500000.0000000 iterations\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.231 reduction: -1.231\n"
+      "Physical qubits ratio: 2.276 reduction: -1.276\n"
      ]
     }
    ],
@@ -369,12 +395,70 @@
     "\n",
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
-    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")"
+    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")\n",
+    "\n",
+    "qubitized_summary = summarize_ftqc_resource_comparison(\n",
+    "    thc,\n",
+    "    scdf,\n",
+    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    ")\n",
+    "\n",
+    "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "assert qubitized_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "364ca401",
+   "id": "fc9403d5",
+   "metadata": {},
+   "source": [
+    "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "05c84d19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T15:53:28.766044Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.765982Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.768857Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.768533Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'name': 'scdf_block_contract', 'system_qubits': '40', 'normalization': '100000.000000000', 'select_cost_toffoli': '4400', 'prepare_cost_toffoli': '200', 'reflection_cost_toffoli': '50', 'ancilla_qubits': '80', 'logical_qubits': '120', 'walk_cost_toffoli': '4850', 'references': [{'key': 'arXiv:1902.02134', 'title': 'Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization', 'url': 'https://arxiv.org/abs/1902.02134', 'note': 'Provides sparse and low-rank qubitized chemistry cost models that motivate representation-specific logical-resource scaling.'}, {'key': 'arXiv:2403.03502', 'title': 'Reducing the runtime of fault-tolerant quantum simulations in chemistry through symmetry-compressed double factorization', 'url': 'https://arxiv.org/abs/2403.03502', 'note': 'Introduces symmetry-compressed double factorization and reports Hamiltonian 1-norm and Toffoli-count reductions.'}, {'key': 'arXiv:2412.01338', 'title': 'Simultaneously optimizing symmetry shifts and tensor factorizations for cost-efficient Fault-Tolerant Quantum Simulations of electronic Hamiltonians', 'url': 'https://arxiv.org/abs/2412.01338', 'note': 'Optimizes symmetry shifts together with tensor factorizations to reduce block-encoding normalization.'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "scdf_block = block_encoding_from_chemistry_model(\n",
+    "    scdf_model,\n",
+    "    prepare_cost_toffoli=sp.Integer(200),\n",
+    "    reflection_cost_toffoli=sp.Integer(50),\n",
+    "    name=\"scdf_block_contract\",\n",
+    ")\n",
+    "scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
+    "    scdf_block,\n",
+    "    precision=precision,\n",
+    "    qpe_register_qubits=12,\n",
+    "    cost_model=cost_model,\n",
+    ")\n",
+    "\n",
+    "print(scdf_block.to_dict())\n",
+    "assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450\n",
+    "assert scdf_block_estimate.target_precision == precision\n",
+    "assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ce0d09d",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -384,14 +468,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "513362ae",
+   "execution_count": 9,
+   "id": "e93bb61c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.413348Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.413283Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.417548Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.417165Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.769896Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.769840Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.773842Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.773476Z"
     }
    },
    "outputs": [
@@ -454,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a960bae",
+   "id": "3e85e022",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -464,14 +548,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "ee8f8d92",
+   "execution_count": 10,
+   "id": "3f4ad928",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T11:29:53.418581Z",
-     "iopub.status.busy": "2026-06-22T11:29:53.418526Z",
-     "iopub.status.idle": "2026-06-22T11:29:53.421068Z",
-     "shell.execute_reply": "2026-06-22T11:29:53.420687Z"
+     "iopub.execute_input": "2026-06-22T15:53:28.774859Z",
+     "iopub.status.busy": "2026-06-22T15:53:28.774805Z",
+     "iopub.status.idle": "2026-06-22T15:53:28.777256Z",
+     "shell.execute_reply": "2026-06-22T15:53:28.776897Z"
     }
    },
    "outputs": [
@@ -479,10 +563,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.200e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.000e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.160e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.750e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.280e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.560e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.280e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 1.920e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.250e+5}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.888e+5}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.688e+5}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 2.016e+4}\n"
      ]
     }
    ],
@@ -513,7 +597,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a3e6993",
+   "id": "d71d40a8",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -522,6 +606,8 @@
     "\n",
     "- FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。\n",
     "- Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。\n",
+    "- logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。\n",
+    "- chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。\n",
     "- unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。"
    ]
   }

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -31,13 +31,17 @@ from openfermion import QubitOperator
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
-    ChemistryQPEModel,
     ChemistryQPEMethod,
-    FTQCCostModel,
+    ChemistryQPEModel,
+    FTQCResourceQuantity,
+    SurfaceCodeDistanceBudget,
+    block_encoding_from_chemistry_model,
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
+    estimate_qubitized_qpe_from_block_encoding,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
     iter_ftqc_resource_quantity_specs,
+    summarize_ftqc_resource_comparison,
     summarize_openfermion_qubit_operator,
     summarize_pauli_hamiltonian,
 )
@@ -64,12 +68,25 @@ from qamomile.circuit.estimator.algorithmic import (
 n_spin_orbitals = 40
 precision = sp.Float("0.0016")  # Hartree単位のおおよそのchemical accuracy
 
-cost_model = FTQCCostModel(
-    physical_qubits_per_logical=800,
-    logical_cycle_time_seconds=sp.Float("1e-6"),
-    factory_qubits=20000,
-    toffoli_throughput_per_second=sp.Float("2e6"),
+distance_budget = SurfaceCodeDistanceBudget(
+    physical_error_rate=sp.Float("1e-3"),
+    threshold_error_rate=sp.Float("1e-2"),
+    target_logical_failure_probability=sp.Float("1e-9"),
+    logical_operation_budget=1000,
 )
+architecture = distance_budget.to_surface_code_cost_model(
+    physical_cycle_time_seconds=sp.Float("5e-8"),
+    physical_qubits_per_logical_factor=2,
+    logical_cycle_factor=1,
+    factory_count=4,
+    physical_qubits_per_factory=5000,
+    factory_cycles_per_toffoli=2,
+)
+cost_model = architecture.to_cost_model()
+
+assert distance_budget.code_distance == 21
+assert cost_model.physical_qubits_per_logical == 882
+assert cost_model.factory_qubits == 20000
 
 # %% [markdown]
 # ## Resource Quantities
@@ -86,12 +103,15 @@ quantity_catalog = [
     if spec.quantity.value
     in {
         "lambda_norm",
+        "target_precision",
         "qpe_iterations",
         "toffoli_gates",
         "t_gates",
         "logical_qubits",
         "physical_qubits",
         "runtime_seconds",
+        "logical_error_rate",
+        "code_distance",
     }
 ]
 
@@ -100,12 +120,15 @@ for row in quantity_catalog:
 
 assert {row["quantity"] for row in quantity_catalog} == {
     "lambda_norm",
+    "target_precision",
     "qpe_iterations",
     "toffoli_gates",
     "t_gates",
     "logical_qubits",
     "physical_qubits",
     "runtime_seconds",
+    "logical_error_rate",
+    "code_distance",
 }
 
 # %% [markdown]
@@ -220,6 +243,37 @@ assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
 assert qubitized_savings[1].ratio == sp.Float("0.55")
 
+qubitized_summary = summarize_ftqc_resource_comparison(
+    thc,
+    scdf,
+    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+)
+
+assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
+assert qubitized_summary.larger[0].quantity == FTQCResourceQuantity.PHYSICAL_QUBITS
+
+# %% [markdown]
+# 同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。
+
+# %%
+scdf_block = block_encoding_from_chemistry_model(
+    scdf_model,
+    prepare_cost_toffoli=sp.Integer(200),
+    reflection_cost_toffoli=sp.Integer(50),
+    name="scdf_block_contract",
+)
+scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(
+    scdf_block,
+    precision=precision,
+    qpe_register_qubits=12,
+    cost_model=cost_model,
+)
+
+print(scdf_block.to_dict())
+assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450
+assert scdf_block_estimate.target_precision == precision
+assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
+
 # %% [markdown]
 # ## Early-FTQC Trotter QPE
 #
@@ -305,4 +359,6 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 #
 # - FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。
 # - Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。
+# - logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。
+# - chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。
 # - unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。


### PR DESCRIPTION
## Summary
- update the FTQC chemistry tutorial to use an explicit surface-code distance budget before lifting estimates to physical resources
- demonstrate chemistry-model to block-encoding contract conversion in the algorithm walkthrough
- use the comparison-summary helper to distinguish resource reductions from physical-qubit regressions

## Validation
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k ftqc_chemistry_resource_estimation`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q`
- `uv run pytest -m docs tests/docs/test_tag_whitelist.py -q`
- `uv run jupytext --to ipynb --test docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`
- `uv run ruff check qamomile/ tests/ docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `git diff --check`