### PR TITLE
Adapt FTQC estimates to logical resource shape

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b740bb5e",
+   "id": "d24f5609",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7f1b32e0",
+   "id": "23b7d0ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.205006Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.204816Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.210215Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.209257Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.482861Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.482652Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.488723Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.487935Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "186ee169",
+   "id": "57b5ad74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.212269Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.212092Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.593053Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.585797Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.490852Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.490704Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.849322Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.848922Z"
     }
    },
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1ceab73",
+   "id": "63a60c60",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e967e6ad",
+   "id": "044e627c",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47dfdc84",
+   "id": "6582465a",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -127,13 +127,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "04f6d7cc",
+   "id": "bd1713d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.605279Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.603685Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.614745Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.614095Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.850821Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.850744Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.853913Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.853553Z"
     }
    },
    "outputs": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df74ff59",
+   "id": "df0eb1ca",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -221,13 +221,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2fa49d39",
+   "id": "f54e8d62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.801267Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.800754Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.856635Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.856086Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.854893Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.854843Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.876235Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.875940Z"
     }
    },
    "outputs": [
@@ -235,13 +235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'physical_error_rate': '0.00100000000000000', 'threshold_error_rate': '0.0100000000000000', 'target_logical_failure_probability': '1.00000000000000e-9', 'logical_operation_budget': '1000', 'prefactor': '0.100000000000000', 'logical_failure_probability_per_operation': '1.00000000000000e-12', 'code_distance': '21', 'logical_error_rate': '1.00000000000000e-12'}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "{'physical_error_rate': '0.00100000000000000', 'threshold_error_rate': '0.0100000000000000', 'target_logical_failure_probability': '1.00000000000000e-9', 'logical_operation_budget': '1000', 'prefactor': '0.100000000000000', 'logical_failure_probability_per_operation': '1.00000000000000e-12', 'code_distance': '21', 'logical_error_rate': '1.00000000000000e-12'}\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
       "Physical qubits ratio: 2.276 reduction: -1.276\n"
