### PR TITLE
Preserve FTQC architecture provenance

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e68cbaf8",
+   "id": "72116035",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7840a4d7",
+   "id": "796f48d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:25.039745Z",
-     "iopub.status.busy": "2026-06-22T15:53:25.039557Z",
-     "iopub.status.idle": "2026-06-22T15:53:25.044142Z",
-     "shell.execute_reply": "2026-06-22T15:53:25.043293Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.743212Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.742976Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.748200Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.747441Z"
     }
    },
    "outputs": [],
@@ -39,13 +39,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "47131420",
+   "id": "8786c70c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:25.046178Z",
-     "iopub.status.busy": "2026-06-22T15:53:25.046045Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.707219Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.706757Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.750047Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.749904Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.242254Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.241865Z"
     }
    },
    "outputs": [],
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7105b94",
+   "id": "4632455f",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "802a1c1b",
+   "id": "e0747080",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -118,13 +118,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5f657435",
+   "id": "d353e97b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.708832Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.708685Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.712086Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.711779Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.244094Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.243893Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.247311Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.246833Z"
     }
    },
    "outputs": [],
@@ -146,16 +146,16 @@
     "    physical_qubits_per_factory=5000,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "cost_model = architecture.to_cost_model()\n",
+    "cost_model = architecture\n",
     "\n",
     "assert distance_budget.code_distance == 21\n",
-    "assert cost_model.physical_qubits_per_logical == 882\n",
-    "assert cost_model.factory_qubits == 20000"
+    "assert architecture.physical_qubits_per_logical == 882\n",
+    "assert architecture.factory_qubits == 20000"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f96f6245",
+   "id": "17ef5f87",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -169,13 +169,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2abeb0bb",
+   "id": "9af5a3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.713117Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.713062Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.715523Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.715152Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.248366Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.248310Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.250775Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.250363Z"
     }
    },
    "outputs": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c25ede9",
+   "id": "5405ff32",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -247,13 +247,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "11facc9c",
+   "id": "c06132c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.716769Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.716715Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.719361Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.718998Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.252192Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.252133Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.254769Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.254373Z"
     }
    },
    "outputs": [],
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7ab8218",
+   "id": "c3523f48",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -288,13 +288,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "1733441c",
+   "id": "1eb689f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.720455Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.720399Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.722511Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.722168Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.255802Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.255746Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.258092Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.257597Z"
     }
    },
    "outputs": [],
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2dee38f",
+   "id": "5054bdf3",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -339,13 +339,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4328e8e8",
+   "id": "5981cfdb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.723542Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.723488Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.747874Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.747346Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.259055Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.258999Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.276088Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.275806Z"
     }
    },
    "outputs": [
@@ -397,6 +397,8 @@
     "\n",
     "assert scdf.qpe_iterations < thc.qpe_iterations\n",
     "assert scdf.toffoli_gates < thc.toffoli_gates\n",
+    "assert scdf.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
+    "assert scdf.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
     "\n",
     "print(\"THC Toffoli gates:\", sp.N(thc.toffoli_gates, 4))\n",
     "print(\"SCDF-style Toffoli gates:\", sp.N(scdf.toffoli_gates, 4))\n",
@@ -437,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78bff46c",
+   "id": "e7f0b355",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -449,13 +451,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9dd11f3a",
+   "id": "3d6ea57e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.748958Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.748894Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.751762Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.751405Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.277321Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.277257Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.280304Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.279967Z"
     }
    },
    "outputs": [
@@ -489,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64bcd147",
+   "id": "6240d3e1",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -504,13 +506,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8ed89819",
+   "id": "31c01122",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.752765Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.752716Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.756756Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.756398Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.281274Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.281219Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.285719Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.285317Z"
     }
    },
    "outputs": [
@@ -573,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "715c620c",
+   "id": "1f1018e5",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -587,13 +589,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b5e6097a",
+   "id": "fd15a4f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:26.757822Z",
-     "iopub.status.busy": "2026-06-22T15:53:26.757765Z",
-     "iopub.status.idle": "2026-06-22T15:53:26.760281Z",
-     "shell.execute_reply": "2026-06-22T15:53:26.759894Z"
+     "iopub.execute_input": "2026-06-22T17:28:39.286785Z",
+     "iopub.status.busy": "2026-06-22T17:28:39.286729Z",
+     "iopub.status.idle": "2026-06-22T17:28:39.289356Z",
+     "shell.execute_reply": "2026-06-22T17:28:39.289030Z"
     }
    },
    "outputs": [
@@ -635,7 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69f379b0",
+   "id": "90ce8ca0",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -649,6 +651,8 @@
     "  into backend-specific chemistry loading circuits.\n",
     "- Selected surface-code distance from an explicit logical failure budget\n",
     "  before lifting logical resources to physical resources.\n",
+    "- Kept architecture quantities such as code distance attached to each\n",
+    "  resource estimate for later report auditing.\n",
     "- Converted a chemistry QPE model into a block-encoding contract so PREPARE,\n",
     "  SELECT, reflection, and workspace costs can be reviewed separately.\n",
     "- Demonstrated how a unitary-weight concentration factor can be modeled as a\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -102,11 +102,11 @@ architecture = distance_budget.to_surface_code_cost_model(
     physical_qubits_per_factory=5000,
     factory_cycles_per_toffoli=2,
 )
-cost_model = architecture.to_cost_model()
+cost_model = architecture
 
 assert distance_budget.code_distance == 21
-assert cost_model.physical_qubits_per_logical == 882
-assert cost_model.factory_qubits == 20000
+assert architecture.physical_qubits_per_logical == 882
+assert architecture.factory_qubits == 20000
 
 # %% [markdown]
 # ## Resource Quantities
