### PR TITLE
Allocate FTQC accuracy budgets

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "72116035",
+   "id": "5e996497",
    "metadata": {},
    "source": [
     "---\n",
@@ -21,13 +21,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "796f48d4",
+   "id": "a867f3f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.743212Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.742976Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.748200Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.747441Z"
+     "iopub.execute_input": "2026-06-22T18:33:32.184159Z",
+     "iopub.status.busy": "2026-06-22T18:33:32.183879Z",
+     "iopub.status.idle": "2026-06-22T18:33:32.188857Z",
+     "shell.execute_reply": "2026-06-22T18:33:32.187945Z"
     }
    },
    "outputs": [],
@@ -39,13 +39,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8786c70c",
+   "id": "ab1deb43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.750047Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.749904Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.242254Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.241865Z"
+     "iopub.execute_input": "2026-06-22T18:33:32.191541Z",
+     "iopub.status.busy": "2026-06-22T18:33:32.191371Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.101109Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.100559Z"
     }
    },
    "outputs": [],
@@ -57,6 +57,7 @@
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
+    "    FTQCAccuracyBudget,\n",
     "    FTQCResourceQuantity,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
@@ -73,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4632455f",
+   "id": "b07b7e65",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -98,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0747080",
+   "id": "f25a90da",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -118,19 +119,24 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d353e97b",
+   "id": "828dc9c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.244094Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.243893Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.247311Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.246833Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.102707Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.102529Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.106556Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.106133Z"
     }
    },
    "outputs": [],
    "source": [
     "n_spin_orbitals = 40\n",
-    "precision = sp.Float(\"0.0016\")  # about chemical accuracy in Hartree\n",
+    "target_precision = sp.Float(\"0.0016\")  # about chemical accuracy in Hartree\n",
+    "accuracy_budget = FTQCAccuracyBudget(\n",
+    "    target_precision=target_precision,\n",
+    "    truncation_error=sp.Float(\"1e-4\"),\n",
+    ")\n",
+    "qpe_precision = accuracy_budget.qpe_precision\n",
     "\n",
     "distance_budget = SurfaceCodeDistanceBudget(\n",
     "    physical_error_rate=sp.Float(\"1e-3\"),\n",
@@ -150,12 +156,13 @@
     "\n",
     "assert distance_budget.code_distance == 21\n",
     "assert architecture.physical_qubits_per_logical == 882\n",
-    "assert architecture.factory_qubits == 20000"
+    "assert architecture.factory_qubits == 20000\n",
+    "assert sp.Abs(qpe_precision - sp.Float(\"0.0015\")) < sp.Float(\"1e-12\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17ef5f87",
+   "id": "9b3cd6c3",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -169,13 +176,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9af5a3e2",
+   "id": "af088101",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.248366Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.248310Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.250775Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.250363Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.107792Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.107723Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.110132Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.109732Z"
     }
    },
    "outputs": [
@@ -234,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5405ff32",
+   "id": "5c2db0c8",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -247,13 +254,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c06132c7",
+   "id": "e2c71bfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.252192Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.252133Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.254769Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.254373Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.111320Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.111259Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.114058Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.113627Z"
     }
    },
    "outputs": [],
@@ -276,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3523f48",
+   "id": "ff51c35a",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -288,13 +295,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "1eb689f0",
+   "id": "5ade0809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.255802Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.255746Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.258092Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.257597Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.115154Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.115080Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.117436Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.116971Z"
     }
    },
    "outputs": [],
@@ -317,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5054bdf3",
+   "id": "b1187aaf",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -327,7 +334,7 @@
     "representation-dependent one-walk Toffoli cost:\n",
     "\n",
     "```text\n",
-    "qpe_iterations = lambda_norm / precision\n",
+    "qpe_iterations = lambda_norm / qpe_precision\n",
     "toffoli_gates = qpe_iterations * walk_cost_toffoli\n",
     "```\n",
     "\n",
@@ -339,13 +346,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "5981cfdb",
+   "id": "cf82db42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.259055Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.258999Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.276088Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.275806Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.118490Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.118426Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.137235Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.136811Z"
     }
    },
    "outputs": [
@@ -353,13 +360,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC Toffoli gates: 5.000e+11\n",
-      "SCDF-style Toffoli gates: 2.750e+11\n",
+      "THC Toffoli gates: 5.333e+11\n",
+      "SCDF-style Toffoli gates: 2.933e+11\n",
       "Toy Pauli terms: 2\n",
       "SCDF-style logical qubits: 120\n",
       "Physical qubits 125840 physical qubits\n",
-      "Toffoli gates 275000000000.000 Toffoli gates\n",
-      "QPE iterations 62500000.0000000 iterations\n",
+      "Toffoli gates 293333333333.333 Toffoli gates\n",
+      "QPE iterations 66666666.6666667 iterations\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
       "Physical qubits ratio: 2.276 reduction: -1.276\n"
@@ -367,31 +374,35 @@
     }
    ],
    "source": [
-    "thc_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary,\n",
-    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
-    "    walk_cost_toffoli=sp.Integer(4_000),\n",
-    "    description=\"THC-style scaled toy model\",\n",
+    "thc_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary,\n",
+    "        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "        walk_cost_toffoli=sp.Integer(4_000),\n",
+    "        description=\"THC-style scaled toy model\",\n",
+    "    )\n",
     ")\n",
-    "scdf_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
-    "        sp.Float(\"0.5\"),\n",
-    "        source=\"SCDF-style scaled toy model\",\n",
-    "    ),\n",
-    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
-    "    walk_cost_toffoli=sp.Integer(4_400),\n",
-    "    second_factor_rank=9,\n",
-    "    description=\"SCDF-style scaled toy model\",\n",
+    "scdf_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "            sp.Float(\"0.5\"),\n",
+    "            source=\"SCDF-style scaled toy model\",\n",
+    "        ),\n",
+    "        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "        walk_cost_toffoli=sp.Integer(4_400),\n",
+    "        second_factor_rank=9,\n",
+    "        description=\"SCDF-style scaled toy model\",\n",
+    "    )\n",
     ")\n",
     "\n",
     "thc = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    thc_model,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "scdf = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    scdf_model,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -425,7 +436,7 @@
     "\n",
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
-    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")\n",
+    "assert sp.Abs(qubitized_savings[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
     "\n",
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
@@ -439,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7f0b355",
+   "id": "ca7e08df",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -451,13 +462,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3d6ea57e",
+   "id": "1094e4a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.277321Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.277257Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.280304Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.279967Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.138393Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.138327Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.141830Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.141345Z"
     }
    },
    "outputs": [
@@ -478,20 +489,20 @@
     ")\n",
     "scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
     "    scdf_block,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    qpe_register_qubits=12,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
     "print(scdf_block.to_dict())\n",
     "assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450\n",
-    "assert scdf_block_estimate.target_precision == precision\n",
+    "assert scdf_block_estimate.target_precision == qpe_precision\n",
     "assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6240d3e1",
+   "id": "e6ec891d",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -506,13 +517,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "31c01122",
+   "id": "3ce8743f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.281274Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.281219Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.285719Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.285317Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.142899Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.142836Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.147880Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.147418Z"
     }
    },
    "outputs": [
@@ -520,9 +531,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Plain Trotter QPE depth proxy: 2.560e+11\n",
-      "UWC-style Trotter QPE depth proxy: 1.280e+10\n",
-      "UWC-style T gates: 3.840e+10\n",
+      "Plain Trotter QPE depth proxy: 2.731e+11\n",
+      "UWC-style Trotter QPE depth proxy: 1.365e+10\n",
+      "UWC-style T gates: 4.096e+10\n",
       "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
       "Logical depth ratio: 0.05000 reduction: 0.9500\n"
      ]
