### PR TITLE
Catalog block-encoding subroutine resources

### DIFF
--- a/docs/en/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/en/usage/block_encoding_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6921a98f",
+   "id": "48fa93e8",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f60e69e3",
+   "id": "545f57ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.233574Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.232298Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.241745Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.240832Z"
+     "iopub.execute_input": "2026-06-22T20:57:42.678642Z",
+     "iopub.status.busy": "2026-06-22T20:57:42.678423Z",
+     "iopub.status.idle": "2026-06-22T20:57:42.685825Z",
+     "shell.execute_reply": "2026-06-22T20:57:42.684879Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ccc5ad1c",
+   "id": "c0a85d85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.248493Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.248179Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.636847Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.636358Z"
+     "iopub.execute_input": "2026-06-22T20:57:42.688995Z",
+     "iopub.status.busy": "2026-06-22T20:57:42.688823Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.020503Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.020064Z"
     }
    },
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1838f900",
+   "id": "f211f51d",
    "metadata": {},
    "source": [
     "## Workflow\n",
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fee091c",
+   "id": "1f36374c",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -97,13 +97,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4583206c",
+   "id": "763f9ee8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.640471Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.640339Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.643245Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.642835Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.022014Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.021926Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.025177Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.024651Z"
     }
    },
    "outputs": [
@@ -130,12 +130,62 @@
     "\n",
     "assert block.logical_qubits == 17\n",
     "assert block.walk_cost_toffoli == 188\n",
-    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188"
+    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188\n",
+    "assert block.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 30\n",
+    "assert block.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 120\n",
+    "assert block.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == 8"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8aebd95f",
+   "id": "234a7901",
+   "metadata": {},
+   "source": [
+    "These subroutine costs also use canonical quantity keys. That makes reports\n",
+    "less dependent on the field names of `BlockEncodingResource` itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "014d0795",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T20:57:43.026163Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.026108Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.028138Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.027713Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "system_qubits = 12\n",
+      "block_encoding_ancilla_qubits = 5\n",
+      "prepare_cost_toffoli = 30\n",
+      "select_cost_toffoli = 120\n",
+      "reflection_cost_toffoli = 8\n",
+      "walk_cost_toffoli = 188\n"
+     ]
+    }
+   ],
+   "source": [
+    "for quantity in (\n",
+    "    FTQCResourceQuantity.SYSTEM_QUBITS,\n",
+    "    FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS,\n",
+    "    FTQCResourceQuantity.PREPARE_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.SELECT_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.WALK_COST_TOFFOLI,\n",
+    "):\n",
+    "    print(quantity.value, \"=\", block.resource_values()[quantity])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adc01070",
    "metadata": {},
    "source": [
     "## Qubitized QPE\n",
@@ -147,14 +197,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "aaa9d778",
+   "execution_count": 5,
+   "id": "3a90d294",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.644442Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.644369Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.650122Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.649727Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.028992Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.028940Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.048972Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.048588Z"
     }
    },
    "outputs": [
@@ -192,12 +242,14 @@
     "assert estimate.logical_qubits == 23\n",
     "assert estimate.physical_qubits == 4300\n",
     "assert estimate.assumptions[\"block_encoding\"] == \"toy_lcu\"\n",
+    "assert estimate.resource_values()[FTQCResourceQuantity.QPE_REGISTER_QUBITS] == 6\n",
+    "assert estimate.to_dict()[\"algorithm_values\"][\"prepare_cost_toffoli\"] == \"30\"\n",
     "assert any(reference.key == \"arXiv:1610.06546\" for reference in estimate.references)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "958b6ce0",
+   "id": "8dcd6f25",
    "metadata": {},
    "source": [
     "## Compare Representations\n",
@@ -209,14 +261,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "a65abbbf",
+   "execution_count": 6,
+   "id": "1f3b28f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.651147Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.651079Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.654676Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.654375Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.050119Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.050051Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.054485Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.054160Z"
     }
    },
    "outputs": [
@@ -264,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c0f0409",
+   "id": "292ff597",
    "metadata": {},
    "source": [
     "## Bridge from Chemistry Models\n",
@@ -277,14 +329,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "79a89877",
+   "execution_count": 7,
+   "id": "aa3db9a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:42.655692Z",
-     "iopub.status.busy": "2026-06-22T14:02:42.655634Z",
-     "iopub.status.idle": "2026-06-22T14:02:42.784799Z",
-     "shell.execute_reply": "2026-06-22T14:02:42.784328Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.055470Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.055417Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.142620Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.142224Z"
     }
    },
    "outputs": [
@@ -329,7 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a44fb5a6",
+   "id": "d69a767e",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -343,7 +395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e775b7e",
+   "id": "d2cc0db2",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -352,6 +404,8 @@
     "\n",
     "- Block-encoding estimates separate normalization, PREPARE, SELECT,\n",
     "  reflection, ancilla, and QPE readout costs.\n",
+    "- PREPARE, SELECT, reflection, workspace, and QPE readout quantities have\n",
+    "  canonical resource keys for downstream reports.\n",
     "- Qubitized QPE composes the block-encoding walk cost with\n",
     "  normalization-over-precision iterations.\n",
     "- Chemistry QPE models can be converted into the same block-encoding\n",

--- a/docs/en/usage/block_encoding_resource_estimation.py
+++ b/docs/en/usage/block_encoding_resource_estimation.py
@@ -79,6 +79,24 @@ print(block.to_dict())
 assert block.logical_qubits == 17
 assert block.walk_cost_toffoli == 188
 assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188
+assert block.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 30
+assert block.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 120
+assert block.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == 8
+
+# %% [markdown]
+# These subroutine costs also use canonical quantity keys. That makes reports
+# less dependent on the field names of `BlockEncodingResource` itself.
+
+# %%
+for quantity in (
+    FTQCResourceQuantity.SYSTEM_QUBITS,
+    FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS,
+    FTQCResourceQuantity.PREPARE_COST_TOFFOLI,
+    FTQCResourceQuantity.SELECT_COST_TOFFOLI,
+    FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,
+    FTQCResourceQuantity.WALK_COST_TOFFOLI,
+):
+    print(quantity.value, "=", block.resource_values()[quantity])
 
 # %% [markdown]
 # ## Qubitized QPE
@@ -111,6 +129,8 @@ assert estimate.toffoli_gates == 15040
 assert estimate.logical_qubits == 23
 assert estimate.physical_qubits == 4300
 assert estimate.assumptions["block_encoding"] == "toy_lcu"
+assert estimate.resource_values()[FTQCResourceQuantity.QPE_REGISTER_QUBITS] == 6
+assert estimate.to_dict()["algorithm_values"]["prepare_cost_toffoli"] == "30"
 assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
 
 # %% [markdown]
@@ -205,6 +225,8 @@ assert any(
 #
 # - Block-encoding estimates separate normalization, PREPARE, SELECT,
 #   reflection, ancilla, and QPE readout costs.
+# - PREPARE, SELECT, reflection, workspace, and QPE readout quantities have
+#   canonical resource keys for downstream reports.
 # - Qubitized QPE composes the block-encoding walk cost with
 #   normalization-over-precision iterations.
 # - Chemistry QPE models can be converted into the same block-encoding

--- a/docs/ja/usage/block_encoding_resource_estimation.ipynb
+++ b/docs/ja/usage/block_encoding_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5424621c",
+   "id": "a5af0956",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5e639b65",
+   "id": "d8fd2902",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:44.957070Z",
-     "iopub.status.busy": "2026-06-22T14:02:44.956751Z",
-     "iopub.status.idle": "2026-06-22T14:02:45.162478Z",
-     "shell.execute_reply": "2026-06-22T14:02:45.161584Z"
+     "iopub.execute_input": "2026-06-22T20:57:42.678927Z",
+     "iopub.status.busy": "2026-06-22T20:57:42.678706Z",
+     "iopub.status.idle": "2026-06-22T20:57:42.685998Z",
+     "shell.execute_reply": "2026-06-22T20:57:42.684880Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "aa6cfc02",
+   "id": "f7b47064",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:45.408539Z",
-     "iopub.status.busy": "2026-06-22T14:02:45.406585Z",
-     "iopub.status.idle": "2026-06-22T14:02:46.178120Z",
-     "shell.execute_reply": "2026-06-22T14:02:46.177719Z"
+     "iopub.execute_input": "2026-06-22T20:57:42.688883Z",
+     "iopub.status.busy": "2026-06-22T20:57:42.688714Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.020506Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.020063Z"
     }
    },
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0be28c8",
+   "id": "883c47ca",
    "metadata": {},
    "source": [
     "## Workflow\n",
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbba5660",
+   "id": "7933766e",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -91,13 +91,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fe893204",
+   "id": "66cea120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:46.179994Z",
-     "iopub.status.busy": "2026-06-22T14:02:46.179873Z",
-     "iopub.status.idle": "2026-06-22T14:02:46.183075Z",
-     "shell.execute_reply": "2026-06-22T14:02:46.182072Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.022039Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.021949Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.024948Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.024650Z"
     }
    },
    "outputs": [
@@ -124,12 +124,61 @@
     "\n",
     "assert block.logical_qubits == 17\n",
     "assert block.walk_cost_toffoli == 188\n",
-    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188"
+    "assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188\n",
+    "assert block.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 30\n",
+    "assert block.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 120\n",
+    "assert block.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == 8"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "84549c5f",
+   "id": "fbaeaca0",
+   "metadata": {},
+   "source": [
+    "これらのsubroutine costもcanonical quantity keyで読めます。これにより、report側が`BlockEncodingResource`自体のfield名に依存しにくくなります。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bb68cbf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T20:57:43.026132Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.026063Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.027984Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.027609Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "system_qubits = 12\n",
+      "block_encoding_ancilla_qubits = 5\n",
+      "prepare_cost_toffoli = 30\n",
+      "select_cost_toffoli = 120\n",
+      "reflection_cost_toffoli = 8\n",
+      "walk_cost_toffoli = 188\n"
+     ]
+    }
+   ],
+   "source": [
+    "for quantity in (\n",
+    "    FTQCResourceQuantity.SYSTEM_QUBITS,\n",
+    "    FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS,\n",
+    "    FTQCResourceQuantity.PREPARE_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.SELECT_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,\n",
+    "    FTQCResourceQuantity.WALK_COST_TOFFOLI,\n",
+    "):\n",
+    "    print(quantity.value, \"=\", block.resource_values()[quantity])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2140bf81",
    "metadata": {},
    "source": [
     "## Qubitized QPE\n",
@@ -139,14 +188,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "90088ec6",
+   "execution_count": 5,
+   "id": "ac1607dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:46.186847Z",
-     "iopub.status.busy": "2026-06-22T14:02:46.186675Z",
-     "iopub.status.idle": "2026-06-22T14:02:46.206564Z",
-     "shell.execute_reply": "2026-06-22T14:02:46.201676Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.028989Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.028939Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.048905Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.048496Z"
     }
    },
    "outputs": [
@@ -184,12 +233,14 @@
     "assert estimate.logical_qubits == 23\n",
     "assert estimate.physical_qubits == 4300\n",
     "assert estimate.assumptions[\"block_encoding\"] == \"toy_lcu\"\n",
+    "assert estimate.resource_values()[FTQCResourceQuantity.QPE_REGISTER_QUBITS] == 6\n",
+    "assert estimate.to_dict()[\"algorithm_values\"][\"prepare_cost_toffoli\"] == \"30\"\n",
     "assert any(reference.key == \"arXiv:1610.06546\" for reference in estimate.references)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7f1b4b2d",
+   "id": "61e764c2",
    "metadata": {},
    "source": [
     "## 表現を比較する\n",
@@ -199,14 +250,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "43570e22",
+   "execution_count": 6,
+   "id": "8ef15d4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:46.291196Z",
-     "iopub.status.busy": "2026-06-22T14:02:46.291043Z",
-     "iopub.status.idle": "2026-06-22T14:02:46.334461Z",
-     "shell.execute_reply": "2026-06-22T14:02:46.322942Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.050044Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.049969Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.054241Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.053901Z"
     }
    },
    "outputs": [
@@ -254,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "618f1826",
+   "id": "e08af42e",
    "metadata": {},
    "source": [
     "## Chemistry modelからのbridge\n",
@@ -264,14 +315,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "5ccbc030",
+   "execution_count": 7,
+   "id": "96cd95f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T14:02:46.350409Z",
-     "iopub.status.busy": "2026-06-22T14:02:46.347498Z",
-     "iopub.status.idle": "2026-06-22T14:02:46.577791Z",
-     "shell.execute_reply": "2026-06-22T14:02:46.577317Z"
+     "iopub.execute_input": "2026-06-22T20:57:43.055200Z",
+     "iopub.status.busy": "2026-06-22T20:57:43.055150Z",
+     "iopub.status.idle": "2026-06-22T20:57:43.142673Z",
+     "shell.execute_reply": "2026-06-22T20:57:43.142225Z"
     }
    },
    "outputs": [
@@ -316,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa283ee6",
+   "id": "c2f4fe6c",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -328,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7547959",
+   "id": "3e4d6adb",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -336,6 +387,7 @@
     "このnotebookでは、次のことを学びました。\n",
     "\n",
     "- Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。\n",
+    "- PREPARE、SELECT、reflection、workspace、QPE readoutの量には、downstream report向けのcanonical resource keyがあります。\n",
     "- Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。\n",
     "- Chemistry QPE modelは同じblock-encoding contractへ変換でき、複数のviewを比較できます。\n",
     "- あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。"

--- a/docs/ja/usage/block_encoding_resource_estimation.py
+++ b/docs/ja/usage/block_encoding_resource_estimation.py
@@ -73,6 +73,23 @@ print(block.to_dict())
 assert block.logical_qubits == 17
 assert block.walk_cost_toffoli == 188
 assert block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 188
+assert block.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 30
+assert block.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 120
+assert block.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == 8
+
+# %% [markdown]
+# これらのsubroutine costもcanonical quantity keyで読めます。これにより、report側が`BlockEncodingResource`自体のfield名に依存しにくくなります。
+
+# %%
+for quantity in (
+    FTQCResourceQuantity.SYSTEM_QUBITS,
+    FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS,
+    FTQCResourceQuantity.PREPARE_COST_TOFFOLI,
+    FTQCResourceQuantity.SELECT_COST_TOFFOLI,
+    FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,
+    FTQCResourceQuantity.WALK_COST_TOFFOLI,
+):
+    print(quantity.value, "=", block.resource_values()[quantity])
 
 # %% [markdown]
 # ## Qubitized QPE
@@ -103,6 +120,8 @@ assert estimate.toffoli_gates == 15040
 assert estimate.logical_qubits == 23
 assert estimate.physical_qubits == 4300
 assert estimate.assumptions["block_encoding"] == "toy_lcu"
+assert estimate.resource_values()[FTQCResourceQuantity.QPE_REGISTER_QUBITS] == 6
+assert estimate.to_dict()["algorithm_values"]["prepare_cost_toffoli"] == "30"
 assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
 
 # %% [markdown]
@@ -189,6 +208,7 @@ assert any(
 # このnotebookでは、次のことを学びました。
 #
 # - Block-encoding estimateでは、normalization、PREPARE、SELECT、reflection、ancilla、QPE readout costを分けて扱います。
+# - PREPARE、SELECT、reflection、workspace、QPE readoutの量には、downstream report向けのcanonical resource keyがあります。
 # - Qubitized QPEは、block-encodingのwalk costとnormalization-over-precision iterationを合成します。
 # - Chemistry QPE modelは同じblock-encoding contractへ変換でき、複数のviewを比較できます。
 # - あるsubroutineが高価になっても、representation trade-offによって総Toffoli countが下がる場合があります。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -67,9 +67,11 @@ def _block_encoding_qpe_formulas() -> tuple[FTQCResourceFormula, ...]:
     """
     normalization = _positive_symbol(FTQCResourceQuantity.LAMBDA_NORM.value)
     target_precision = _positive_symbol(FTQCResourceQuantity.TARGET_PRECISION.value)
-    prepare_cost = _nonnegative_symbol("prepare_cost_toffoli")
-    select_cost = _nonnegative_symbol("select_cost_toffoli")
-    reflection_cost = _nonnegative_symbol("reflection_cost_toffoli")
+    prepare_cost = _nonnegative_symbol(FTQCResourceQuantity.PREPARE_COST_TOFFOLI.value)
+    select_cost = _nonnegative_symbol(FTQCResourceQuantity.SELECT_COST_TOFFOLI.value)
+    reflection_cost = _nonnegative_symbol(
+        FTQCResourceQuantity.REFLECTION_COST_TOFFOLI.value
+    )
     qpe_iterations = _nonnegative_symbol(FTQCResourceQuantity.QPE_ITERATIONS.value)
     walk_cost = _nonnegative_symbol(FTQCResourceQuantity.WALK_COST_TOFFOLI.value)
     toffoli_gates = _nonnegative_symbol(FTQCResourceQuantity.TOFFOLI_GATES.value)
@@ -89,6 +91,11 @@ def _block_encoding_qpe_formulas() -> tuple[FTQCResourceFormula, ...]:
         FTQCResourceFormula(
             quantity=FTQCResourceQuantity.WALK_COST_TOFFOLI,
             expression=2 * prepare_cost + select_cost + reflection_cost,
+            depends_on=(
+                FTQCResourceQuantity.PREPARE_COST_TOFFOLI,
+                FTQCResourceQuantity.SELECT_COST_TOFFOLI,
+                FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,
+            ),
             description=(
                 "Compose one qubitized walk from PREPARE, inverse PREPARE, "
                 "SELECT, and reflection costs."
@@ -270,7 +277,12 @@ class BlockEncodingResource:
         """
         return {
             FTQCResourceQuantity.LOGICAL_QUBITS: self.logical_qubits,
+            FTQCResourceQuantity.SYSTEM_QUBITS: self._system_qubits,
             FTQCResourceQuantity.LAMBDA_NORM: self._normalization,
+            FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS: self._ancilla_qubits,
+            FTQCResourceQuantity.PREPARE_COST_TOFFOLI: self._prepare_cost_toffoli,
+            FTQCResourceQuantity.SELECT_COST_TOFFOLI: self._select_cost_toffoli,
+            FTQCResourceQuantity.REFLECTION_COST_TOFFOLI: self._reflection_cost_toffoli,
             FTQCResourceQuantity.WALK_COST_TOFFOLI: self.walk_cost_toffoli,
         }
 
@@ -370,6 +382,12 @@ def estimate_qubitized_qpe_from_block_encoding(
     toffoli_gates = sp.simplify(qpe_iterations * block_encoding.walk_cost_toffoli)
     logical_depth = toffoli_gates
     logical_qubits = sp.simplify(block_encoding.logical_qubits + qpe_qubits)
+    algorithm_values: dict[FTQCResourceQuantity, sp.Expr] = {
+        quantity: value
+        for quantity, value in block_encoding.resource_values().items()
+        if quantity != FTQCResourceQuantity.LOGICAL_QUBITS
+    }
+    algorithm_values[FTQCResourceQuantity.QPE_REGISTER_QUBITS] = qpe_qubits
     model, architecture_values = _normalize_cost_model(cost_model)
     runtime_seconds = model.runtime_seconds_for(logical_depth, toffoli_gates)
     physical_qubits = model.physical_qubits_for(logical_qubits)
@@ -408,11 +426,13 @@ def estimate_qubitized_qpe_from_block_encoding(
             qpe_iterations,
             logical_depth,
             runtime_seconds,
+            *algorithm_values.values(),
             *architecture_values.values(),
         ),
         assumptions=assumptions,
         references=references_for_estimate,
         formulas=_block_encoding_qpe_formulas(),
+        algorithm_values=algorithm_values,
         architecture_values=architecture_values,
     )
 

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -42,6 +42,12 @@ class FTQCResourceQuantity(enum.StrEnum):
         MAX_LOCALITY: Maximum Pauli-string locality.
         TARGET_PRECISION: Target algorithmic energy or phase precision.
         TRUNCATION_ERROR: Representation-level approximation error budget.
+        SYSTEM_QUBITS: Logical system-register qubits encoded by a
+            block-encoding model.
+        BLOCK_ENCODING_ANCILLA_QUBITS: Ancilla and workspace qubits required
+            by a block encoding before QPE readout qubits are added.
+        QPE_REGISTER_QUBITS: Phase-readout qubits used by an explicit QPE
+            circuit.
         STATE_PREPARATION_SUCCESS_PROBABILITY: Success probability or squared
             overlap of the prepared state with the target eigenstate subspace.
         QPE_REPETITIONS: Expected number of QPE runs needed to obtain one
@@ -52,6 +58,12 @@ class FTQCResourceQuantity(enum.StrEnum):
             symmetry-filtering attempt.
         STATE_PREPARATION_LOGICAL_DEPTH: Logical-depth overhead of one
             state-preparation or symmetry-filtering attempt.
+        PREPARE_COST_TOFFOLI: Toffoli cost of one PREPARE or inverse PREPARE
+            subroutine call.
+        SELECT_COST_TOFFOLI: Toffoli cost of one SELECT or oracle subroutine
+            call.
+        REFLECTION_COST_TOFFOLI: Toffoli cost of the reflection subroutine used
+            by one qubitized walk.
         WALK_COST_TOFFOLI: Toffoli cost of one qubitized walk.
         QPE_ITERATIONS: Number of phase-estimation walk or time-evolution
             calls.
@@ -96,11 +108,17 @@ class FTQCResourceQuantity(enum.StrEnum):
     MAX_LOCALITY = "max_locality"
     TARGET_PRECISION = "target_precision"
     TRUNCATION_ERROR = "truncation_error"
+    SYSTEM_QUBITS = "system_qubits"
+    BLOCK_ENCODING_ANCILLA_QUBITS = "block_encoding_ancilla_qubits"
+    QPE_REGISTER_QUBITS = "qpe_register_qubits"
     STATE_PREPARATION_SUCCESS_PROBABILITY = "state_preparation_success_probability"
     QPE_REPETITIONS = "qpe_repetitions"
     STATE_PREPARATION_TOFFOLI = "state_preparation_toffoli"
     STATE_PREPARATION_T_GATES = "state_preparation_t_gates"
     STATE_PREPARATION_LOGICAL_DEPTH = "state_preparation_logical_depth"
+    PREPARE_COST_TOFFOLI = "prepare_cost_toffoli"
+    SELECT_COST_TOFFOLI = "select_cost_toffoli"
+    REFLECTION_COST_TOFFOLI = "reflection_cost_toffoli"
     WALK_COST_TOFFOLI = "walk_cost_toffoli"
     QPE_ITERATIONS = "qpe_iterations"
     LOGICAL_QUBITS = "logical_qubits"
@@ -483,6 +501,27 @@ FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
         "Representation-level approximation error budget before QPE sampling.",
     ),
     FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.SYSTEM_QUBITS,
+        "System qubits",
+        "qubits",
+        FTQCResourceCategory.PROBLEM,
+        "Logical system-register qubits encoded by a block-encoding model.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS,
+        "Block-encoding ancilla qubits",
+        "qubits",
+        FTQCResourceCategory.ALGORITHM,
+        "Ancilla and workspace qubits required by a block encoding before QPE readout.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.QPE_REGISTER_QUBITS,
+        "QPE register qubits",
+        "qubits",
+        FTQCResourceCategory.ALGORITHM,
+        "Phase-readout qubits used by an explicit QPE circuit.",
+    ),
+    FTQCResourceQuantitySpec(
         FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY,
         "State-preparation success probability",
         "probability",
@@ -516,6 +555,27 @@ FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
         "logical layers / run",
         FTQCResourceCategory.ALGORITHM,
         "Logical-depth overhead of one state-preparation or filtering attempt.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.PREPARE_COST_TOFFOLI,
+        "PREPARE cost",
+        "Toffoli gates / call",
+        FTQCResourceCategory.ALGORITHM,
+        "Toffoli cost of one PREPARE or inverse PREPARE subroutine call.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.SELECT_COST_TOFFOLI,
+        "SELECT cost",
+        "Toffoli gates / call",
+        FTQCResourceCategory.ALGORITHM,
+        "Toffoli cost of one SELECT or oracle subroutine call.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,
+        "Reflection cost",
+        "Toffoli gates / call",
+        FTQCResourceCategory.ALGORITHM,
+        "Toffoli cost of the reflection subroutine used by one qubitized walk.",
     ),
     FTQCResourceQuantitySpec(
         FTQCResourceQuantity.WALK_COST_TOFFOLI,

--- a/tests/circuit/estimator/test_ftqc_block_encoding.py
+++ b/tests/circuit/estimator/test_ftqc_block_encoding.py
@@ -40,6 +40,16 @@ def test_block_encoding_resource_separates_prepare_select_and_reflection():
     assert block.logical_qubits == n + ancilla
     assert block.walk_cost_toffoli == 2 * prep + select + reflect
     assert block.resource_values()[FTQCResourceQuantity.LAMBDA_NORM] == alpha
+    assert block.resource_values()[FTQCResourceQuantity.SYSTEM_QUBITS] == n
+    assert (
+        block.resource_values()[FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS]
+        == ancilla
+    )
+    assert block.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == prep
+    assert block.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == select
+    assert (
+        block.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == reflect
+    )
     assert (
         block.resource_values()[FTQCResourceQuantity.WALK_COST_TOFFOLI]
         == 2 * prep + select + reflect
@@ -77,10 +87,16 @@ def test_qubitized_qpe_from_block_encoding_tracks_walk_calls_and_costs():
     assert estimate.qpe_iterations == 50
     assert estimate.target_precision == 2
     assert estimate.resource_values()[FTQCResourceQuantity.TARGET_PRECISION] == 2
+    assert estimate.resource_values()[FTQCResourceQuantity.SYSTEM_QUBITS] == 6
+    assert estimate.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 20
+    assert estimate.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 50
+    assert estimate.resource_values()[FTQCResourceQuantity.REFLECTION_COST_TOFFOLI] == 5
+    assert estimate.resource_values()[FTQCResourceQuantity.QPE_REGISTER_QUBITS] == 4
     assert estimate.toffoli_gates == 4750
     assert estimate.physical_qubits == 1310
     assert sp.Abs(estimate.runtime_seconds - sp.Float("0.00475")) < sp.Float("1e-12")
     assert estimate.assumptions["block_encoding"] == "toy_lcu"
+    assert estimate.to_dict()["algorithm_values"]["prepare_cost_toffoli"] == "20"
     assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)
 
 

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -39,9 +39,15 @@ def test_ftqc_quantity_specs_cover_core_resource_layers():
     assert FTQCResourceQuantity.LAMBDA_NORM in quantities
     assert FTQCResourceQuantity.TARGET_PRECISION in quantities
     assert FTQCResourceQuantity.TRUNCATION_ERROR in quantities
+    assert FTQCResourceQuantity.SYSTEM_QUBITS in quantities
+    assert FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS in quantities
+    assert FTQCResourceQuantity.QPE_REGISTER_QUBITS in quantities
     assert FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY in quantities
     assert FTQCResourceQuantity.QPE_REPETITIONS in quantities
     assert FTQCResourceQuantity.STATE_PREPARATION_TOFFOLI in quantities
+    assert FTQCResourceQuantity.PREPARE_COST_TOFFOLI in quantities
+    assert FTQCResourceQuantity.SELECT_COST_TOFFOLI in quantities
+    assert FTQCResourceQuantity.REFLECTION_COST_TOFFOLI in quantities
     assert FTQCResourceQuantity.TOFFOLI_GATES in quantities
     assert FTQCResourceQuantity.LOGICAL_ERROR_RATE in quantities
     assert FTQCResourceQuantity.PHYSICAL_ERROR_RATE in quantities


### PR DESCRIPTION
## Summary

This stacked draft PR builds on #499 by making block-encoding subroutine costs first-class FTQC resource quantities.

- adds canonical quantity keys for system qubits, block-encoding ancilla qubits, QPE register qubits, PREPARE cost, SELECT cost, and reflection cost
- records PREPARE, SELECT, reflection, ancilla, and QPE readout values in block-encoding and QPE resource outputs
- updates block-encoding formula provenance to depend on canonical subroutine quantities instead of ad hoc symbol names
- updates the English and Japanese block-encoding usage docs and executed notebooks

## Local review

No findings after reviewing the stacked diff against `codex/ftqc-qpe-success-budget`.

Mechanical checks:

- `uv run ruff check qamomile/ tests/` passed
- `uv run ruff format --check qamomile/ tests/` passed
- `uv run zuban check qamomile/` passed

## Validation

- `uv run pytest tests/circuit/estimator/test_ftqc_block_encoding.py tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run ruff check qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py qamomile/circuit/estimator/algorithmic/ftqc_resources.py tests/circuit/estimator/test_ftqc_block_encoding.py tests/circuit/estimator/test_ftqc_resources.py docs/en/usage/block_encoding_resource_estimation.py docs/ja/usage/block_encoding_resource_estimation.py`
- `uv run zuban check qamomile/`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/block_encoding_resource_estimation.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/block_encoding_resource_estimation.ipynb`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'block_encoding_resource_estimation'`
- `uv run jupytext --to ipynb --test docs/en/usage/block_encoding_resource_estimation.py docs/ja/usage/block_encoding_resource_estimation.py`