@@ -243,6 +243,8 @@ scdf = estimate_qubitized_chemistry_qpe_from_model(
 
 assert scdf.qpe_iterations < thc.qpe_iterations
 assert scdf.toffoli_gates < thc.toffoli_gates
+assert scdf.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
+assert scdf.to_dict()["architecture_values"]["code_distance"] == "21"
 
 print("THC Toffoli gates:", sp.N(thc.toffoli_gates, 4))
 print("SCDF-style Toffoli gates:", sp.N(scdf.toffoli_gates, 4))
@@ -402,6 +404,8 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 #   into backend-specific chemistry loading circuits.
 # - Selected surface-code distance from an explicit logical failure budget
 #   before lifting logical resources to physical resources.
+# - Kept architecture quantities such as code distance attached to each
+#   resource estimate for later report auditing.
 # - Converted a chemistry QPE model into a block-encoding contract so PREPARE,
 #   SELECT, reflection, and workspace costs can be reviewed separately.
 # - Demonstrated how a unitary-weight concentration factor can be modeled as a

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d24f5609",
+   "id": "25a2d6d4",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "23b7d0ad",
+   "id": "06d604a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.482861Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.482652Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.488723Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.487935Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.643400Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.643184Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.649670Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.648559Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "57b5ad74",
+   "id": "5fdf01da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.490852Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.490704Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.849322Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.848922Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.651791Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.651642Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.938996Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.938573Z"
     }
    },
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63a60c60",
+   "id": "f9eba8cc",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "044e627c",
+   "id": "c2637aaa",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6582465a",
+   "id": "e9adb62f",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -127,13 +127,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bd1713d5",
+   "id": "d76071ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.850821Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.850744Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.853913Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.853553Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.940304Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.940209Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.943402Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.943073Z"
     }
    },
    "outputs": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df0eb1ca",
+   "id": "4b5730c8",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -221,13 +221,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f54e8d62",
+   "id": "60af0ab6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.854893Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.854843Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.876235Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.875940Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.944403Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.944355Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.964902Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.964512Z"
     }
    },
    "outputs": [
@@ -279,7 +279,7 @@
     "    physical_qubits_per_factory=5000,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "cost_model = architecture.to_cost_model()\n",
+    "cost_model = architecture\n",
     "\n",
     "assert architecture.code_distance == 21\n",
     "assert architecture.physical_qubits_per_logical == 882\n",
@@ -316,6 +316,9 @@
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
+    "assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
+    "assert compressed.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
+    "\n",
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
     "    compressed,\n",
@@ -332,7 +335,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc2a6f2f",
+   "id": "7431a5b3",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -343,13 +346,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8a7a3bc4",
+   "id": "c1a4afb2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.877362Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.877312Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.879901Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.879584Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.965881Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.965830Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.968407Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.968112Z"
     }
    },
    "outputs": [
@@ -382,7 +385,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc95c98e",
+   "id": "a5d50be4",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -396,13 +399,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "bdd080b4",
+   "id": "d8f56a8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.880853Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.880803Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.882797Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.882486Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.969383Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.969334Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.971444Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.971147Z"
     }
    },
    "outputs": [
@@ -428,7 +431,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c67df78",
+   "id": "354e61dc",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -442,13 +445,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "520a7685",
+   "id": "eda988e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.883786Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.883740Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.885941Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.885578Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.972262Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.972212Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.974395Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.974071Z"
     }
    },
    "outputs": [
@@ -484,7 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f398a1bd",
+   "id": "d3b71ea2",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -496,13 +499,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "94992ad4",
+   "id": "82a2d6ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.886808Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.886757Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.890177Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.889835Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.975412Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.975352Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.978573Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.978287Z"
     }
    },
    "outputs": [
@@ -525,7 +528,7 @@
     "    physical_qubits_per_factory=2500,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())\n",
+    "relifted_baseline = baseline.with_cost_model(faster_architecture)\n",
     "\n",
     "architecture_comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
@@ -538,13 +541,14 @@
     "\n",
     "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
     "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
+    "assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10\n",
     "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0\n",
     "assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2c83a684",
+   "id": "9c645744",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -556,13 +560,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "da780c14",
+   "id": "f326fe97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:48.891230Z",
-     "iopub.status.busy": "2026-06-22T16:54:48.891179Z",
-     "iopub.status.idle": "2026-06-22T16:54:48.895480Z",
-     "shell.execute_reply": "2026-06-22T16:54:48.895083Z"
+     "iopub.execute_input": "2026-06-22T17:28:35.979640Z",
+     "iopub.status.busy": "2026-06-22T17:28:35.979589Z",
+     "iopub.status.idle": "2026-06-22T17:28:35.984341Z",
+     "shell.execute_reply": "2026-06-22T17:28:35.983958Z"
     }
    },
    "outputs": [
@@ -610,7 +614,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "437ff974",
+   "id": "0ddb35c4",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -635,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc371f5b",
+   "id": "d924466b",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -651,6 +655,8 @@
     "  cost model consumed by chemistry estimators.\n",
     "- Surface-code distance can be selected from a logical failure budget before\n",
     "  lifting logical resources to physical qubits and runtime.\n",
+    "- Architecture quantities such as code distance remain on each estimate so\n",
+    "  reports can audit the physical-resource assumptions.\n",
     "- Estimates carry research references so reports can audit which paper\n",
     "  motivated a symbolic model.\n",
     "- FTQC estimates can be viewed as common logical `ResourceEstimate` objects\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -162,7 +162,7 @@ architecture = distance_budget.to_surface_code_cost_model(
     physical_qubits_per_factory=5000,
     factory_cycles_per_toffoli=2,
 )
-cost_model = architecture.to_cost_model()
+cost_model = architecture
 
 assert architecture.code_distance == 21
 assert architecture.physical_qubits_per_logical == 882
@@ -198,6 +198,9 @@ compressed = estimate_qubitized_chemistry_qpe_from_model(
     precision=sp.Float("0.0016"),
     cost_model=cost_model,
 )
+
+assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
+assert compressed.to_dict()["architecture_values"]["code_distance"] == "21"
 
 comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -284,7 +287,7 @@ faster_architecture = SurfaceCodeCostModel(
     physical_qubits_per_factory=2500,
     factory_cycles_per_toffoli=2,
 )
-relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())
+relifted_baseline = baseline.with_cost_model(faster_architecture)
 
 architecture_comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -297,6 +300,7 @@ for row in architecture_comparison:
 
 assert relifted_baseline.logical_qubits == baseline.logical_qubits
 assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
+assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10
 assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0
 assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0
 