@@ -531,7 +542,7 @@
    "source": [
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
     "    cost_model=cost_model,\n",
@@ -539,7 +550,7 @@
     "\n",
     "uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
     "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
@@ -575,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f1018e5",
+   "id": "d23b2048",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -589,13 +600,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "fd15a4f2",
+   "id": "e6a55cfd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:39.286785Z",
-     "iopub.status.busy": "2026-06-22T17:28:39.286729Z",
-     "iopub.status.idle": "2026-06-22T17:28:39.289356Z",
-     "shell.execute_reply": "2026-06-22T17:28:39.289030Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.148934Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.148861Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.151499Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.151028Z"
     }
    },
    "outputs": [
@@ -603,10 +614,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.250e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.888e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.688e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 2.016e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'runtime_seconds': 5.600e+5}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'runtime_seconds': 3.080e+5}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'runtime_seconds': 2.867e+5}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'runtime_seconds': 2.150e+4}\n"
      ]
     }
    ],
@@ -637,7 +648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90ce8ca0",
+   "id": "38e17f58",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -647,6 +658,8 @@
     "- Separated FTQC chemistry resource quantities into Hamiltonian\n",
     "  normalization, QPE iterations, non-Clifford counts, logical qubits,\n",
     "  physical qubits, and runtime proxies.\n",
+    "- Allocated a total target precision into truncation error and QPE precision\n",
+    "  before building comparable estimates.\n",
     "- Compared qubitized QPE representations without lowering the Qamomile IR\n",
     "  into backend-specific chemistry loading circuits.\n",
     "- Selected surface-code distance from an explicit logical failure budget\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -37,6 +37,7 @@ import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCResourceQuantity,
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
@@ -86,7 +87,12 @@ from qamomile.circuit.estimator.algorithmic import (
 
 # %%
 n_spin_orbitals = 40
-precision = sp.Float("0.0016")  # about chemical accuracy in Hartree
+target_precision = sp.Float("0.0016")  # about chemical accuracy in Hartree
+accuracy_budget = FTQCAccuracyBudget(
+    target_precision=target_precision,
+    truncation_error=sp.Float("1e-4"),
+)
+qpe_precision = accuracy_budget.qpe_precision
 
 distance_budget = SurfaceCodeDistanceBudget(
     physical_error_rate=sp.Float("1e-3"),
@@ -107,6 +113,7 @@ cost_model = architecture
 assert distance_budget.code_distance == 21
 assert architecture.physical_qubits_per_logical == 882
 assert architecture.factory_qubits == 20000
+assert sp.Abs(qpe_precision - sp.Float("0.0015")) < sp.Float("1e-12")
 
 # %% [markdown]
 # ## Resource Quantities
@@ -204,7 +211,7 @@ assert openfermion_summary.constant == toy_summary.constant
 # representation-dependent one-walk Toffoli cost:
 #
 # ```text
-# qpe_iterations = lambda_norm / precision
+# qpe_iterations = lambda_norm / qpe_precision
 # toffoli_gates = qpe_iterations * walk_cost_toffoli
 # ```
 #
@@ -213,31 +220,35 @@ assert openfermion_summary.constant == toy_summary.constant
 # choices.
 
 # %%
-thc_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary,
-    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
-    walk_cost_toffoli=sp.Integer(4_000),
-    description="THC-style scaled toy model",
+thc_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary,
+        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+        walk_cost_toffoli=sp.Integer(4_000),
+        description="THC-style scaled toy model",
+    )
 )
-scdf_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary.with_lambda_scale(
-        sp.Float("0.5"),
-        source="SCDF-style scaled toy model",
-    ),
-    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
-    walk_cost_toffoli=sp.Integer(4_400),
-    second_factor_rank=9,
-    description="SCDF-style scaled toy model",
+scdf_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary.with_lambda_scale(
+            sp.Float("0.5"),
+            source="SCDF-style scaled toy model",
+        ),
+        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+        walk_cost_toffoli=sp.Integer(4_400),
+        second_factor_rank=9,
+        description="SCDF-style scaled toy model",
+    )
 )
 
 thc = estimate_qubitized_chemistry_qpe_from_model(
     thc_model,
-    precision=precision,
+    precision=qpe_precision,
     cost_model=cost_model,
 )
 scdf = estimate_qubitized_chemistry_qpe_from_model(
     scdf_model,
-    precision=precision,
+    precision=qpe_precision,
     cost_model=cost_model,
 )
 
@@ -271,7 +282,7 @@ for row in qubitized_savings:
 
 assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
-assert qubitized_savings[1].ratio == sp.Float("0.55")
+assert sp.Abs(qubitized_savings[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
@@ -297,14 +308,14 @@ scdf_block = block_encoding_from_chemistry_model(
 )
 scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(
     scdf_block,
-    precision=precision,
+    precision=qpe_precision,
     qpe_register_qubits=12,
     cost_model=cost_model,
 )
 
 print(scdf_block.to_dict())
 assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450
-assert scdf_block_estimate.target_precision == precision
+assert scdf_block_estimate.target_precision == qpe_precision
 assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 
 # %% [markdown]
@@ -319,7 +330,7 @@ assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 # %%
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
-    precision=precision,
+    precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
     cost_model=cost_model,
@@ -327,7 +338,7 @@ plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
 
 uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
-    precision=precision,
+    precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
     unitary_weight_factor=sp.Float("0.1"),
@@ -400,6 +411,8 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 # - Separated FTQC chemistry resource quantities into Hamiltonian
 #   normalization, QPE iterations, non-Clifford counts, logical qubits,
 #   physical qubits, and runtime proxies.
+# - Allocated a total target precision into truncation error and QPE precision
+#   before building comparable estimates.
 # - Compared qubitized QPE representations without lowering the Qamomile IR
 #   into backend-specific chemistry loading circuits.
 # - Selected surface-code distance from an explicit logical failure budget

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "25a2d6d4",
+   "id": "9327cc63",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "06d604a5",
+   "id": "d07a4390",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.643400Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.643184Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.649670Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.648559Z"
+     "iopub.execute_input": "2026-06-22T18:54:51.630346Z",
+     "iopub.status.busy": "2026-06-22T18:54:51.630109Z",
+     "iopub.status.idle": "2026-06-22T18:54:51.635251Z",
+     "shell.execute_reply": "2026-06-22T18:54:51.634513Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5fdf01da",
+   "id": "ff423840",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.651791Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.651642Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.938996Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.938573Z"
+     "iopub.execute_input": "2026-06-22T18:54:51.637674Z",
+     "iopub.status.busy": "2026-06-22T18:54:51.637496Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.045695Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.045154Z"
     }
    },
    "outputs": [],
@@ -55,6 +55,7 @@
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
+    "    FTQCAccuracyBudget,\n",
     "    FTQCResourceCategory,\n",
     "    FTQCResourceQuantity,\n",
     "    SurfaceCodeCostModel,\n",