@@ -338,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b99b28e7",
+   "id": "dc2a6f2f",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -349,13 +343,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "39682127",
+   "id": "8a7a3bc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.857929Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.857851Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.861363Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.860904Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.877362Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.877312Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.879901Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.879584Z"
     }
    },
    "outputs": [
@@ -388,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca482d5b",
+   "id": "cc95c98e",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -402,13 +396,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b97b335f",
+   "id": "bdd080b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.863067Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.863000Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.865640Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.865061Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.880853Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.880803Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.882797Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.882486Z"
     }
    },
    "outputs": [
@@ -434,7 +428,63 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c63359d",
+   "id": "5c67df78",
+   "metadata": {},
+   "source": [
+    "## Common Logical Resource Shape\n",
+    "\n",
+    "FTQC estimates can also expose their logical work through the same\n",
+    "`ResourceEstimate` shape used by circuit-level `estimate_resources()`. This\n",
+    "view deliberately omits physical qubits and runtime, which remain on the\n",
+    "FTQC estimate because they depend on architecture assumptions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "520a7685",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T16:54:48.883786Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.883740Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.885941Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.885578Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resource Estimate:\n",
+      "  Qubits: 120\n",
+      "  Gates:\n",
+      "    Total: 275000000000.000\n",
+      "    Single-qubit: 0\n",
+      "    Two-qubit: 0\n",
+      "    Multi-qubit: 275000000000.000\n",
+      "    T gates: 0\n",
+      "    Clifford gates: 0\n",
+      "    Rotation gates: 0\n",
+      "  Oracle Calls:\n",
+      "    qpe_iterations: 62500000.0000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "logical_view = compressed.to_logical_resource_estimate()\n",
+    "\n",
+    "print(logical_view)\n",
+    "assert logical_view.qubits == compressed.logical_qubits\n",
+    "assert logical_view.gates.total == compressed.toffoli_gates\n",
+    "assert logical_view.gates.multi_qubit == compressed.toffoli_gates\n",
+    "assert logical_view.gates.oracle_calls[\"qpe_iterations\"] == compressed.qpe_iterations\n",
+    "assert \"physical_qubits_per_logical\" not in logical_view.parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f398a1bd",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -445,14 +495,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "381a79a6",
+   "execution_count": 8,
+   "id": "94992ad4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.868180Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.868086Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.872786Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.872341Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.886808Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.886757Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.890177Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.889835Z"
     }
    },
    "outputs": [
@@ -494,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2da6d950",
+   "id": "2c83a684",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -505,14 +555,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "25c6f69a",
+   "execution_count": 9,
+   "id": "da780c14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:31.873776Z",
-     "iopub.status.busy": "2026-06-22T15:29:31.873716Z",
-     "iopub.status.idle": "2026-06-22T15:29:31.879822Z",
-     "shell.execute_reply": "2026-06-22T15:29:31.879167Z"
+     "iopub.execute_input": "2026-06-22T16:54:48.891230Z",
+     "iopub.status.busy": "2026-06-22T16:54:48.891179Z",
+     "iopub.status.idle": "2026-06-22T16:54:48.895480Z",
+     "shell.execute_reply": "2026-06-22T16:54:48.895083Z"
     }
    },
    "outputs": [
@@ -560,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7c4e54c",
+   "id": "437ff974",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -585,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a28bc87c",
+   "id": "bc371f5b",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -603,6 +653,8 @@
     "  lifting logical resources to physical qubits and runtime.\n",
     "- Estimates carry research references so reports can audit which paper\n",
     "  motivated a symbolic model.\n",
+    "- FTQC estimates can be viewed as common logical `ResourceEstimate` objects\n",
+    "  when reports need the same shape as circuit-level estimates.\n",
     "- Existing logical estimates can be relifted under new architecture\n",
     "  assumptions without rebuilding the algorithm estimate.\n",
     "- `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -251,6 +251,24 @@ assert "arXiv:2412.01338" in compressed_reference_keys
 assert compressed.to_dict()["references"][0]["url"].startswith("https://arxiv.org/")
 
 # %% [markdown]
+# ## Common Logical Resource Shape
+#
+# FTQC estimates can also expose their logical work through the same
+# `ResourceEstimate` shape used by circuit-level `estimate_resources()`. This
+# view deliberately omits physical qubits and runtime, which remain on the
+# FTQC estimate because they depend on architecture assumptions.
+
+# %%
+logical_view = compressed.to_logical_resource_estimate()
+
+print(logical_view)
+assert logical_view.qubits == compressed.logical_qubits
+assert logical_view.gates.total == compressed.toffoli_gates
+assert logical_view.gates.multi_qubit == compressed.toffoli_gates
+assert logical_view.gates.oracle_calls["qpe_iterations"] == compressed.qpe_iterations
+assert "physical_qubits_per_logical" not in logical_view.parameters
+
+# %% [markdown]
 # ## Architecture Sensitivity
 #
 # Once an estimate exists, relift it with a different architecture model to
@@ -355,6 +373,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   lifting logical resources to physical qubits and runtime.
 # - Estimates carry research references so reports can audit which paper
 #   motivated a symbolic model.
+# - FTQC estimates can be viewed as common logical `ResourceEstimate` objects
+#   when reports need the same shape as circuit-level estimates.
 # - Existing logical estimates can be relifted under new architecture
 #   assumptions without rebuilding the algorithm estimate.
 # - `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f6a73d73",
+   "id": "a920327c",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "3ca9831b",
+   "id": "2c6269ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:32.728152Z",
-     "iopub.status.busy": "2026-06-22T15:29:32.727996Z",
-     "iopub.status.idle": "2026-06-22T15:29:32.733186Z",
-     "shell.execute_reply": "2026-06-22T15:29:32.732524Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.664465Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.664252Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.670868Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.669927Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f2e23c2a",
+   "id": "1a99c7f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:32.735191Z",
-     "iopub.status.busy": "2026-06-22T15:29:32.735035Z",
-     "iopub.status.idle": "2026-06-22T15:29:32.975872Z",
-     "shell.execute_reply": "2026-06-22T15:29:32.975435Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.673205Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.673010Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.882623Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.882196Z"
     }
    },
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39f8d7fd",
+   "id": "14faa161",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35fb05ab",
+   "id": "1f889197",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fade231c",
+   "id": "f1ff76f4",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -113,13 +113,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b1e8141d",
+   "id": "47a892d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:32.977385Z",
-     "iopub.status.busy": "2026-06-22T15:29:32.977290Z",
-     "iopub.status.idle": "2026-06-22T15:29:32.980777Z",
-     "shell.execute_reply": "2026-06-22T15:29:32.980391Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.884198Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.884099Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.887298Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.886852Z"
     }
    },
    "outputs": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dac78e84",