@@ -371,6 +375,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   cost model consumed by chemistry estimators.
 # - Surface-code distance can be selected from a logical failure budget before
 #   lifting logical resources to physical qubits and runtime.
+# - Architecture quantities such as code distance remain on each estimate so
+#   reports can audit the physical-resource assumptions.
 # - Estimates carry research references so reports can audit which paper
 #   motivated a symbolic model.
 # - FTQC estimates can be viewed as common logical `ResourceEstimate` objects

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dccc0aaa",
+   "id": "d2c5b94e",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d131c015",
+   "id": "04be26ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:27.733925Z",
-     "iopub.status.busy": "2026-06-22T15:53:27.733762Z",
-     "iopub.status.idle": "2026-06-22T15:53:27.737584Z",
-     "shell.execute_reply": "2026-06-22T15:53:27.737023Z"
+     "iopub.execute_input": "2026-06-22T17:28:40.292598Z",
+     "iopub.status.busy": "2026-06-22T17:28:40.292388Z",
+     "iopub.status.idle": "2026-06-22T17:28:40.298939Z",
+     "shell.execute_reply": "2026-06-22T17:28:40.298109Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f8f0d10a",
+   "id": "8ad04416",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:27.739267Z",
-     "iopub.status.busy": "2026-06-22T15:53:27.739151Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.732366Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.731847Z"
+     "iopub.execute_input": "2026-06-22T17:28:40.302132Z",
+     "iopub.status.busy": "2026-06-22T17:28:40.301837Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.332785Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.332346Z"
     }
    },
    "outputs": [],
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02a48593",
+   "id": "403af22a",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "427ea219",
+   "id": "19340586",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -98,13 +98,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f6771888",
+   "id": "3b6959b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.733800Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.733666Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.737193Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.736879Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.334350Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.334152Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.337619Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.337190Z"
     }
    },
    "outputs": [],
@@ -126,16 +126,16 @@
     "    physical_qubits_per_factory=5000,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "cost_model = architecture.to_cost_model()\n",
+    "cost_model = architecture\n",
     "\n",
     "assert distance_budget.code_distance == 21\n",
-    "assert cost_model.physical_qubits_per_logical == 882\n",
-    "assert cost_model.factory_qubits == 20000"
+    "assert architecture.physical_qubits_per_logical == 882\n",
+    "assert architecture.factory_qubits == 20000"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb0d395f",
+   "id": "93df36a2",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -149,13 +149,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f5085044",
+   "id": "43583e83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.738326Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.738271Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.740672Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.740339Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.338749Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.338691Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.341062Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.340770Z"
     }
    },
    "outputs": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcc0ba4a",
+   "id": "0928a481",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -223,13 +223,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "52709233",
+   "id": "1464a33b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.741748Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.741689Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.744403Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.743954Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.342229Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.342174Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.344777Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.344382Z"
     }
    },
    "outputs": [],
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acd8e21d",
+   "id": "48736e46",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -264,13 +264,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "c4fc1b7e",
+   "id": "26614385",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.745528Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.745466Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.747658Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.747222Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.345670Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.345610Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.347740Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.347346Z"
     }
    },
    "outputs": [],
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "129dee6e",
+   "id": "87b43b2b",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -311,13 +311,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "0ce8060c",
+   "id": "6e74f8d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.748683Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.748627Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.764949Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.764601Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.348983Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.348929Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.365956Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.365569Z"
     }
    },
    "outputs": [
@@ -369,6 +369,8 @@
     "\n",
     "assert scdf.qpe_iterations < thc.qpe_iterations\n",
     "assert scdf.toffoli_gates < thc.toffoli_gates\n",
+    "assert scdf.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
+    "assert scdf.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
     "\n",
     "print(\"THC Toffoli gates:\", sp.N(thc.toffoli_gates, 4))\n",
     "print(\"SCDF-style Toffoli gates:\", sp.N(scdf.toffoli_gates, 4))\n",
@@ -409,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc9403d5",
+   "id": "d6920490",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -418,13 +420,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "05c84d19",
+   "id": "9e2415ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.766044Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.765982Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.768857Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.768533Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.367082Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.367021Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.369990Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.369679Z"
     }
    },
    "outputs": [
@@ -458,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ce0d09d",
+   "id": "e7333d49",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -469,13 +471,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e93bb61c",
+   "id": "2be74b3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.769896Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.769840Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.773842Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.773476Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.371044Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.370989Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.375535Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.375208Z"
     }
    },
    "outputs": [
@@ -538,7 +540,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e85e022",
+   "id": "a9e344f9",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -549,13 +551,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3f4ad928",
+   "id": "918c188b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T15:53:28.774859Z",
-     "iopub.status.busy": "2026-06-22T15:53:28.774805Z",
-     "iopub.status.idle": "2026-06-22T15:53:28.777256Z",
-     "shell.execute_reply": "2026-06-22T15:53:28.776897Z"
+     "iopub.execute_input": "2026-06-22T17:28:41.376677Z",
+     "iopub.status.busy": "2026-06-22T17:28:41.376610Z",
+     "iopub.status.idle": "2026-06-22T17:28:41.379170Z",
+     "shell.execute_reply": "2026-06-22T17:28:41.378847Z"
     }
    },
    "outputs": [
@@ -597,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d71d40a8",
+   "id": "cb643701",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -607,6 +609,7 @@
     "- FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。\n",
     "- Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。\n",
     "- logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。\n",
+    "- code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。\n",
     "- chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。\n",
     "- unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。"
    ]

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -82,11 +82,11 @@ architecture = distance_budget.to_surface_code_cost_model(
     physical_qubits_per_factory=5000,
     factory_cycles_per_toffoli=2,
 )
-cost_model = architecture.to_cost_model()
+cost_model = architecture
 
 assert distance_budget.code_distance == 21
-assert cost_model.physical_qubits_per_logical == 882
-assert cost_model.factory_qubits == 20000
+assert architecture.physical_qubits_per_logical == 882
+assert architecture.factory_qubits == 20000
 
 # %% [markdown]
 # ## Resource Quantities