@@ -70,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9eba8cc",
+   "id": "b418923e",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -95,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2637aaa",
+   "id": "bf8fb8a0",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -115,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9adb62f",
+   "id": "bb8d0332",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -127,13 +128,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d76071ad",
+   "id": "4933637b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.940304Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.940209Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.943402Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.943073Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.047333Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.047229Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.050658Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.049981Z"
     }
    },
    "outputs": [
@@ -208,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b5730c8",
+   "id": "f93c1a20",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -221,13 +222,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "60af0ab6",
+   "id": "e29a0261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.944403Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.944355Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.964902Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.964512Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.051926Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.051869Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.079019Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.078508Z"
     }
    },
    "outputs": [
@@ -236,6 +237,7 @@
      "output_type": "stream",
      "text": [
       "{'physical_error_rate': '0.00100000000000000', 'threshold_error_rate': '0.0100000000000000', 'target_logical_failure_probability': '1.00000000000000e-9', 'logical_operation_budget': '1000', 'prefactor': '0.100000000000000', 'logical_failure_probability_per_operation': '1.00000000000000e-12', 'code_distance': '21', 'logical_error_rate': '1.00000000000000e-12'}\n",
+      "{'target_precision': '0.00160000000000000', 'truncation_error': '0.000100000000000000', 'safety_margin': '0', 'qpe_precision': '0.00150000000000000'}\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
       "Physical qubits ratio: 2.276 reduction: -1.276\n"
@@ -290,34 +292,48 @@
     "    \"1e-9\",\n",
     ")\n",
     "\n",
-    "baseline_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary,\n",
-    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
-    "    walk_cost_toffoli=sp.Integer(4_000),\n",
+    "accuracy_budget = FTQCAccuracyBudget(\n",
+    "    target_precision=sp.Float(\"0.0016\"),\n",
+    "    truncation_error=sp.Float(\"1e-4\"),\n",
     ")\n",
-    "compressed_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
-    "        sp.Float(\"0.5\"),\n",
-    "        source=\"compressed_scaled_toy_pauli_lcu\",\n",
-    "    ),\n",
-    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
-    "    walk_cost_toffoli=sp.Integer(4_400),\n",
-    "    second_factor_rank=9,\n",
+    "print(accuracy_budget.to_dict())\n",
+    "assert sp.Abs(accuracy_budget.qpe_precision - sp.Float(\"0.0015\")) < sp.Float(\"1e-12\")\n",
+    "\n",
+    "baseline_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary,\n",
+    "        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "        walk_cost_toffoli=sp.Integer(4_000),\n",
+    "    )\n",
+    ")\n",
+    "compressed_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "            sp.Float(\"0.5\"),\n",
+    "            source=\"compressed_scaled_toy_pauli_lcu\",\n",
+    "        ),\n",
+    "        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "        walk_cost_toffoli=sp.Integer(4_400),\n",
+    "        second_factor_rank=9,\n",
+    "    )\n",
     ")\n",
     "\n",
     "baseline = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    baseline_model,\n",
-    "    precision=sp.Float(\"0.0016\"),\n",
+    "    precision=accuracy_budget.qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "compressed = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    compressed_model,\n",
-    "    precision=sp.Float(\"0.0016\"),\n",
+    "    precision=accuracy_budget.qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
     "assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
     "assert compressed.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
+    "assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR] == (\n",
+    "    sp.Float(\"1e-4\")\n",
+    ")\n",
     "\n",
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
@@ -330,12 +346,12 @@
     "\n",
     "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
     "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
-    "assert comparison[1].ratio == sp.Float(\"0.55\")"
+    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7431a5b3",
+   "id": "793283f2",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -346,13 +362,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c1a4afb2",
+   "id": "dec956ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.965881Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.965830Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.968407Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.968112Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.080177Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.080120Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.083470Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.082907Z"
     }
    },
    "outputs": [
@@ -385,7 +401,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5d50be4",
+   "id": "e688e21e",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -399,13 +415,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d8f56a8b",
+   "id": "27deac85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.969383Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.969334Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.971444Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.971147Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.084859Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.084789Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.087334Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.086769Z"
     }
    },
    "outputs": [
@@ -431,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "354e61dc",
+   "id": "8c72c4fe",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -445,13 +461,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "eda988e5",
+   "id": "1cf0a818",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.972262Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.972212Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.974395Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.974071Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.088639Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.088572Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.090780Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.090341Z"
     }
    },
    "outputs": [
@@ -462,15 +478,15 @@
       "Resource Estimate:\n",
       "  Qubits: 120\n",
       "  Gates:\n",
-      "    Total: 275000000000.000\n",
+      "    Total: 293333333333.333\n",
       "    Single-qubit: 0\n",
       "    Two-qubit: 0\n",
-      "    Multi-qubit: 275000000000.000\n",
+      "    Multi-qubit: 293333333333.333\n",
       "    T gates: 0\n",
       "    Clifford gates: 0\n",
       "    Rotation gates: 0\n",
       "  Oracle Calls:\n",
-      "    qpe_iterations: 62500000.0000000\n"
+      "    qpe_iterations: 66666666.6666667\n"
      ]
     }
    ],
@@ -487,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3b71ea2",
+   "id": "053a7d5f",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -499,13 +515,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "82a2d6ba",
+   "id": "5d30493a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.975412Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.975352Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.978573Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.978287Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.091822Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.091758Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.096119Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.095234Z"
     }
    },
    "outputs": [
@@ -542,13 +558,17 @@
     "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
     "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
     "assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10\n",
-    "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0\n",
-    "assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0"
+    "assert sp.Abs(architecture_comparison[0].ratio - sp.Rational(350, 691)) < sp.Float(\n",
+    "    \"1e-12\"\n",
+    ")\n",
+    "assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float(\n",
+    "    \"1e-12\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9c645744",
+   "id": "c6457dae",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -560,13 +580,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f326fe97",
+   "id": "4e95c286",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:35.979640Z",
-     "iopub.status.busy": "2026-06-22T17:28:35.979589Z",
-     "iopub.status.idle": "2026-06-22T17:28:35.984341Z",
-     "shell.execute_reply": "2026-06-22T17:28:35.983958Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.097925Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.097864Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.102805Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.102248Z"
     }
    },
    "outputs": [
@@ -614,7 +634,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ddb35c4",
+   "id": "f6045bed",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -639,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d924466b",
+   "id": "40165a82",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -651,6 +671,8 @@
     "  logical depth, physical qubits, and runtime separately.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
     "  remains backend-neutral.\n",
+    "- Accuracy budgets split a total target precision into representation\n",
+    "  truncation error and QPE precision before estimates are compared.\n",
     "- Surface-code assumptions can be modeled separately and converted into the\n",
     "  cost model consumed by chemistry estimators.\n",
     "- Surface-code distance can be selected from a logical failure budget before\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -35,6 +35,7 @@ import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCResourceCategory,
     FTQCResourceQuantity,
     SurfaceCodeCostModel,
@@ -173,34 +174,48 @@ assert sp.Abs(
     "1e-9",
 )
 
-baseline_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary,
-    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
-    walk_cost_toffoli=sp.Integer(4_000),
+accuracy_budget = FTQCAccuracyBudget(
+    target_precision=sp.Float("0.0016"),
+    truncation_error=sp.Float("1e-4"),
 )
-compressed_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary.with_lambda_scale(
-        sp.Float("0.5"),
-        source="compressed_scaled_toy_pauli_lcu",
-    ),
-    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
-    walk_cost_toffoli=sp.Integer(4_400),
-    second_factor_rank=9,
+print(accuracy_budget.to_dict())
+assert sp.Abs(accuracy_budget.qpe_precision - sp.Float("0.0015")) < sp.Float("1e-12")
+
+baseline_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary,
+        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+        walk_cost_toffoli=sp.Integer(4_000),
+    )
+)
+compressed_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary.with_lambda_scale(
+            sp.Float("0.5"),
+            source="compressed_scaled_toy_pauli_lcu",
+        ),
+        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+        walk_cost_toffoli=sp.Integer(4_400),
+        second_factor_rank=9,
+    )
 )
 
 baseline = estimate_qubitized_chemistry_qpe_from_model(
     baseline_model,
-    precision=sp.Float("0.0016"),
+    precision=accuracy_budget.qpe_precision,
     cost_model=cost_model,
 )
 compressed = estimate_qubitized_chemistry_qpe_from_model(
     compressed_model,
-    precision=sp.Float("0.0016"),
+    precision=accuracy_budget.qpe_precision,
     cost_model=cost_model,
 )
 
 assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
 assert compressed.to_dict()["architecture_values"]["code_distance"] == "21"
+assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR] == (
+    sp.Float("1e-4")
+)
 
 comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -213,7 +228,7 @@ for row in comparison:
 
 assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
 assert comparison[0].ratio == sp.Float("0.5")
-assert comparison[1].ratio == sp.Float("0.55")
+assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 
 # %% [markdown]
 # For design reviews, the summary helper groups the same rows by whether the
@@ -301,8 +316,12 @@ for row in architecture_comparison:
 assert relifted_baseline.logical_qubits == baseline.logical_qubits
 assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
 assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10
-assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0
-assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0
+assert sp.Abs(architecture_comparison[0].ratio - sp.Rational(350, 691)) < sp.Float(
+    "1e-12"
+)
+assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float(
+    "1e-12"
+)
 
 # %% [markdown]
 # ## Early-FTQC Pattern
@@ -371,6 +390,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   logical depth, physical qubits, and runtime separately.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
 #   remains backend-neutral.
+# - Accuracy budgets split a total target precision into representation
+#   truncation error and QPE precision before estimates are compared.
 # - Surface-code assumptions can be modeled separately and converted into the
 #   cost model consumed by chemistry estimators.
 # - Surface-code distance can be selected from a logical failure budget before

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2c5b94e",
+   "id": "1463625a",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "04be26ec",
+   "id": "abfa7d75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:40.292598Z",
-     "iopub.status.busy": "2026-06-22T17:28:40.292388Z",
-     "iopub.status.idle": "2026-06-22T17:28:40.298939Z",
-     "shell.execute_reply": "2026-06-22T17:28:40.298109Z"
+     "iopub.execute_input": "2026-06-22T18:33:32.184532Z",
+     "iopub.status.busy": "2026-06-22T18:33:32.184232Z",
+     "iopub.status.idle": "2026-06-22T18:33:32.189347Z",
+     "shell.execute_reply": "2026-06-22T18:33:32.188314Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8ad04416",
+   "id": "6f67ba6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:40.302132Z",
-     "iopub.status.busy": "2026-06-22T17:28:40.301837Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.332785Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.332346Z"
+     "iopub.execute_input": "2026-06-22T18:33:32.191755Z",
+     "iopub.status.busy": "2026-06-22T18:33:32.191598Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.101375Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.100877Z"
     }
    },
    "outputs": [],
@@ -53,6 +53,7 @@
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
+    "    FTQCAccuracyBudget,\n",
     "    FTQCResourceQuantity,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
@@ -69,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "403af22a",
+   "id": "4ad8c2b5",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19340586",
+   "id": "8b903580",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -98,19 +99,24 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3b6959b4",
+   "id": "5f008f60",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.334350Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.334152Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.337619Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.337190Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.102952Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.102799Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.106847Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.106465Z"
     }
    },
    "outputs": [],
    "source": [
     "n_spin_orbitals = 40\n",
-    "precision = sp.Float(\"0.0016\")  # Hartree単位のおおよそのchemical accuracy\n",
+    "target_precision = sp.Float(\"0.0016\")  # Hartree単位のおおよそのchemical accuracy\n",
+    "accuracy_budget = FTQCAccuracyBudget(\n",
+    "    target_precision=target_precision,\n",
+    "    truncation_error=sp.Float(\"1e-4\"),\n",
+    ")\n",
+    "qpe_precision = accuracy_budget.qpe_precision\n",
     "\n",
     "distance_budget = SurfaceCodeDistanceBudget(\n",
     "    physical_error_rate=sp.Float(\"1e-3\"),\n",
@@ -130,12 +136,13 @@
     "\n",
     "assert distance_budget.code_distance == 21\n",
     "assert architecture.physical_qubits_per_logical == 882\n",
-    "assert architecture.factory_qubits == 20000"
+    "assert architecture.factory_qubits == 20000\n",
+    "assert sp.Abs(qpe_precision - sp.Float(\"0.0015\")) < sp.Float(\"1e-12\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "93df36a2",
+   "id": "1b52692f",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -149,13 +156,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "43583e83",
+   "id": "26e9a533",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.338749Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.338691Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.341062Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.340770Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.108023Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.107955Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.110462Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.109951Z"
     }
    },
    "outputs": [
@@ -214,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0928a481",
+   "id": "a0a014b3",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -223,13 +230,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "1464a33b",
+   "id": "65eabee0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.342229Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.342174Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.344777Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.344382Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.111494Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.111430Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.114216Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.113779Z"
     }
    },
    "outputs": [],
@@ -252,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48736e46",
+   "id": "4e4d2224",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -264,13 +271,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "26614385",
+   "id": "dde53f81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.345670Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.345610Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.347740Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.347346Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.115241Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.115182Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.117535Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.117093Z"
     }
    },
    "outputs": [],
@@ -293,7 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87b43b2b",
+   "id": "44cf7adb",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -301,7 +308,7 @@
     "Qamomileはchemistry factorization costをIRの外側に保ちます。model-driven Estimatorは、Hamiltonian summaryとrepresentation-dependentなone-walk Toffoli costを入力として受け取ります。\n",
     "\n",
     "```text\n",
-    "qpe_iterations = lambda_norm / precision\n",
+    "qpe_iterations = lambda_norm / qpe_precision\n",
     "toffoli_gates = qpe_iterations * walk_cost_toffoli\n",
     "```\n",
     "\n",