+   "id": "3da159c6",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -205,13 +205,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "23cb330b",
+   "id": "3c614e84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:32.981815Z",
-     "iopub.status.busy": "2026-06-22T15:29:32.981748Z",
-     "iopub.status.idle": "2026-06-22T15:29:33.001726Z",
-     "shell.execute_reply": "2026-06-22T15:29:33.001288Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.888316Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.888257Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.906286Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.905934Z"
     }
    },
    "outputs": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e217b85c",
+   "id": "f720a3b2",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -325,13 +325,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "125b25e5",
+   "id": "9c322bfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:33.002771Z",
-     "iopub.status.busy": "2026-06-22T15:29:33.002701Z",
-     "iopub.status.idle": "2026-06-22T15:29:33.005779Z",
-     "shell.execute_reply": "2026-06-22T15:29:33.005350Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.907320Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.907261Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.910164Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.909768Z"
     }
    },
    "outputs": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "976f204e",
+   "id": "6cd4d28e",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -375,13 +375,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ccaf954a",
+   "id": "2ac8850c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:33.007354Z",
-     "iopub.status.busy": "2026-06-22T15:29:33.007242Z",
-     "iopub.status.idle": "2026-06-22T15:29:33.009654Z",
-     "shell.execute_reply": "2026-06-22T15:29:33.009305Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.911195Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.911133Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.913321Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.912971Z"
     }
    },
    "outputs": [
@@ -407,7 +407,60 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe9f568e",
+   "id": "0a7ffa05",
+   "metadata": {},
+   "source": [
+    "## 共通の論理リソース形状\n",
+    "\n",
+    "FTQC estimateは、circuit-levelの`estimate_resources()`と同じ`ResourceEstimate`形状でlogical workを公開することもできます。このviewはphysical量子ビットとruntimeを意図的に含めません。これらはarchitecture仮定に依存するため、FTQC estimate側に残します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bf998540",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T16:54:49.914350Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.914296Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.916353Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.915980Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resource Estimate:\n",
+      "  Qubits: 120\n",
+      "  Gates:\n",
+      "    Total: 275000000000.000\n",
+      "    Single-qubit: 0\n",
+      "    Two-qubit: 0\n",
+      "    Multi-qubit: 275000000000.000\n",
+      "    T gates: 0\n",
+      "    Clifford gates: 0\n",
+      "    Rotation gates: 0\n",
+      "  Oracle Calls:\n",
+      "    qpe_iterations: 62500000.0000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "logical_view = compressed.to_logical_resource_estimate()\n",
+    "\n",
+    "print(logical_view)\n",
+    "assert logical_view.qubits == compressed.logical_qubits\n",
+    "assert logical_view.gates.total == compressed.toffoli_gates\n",
+    "assert logical_view.gates.multi_qubit == compressed.toffoli_gates\n",
+    "assert logical_view.gates.oracle_calls[\"qpe_iterations\"] == compressed.qpe_iterations\n",
+    "assert \"physical_qubits_per_logical\" not in logical_view.parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56f0d315",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -417,14 +470,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "aa838cfd",
+   "execution_count": 8,
+   "id": "c9108916",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:33.010818Z",
-     "iopub.status.busy": "2026-06-22T15:29:33.010749Z",
-     "iopub.status.idle": "2026-06-22T15:29:33.014400Z",
-     "shell.execute_reply": "2026-06-22T15:29:33.014001Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.917490Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.917430Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.920830Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.920477Z"
     }
    },
    "outputs": [
@@ -466,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9221c67c",
+   "id": "117c6712",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -476,14 +529,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "7130f47c",
+   "execution_count": 9,
+   "id": "1820f0c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:29:33.015368Z",
-     "iopub.status.busy": "2026-06-22T15:29:33.015301Z",
-     "iopub.status.idle": "2026-06-22T15:29:33.019759Z",
-     "shell.execute_reply": "2026-06-22T15:29:33.019443Z"
+     "iopub.execute_input": "2026-06-22T16:54:49.921809Z",
+     "iopub.status.busy": "2026-06-22T16:54:49.921755Z",
+     "iopub.status.idle": "2026-06-22T16:54:49.925996Z",
+     "shell.execute_reply": "2026-06-22T16:54:49.925670Z"
     }
    },
    "outputs": [
@@ -531,7 +584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aea86f67",
+   "id": "f0653918",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -550,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b6ae31e",
+   "id": "4dec7b5d",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -562,6 +615,7 @@
     "- Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。\n",
     "- Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。\n",
     "- estimateに研究referenceを保持し、どの論文がsymbolic modelの根拠になったかをreportでauditできるようにします。\n",
+    "- reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。\n",
     "- 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。\n",
     "- `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。\n",
     "- `summarize_ftqc_resource_comparison`を使うと、その行を小さい、大きい、変わらない、symbolicな変化へ分けて設計レビューできます。"

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -230,6 +230,21 @@ assert "arXiv:2412.01338" in compressed_reference_keys
 assert compressed.to_dict()["references"][0]["url"].startswith("https://arxiv.org/")
 
 # %% [markdown]
+# ## 共通の論理リソース形状
+#
+# FTQC estimateは、circuit-levelの`estimate_resources()`と同じ`ResourceEstimate`形状でlogical workを公開することもできます。このviewはphysical量子ビットとruntimeを意図的に含めません。これらはarchitecture仮定に依存するため、FTQC estimate側に残します。
+
+# %%
+logical_view = compressed.to_logical_resource_estimate()
+
+print(logical_view)
+assert logical_view.qubits == compressed.logical_qubits
+assert logical_view.gates.total == compressed.toffoli_gates
+assert logical_view.gates.multi_qubit == compressed.toffoli_gates
+assert logical_view.gates.oracle_calls["qpe_iterations"] == compressed.qpe_iterations
+assert "physical_qubits_per_logical" not in logical_view.parameters
+
+# %% [markdown]
 # ## Architecture感度
 #
 # estimateを作った後で別のarchitecture modelへreliftすると、algorithm modelを作り直さずにhardware仮定を調べられます。
@@ -320,6 +335,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # - Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。
 # - Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。
 # - estimateに研究referenceを保持し、どの論文がsymbolic modelの根拠になったかをreportでauditできるようにします。
+# - reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。
 # - 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。
 # - `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。
 # - `summarize_ftqc_resource_comparison`を使うと、その行を小さい、大きい、変わらない、symbolicな変化へ分けて設計レビューできます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -14,6 +14,8 @@ from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceQuantity,
     describe_ftqc_resource_quantity,
 )