@@ -215,6 +215,8 @@ scdf = estimate_qubitized_chemistry_qpe_from_model(
 
 assert scdf.qpe_iterations < thc.qpe_iterations
 assert scdf.toffoli_gates < thc.toffoli_gates
+assert scdf.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
+assert scdf.to_dict()["architecture_values"]["code_distance"] == "21"
 
 print("THC Toffoli gates:", sp.N(thc.toffoli_gates, 4))
 print("SCDF-style Toffoli gates:", sp.N(scdf.toffoli_gates, 4))
@@ -360,5 +362,6 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 # - FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。
 # - Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。
 # - logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。
+# - code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。
 # - chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。
 # - unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a920327c",
+   "id": "646732f8",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2c6269ef",
+   "id": "74f9dd2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.664465Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.664252Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.670868Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.669927Z"
+     "iopub.execute_input": "2026-06-22T17:28:36.752435Z",
+     "iopub.status.busy": "2026-06-22T17:28:36.752226Z",
+     "iopub.status.idle": "2026-06-22T17:28:36.757630Z",
+     "shell.execute_reply": "2026-06-22T17:28:36.757005Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "1a99c7f6",
+   "id": "d242cf1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.673205Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.673010Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.882623Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.882196Z"
+     "iopub.execute_input": "2026-06-22T17:28:36.760430Z",
+     "iopub.status.busy": "2026-06-22T17:28:36.760230Z",
+     "iopub.status.idle": "2026-06-22T17:28:36.975806Z",
+     "shell.execute_reply": "2026-06-22T17:28:36.975314Z"
     }
    },
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14faa161",
+   "id": "ddbdbe2a",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f889197",
+   "id": "ecbb778f",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1ff76f4",
+   "id": "ad1ccdad",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -113,13 +113,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "47a892d1",
+   "id": "6b29618f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.884198Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.884099Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.887298Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.886852Z"
+     "iopub.execute_input": "2026-06-22T17:28:36.977502Z",
+     "iopub.status.busy": "2026-06-22T17:28:36.977404Z",
+     "iopub.status.idle": "2026-06-22T17:28:36.980532Z",
+     "shell.execute_reply": "2026-06-22T17:28:36.980135Z"
     }
    },
    "outputs": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3da159c6",
+   "id": "019f09fd",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -205,13 +205,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3c614e84",
+   "id": "ad1e0009",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.888316Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.888257Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.906286Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.905934Z"
+     "iopub.execute_input": "2026-06-22T17:28:36.981522Z",
+     "iopub.status.busy": "2026-06-22T17:28:36.981462Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.000371Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.000015Z"
     }
    },
    "outputs": [
@@ -263,7 +263,7 @@
     "    physical_qubits_per_factory=5000,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "cost_model = architecture.to_cost_model()\n",
+    "cost_model = architecture\n",
     "\n",
     "assert architecture.code_distance == 21\n",
     "assert architecture.physical_qubits_per_logical == 882\n",
@@ -300,6 +300,9 @@
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
+    "assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
+    "assert compressed.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
+    "\n",
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
     "    compressed,\n",
@@ -316,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f720a3b2",
+   "id": "919905f2",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -325,13 +328,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9c322bfe",
+   "id": "edc730b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.907320Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.907261Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.910164Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.909768Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.001484Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.001427Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.004298Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.003944Z"
     }
    },
    "outputs": [
@@ -364,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cd4d28e",
+   "id": "c2d0cac7",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -375,13 +378,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2ac8850c",
+   "id": "edd6354a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.911195Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.911133Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.913321Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.912971Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.005365Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.005307Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.007462Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.007182Z"
     }
    },
    "outputs": [
@@ -407,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a7ffa05",
+   "id": "6c6b6c65",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -418,13 +421,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "bf998540",
+   "id": "f29f2822",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.914350Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.914296Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.916353Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.915980Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.008638Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.008583Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.010751Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.010425Z"
     }
    },
    "outputs": [
@@ -460,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56f0d315",
+   "id": "b781362e",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -471,13 +474,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c9108916",
+   "id": "83bbd3fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.917490Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.917430Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.920830Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.920477Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.011856Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.011799Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.015378Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.015023Z"
     }
    },
    "outputs": [
@@ -500,7 +503,7 @@
     "    physical_qubits_per_factory=2500,\n",
     "    factory_cycles_per_toffoli=2,\n",
     ")\n",
-    "relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())\n",
+    "relifted_baseline = baseline.with_cost_model(faster_architecture)\n",
     "\n",
     "architecture_comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
@@ -513,13 +516,14 @@
     "\n",
     "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
     "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
+    "assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10\n",
     "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0\n",
     "assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "117c6712",
+   "id": "0871a7d1",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -530,13 +534,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1820f0c0",
+   "id": "be4a4c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T16:54:49.921809Z",
-     "iopub.status.busy": "2026-06-22T16:54:49.921755Z",
-     "iopub.status.idle": "2026-06-22T16:54:49.925996Z",
-     "shell.execute_reply": "2026-06-22T16:54:49.925670Z"
+     "iopub.execute_input": "2026-06-22T17:28:37.016345Z",
+     "iopub.status.busy": "2026-06-22T17:28:37.016288Z",
+     "iopub.status.idle": "2026-06-22T17:28:37.020523Z",
+     "shell.execute_reply": "2026-06-22T17:28:37.020141Z"
     }
    },
    "outputs": [
@@ -584,7 +588,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0653918",
+   "id": "fad1be10",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -603,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dec7b5d",
+   "id": "b2bb018b",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -614,6 +618,7 @@
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。\n",
     "- Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。\n",
+    "- code distanceなどのarchitecture quantityは各estimateに残るため、reportでphysical resource仮定をauditできます。\n",
     "- estimateに研究referenceを保持し、どの論文がsymbolic modelの根拠になったかをreportでauditできるようにします。\n",
     "- reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。\n",
     "- 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -146,7 +146,7 @@ architecture = distance_budget.to_surface_code_cost_model(
     physical_qubits_per_factory=5000,
     factory_cycles_per_toffoli=2,
 )
-cost_model = architecture.to_cost_model()
+cost_model = architecture
 
 assert architecture.code_distance == 21
 assert architecture.physical_qubits_per_logical == 882