@@ -311,13 +318,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6e74f8d7",
+   "id": "973833ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.348983Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.348929Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.365956Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.365569Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.118593Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.118531Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.136940Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.136563Z"
     }
    },
    "outputs": [
@@ -325,13 +332,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC Toffoli gates: 5.000e+11\n",
-      "SCDF-style Toffoli gates: 2.750e+11\n",
+      "THC Toffoli gates: 5.333e+11\n",
+      "SCDF-style Toffoli gates: 2.933e+11\n",
       "Toy Pauli terms: 2\n",
       "SCDF-style logical qubits: 120\n",
       "Physical qubits 125840 physical qubits\n",
-      "Toffoli gates 275000000000.000 Toffoli gates\n",
-      "QPE iterations 62500000.0000000 iterations\n",
+      "Toffoli gates 293333333333.333 Toffoli gates\n",
+      "QPE iterations 66666666.6666667 iterations\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
       "Physical qubits ratio: 2.276 reduction: -1.276\n"
@@ -339,31 +346,35 @@
     }
    ],
    "source": [
-    "thc_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary,\n",
-    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
-    "    walk_cost_toffoli=sp.Integer(4_000),\n",
-    "    description=\"THC-style scaled toy model\",\n",
+    "thc_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary,\n",
+    "        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "        walk_cost_toffoli=sp.Integer(4_000),\n",
+    "        description=\"THC-style scaled toy model\",\n",
+    "    )\n",
     ")\n",
-    "scdf_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
-    "        sp.Float(\"0.5\"),\n",
-    "        source=\"SCDF-style scaled toy model\",\n",
-    "    ),\n",
-    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
-    "    walk_cost_toffoli=sp.Integer(4_400),\n",
-    "    second_factor_rank=9,\n",
-    "    description=\"SCDF-style scaled toy model\",\n",
+    "scdf_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "            sp.Float(\"0.5\"),\n",
+    "            source=\"SCDF-style scaled toy model\",\n",
+    "        ),\n",
+    "        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "        walk_cost_toffoli=sp.Integer(4_400),\n",
+    "        second_factor_rank=9,\n",
+    "        description=\"SCDF-style scaled toy model\",\n",
+    "    )\n",
     ")\n",
     "\n",
     "thc = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    thc_model,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "scdf = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    scdf_model,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -397,7 +408,7 @@
     "\n",
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
-    "assert qubitized_savings[1].ratio == sp.Float(\"0.55\")\n",
+    "assert sp.Abs(qubitized_savings[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
     "\n",
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
@@ -411,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6920490",
+   "id": "8f1d80fc",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -420,13 +431,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9e2415ca",
+   "id": "72ab4193",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.367082Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.367021Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.369990Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.369679Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.138170Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.138098Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.141506Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.141137Z"
     }
    },
    "outputs": [
@@ -447,20 +458,20 @@
     ")\n",
     "scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(\n",
     "    scdf_block,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    qpe_register_qubits=12,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
     "print(scdf_block.to_dict())\n",
     "assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450\n",
-    "assert scdf_block_estimate.target_precision == precision\n",
+    "assert scdf_block_estimate.target_precision == qpe_precision\n",
     "assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e7333d49",
+   "id": "5d62e88f",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -471,13 +482,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "2be74b3a",
+   "id": "589f4607",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.371044Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.370989Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.375535Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.375208Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.142626Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.142571Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.147596Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.147184Z"
     }
    },
    "outputs": [
@@ -485,9 +496,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Plain Trotter QPE depth proxy: 2.560e+11\n",
-      "UWC-style Trotter QPE depth proxy: 1.280e+10\n",
-      "UWC-style T gates: 3.840e+10\n",
+      "Plain Trotter QPE depth proxy: 2.731e+11\n",
+      "UWC-style Trotter QPE depth proxy: 1.365e+10\n",
+      "UWC-style T gates: 4.096e+10\n",
       "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
       "Logical depth ratio: 0.05000 reduction: 0.9500\n"
      ]
@@ -496,7 +507,7 @@
    "source": [
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
     "    cost_model=cost_model,\n",
@@ -504,7 +515,7 @@
     "\n",
     "uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
-    "    precision=precision,\n",
+    "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
     "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
@@ -540,7 +551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9e344f9",
+   "id": "f78b0092",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -551,13 +562,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "918c188b",
+   "id": "956f572c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:41.376677Z",
-     "iopub.status.busy": "2026-06-22T17:28:41.376610Z",
-     "iopub.status.idle": "2026-06-22T17:28:41.379170Z",
-     "shell.execute_reply": "2026-06-22T17:28:41.378847Z"
+     "iopub.execute_input": "2026-06-22T18:33:34.148865Z",
+     "iopub.status.busy": "2026-06-22T18:33:34.148782Z",
+     "iopub.status.idle": "2026-06-22T18:33:34.151334Z",
+     "shell.execute_reply": "2026-06-22T18:33:34.150921Z"
     }
    },
    "outputs": [
@@ -565,10 +576,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 5.000e+11, 't_gates': 0, 'runtime_seconds': 5.250e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.250e+7, 'toffoli_gates': 2.750e+11, 't_gates': 0, 'runtime_seconds': 2.888e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+8, 'toffoli_gates': 0, 't_gates': 2.560e+11, 'runtime_seconds': 2.688e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.250e+7, 'toffoli_gates': 0, 't_gates': 3.840e+10, 'runtime_seconds': 2.016e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'runtime_seconds': 5.600e+5}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'runtime_seconds': 3.080e+5}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'runtime_seconds': 2.867e+5}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'runtime_seconds': 2.150e+4}\n"
      ]
     }
    ],
@@ -599,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb643701",
+   "id": "1b76f649",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -607,6 +618,7 @@
     "このノートブックでは、次のことを確認しました。\n",
     "\n",
     "- FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。\n",
+    "- comparableなestimateを作る前に、total target precisionをtruncation errorとQPE precisionへ割り当てました。\n",
     "- Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。\n",
     "- logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。\n",
     "- code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。\n",

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -33,6 +33,7 @@ import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCResourceQuantity,
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
@@ -66,7 +67,12 @@ from qamomile.circuit.estimator.algorithmic import (
 
 # %%
 n_spin_orbitals = 40
-precision = sp.Float("0.0016")  # Hartree単位のおおよそのchemical accuracy
+target_precision = sp.Float("0.0016")  # Hartree単位のおおよそのchemical accuracy
+accuracy_budget = FTQCAccuracyBudget(
+    target_precision=target_precision,
+    truncation_error=sp.Float("1e-4"),
+)
+qpe_precision = accuracy_budget.qpe_precision
 
 distance_budget = SurfaceCodeDistanceBudget(
     physical_error_rate=sp.Float("1e-3"),
@@ -87,6 +93,7 @@ cost_model = architecture
 assert distance_budget.code_distance == 21
 assert architecture.physical_qubits_per_logical == 882
 assert architecture.factory_qubits == 20000
+assert sp.Abs(qpe_precision - sp.Float("0.0015")) < sp.Float("1e-12")
 
 # %% [markdown]
 # ## Resource Quantities
@@ -178,38 +185,42 @@ assert openfermion_summary.constant == toy_summary.constant
 # Qamomileはchemistry factorization costをIRの外側に保ちます。model-driven Estimatorは、Hamiltonian summaryとrepresentation-dependentなone-walk Toffoli costを入力として受け取ります。
 #
 # ```text
-# qpe_iterations = lambda_norm / precision
+# qpe_iterations = lambda_norm / qpe_precision
 # toffoli_gates = qpe_iterations * walk_cost_toffoli
 # ```
 #
 # これによりモデルを明確に保てます。Hamiltonian normalizationを変えること、walk circuitを変えること、physical architectureを変えることは、それぞれ別の設計選択です。
 
 # %%
-thc_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary,
-    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
-    walk_cost_toffoli=sp.Integer(4_000),
-    description="THC-style scaled toy model",
+thc_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary,
+        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+        walk_cost_toffoli=sp.Integer(4_000),
+        description="THC-style scaled toy model",
+    )
 )
-scdf_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary.with_lambda_scale(
-        sp.Float("0.5"),
-        source="SCDF-style scaled toy model",
-    ),
-    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
-    walk_cost_toffoli=sp.Integer(4_400),
-    second_factor_rank=9,
-    description="SCDF-style scaled toy model",
+scdf_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary.with_lambda_scale(
+            sp.Float("0.5"),
+            source="SCDF-style scaled toy model",
+        ),
+        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+        walk_cost_toffoli=sp.Integer(4_400),
+        second_factor_rank=9,
+        description="SCDF-style scaled toy model",
+    )
 )
 
 thc = estimate_qubitized_chemistry_qpe_from_model(
     thc_model,
-    precision=precision,
+    precision=qpe_precision,
     cost_model=cost_model,
 )
 scdf = estimate_qubitized_chemistry_qpe_from_model(
     scdf_model,
-    precision=precision,
+    precision=qpe_precision,
     cost_model=cost_model,
 )
 