+from qamomile.circuit.estimator.gate_counter import GateCount
+from qamomile.circuit.estimator.resource_estimator import ResourceEstimate
 
 if TYPE_CHECKING:
     import qamomile.observable as qm_o
@@ -1031,6 +1033,54 @@ class FTQCResourceEstimate:
             rows.append(row)
         return rows
 
+    def to_logical_resource_estimate(self) -> ResourceEstimate:
+        """Convert logical FTQC work into the common resource-estimate shape.
+
+        The returned estimate intentionally contains only logical-circuit-like
+        quantities. Physical qubits, runtime, architecture assumptions, and
+        research references remain on ``FTQCResourceEstimate`` so callers do
+        not accidentally treat architecture-lifted resources as circuit gate
+        counts.
+
+        Returns:
+            ResourceEstimate: Existing circuit-resource container populated
+                with logical qubits, non-Clifford counts, Clifford counts, and
+                QPE iteration count as an oracle-call proxy.
+        """
+        total_gates = sp.simplify(
+            self.toffoli_gates + self.t_gates + self.clifford_gates
+        )
+        gates = GateCount(
+            total=total_gates,
+            single_qubit=sp.simplify(self.t_gates + self.clifford_gates),
+            two_qubit=sp.Integer(0),
+            multi_qubit=self.toffoli_gates,
+            t_gates=self.t_gates,
+            clifford_gates=self.clifford_gates,
+            rotation_gates=sp.Integer(0),
+            oracle_calls={"qpe_iterations": self.qpe_iterations},
+            oracle_queries={},
+        )
+        parameters = _collect_parameters(
+            (
+                self.logical_qubits,
+                gates.total,
+                gates.single_qubit,
+                gates.two_qubit,
+                gates.multi_qubit,
+                gates.t_gates,
+                gates.clifford_gates,
+                gates.rotation_gates,
+                *gates.oracle_calls.values(),
+                *gates.oracle_queries.values(),
+            )
+        )
+        return ResourceEstimate(
+            qubits=self.logical_qubits,
+            gates=gates,
+            parameters=parameters,
+        )
+
     def with_cost_model(self, cost_model: FTQCCostModel) -> FTQCResourceEstimate:
         """Relift physical resources with a different architecture model.
 
@@ -1996,11 +2046,6 @@ def _build_estimate(
         logical_depth,
         runtime_seconds,
     ]
-    symbols: set[sp.Symbol] = set()
-    for expr in expressions:
-        for symbol in expr.free_symbols:
-            if isinstance(symbol, sp.Symbol):
-                symbols.add(symbol)
     return FTQCResourceEstimate(
         algorithm=algorithm,
         logical_qubits=sp.simplify(logical_qubits),
@@ -2012,10 +2057,31 @@ def _build_estimate(
         target_precision=sp.simplify(target_precision),
         logical_depth=sp.simplify(logical_depth),
         runtime_seconds=sp.simplify(runtime_seconds),
-        parameters={str(symbol): symbol for symbol in sorted(symbols, key=str)},
+        parameters=_collect_parameters(expressions),
         assumptions=assumptions,
         references=_combine_references(references),
     )
+
+
+def _collect_parameters(
+    expressions: tuple[sp.Expr, ...] | list[sp.Expr],
+) -> dict[str, sp.Symbol]:
+    """Collect free SymPy symbols from resource expressions.
+
+    Args:
+        expressions (tuple[sp.Expr, ...] | list[sp.Expr]): Resource
+            expressions whose free symbols should become substitution
+            parameters.
+
+    Returns:
+        dict[str, sp.Symbol]: Free symbols keyed by their display name.
+    """
+    symbols: set[sp.Symbol] = set()
+    for expr in expressions:
+        for symbol in expr.free_symbols:
+            if isinstance(symbol, sp.Symbol):
+                symbols.add(symbol)
+    return {str(symbol): symbol for symbol in sorted(symbols, key=str)}
 
 
 def _combine_references(

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -45,6 +45,34 @@ def test_qubitized_qpe_tracks_lambda_precision_and_walk_cost():
     assert estimate.resource_values()[FTQCResourceQuantity.TARGET_PRECISION] == eps
 
 
+def test_ftqc_estimate_converts_to_common_logical_resource_estimate():
+    """FTQC estimates expose logical work through the shared resource shape."""
+    n, lam, eps, walk = sp.symbols("n lambda eps C_W", positive=True)
+
+    estimate = estimate_qubitized_chemistry_qpe(
+        n,
+        lambda_norm=lam,
+        precision=eps,
+        walk_cost_toffoli=walk,
+        logical_qubits=n,
+    )
+
+    logical = estimate.to_logical_resource_estimate()
+    concrete = logical.substitute(**{"n": 10, "lambda": 100, "eps": 2, "C_W": 5})
+
+    assert logical.qubits == estimate.logical_qubits
+    assert logical.gates.total == lam * walk / eps
+    assert logical.gates.multi_qubit == estimate.toffoli_gates
+    assert logical.gates.t_gates == 0
+    assert logical.gates.clifford_gates == 0
+    assert logical.gates.oracle_calls["qpe_iterations"] == estimate.qpe_iterations
+    assert set(logical.parameters) == {"C_W", "eps", "lambda", "n"}
+    assert "physical_qubits_per_logical" not in logical.parameters
+    assert concrete.qubits == 10
+    assert concrete.gates.total == 250
+    assert concrete.gates.oracle_calls["qpe_iterations"] == 50
+
+
 def test_qubitized_qpe_uses_representation_specific_logical_qubits():
     """Representation defaults follow the chemistry-resource scaling table."""
     n, sparsity, rank = sp.symbols("n S Xi", positive=True)


### PR DESCRIPTION
## Summary
- add `FTQCResourceEstimate.to_logical_resource_estimate()` so FTQC logical work can reuse the existing `ResourceEstimate` shape
- keep physical qubits, runtime, architecture assumptions, and references on the FTQC estimate to avoid mixing architecture-lifted values with circuit gate counts
- document the logical view in the FTQC resource-estimation design page and refresh the EN/JA notebooks

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_resource_estimation.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design'`\n- `uv run ruff check qamomile/ tests/`\n- `uv run ruff format --check qamomile/ tests/`\n- `uv run zuban check qamomile/`\n- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`\n- `git diff --check`\n\n## Local review\n- Ran the required local-review mechanical checks before opening this draft PR. No findings remained from the latest branch changes.