@@ -182,6 +182,9 @@ compressed = estimate_qubitized_chemistry_qpe_from_model(
     precision=sp.Float("0.0016"),
     cost_model=cost_model,
 )
+
+assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
+assert compressed.to_dict()["architecture_values"]["code_distance"] == "21"
 
 comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -259,7 +262,7 @@ faster_architecture = SurfaceCodeCostModel(
     physical_qubits_per_factory=2500,
     factory_cycles_per_toffoli=2,
 )
-relifted_baseline = baseline.with_cost_model(faster_architecture.to_cost_model())
+relifted_baseline = baseline.with_cost_model(faster_architecture)
 
 architecture_comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -272,6 +275,7 @@ for row in architecture_comparison:
 
 assert relifted_baseline.logical_qubits == baseline.logical_qubits
 assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
+assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10
 assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0
 assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0
 
@@ -334,6 +338,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。
 # - Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。
+# - code distanceなどのarchitecture quantityは各estimateに残るため、reportでphysical resource仮定をauditできます。
 # - estimateに研究referenceを保持し、どの論文がsymbolic modelの根拠になったかをreportでauditできるようにします。
 # - reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。
 # - 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -12,6 +12,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     FTQCCostModel,
     FTQCReference,
     FTQCResourceEstimate,
+    SurfaceCodeCostModel,
     references_for_chemistry_qpe_method,
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
@@ -214,7 +215,7 @@ def estimate_qubitized_qpe_from_block_encoding(
     precision: _SympyLike,
     *,
     qpe_register_qubits: _SympyLike = 0,
-    cost_model: FTQCCostModel | None = None,
+    cost_model: FTQCCostModel | SurfaceCodeCostModel | None = None,
     references: tuple[FTQCReference, ...] = (),
 ) -> FTQCResourceEstimate:
     """Estimate qubitized QPE resources from a block-encoding model.
@@ -228,9 +229,9 @@ def estimate_qubitized_qpe_from_block_encoding(
             used by an explicit QPE circuit. Defaults to zero so callers can
             separately decide whether phase-readout qubits are included in
             the block-encoding workspace.
-        cost_model (FTQCCostModel | None): Architecture model used to lift
-            logical estimates to physical qubits and runtime. Defaults to a
-            symbolic architecture model.
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model used to lift logical estimates to physical
+            qubits and runtime. Defaults to a symbolic architecture model.
         references (tuple[FTQCReference, ...]): Additional research sources
             to attach to the estimate.
 
@@ -250,7 +251,7 @@ def estimate_qubitized_qpe_from_block_encoding(
     toffoli_gates = sp.simplify(qpe_iterations * block_encoding.walk_cost_toffoli)
     logical_depth = toffoli_gates
     logical_qubits = sp.simplify(block_encoding.logical_qubits + qpe_qubits)
-    model = cost_model or FTQCCostModel()
+    model, architecture_values = _normalize_cost_model(cost_model)
     runtime_seconds = model.runtime_seconds_for(logical_depth, toffoli_gates)
     physical_qubits = model.physical_qubits_for(logical_qubits)
     assumptions = {
@@ -288,9 +289,11 @@ def estimate_qubitized_qpe_from_block_encoding(
             qpe_iterations,
             logical_depth,
             runtime_seconds,
+            *architecture_values.values(),
         ),
         assumptions=assumptions,
         references=references_for_estimate,
+        architecture_values=architecture_values,
     )
 
 
@@ -377,6 +380,34 @@ def _collect_parameters(*expressions: sp.Expr) -> dict[str, sp.Symbol]:
             if isinstance(symbol, sp.Symbol):
                 symbols.add(symbol)
     return {str(symbol): symbol for symbol in sorted(symbols, key=str)}
+
+
+def _normalize_cost_model(
+    cost_model: FTQCCostModel | SurfaceCodeCostModel | None,
+) -> tuple[FTQCCostModel, dict[FTQCResourceQuantity, sp.Expr]]:
+    """Normalize an architecture model for block-encoding estimates.
+
+    Args:
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model supplied by the caller. ``None`` creates a
+            symbolic ``FTQCCostModel``.
+
+    Returns:
+        tuple[FTQCCostModel, dict[FTQCResourceQuantity, sp.Expr]]: The
+            cost-model interface used for lifting and the canonical
+            architecture quantities retained on the estimate.
+
+    Raises:
+        TypeError: If ``cost_model`` is not a supported architecture model.
+    """
+    if cost_model is None:
+        model = FTQCCostModel()
+        return model, model.resource_values()
+    if isinstance(cost_model, SurfaceCodeCostModel):
+        return cost_model.to_cost_model(), cost_model.resource_values()
+    if isinstance(cost_model, FTQCCostModel):
+        return cost_model, cost_model.resource_values()
+    raise TypeError("cost_model must be an FTQCCostModel or SurfaceCodeCostModel.")
 
 
 def _combine_references(

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -902,6 +902,9 @@ class SurfaceCodeCostModel:
         )
 
 
+_FTQCCostModelLike = FTQCCostModel | SurfaceCodeCostModel
+
+
 @dataclass(frozen=True)
 class FTQCResourceEstimate:
     """Represent algorithm-level FTQC resource estimates.
@@ -927,6 +930,9 @@ class FTQCResourceEstimate:
         assumptions (dict[str, str]): Reader-facing notes about model choices.
         references (tuple[FTQCReference, ...]): Research sources that motivate
             the estimate's scaling model or resource assumptions.
+        architecture_values (dict[FTQCResourceQuantity, sp.Expr]): Architecture
+            quantities used to lift logical resources to physical resources.
+            These are keyed by the canonical FTQC quantity catalog.
 
     Example:
         >>> n, lam, eps, walk = sp.symbols("n lambda eps C_W", positive=True)
@@ -948,6 +954,9 @@ class FTQCResourceEstimate:
     parameters: dict[str, sp.Symbol] = field(default_factory=dict)
     assumptions: dict[str, str] = field(default_factory=dict)
     references: tuple[FTQCReference, ...] = ()