@@ -243,7 +254,7 @@ for row in qubitized_savings:
 
 assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
-assert qubitized_savings[1].ratio == sp.Float("0.55")
+assert sp.Abs(qubitized_savings[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
@@ -266,14 +277,14 @@ scdf_block = block_encoding_from_chemistry_model(
 )
 scdf_block_estimate = estimate_qubitized_qpe_from_block_encoding(
     scdf_block,
-    precision=precision,
+    precision=qpe_precision,
     qpe_register_qubits=12,
     cost_model=cost_model,
 )
 
 print(scdf_block.to_dict())
 assert scdf_block.walk_cost_toffoli == scdf_model.walk_cost_toffoli + 450
-assert scdf_block_estimate.target_precision == precision
+assert scdf_block_estimate.target_precision == qpe_precision
 assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 
 # %% [markdown]
@@ -284,7 +295,7 @@ assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 # %%
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
-    precision=precision,
+    precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
     cost_model=cost_model,
@@ -292,7 +303,7 @@ plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
 
 uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
-    precision=precision,
+    precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
     unitary_weight_factor=sp.Float("0.1"),
@@ -360,6 +371,7 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 # このノートブックでは、次のことを確認しました。
 #
 # - FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。
+# - comparableなestimateを作る前に、total target precisionをtruncation errorとQPE precisionへ割り当てました。
 # - Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。
 # - logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。
 # - code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "646732f8",
+   "id": "92ce1a58",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "74f9dd2a",
+   "id": "76fcc3c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:36.752435Z",
-     "iopub.status.busy": "2026-06-22T17:28:36.752226Z",
-     "iopub.status.idle": "2026-06-22T17:28:36.757630Z",
-     "shell.execute_reply": "2026-06-22T17:28:36.757005Z"
+     "iopub.execute_input": "2026-06-22T18:54:51.630232Z",
+     "iopub.status.busy": "2026-06-22T18:54:51.629982Z",
+     "iopub.status.idle": "2026-06-22T18:54:51.635180Z",
+     "shell.execute_reply": "2026-06-22T18:54:51.634493Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d242cf1c",
+   "id": "63ae83fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:36.760430Z",
-     "iopub.status.busy": "2026-06-22T17:28:36.760230Z",
-     "iopub.status.idle": "2026-06-22T17:28:36.975806Z",
-     "shell.execute_reply": "2026-06-22T17:28:36.975314Z"
+     "iopub.execute_input": "2026-06-22T18:54:51.637740Z",
+     "iopub.status.busy": "2026-06-22T18:54:51.637558Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.045708Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.045154Z"
     }
    },
    "outputs": [],
@@ -52,6 +52,7 @@
     "from qamomile.circuit.estimator.algorithmic import (\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
+    "    FTQCAccuracyBudget,\n",
     "    FTQCResourceCategory,\n",
     "    FTQCResourceQuantity,\n",
     "    SurfaceCodeCostModel,\n",
@@ -67,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddbdbe2a",
+   "id": "0f8f7b90",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -84,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecbb778f",
+   "id": "57aaddf9",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad1ccdad",
+   "id": "7f1c6de8",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -113,13 +114,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6b29618f",
+   "id": "8f6730d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:36.977502Z",
-     "iopub.status.busy": "2026-06-22T17:28:36.977404Z",
-     "iopub.status.idle": "2026-06-22T17:28:36.980532Z",
-     "shell.execute_reply": "2026-06-22T17:28:36.980135Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.047350Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.047250Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.050726Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.049987Z"
     }
    },
    "outputs": [
@@ -194,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "019f09fd",
+   "id": "441b9d31",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -205,13 +206,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ad1e0009",
+   "id": "52c83f9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:36.981522Z",
-     "iopub.status.busy": "2026-06-22T17:28:36.981462Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.000371Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.000015Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.051865Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.051807Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.079042Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.078540Z"
     }
    },
    "outputs": [
@@ -220,6 +221,7 @@
      "output_type": "stream",
      "text": [
       "{'physical_error_rate': '0.00100000000000000', 'threshold_error_rate': '0.0100000000000000', 'target_logical_failure_probability': '1.00000000000000e-9', 'logical_operation_budget': '1000', 'prefactor': '0.100000000000000', 'logical_failure_probability_per_operation': '1.00000000000000e-12', 'code_distance': '21', 'logical_error_rate': '1.00000000000000e-12'}\n",
+      "{'target_precision': '0.00160000000000000', 'truncation_error': '0.000100000000000000', 'safety_margin': '0', 'qpe_precision': '0.00150000000000000'}\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
       "Physical qubits ratio: 2.276 reduction: -1.276\n"
@@ -274,34 +276,48 @@
     "    \"1e-9\",\n",
     ")\n",
     "\n",
-    "baseline_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary,\n",
-    "    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
-    "    walk_cost_toffoli=sp.Integer(4_000),\n",
+    "accuracy_budget = FTQCAccuracyBudget(\n",
+    "    target_precision=sp.Float(\"0.0016\"),\n",
+    "    truncation_error=sp.Float(\"1e-4\"),\n",
     ")\n",
-    "compressed_model = ChemistryQPEModel(\n",
-    "    hamiltonian=scaled_summary.with_lambda_scale(\n",
-    "        sp.Float(\"0.5\"),\n",
-    "        source=\"compressed_scaled_toy_pauli_lcu\",\n",
-    "    ),\n",
-    "    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
-    "    walk_cost_toffoli=sp.Integer(4_400),\n",
-    "    second_factor_rank=9,\n",
+    "print(accuracy_budget.to_dict())\n",
+    "assert sp.Abs(accuracy_budget.qpe_precision - sp.Float(\"0.0015\")) < sp.Float(\"1e-12\")\n",
+    "\n",
+    "baseline_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary,\n",
+    "        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,\n",
+    "        walk_cost_toffoli=sp.Integer(4_000),\n",
+    "    )\n",
+    ")\n",
+    "compressed_model = accuracy_budget.with_model(\n",
+    "    ChemistryQPEModel(\n",
+    "        hamiltonian=scaled_summary.with_lambda_scale(\n",
+    "            sp.Float(\"0.5\"),\n",
+    "            source=\"compressed_scaled_toy_pauli_lcu\",\n",
+    "        ),\n",
+    "        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,\n",
+    "        walk_cost_toffoli=sp.Integer(4_400),\n",
+    "        second_factor_rank=9,\n",
+    "    )\n",
     ")\n",
     "\n",
     "baseline = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    baseline_model,\n",
-    "    precision=sp.Float(\"0.0016\"),\n",
+    "    precision=accuracy_budget.qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "compressed = estimate_qubitized_chemistry_qpe_from_model(\n",
     "    compressed_model,\n",
-    "    precision=sp.Float(\"0.0016\"),\n",
+    "    precision=accuracy_budget.qpe_precision,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
     "assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21\n",
     "assert compressed.to_dict()[\"architecture_values\"][\"code_distance\"] == \"21\"\n",
+    "assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR] == (\n",
+    "    sp.Float(\"1e-4\")\n",
+    ")\n",
     "\n",
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
@@ -314,12 +330,12 @@
     "\n",
     "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
     "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
-    "assert comparison[1].ratio == sp.Float(\"0.55\")"
+    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "919905f2",
+   "id": "f5ba389d",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -328,13 +344,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "edc730b5",
+   "id": "9168a744",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.001484Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.001427Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.004298Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.003944Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.080217Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.080151Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.083321Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.082906Z"
     }
    },
    "outputs": [
@@ -367,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2d0cac7",
+   "id": "cc2b7e03",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -378,13 +394,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "edd6354a",
+   "id": "abd114b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.005365Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.005307Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.007462Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.007182Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.084761Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.084689Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.087058Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.086462Z"
     }
    },
    "outputs": [
@@ -410,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c6b6c65",
+   "id": "95dc88bc",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -421,13 +437,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f29f2822",
+   "id": "40e686a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.008638Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.008583Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.010751Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.010425Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.088312Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.088175Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.090508Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.089987Z"
     }
    },
    "outputs": [
@@ -438,15 +454,15 @@
       "Resource Estimate:\n",
       "  Qubits: 120\n",
       "  Gates:\n",
-      "    Total: 275000000000.000\n",
+      "    Total: 293333333333.333\n",
       "    Single-qubit: 0\n",
       "    Two-qubit: 0\n",
-      "    Multi-qubit: 275000000000.000\n",
+      "    Multi-qubit: 293333333333.333\n",
       "    T gates: 0\n",
       "    Clifford gates: 0\n",
       "    Rotation gates: 0\n",
       "  Oracle Calls:\n",
-      "    qpe_iterations: 62500000.0000000\n"
+      "    qpe_iterations: 66666666.6666667\n"
      ]
     }
    ],
@@ -463,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b781362e",
+   "id": "f7621492",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -474,13 +490,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "83bbd3fa",
+   "id": "d040e8e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.011856Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.011799Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.015378Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.015023Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.091662Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.091585Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.095481Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.094972Z"
     }
    },
    "outputs": [
@@ -517,13 +533,17 @@
     "assert relifted_baseline.logical_qubits == baseline.logical_qubits\n",
     "assert relifted_baseline.toffoli_gates == baseline.toffoli_gates\n",
     "assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10\n",
-    "assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0\n",
-    "assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0"
+    "assert sp.Abs(architecture_comparison[0].ratio - sp.Rational(350, 691)) < sp.Float(\n",
+    "    \"1e-12\"\n",
+    ")\n",
+    "assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float(\n",
+    "    \"1e-12\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0871a7d1",
+   "id": "db02bd5f",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -534,13 +554,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "be4a4c03",
+   "id": "13ad5050",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T17:28:37.016345Z",
-     "iopub.status.busy": "2026-06-22T17:28:37.016288Z",
-     "iopub.status.idle": "2026-06-22T17:28:37.020523Z",
-     "shell.execute_reply": "2026-06-22T17:28:37.020141Z"
+     "iopub.execute_input": "2026-06-22T18:54:52.097605Z",
+     "iopub.status.busy": "2026-06-22T18:54:52.097503Z",
+     "iopub.status.idle": "2026-06-22T18:54:52.102463Z",
+     "shell.execute_reply": "2026-06-22T18:54:52.101836Z"
     }
    },
    "outputs": [
@@ -588,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fad1be10",
+   "id": "c274be51",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -607,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2bb018b",
+   "id": "19e03676",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -616,6 +636,7 @@
     "\n",
     "- 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
+    "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",
     "- Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。\n",
     "- Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。\n",
     "- code distanceなどのarchitecture quantityは各estimateに残るため、reportでphysical resource仮定をauditできます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -32,6 +32,7 @@ import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCResourceCategory,
     FTQCResourceQuantity,
     SurfaceCodeCostModel,
@@ -157,34 +158,48 @@ assert sp.Abs(
     "1e-9",
 )
 
-baseline_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary,
-    method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
-    walk_cost_toffoli=sp.Integer(4_000),
+accuracy_budget = FTQCAccuracyBudget(
+    target_precision=sp.Float("0.0016"),
+    truncation_error=sp.Float("1e-4"),
 )
-compressed_model = ChemistryQPEModel(
-    hamiltonian=scaled_summary.with_lambda_scale(
-        sp.Float("0.5"),
-        source="compressed_scaled_toy_pauli_lcu",
-    ),
-    method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
-    walk_cost_toffoli=sp.Integer(4_400),
-    second_factor_rank=9,
+print(accuracy_budget.to_dict())
+assert sp.Abs(accuracy_budget.qpe_precision - sp.Float("0.0015")) < sp.Float("1e-12")
+
+baseline_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary,
+        method=ChemistryQPEMethod.TENSOR_HYPERCONTRACTION,
+        walk_cost_toffoli=sp.Integer(4_000),
+    )
+)
+compressed_model = accuracy_budget.with_model(
+    ChemistryQPEModel(
+        hamiltonian=scaled_summary.with_lambda_scale(
+            sp.Float("0.5"),
+            source="compressed_scaled_toy_pauli_lcu",
+        ),
+        method=ChemistryQPEMethod.SYMMETRY_COMPRESSED_DF,
+        walk_cost_toffoli=sp.Integer(4_400),
+        second_factor_rank=9,
+    )
 )
 
 baseline = estimate_qubitized_chemistry_qpe_from_model(
     baseline_model,
-    precision=sp.Float("0.0016"),
+    precision=accuracy_budget.qpe_precision,
     cost_model=cost_model,
 )
 compressed = estimate_qubitized_chemistry_qpe_from_model(
     compressed_model,
-    precision=sp.Float("0.0016"),
+    precision=accuracy_budget.qpe_precision,
     cost_model=cost_model,
 )
 
 assert compressed.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 21
 assert compressed.to_dict()["architecture_values"]["code_distance"] == "21"
+assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR] == (
+    sp.Float("1e-4")
+)
 
 comparison = compare_ftqc_resource_estimates(
     baseline,
@@ -197,7 +212,7 @@ for row in comparison:
 
 assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
 assert comparison[0].ratio == sp.Float("0.5")
-assert comparison[1].ratio == sp.Float("0.55")
+assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 
 # %% [markdown]
 # 設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。
@@ -276,8 +291,12 @@ for row in architecture_comparison:
 assert relifted_baseline.logical_qubits == baseline.logical_qubits
 assert relifted_baseline.toffoli_gates == baseline.toffoli_gates
 assert relifted_baseline.resource_values()[FTQCResourceQuantity.CODE_DISTANCE] == 10
-assert sp.simplify(architecture_comparison[0].ratio - sp.Rational(350, 691)) == 0
-assert sp.simplify(architecture_comparison[1].ratio - sp.Rational(10, 21)) == 0
+assert sp.Abs(architecture_comparison[0].ratio - sp.Rational(350, 691)) < sp.Float(
+    "1e-12"
+)
+assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float(
+    "1e-12"
+)
 
 # %% [markdown]
 # ## Early-FTQCのパターン
@@ -336,6 +355,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #
 # - 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
+# - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。
 # - Surface-code仮定は別にmodel化し、chemistry推定器が使うcost modelへ変換できます。
 # - Surface-code distanceは、logical failure budgetから選んだうえで、logical resourceをphysical量子ビットとruntimeへliftできます。
 # - code distanceなどのarchitecture quantityは各estimateに残るため、reportでphysical resource仮定をauditできます。

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -19,6 +19,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_block_encoding import (
 from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCCostModel,
     FTQCReference,
     FTQCResourceEstimate,
@@ -64,6 +65,7 @@ __all__ = [
     "FTQCResourceComparisonRow",
     "FTQCResourceComparisonSummary",
     "FTQCCostModel",
+    "FTQCAccuracyBudget",
     "FTQCReference",
     "FTQCResourceEstimate",
     "FTQCResourceQuantity",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 import math
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 import sympy as sp
@@ -1288,6 +1288,135 @@ class PauliHamiltonianResource:
             FTQCResourceQuantity.LAMBDA_NORM: self.lambda_norm,
             FTQCResourceQuantity.MAX_LOCALITY: self.max_locality,
         }
+
+
+@dataclass(frozen=True)
+class FTQCAccuracyBudget:
+    """Allocate a total FTQC energy-error budget across model components.
+
+    The budget separates representation error, such as tensor-factorization
+    truncation, from the precision left for phase estimation. This keeps
+    chemistry estimates comparable: two models can share the same total target
+    precision while spending different amounts on representation error.
+
+    Args:
+        target_precision (sp.Expr | int | float): Total energy-error budget.
+        truncation_error (sp.Expr | int | float): Error already spent by the
+            Hamiltonian representation before QPE. Defaults to zero.
+        safety_margin (sp.Expr | int | float): Optional unallocated margin
+            reserved for synthesis, fitting, or other modeled error sources.
+            Defaults to zero.
+
+    Raises:
+        ValueError: If the total target precision is non-positive, if either
+            non-QPE component is negative, or if the remaining QPE precision is
+            provably non-positive.
+
+    Example:
+        >>> budget = FTQCAccuracyBudget(
+        ...     target_precision=sp.Float("1.6e-3"),
+        ...     truncation_error=sp.Float("1e-4"),
+        ... )
+        >>> budget.qpe_precision
+        0.00150000000000000
+    """
+
+    target_precision: _SympyLike
+    truncation_error: _SympyLike = 0
+    safety_margin: _SympyLike = 0
+
+    def __post_init__(self) -> None:
+        """Validate the accuracy-budget fields after construction.
+
+        Raises:
+            ValueError: If any budget component violates the allocation
+                contract.
+        """
+        _validate_positive(self._target_precision, "target_precision")
+        _validate_nonnegative(self._truncation_error, "truncation_error")
+        _validate_nonnegative(self._safety_margin, "safety_margin")
+        _validate_positive(self.qpe_precision, "qpe_precision")
+
+    @property
+    def qpe_precision(self) -> sp.Expr:
+        """Return the precision remaining for QPE iterations.
+
+        Returns:
+            sp.Expr: ``target_precision - truncation_error - safety_margin``.
+        """
+        return sp.simplify(
+            self._target_precision - self._truncation_error - self._safety_margin
+        )
+
+    def with_model(self, model: ChemistryQPEModel) -> ChemistryQPEModel:
+        """Return a chemistry model carrying this budget's truncation error.
+
+        Args:
+            model (ChemistryQPEModel): Chemistry model whose representation
+                error should be aligned with this accuracy budget.
+
+        Returns:
+            ChemistryQPEModel: Copy of ``model`` with ``truncation_error`` set
+                to this budget's truncation error.
+
+        Raises:
+            TypeError: If ``model`` is not a ``ChemistryQPEModel``.
+        """
+        if not isinstance(model, ChemistryQPEModel):
+            raise TypeError("model must be a ChemistryQPEModel instance.")
+        return replace(model, truncation_error=self._truncation_error)
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the accuracy budget.
+
+        Returns:
+            dict[str, str]: JSON-friendly accuracy-budget values.
+        """
+        return {
+            "target_precision": str(self._target_precision),
+            "truncation_error": str(self._truncation_error),
+            "safety_margin": str(self._safety_margin),
+            "qpe_precision": str(self.qpe_precision),
+        }
+
+    def resource_values(self) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return accuracy-budget values keyed by canonical quantities.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Target precision and
+                truncation-error quantities.
+        """
+        return {
+            FTQCResourceQuantity.TARGET_PRECISION: self._target_precision,
+            FTQCResourceQuantity.TRUNCATION_ERROR: self._truncation_error,
+        }
+
+    @property
+    def _target_precision(self) -> sp.Expr:
+        """Return ``target_precision`` as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted total target precision.
+        """
+        return _as_expr(self.target_precision, "target_precision")
+
+    @property
+    def _truncation_error(self) -> sp.Expr:
+        """Return ``truncation_error`` as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted truncation error.
+        """
+        return _as_expr(self.truncation_error, "truncation_error")
+
+    @property
+    def _safety_margin(self) -> sp.Expr:
+        """Return ``safety_margin`` as a SymPy expression.
+
+        Returns:
+            sp.Expr: Converted safety margin.
+        """
+        return _as_expr(self.safety_margin, "safety_margin")
 
 
 @dataclass(frozen=True)

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -9,6 +9,7 @@ import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
+    FTQCAccuracyBudget,
     FTQCCostModel,
     FTQCReference,
     FTQCResourceQuantity,
@@ -165,6 +166,50 @@ def test_model_references_are_preserved_and_deduplicated():
     assert reference_keys[-1] == "internal:toy-model"
     assert relifted.references == estimate.references
     assert relifted.target_precision == estimate.target_precision
+
+
+def test_accuracy_budget_allocates_precision_to_qpe_and_truncation():
+    """Accuracy budgets align total target precision with model truncation."""
+    summary = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    model = ChemistryQPEModel(
+        hamiltonian=summary,
+        method=ChemistryQPEMethod.SPARSE,
+        walk_cost_toffoli=11,
+    )
+    budget = FTQCAccuracyBudget(
+        target_precision=sp.Float("1.6e-3"),
+        truncation_error=sp.Float("1e-4"),
+        safety_margin=sp.Float("5e-5"),
+    )
+
+    budgeted_model = budget.with_model(model)
+    estimate = estimate_qubitized_chemistry_qpe_from_model(
+        budgeted_model,
+        precision=budget.qpe_precision,
+    )
+
+    assert sp.Abs(budget.qpe_precision - sp.Float("0.00145")) < sp.Float("1e-12")
+    assert budgeted_model.truncation_error == sp.Float("1e-4")
+    assert model.truncation_error == 0
+    assert estimate.target_precision == budget.qpe_precision
+    assert sp.sympify(estimate.assumptions["truncation_error"]) == sp.Float("1e-4")
+    assert budget.resource_values()[FTQCResourceQuantity.TARGET_PRECISION] == sp.Float(
+        "1.6e-3"
+    )
+    assert budget.to_dict()["qpe_precision"] == "0.00145000000000000"
+
+
+def test_accuracy_budget_rejects_overallocated_error_budget():
+    """Accuracy budgets reject non-positive precision left for QPE."""
+    with pytest.raises(ValueError, match="qpe_precision"):
+        FTQCAccuracyBudget(
+            target_precision=sp.Float("1e-3"),
+            truncation_error=sp.Float("8e-4"),
+            safety_margin=sp.Float("2e-4"),
+        )
+
+    with pytest.raises(TypeError, match="ChemistryQPEModel"):
+        FTQCAccuracyBudget(target_precision=1).with_model(object())
 
 
 def test_cost_model_lifts_logical_estimates_to_physical_runtime():


### PR DESCRIPTION
## Summary
- Add `FTQCAccuracyBudget` to split total target precision into truncation error, safety margin, and QPE precision.
- Apply the budget helper to FTQC chemistry models and exported algorithmic APIs.
- Update English and Japanese FTQC tutorials plus executed notebooks to compare estimates under the same total precision budget.

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design or ftqc_chemistry_resource_estimation'`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`

## Local Review
- Mechanical checks passed with the current project zuban command.
- The legacy command written in the local-review skill, `uv run zuban qamomile/`, no longer matches the zuban CLI and exits with a subcommand usage error.