+    architecture_values: dict[FTQCResourceQuantity, sp.Expr] = field(
+        default_factory=dict
+    )
 
     def substitute(self, **values: int | float) -> FTQCResourceEstimate:
         """Substitute concrete values into all symbolic fields.
@@ -997,6 +1006,10 @@ class FTQCResourceEstimate:
             },
             "assumptions": dict(self.assumptions),
             "references": [reference.to_dict() for reference in self.references],
+            "architecture_values": {
+                quantity.value: str(value)
+                for quantity, value in self.architecture_values.items()
+            },
         }
 
     def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
@@ -1006,7 +1019,7 @@ class FTQCResourceEstimate:
             dict[FTQCResourceQuantity, sp.Expr]: Resource values for logical
                 and physical output quantities.
         """
-        return {
+        values = {
             FTQCResourceQuantity.LOGICAL_QUBITS: self.logical_qubits,
             FTQCResourceQuantity.PHYSICAL_QUBITS: self.physical_qubits,
             FTQCResourceQuantity.TOFFOLI_GATES: self.toffoli_gates,
@@ -1017,6 +1030,8 @@ class FTQCResourceEstimate:
             FTQCResourceQuantity.LOGICAL_DEPTH: self.logical_depth,
             FTQCResourceQuantity.RUNTIME_SECONDS: self.runtime_seconds,
         }
+        values.update(self.architecture_values)
+        return values
 
     def to_quantity_table(self) -> list[dict[str, str]]:
         """Serialize estimate values with quantity metadata.
@@ -1081,7 +1096,10 @@ class FTQCResourceEstimate:
             parameters=parameters,
         )
 
-    def with_cost_model(self, cost_model: FTQCCostModel) -> FTQCResourceEstimate:
+    def with_cost_model(
+        self,
+        cost_model: _FTQCCostModelLike,
+    ) -> FTQCResourceEstimate:
         """Relift physical resources with a different architecture model.
 
         The logical algorithm quantities are preserved. Physical qubits and
@@ -1090,35 +1108,39 @@ class FTQCResourceEstimate:
         non-Clifford throughput demand.
 
         Args:
-            cost_model (FTQCCostModel): Architecture model used for the new
-                physical-qubit and runtime estimates.
+            cost_model (FTQCCostModel | SurfaceCodeCostModel): Architecture
+                model used for the new physical-qubit and runtime estimates.
 
         Returns:
             FTQCResourceEstimate: Estimate with identical logical resources
                 and updated physical resources.
         """
+        normalized_cost_model, architecture_values = _normalize_cost_model(cost_model)
         assumptions = dict(self.assumptions)
         assumptions["architecture_relift"] = (
             "physical_qubits and runtime_seconds were recomputed from an "
-            "existing logical estimate with a replacement FTQCCostModel."
+            "existing logical estimate with a replacement architecture model."
         )
         non_clifford_gates = sp.simplify(self.toffoli_gates + self.t_gates)
         return _build_estimate(
             algorithm=self.algorithm,
             logical_qubits=self.logical_qubits,
-            physical_qubits=cost_model.physical_qubits_for(self.logical_qubits),
+            physical_qubits=normalized_cost_model.physical_qubits_for(
+                self.logical_qubits
+            ),
             toffoli_gates=self.toffoli_gates,
             t_gates=self.t_gates,
             clifford_gates=self.clifford_gates,
             qpe_iterations=self.qpe_iterations,
             target_precision=self.target_precision,
             logical_depth=self.logical_depth,
-            runtime_seconds=cost_model.runtime_seconds_for(
+            runtime_seconds=normalized_cost_model.runtime_seconds_for(
                 self.logical_depth,
                 non_clifford_gates,
             ),
             assumptions=assumptions,
             references=self.references,
+            architecture_values=architecture_values,
         )
 
     def _map_exprs(self, fn: Callable[[sp.Expr], sp.Expr]) -> FTQCResourceEstimate:
@@ -1145,6 +1167,10 @@ class FTQCResourceEstimate:
             parameters=self.parameters,
             assumptions=self.assumptions,
             references=self.references,
+            architecture_values={
+                quantity: fn(value)
+                for quantity, value in self.architecture_values.items()
+            },
         )
 
 
@@ -1613,7 +1639,7 @@ def estimate_qubitized_chemistry_qpe(
     sparsity: sp.Expr | int | None = None,
     second_factor_rank: sp.Expr | int | None = None,
     logical_qubits: sp.Expr | int | None = None,
-    cost_model: FTQCCostModel | None = None,
+    cost_model: _FTQCCostModelLike | None = None,
     references: tuple[FTQCReference, ...] = (),
 ) -> FTQCResourceEstimate:
     """Estimate qubitized QPE resources for molecular Hamiltonians.
@@ -1639,9 +1665,9 @@ def estimate_qubitized_chemistry_qpe(
             symbolic ``Xi``.
         logical_qubits (sp.Expr | int | None): Explicit logical-qubit count.
             When omitted, a representation-level scaling model is used.
-        cost_model (FTQCCostModel | None): Architecture model used to lift
-            logical estimates to physical qubits and runtime. Defaults to a
-            symbolic model.
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model used to lift logical estimates to physical
+            qubits and runtime. Defaults to a symbolic model.
         references (tuple[FTQCReference, ...]): Additional research sources
             to attach to the estimate. Method-level default references are
             attached automatically.
@@ -1675,7 +1701,7 @@ def estimate_qubitized_chemistry_qpe(
         logical_expr = _as_expr(logical_qubits, "logical_qubits")
         _validate_positive(logical_expr, "logical_qubits")
 
-    model = cost_model or FTQCCostModel()
+    model, architecture_values = _normalize_cost_model(cost_model)
     qpe_iterations = sp.simplify(lambda_expr / precision_expr)
     toffoli_gates = sp.simplify(qpe_iterations * walk_expr)
     logical_depth = toffoli_gates
@@ -1705,6 +1731,7 @@ def estimate_qubitized_chemistry_qpe(
             _METHOD_REFERENCES[method_enum],
             references,
         ),
+        architecture_values=architecture_values,
     )
 
 
@@ -1712,7 +1739,7 @@ def estimate_qubitized_chemistry_qpe_from_model(
     model: ChemistryQPEModel,
     precision: _SympyLike,
     *,
-    cost_model: FTQCCostModel | None = None,
+    cost_model: _FTQCCostModelLike | None = None,
 ) -> FTQCResourceEstimate:
     """Estimate qubitized QPE resources from a chemistry model object.
 
@@ -1721,9 +1748,9 @@ def estimate_qubitized_chemistry_qpe_from_model(
             lambda norm, sparsity/rank metadata, and walk cost.
         precision (sp.Expr | int | float): Target phase-estimation energy
             precision.
-        cost_model (FTQCCostModel | None): Architecture model used to lift
-            logical estimates to physical qubits and runtime. Defaults to a
-            symbolic model.
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model used to lift logical estimates to physical
+            qubits and runtime. Defaults to a symbolic model.
 
     Returns:
         FTQCResourceEstimate: Symbolic FTQC resource estimate.
@@ -1774,6 +1801,7 @@ def estimate_qubitized_chemistry_qpe_from_model(
         runtime_seconds=estimate.runtime_seconds,
         assumptions=assumptions,
         references=_combine_references(estimate.references, model.references),
+        architecture_values=estimate.architecture_values,
     )
 
 
@@ -1789,7 +1817,7 @@ def estimate_single_ancilla_trotter_qpe(
     randomized_compilation_factor: _SympyLike = 1,
     rotation_synthesis_t_gates: sp.Expr | int = 1,
     logical_qubits: sp.Expr | int | None = None,
-    cost_model: FTQCCostModel | None = None,
+    cost_model: _FTQCCostModelLike | None = None,
     references: tuple[FTQCReference, ...] = (),
 ) -> FTQCResourceEstimate:
     """Estimate early-FTQC single-ancilla Trotter QPE resources.
@@ -1818,8 +1846,9 @@ def estimate_single_ancilla_trotter_qpe(
         logical_qubits (sp.Expr | int | None): Explicit logical-qubit count.
             Defaults to ``n_spin_orbitals + 1`` for the data register plus
             the Hadamard-test ancilla.
-        cost_model (FTQCCostModel | None): Architecture model used to lift
-            logical estimates to physical qubits and runtime.
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model used to lift logical estimates to physical
+            qubits and runtime.
         references (tuple[FTQCReference, ...]): Additional research sources
             to attach to the estimate. The early-FTQC unitary-weight
             concentration source is attached automatically.
@@ -1872,7 +1901,7 @@ def estimate_single_ancilla_trotter_qpe(
     logical_depth = sp.simplify(qpe_iterations * pauli_rotations)
     t_gates = sp.simplify(logical_depth * rotation_t)
     toffoli_gates = sp.Integer(0)
-    model = cost_model or FTQCCostModel()
+    model, architecture_values = _normalize_cost_model(cost_model)
     physical_qubits = model.physical_qubits_for(logical_expr)
     runtime_seconds = model.runtime_seconds_for(logical_depth, t_gates)
     assumptions = {
@@ -1893,6 +1922,7 @@ def estimate_single_ancilla_trotter_qpe(
         runtime_seconds=runtime_seconds,
         assumptions=assumptions,
         references=_combine_references((_UWC_REFERENCE,), references),
+        architecture_values=architecture_values,
     )
 
 
@@ -1906,7 +1936,7 @@ def estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     randomized_compilation_factor: _SympyLike = 1,
     rotation_synthesis_t_gates: sp.Expr | int = 1,
     logical_qubits: sp.Expr | int | None = None,
-    cost_model: FTQCCostModel | None = None,
+    cost_model: _FTQCCostModelLike | None = None,
     references: tuple[FTQCReference, ...] = (),
 ) -> FTQCResourceEstimate:
     """Estimate single-ancilla Trotter QPE from a Hamiltonian summary.
@@ -1925,8 +1955,9 @@ def estimate_single_ancilla_trotter_qpe_from_hamiltonian(
             rotation. Defaults to one.
         logical_qubits (sp.Expr | int | None): Explicit logical-qubit count.
             Defaults to ``hamiltonian.n_spin_orbitals + 1``.
-        cost_model (FTQCCostModel | None): Architecture model used to lift
-            logical estimates to physical qubits and runtime.
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model used to lift logical estimates to physical
+            qubits and runtime.
         references (tuple[FTQCReference, ...]): Additional research sources
             to attach to the estimate.
 
@@ -2014,6 +2045,7 @@ def _build_estimate(
     runtime_seconds: sp.Expr,
     assumptions: dict[str, str],
     references: tuple[FTQCReference, ...] = (),
+    architecture_values: dict[FTQCResourceQuantity, sp.Expr] | None = None,
 ) -> FTQCResourceEstimate:
     """Create an estimate and collect its free symbolic parameters.
 
@@ -2031,10 +2063,14 @@ def _build_estimate(
         assumptions (dict[str, str]): Notes about model assumptions.
         references (tuple[FTQCReference, ...]): Research sources for the
             scaling model.
+        architecture_values (dict[FTQCResourceQuantity, sp.Expr] | None):
+            Architecture quantities used to lift logical resources to physical
+            resources. Defaults to None.
 
     Returns:
         FTQCResourceEstimate: Estimate with collected parameters.
     """
+    architecture = dict(architecture_values or {})
     expressions = [
         logical_qubits,
         physical_qubits,
@@ -2045,6 +2081,7 @@ def _build_estimate(
         target_precision,
         logical_depth,
         runtime_seconds,
+        *architecture.values(),
     ]
     return FTQCResourceEstimate(
         algorithm=algorithm,
@@ -2060,7 +2097,37 @@ def _build_estimate(
         parameters=_collect_parameters(expressions),
         assumptions=assumptions,
         references=_combine_references(references),
+        architecture_values=architecture,
     )
+
+
+def _normalize_cost_model(
+    cost_model: _FTQCCostModelLike | None,
+) -> tuple[FTQCCostModel, dict[FTQCResourceQuantity, sp.Expr]]:
+    """Normalize an architecture model for estimator use.
+
+    Args:
+        cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
+            Architecture model supplied by the caller. ``None`` creates a
+            symbolic ``FTQCCostModel``.
+
+    Returns:
+        tuple[FTQCCostModel, dict[FTQCResourceQuantity, sp.Expr]]: The
+            low-level cost model used for lifting and the canonical
+            architecture quantities to keep on the estimate.
+
+    Raises:
+        TypeError: If ``cost_model`` is not a supported FTQC architecture
+            model.
+    """
+    if cost_model is None:
+        model = FTQCCostModel()
+        return model, model.resource_values()
+    if isinstance(cost_model, SurfaceCodeCostModel):
+        return cost_model.to_cost_model(), cost_model.resource_values()
+    if isinstance(cost_model, FTQCCostModel):
+        return cost_model, cost_model.resource_values()
+    raise TypeError("cost_model must be an FTQCCostModel or SurfaceCodeCostModel.")
 
 
 def _collect_parameters(

--- a/tests/circuit/estimator/test_ftqc_block_encoding.py
+++ b/tests/circuit/estimator/test_ftqc_block_encoding.py
@@ -13,6 +13,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCCostModel,
     FTQCReference,
     FTQCResourceQuantity,
+    SurfaceCodeCostModel,
     block_encoding_from_chemistry_model,
     estimate_qubitized_qpe_from_block_encoding,
     summarize_pauli_hamiltonian,
@@ -81,6 +82,42 @@ def test_qubitized_qpe_from_block_encoding_tracks_walk_calls_and_costs():
     assert sp.Abs(estimate.runtime_seconds - sp.Float("0.00475")) < sp.Float("1e-12")
     assert estimate.assumptions["block_encoding"] == "toy_lcu"
     assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
+
+
+def test_qubitized_qpe_from_block_encoding_preserves_surface_code_architecture():
+    """Block-encoding estimates retain surface-code architecture quantities."""
+    architecture = SurfaceCodeCostModel(
+        code_distance=5,
+        physical_cycle_time_seconds=sp.Float("1e-6"),
+        physical_qubits_per_logical_factor=2,
+        logical_cycle_factor=1,
+        factory_count=4,
+        physical_qubits_per_factory=1000,
+        factory_cycles_per_toffoli=10,
+    )
+    block = BlockEncodingResource(
+        system_qubits=6,
+        normalization=100,
+        prepare_cost_toffoli=20,
+        select_cost_toffoli=50,
+        reflection_cost_toffoli=5,
+        ancilla_qubits=3,
+        name="toy_lcu",
+    )
+
+    estimate = estimate_qubitized_qpe_from_block_encoding(
+        block,
+        precision=2,
+        qpe_register_qubits=4,
+        cost_model=architecture,
+    )
+
+    values = estimate.resource_values()
+
+    assert estimate.physical_qubits == 4650
+    assert values[FTQCResourceQuantity.CODE_DISTANCE] == 5
+    assert values[FTQCResourceQuantity.FACTORY_COUNT] == 4
+    assert estimate.to_dict()["architecture_values"]["code_distance"] == "5"
 
 
 def test_qubitized_qpe_from_block_encoding_preserves_custom_references():

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -225,6 +225,41 @@ def test_surface_code_cost_model_derives_architecture_knobs():
     assert sp.Abs(estimate.runtime_seconds - sp.Float("5e-4")) < sp.Float("1e-12")
 
 
+def test_surface_code_model_is_preserved_on_resource_estimates():
+    """Architecture-lifted estimates retain canonical surface-code quantities."""
+    architecture = SurfaceCodeCostModel(
+        code_distance=7,
+        physical_cycle_time_seconds=sp.Float("2e-6"),
+        physical_qubits_per_logical_factor=2,
+        logical_cycle_factor=3,
+        factory_count=5,
+        physical_qubits_per_factory=1000,
+        factory_cycles_per_toffoli=4,
+    )
+
+    estimate = estimate_qubitized_chemistry_qpe(
+        n_spin_orbitals=4,
+        lambda_norm=8,
+        precision=2,
+        walk_cost_toffoli=10,
+        logical_qubits=7,
+        cost_model=architecture,
+    )
+
+    values = estimate.resource_values()
+    serialized = estimate.to_dict()
+
+    assert estimate.physical_qubits == 5686
+    assert values[FTQCResourceQuantity.CODE_DISTANCE] == 7
+    assert values[FTQCResourceQuantity.PHYSICAL_CYCLE_TIME_SECONDS] == sp.Float("2e-6")
+    assert values[FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL] == 98
+    assert serialized["architecture_values"]["code_distance"] == "7"
+    assert serialized["architecture_values"]["factory_count"] == "5"
+    assert any(
+        row["quantity"] == "code_distance" for row in estimate.to_quantity_table()
+    )
+
+
 def test_surface_code_distance_budget_selects_odd_distance():
     """Distance budgets select the smallest odd code distance from error inputs."""
     budget = SurfaceCodeDistanceBudget(


### PR DESCRIPTION
## Summary
- allow FTQC chemistry and block-encoding estimators to accept `SurfaceCodeCostModel` directly
- preserve canonical architecture quantities such as code distance, factory count, and physical cycle time on `FTQCResourceEstimate`
- include architecture values in serialized estimates and quantity tables so reports can audit physical-resource assumptions
- update EN/JA FTQC docs and executed notebooks to demonstrate architecture provenance

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_block_encoding.py tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_resource_estimation.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design or ftqc_chemistry_resource_estimation'`\n- `uv run ruff check qamomile/ tests/`\n- `uv run ruff format --check qamomile/ tests/`\n- `uv run zuban check qamomile/`\n- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`\n- `git diff --check`\n\n## Local review\n- Ran the required local-review mechanical checks before opening this draft PR. No findings remained from the latest branch changes.