### PR TITLE
Catalog FTQC research signals

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "94e1bd22",
+   "id": "36469083",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "3e4460df",
+   "id": "a38136b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:32.794590Z",
-     "iopub.status.busy": "2026-06-22T19:27:32.794390Z",
-     "iopub.status.idle": "2026-06-22T19:27:32.801667Z",
-     "shell.execute_reply": "2026-06-22T19:27:32.800153Z"
+     "iopub.execute_input": "2026-06-22T21:25:38.714263Z",
+     "iopub.status.busy": "2026-06-22T21:25:38.714084Z",
+     "iopub.status.idle": "2026-06-22T21:25:38.718063Z",
+     "shell.execute_reply": "2026-06-22T21:25:38.717481Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "385a584b",
+   "id": "b2028f61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:32.804401Z",
-     "iopub.status.busy": "2026-06-22T19:27:32.804238Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.138396Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.137970Z"
+     "iopub.execute_input": "2026-06-22T21:25:38.720110Z",
+     "iopub.status.busy": "2026-06-22T21:25:38.719989Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.047716Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.047185Z"
     }
    },
    "outputs": [],
@@ -63,6 +63,7 @@
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_pauli_hamiltonian,\n",
@@ -71,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c5bdca3",
+   "id": "c5f96ad3",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -96,18 +97,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dfcaf7a",
+   "id": "f6139d82",
    "metadata": {},
    "source": [
     "## Research Signals\n",
     "\n",
     "The current quantity catalog follows the cost drivers used in recent FTQC\n",
-    "chemistry work:\n",
+    "chemistry work. Qamomile exposes that mapping as structured research signals\n",
+    "so reports can show why a quantity is being measured:\n",
     "\n",
     "| Research direction | Cost signal for Qamomile |\n",
     "| --- | --- |\n",
     "| Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |\n",
     "| Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |\n",
+    "| Symmetry-adapted filtering can increase state-preparation success probability before QPE ([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)). | Track success probability, expected QPE repetitions, filtering overhead, T gates, and runtime. |\n",
     "| Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |\n",
     "\n",
     "These are modeling quantities. They should be validated against each paper's\n",
@@ -115,8 +118,46 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "977295b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T21:25:39.049105Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.049019Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.051805Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.051290Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "arXiv:1610.06546 -> lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "arXiv:2403.03502 -> lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
+      "arXiv:2412.01338 -> lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
+      "arXiv:2601.08533 -> state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
+      "arXiv:2603.22778 -> lambda_norm, qpe_iterations, t_gates, logical_depth\n"
+     ]
+    }
+   ],
+   "source": [
+    "research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]\n",
+    "for signal in research_signals:\n",
+    "    print(signal[\"reference_key\"], \"->\", \", \".join(signal[\"quantities\"][:4]))\n",
+    "\n",
+    "signal_by_key = {signal[\"reference_key\"]: signal for signal in research_signals}\n",
+    "assert \"lambda_norm\" in signal_by_key[\"arXiv:2403.03502\"][\"quantities\"]\n",
+    "assert \"state_preparation_success_probability\" in signal_by_key[\"arXiv:2601.08533\"][\n",
+    "    \"quantities\"\n",
+    "]\n",
+    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "9f090336",
+   "id": "c32d3318",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -127,14 +168,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "7b4434dc",
+   "execution_count": 4,
+   "id": "cfbce740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.140132Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.140031Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.143242Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.142838Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.052784Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.052728Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.056037Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.055621Z"
     }
    },
    "outputs": [
@@ -148,6 +189,17 @@
       "max_locality Pauli factors problem\n",
       "target_precision energy algorithm\n",
       "truncation_error energy problem\n",
+      "system_qubits qubits problem\n",
+      "block_encoding_ancilla_qubits qubits algorithm\n",
+      "qpe_register_qubits qubits algorithm\n",
+      "state_preparation_success_probability probability algorithm\n",
+      "qpe_repetitions runs algorithm\n",
+      "state_preparation_toffoli Toffoli gates / run algorithm\n",
+      "state_preparation_t_gates T gates / run algorithm\n",
+      "state_preparation_logical_depth logical layers / run algorithm\n",
+      "prepare_cost_toffoli Toffoli gates / call algorithm\n",
+      "select_cost_toffoli Toffoli gates / call algorithm\n",
+      "reflection_cost_toffoli Toffoli gates / call algorithm\n",
       "walk_cost_toffoli Toffoli gates per walk algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
@@ -209,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56ab4b2b",
+   "id": "111ea04f",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -221,14 +273,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "b473ccb9",
+   "execution_count": 5,
+   "id": "c908ac19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.144244Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.144188Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.172106Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.171702Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.057022Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.056968Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.084838Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.084370Z"
     }
    },
    "outputs": [
@@ -351,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd6b2d4e",
+   "id": "2ff2d256",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -361,14 +413,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "99ff3a70",
+   "execution_count": 6,
+   "id": "953ad3a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.173274Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.173214Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.176287Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.175870Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.085885Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.085829Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.088698Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.088297Z"
     }
    },
    "outputs": [
@@ -401,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "591df6bc",
+   "id": "06979bdb",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -414,14 +466,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "9a62bda6",
+   "execution_count": 7,
+   "id": "0f14b917",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.177394Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.177337Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.179837Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.179394Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.089605Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.089553Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.091676Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.091387Z"
     }
    },
    "outputs": [
@@ -447,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6871c3ff",
+   "id": "e15fb60e",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -460,14 +512,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "71f03195",
+   "execution_count": 8,
+   "id": "55f78a98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.181034Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.180963Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.183817Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.183248Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.092657Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.092601Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.095268Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.094857Z"
     }
    },
    "outputs": [
@@ -500,7 +552,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9886b6ce",
+   "id": "33ee5dec",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -513,14 +565,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "9dee50ed",
+   "execution_count": 9,
+   "id": "9080fa84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.185440Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.185359Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.187536Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.187092Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.096400Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.096343Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.098831Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.098450Z"
     }
    },
    "outputs": [
@@ -556,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc415c52",
+   "id": "f6198ce0",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -567,14 +619,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "6e0c3557",
+   "execution_count": 10,
+   "id": "e0777e8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.188607Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.188533Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.192356Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.191924Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.099967Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.099910Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.103783Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.103464Z"
     }
    },
    "outputs": [
@@ -621,7 +673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f921c97b",
+   "id": "8ebfcd33",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -632,14 +684,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "57e9fe67",
+   "execution_count": 11,
+   "id": "56e9708b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.193516Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.193448Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.200072Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.199774Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.104815Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.104754Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.111647Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.111243Z"
     }
    },
    "outputs": [
@@ -687,7 +739,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd18f465",
+   "id": "b106dcaf",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -712,7 +764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33fe7a5b",
+   "id": "497a020a",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -722,6 +774,8 @@
     "- Recent FTQC chemistry work motivates tracking Hamiltonian normalization,\n",
     "  target precision, truncation error, QPE iterations, non-Clifford counts,\n",
     "  logical depth, physical qubits, and runtime separately.\n",
+    "- `iter_ftqc_research_signals` maps research directions to the canonical\n",
+    "  quantities that Qamomile reports.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
     "  remains backend-neutral.\n",
     "- Accuracy budgets split a total target precision into representation\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -43,6 +43,7 @@ from qamomile.circuit.estimator.algorithmic import (
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
@@ -72,16 +73,30 @@ from qamomile.circuit.estimator.algorithmic import (
 # ## Research Signals
 #
 # The current quantity catalog follows the cost drivers used in recent FTQC
-# chemistry work:
+# chemistry work. Qamomile exposes that mapping as structured research signals
+# so reports can show why a quantity is being measured:
 #
 # | Research direction | Cost signal for Qamomile |
 # | --- | --- |
 # | Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |
 # | Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |
+# | Symmetry-adapted filtering can increase state-preparation success probability before QPE ([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)). | Track success probability, expected QPE repetitions, filtering overhead, T gates, and runtime. |
 # | Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |
 #
 # These are modeling quantities. They should be validated against each paper's
 # assumptions before being used as a molecule-specific resource claim.
+
+# %%
+research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]
+for signal in research_signals:
+    print(signal["reference_key"], "->", ", ".join(signal["quantities"][:4]))
+
+signal_by_key = {signal["reference_key"]: signal for signal in research_signals}
+assert "lambda_norm" in signal_by_key["arXiv:2403.03502"]["quantities"]
+assert "state_preparation_success_probability" in signal_by_key["arXiv:2601.08533"][
+    "quantities"
+]
+assert "t_gates" in signal_by_key["arXiv:2603.22778"]["quantities"]
 
 # %% [markdown]
 # ## Quantity Catalog
@@ -412,6 +427,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # - Recent FTQC chemistry work motivates tracking Hamiltonian normalization,
 #   target precision, truncation error, QPE iterations, non-Clifford counts,
 #   logical depth, physical qubits, and runtime separately.
+# - `iter_ftqc_research_signals` maps research directions to the canonical
+#   quantities that Qamomile reports.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
 #   remains backend-neutral.
 # - Accuracy budgets split a total target precision into representation

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fff3fe58",
+   "id": "4105f4a6",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "39e10a10",
+   "id": "a13f8661",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:32.794607Z",
-     "iopub.status.busy": "2026-06-22T19:27:32.794414Z",
-     "iopub.status.idle": "2026-06-22T19:27:32.801329Z",
-     "shell.execute_reply": "2026-06-22T19:27:32.800098Z"
+     "iopub.execute_input": "2026-06-22T21:25:38.733900Z",
+     "iopub.status.busy": "2026-06-22T21:25:38.733781Z",
+     "iopub.status.idle": "2026-06-22T21:25:38.737005Z",
+     "shell.execute_reply": "2026-06-22T21:25:38.736436Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ceebe185",
+   "id": "dac88f6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:32.804467Z",
-     "iopub.status.busy": "2026-06-22T19:27:32.804286Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.138440Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.137969Z"
+     "iopub.execute_input": "2026-06-22T21:25:38.738777Z",
+     "iopub.status.busy": "2026-06-22T21:25:38.738652Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.047670Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.047202Z"
     }
    },
    "outputs": [],
@@ -60,6 +60,7 @@
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_pauli_hamiltonian,\n",
@@ -68,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9791ce68",
+   "id": "ed6b20f7",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -85,25 +86,64 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a9e0c26",
+   "id": "ded925c4",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
     "\n",
-    "現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。\n",
+    "現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」を示せます。\n",
     "\n",
     "| Research direction | Cost signal for Qamomile |\n",
     "| --- | --- |\n",
     "| Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |\n",
     "| Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |\n",
+    "| Symmetry-adapted filteringはQPE前のstate-preparation success probabilityを高める場合があります([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))。 | success probability、期待QPE repetition、filtering overhead、T gates、runtimeを追跡します。 |\n",
     "| Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |\n",
     "\n",
     "これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "811a28c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T21:25:39.049117Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.049029Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.051691Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.051311Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "arXiv:1610.06546 -> lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "arXiv:2403.03502 -> lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
+      "arXiv:2412.01338 -> lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
+      "arXiv:2601.08533 -> state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
+      "arXiv:2603.22778 -> lambda_norm, qpe_iterations, t_gates, logical_depth\n"
+     ]
+    }
+   ],
+   "source": [
+    "research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]\n",
+    "for signal in research_signals:\n",
+    "    print(signal[\"reference_key\"], \"->\", \", \".join(signal[\"quantities\"][:4]))\n",
+    "\n",
+    "signal_by_key = {signal[\"reference_key\"]: signal for signal in research_signals}\n",
+    "assert \"lambda_norm\" in signal_by_key[\"arXiv:2403.03502\"][\"quantities\"]\n",
+    "assert \"state_preparation_success_probability\" in signal_by_key[\"arXiv:2601.08533\"][\n",
+    "    \"quantities\"\n",
+    "]\n",
+    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "538f202f",
+   "id": "5046ad7e",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -113,14 +153,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "a41e51fc",
+   "execution_count": 4,
+   "id": "1f5ca832",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.140056Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.139957Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.143197Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.142776Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.052709Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.052653Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.055923Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.055520Z"
     }
    },
    "outputs": [
@@ -134,6 +174,17 @@
       "max_locality Pauli factors problem\n",
       "target_precision energy algorithm\n",
       "truncation_error energy problem\n",
+      "system_qubits qubits problem\n",
+      "block_encoding_ancilla_qubits qubits algorithm\n",
+      "qpe_register_qubits qubits algorithm\n",
+      "state_preparation_success_probability probability algorithm\n",
+      "qpe_repetitions runs algorithm\n",
+      "state_preparation_toffoli Toffoli gates / run algorithm\n",
+      "state_preparation_t_gates T gates / run algorithm\n",
+      "state_preparation_logical_depth logical layers / run algorithm\n",
+      "prepare_cost_toffoli Toffoli gates / call algorithm\n",
+      "select_cost_toffoli Toffoli gates / call algorithm\n",
+      "reflection_cost_toffoli Toffoli gates / call algorithm\n",
       "walk_cost_toffoli Toffoli gates per walk algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
@@ -195,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e05a3a14",
+   "id": "6dd0f192",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -205,14 +256,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "5473edc0",
+   "execution_count": 5,
+   "id": "739792be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.144207Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.144153Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.172098Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.171654Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.056898Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.056843Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.084433Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.084035Z"
     }
    },
    "outputs": [
@@ -335,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c3b04c6",
+   "id": "74345e5b",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -343,14 +394,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "d3732a64",
+   "execution_count": 6,
+   "id": "9ff6daf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.173172Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.173112Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.176242Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.175805Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.085519Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.085459Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.088159Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.087785Z"
     }
    },
    "outputs": [
@@ -383,7 +434,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "745eea8c",
+   "id": "adf00a14",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -393,14 +444,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "d381a5ac",
+   "execution_count": 7,
+   "id": "3e3932f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.177312Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.177256Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.179841Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.179390Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.089071Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.089017Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.091263Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.090896Z"
     }
    },
    "outputs": [
@@ -426,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b03ab69",
+   "id": "68f13f1d",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -436,14 +487,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "79006466",
+   "execution_count": 8,
+   "id": "75b9bd48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.180908Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.180842Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.183774Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.183293Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.092264Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.092210Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.094735Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.094404Z"
     }
    },
    "outputs": [
@@ -476,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45586d8a",
+   "id": "deddaeaf",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -486,14 +537,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "48325db2",
+   "execution_count": 9,
+   "id": "8ca60f14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.185450Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.185367Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.187628Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.187201Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.095837Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.095778Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.097843Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.097577Z"
     }
    },
    "outputs": [
@@ -529,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60d5ce4c",
+   "id": "f592db93",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -539,14 +590,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "75fce40e",
+   "execution_count": 10,
+   "id": "1de2ae96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.188794Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.188716Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.192575Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.192164Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.098994Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.098945Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.102839Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.102479Z"
     }
    },
    "outputs": [
@@ -593,7 +644,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66de0d6e",
+   "id": "e6741588",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -603,14 +654,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "81b980cf",
+   "execution_count": 11,
+   "id": "779c0352",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:27:33.193624Z",
-     "iopub.status.busy": "2026-06-22T19:27:33.193559Z",
-     "iopub.status.idle": "2026-06-22T19:27:33.200551Z",
-     "shell.execute_reply": "2026-06-22T19:27:33.200110Z"
+     "iopub.execute_input": "2026-06-22T21:25:39.103919Z",
+     "iopub.status.busy": "2026-06-22T21:25:39.103867Z",
+     "iopub.status.idle": "2026-06-22T21:25:39.110619Z",
+     "shell.execute_reply": "2026-06-22T21:25:39.110230Z"
     }
    },
    "outputs": [
@@ -658,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c78f900",
+   "id": "80d1cd31",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -677,7 +728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcb6d418",
+   "id": "fb478845",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -685,6 +736,7 @@
     "このnotebookでは、次のことを学びました。\n",
     "\n",
     "- 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。\n",
+    "- `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",
     "- Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -40,6 +40,7 @@ from qamomile.circuit.estimator.algorithmic import (
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
@@ -60,15 +61,28 @@ from qamomile.circuit.estimator.algorithmic import (
 # %% [markdown]
 # ## 研究上のシグナル
 #
-# 現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。
+# 現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」を示せます。
 #
 # | Research direction | Cost signal for Qamomile |
 # | --- | --- |
 # | Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |
 # | Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |
+# | Symmetry-adapted filteringはQPE前のstate-preparation success probabilityを高める場合があります([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))。 | success probability、期待QPE repetition、filtering overhead、T gates、runtimeを追跡します。 |
 # | Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |
 #
 # これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。
+
+# %%
+research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]
+for signal in research_signals:
+    print(signal["reference_key"], "->", ", ".join(signal["quantities"][:4]))
+
+signal_by_key = {signal["reference_key"]: signal for signal in research_signals}
+assert "lambda_norm" in signal_by_key["arXiv:2403.03502"]["quantities"]
+assert "state_preparation_success_probability" in signal_by_key["arXiv:2601.08533"][
+    "quantities"
+]
+assert "t_gates" in signal_by_key["arXiv:2603.22778"]["quantities"]
 
 # %% [markdown]
 # ## Quantity Catalog
@@ -375,6 +389,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 # このnotebookでは、次のことを学びました。
 #
 # - 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。
+# - `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。
 # - Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -37,6 +37,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     summarize_pauli_hamiltonian,
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
+    FTQCResearchSignal,
     FTQCResourceCategory,
     FTQCResourceChangeDirection,
     FTQCResourceComparisonRow,
@@ -47,6 +48,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     SupportsFTQCResourceValues,
     compare_ftqc_resource_estimates,
     describe_ftqc_resource_quantity,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
 )
@@ -73,6 +75,7 @@ __all__ = [
     "FTQCResourceEstimate",
     "FTQCResourceQuantity",
     "FTQCResourceQuantitySpec",
+    "FTQCResearchSignal",
     "PauliHamiltonianResource",
     "QPEStatePreparationBudget",
     "SurfaceCodeCostModel",
@@ -90,6 +93,7 @@ __all__ = [
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",
     "hamiltonian_from_openfermion_qubit_operator",
     "references_for_chemistry_qpe_method",
+    "iter_ftqc_research_signals",
     "iter_ftqc_resource_quantity_specs",
     "summarize_openfermion_qubit_operator",
     "summarize_pauli_hamiltonian",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -224,6 +224,50 @@ class FTQCResourceQuantitySpec:
 
 
 @dataclass(frozen=True)
+class FTQCResearchSignal:
+    """Map one research direction to Qamomile resource quantities.
+
+    Attributes:
+        reference_key (str): Stable citation key, usually an arXiv identifier.
+        title (str): Reader-facing title of the research source or direction.
+        url (str): Persistent URL for the source.
+        cost_driver (str): Short explanation of the resource driver that the
+            source changes or highlights.
+        quantities (tuple[FTQCResourceQuantity, ...]): Canonical Qamomile
+            quantities that should be inspected when modeling this direction.
+        design_note (str): Guidance for how Qamomile should represent the
+            signal without prematurely lowering it into backend circuits.
+
+    Example:
+        >>> signal = iter_ftqc_research_signals()[0]
+        >>> signal.to_dict()["reference_key"].startswith("arXiv:")
+        True
+    """
+
+    reference_key: str
+    title: str
+    url: str
+    cost_driver: str
+    quantities: tuple[FTQCResourceQuantity, ...]
+    design_note: str
+
+    def to_dict(self) -> dict[str, str | list[str]]:
+        """Serialize the research signal.
+
+        Returns:
+            dict[str, str | list[str]]: JSON-friendly research signal metadata.
+        """
+        return {
+            "reference_key": self.reference_key,
+            "title": self.title,
+            "url": self.url,
+            "cost_driver": self.cost_driver,
+            "quantities": [quantity.value for quantity in self.quantities],
+            "design_note": self.design_note,
+        }
+
+
+@dataclass(frozen=True)
 class FTQCResourceFormula:
     """Describe how an FTQC resource quantity is derived.
 
@@ -755,6 +799,131 @@ FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
 )
 
 _SPECS_BY_QUANTITY = {spec.quantity: spec for spec in FTQC_RESOURCE_QUANTITY_SPECS}
+
+
+FTQC_RESEARCH_SIGNALS = (
+    FTQCResearchSignal(
+        reference_key="arXiv:1610.06546",
+        title="Hamiltonian simulation by qubitization",
+        url="https://arxiv.org/abs/1610.06546",
+        cost_driver=(
+            "Qubitized walks compose block-encoding PREPARE, SELECT, and "
+            "reflection primitives before QPE repeats the walk."
+        ),
+        quantities=(
+            FTQCResourceQuantity.LAMBDA_NORM,
+            FTQCResourceQuantity.PREPARE_COST_TOFFOLI,
+            FTQCResourceQuantity.SELECT_COST_TOFFOLI,
+            FTQCResourceQuantity.REFLECTION_COST_TOFFOLI,
+            FTQCResourceQuantity.WALK_COST_TOFFOLI,
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.TOFFOLI_GATES,
+        ),
+        design_note=(
+            "Represent the block encoding as algorithmic metadata until a "
+            "loader implementation is ready to emit concrete circuits."
+        ),
+    ),
+    FTQCResearchSignal(
+        reference_key="arXiv:2403.03502",
+        title=(
+            "Symmetry-compressed double factorization for fault-tolerant "
+            "chemistry simulation"
+        ),
+        url="https://arxiv.org/abs/2403.03502",
+        cost_driver=(
+            "Symmetry-compressed factorization reduces Hamiltonian normalization "
+            "and Toffoli-dominated qubitized QPE cost."
+        ),
+        quantities=(
+            FTQCResourceQuantity.LAMBDA_NORM,
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.WALK_COST_TOFFOLI,
+            FTQCResourceQuantity.TOFFOLI_GATES,
+            FTQCResourceQuantity.LOGICAL_QUBITS,
+            FTQCResourceQuantity.RUNTIME_SECONDS,
+        ),
+        design_note=(
+            "Keep factorization ranks, normalization, and walk cost on the "
+            "chemistry model rather than baking them into IR gates."
+        ),
+    ),
+    FTQCResearchSignal(
+        reference_key="arXiv:2412.01338",
+        title=(
+            "Symmetry shifts with tensor factorizations for cost-efficient "
+            "electronic Hamiltonians"
+        ),
+        url="https://arxiv.org/abs/2412.01338",
+        cost_driver=(
+            "Joint symmetry-shift and tensor-factorization optimization reduces "
+            "the block-encoding scaling constant."
+        ),
+        quantities=(
+            FTQCResourceQuantity.LAMBDA_NORM,
+            FTQCResourceQuantity.TRUNCATION_ERROR,
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.TOFFOLI_GATES,
+        ),
+        design_note=(
+            "Model symmetry-shift effects as representation metadata with an "
+            "explicit accuracy budget."
+        ),
+    ),
+    FTQCResearchSignal(
+        reference_key="arXiv:2601.08533",
+        title="Symmetry-adapted state preparation for FTQC chemistry",
+        url="https://arxiv.org/abs/2601.08533",
+        cost_driver=(
+            "Symmetry filtering can increase QPE success probability while "
+            "adding a smaller state-preparation overhead."
+        ),
+        quantities=(
+            FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY,
+            FTQCResourceQuantity.QPE_REPETITIONS,
+            FTQCResourceQuantity.STATE_PREPARATION_T_GATES,
+            FTQCResourceQuantity.STATE_PREPARATION_LOGICAL_DEPTH,
+            FTQCResourceQuantity.T_GATES,
+            FTQCResourceQuantity.RUNTIME_SECONDS,
+        ),
+        design_note=(
+            "Represent overlap and filtering success as an algorithmic budget "
+            "that scales expected QPE work."
+        ),
+    ),
+    FTQCResearchSignal(
+        reference_key="arXiv:2603.22778",
+        title="Chemically accurate QPE in the early fault-tolerant regime",
+        url="https://arxiv.org/abs/2603.22778",
+        cost_driver=(
+            "Single-ancilla Trotter QPE and unitary-weight concentration trade "
+            "block-encoding style costs for T gates, depth, and physical-qubit "
+            "constraints."
+        ),
+        quantities=(
+            FTQCResourceQuantity.LAMBDA_NORM,
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.T_GATES,
+            FTQCResourceQuantity.LOGICAL_DEPTH,
+            FTQCResourceQuantity.PHYSICAL_QUBITS,
+            FTQCResourceQuantity.RUNTIME_SECONDS,
+        ),
+        design_note=(
+            "Track T gates, logical depth, and architecture knobs alongside "
+            "Toffoli-native qubitization estimates."
+        ),
+    ),
+)
+
+
+def iter_ftqc_research_signals() -> tuple[FTQCResearchSignal, ...]:
+    """Return research signals that motivate Qamomile FTQC quantities.
+
+    Returns:
+        tuple[FTQCResearchSignal, ...]: Survey entries mapping research
+            directions to canonical FTQC quantity keys.
+    """
+    return FTQC_RESEARCH_SIGNALS
 
 
 def iter_ftqc_resource_quantity_specs() -> tuple[FTQCResourceQuantitySpec, ...]:

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -10,6 +10,7 @@ from qamomile.circuit.estimator.algorithmic import (
     ChemistryQPEMethod,
     ChemistryQPEModel,
     FTQCCostModel,
+    FTQCResearchSignal,
     FTQCResourceCategory,
     FTQCResourceComparisonRow,
     FTQCResourceComparisonSummary,
@@ -20,6 +21,7 @@ from qamomile.circuit.estimator.algorithmic import (
     describe_ftqc_resource_quantity,
     estimate_qubitized_chemistry_qpe,
     estimate_qubitized_chemistry_qpe_from_model,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
@@ -64,6 +66,33 @@ def test_ftqc_quantity_specs_cover_core_resource_layers():
         FTQCResourceCategory.ARCHITECTURE,
     }.issubset(categories)
     assert len(quantities) == len(specs)
+
+
+def test_ftqc_research_signals_map_sources_to_quantity_catalog():
+    """Research signals explain why FTQC quantities are tracked."""
+    signals = iter_ftqc_research_signals()
+    signal_by_key = {signal.reference_key: signal for signal in signals}
+
+    assert all(isinstance(signal, FTQCResearchSignal) for signal in signals)
+    assert len(signal_by_key) == len(signals)
+    assert "arXiv:2403.03502" in signal_by_key
+    assert "arXiv:2601.08533" in signal_by_key
+    assert "arXiv:2603.22778" in signal_by_key
+    assert all(signal.url.startswith("https://arxiv.org/abs/") for signal in signals)
+
+    scdf = signal_by_key["arXiv:2403.03502"]
+    assert FTQCResourceQuantity.LAMBDA_NORM in scdf.quantities
+    assert FTQCResourceQuantity.TOFFOLI_GATES in scdf.quantities
+
+    state_preparation = signal_by_key["arXiv:2601.08533"]
+    assert (
+        FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY
+        in state_preparation.quantities
+    )
+    assert FTQCResourceQuantity.QPE_REPETITIONS in state_preparation.quantities
+    assert state_preparation.to_dict()["quantities"][0] == (
+        "state_preparation_success_probability"
+    )
 
 
 def test_ftqc_resource_formula_serializes_symbolic_derivations():


### PR DESCRIPTION
## Summary

This stacked draft PR builds on #500 by making the FTQC research survey reusable as structured metadata.

- adds `FTQCResearchSignal` and `iter_ftqc_research_signals()` to map research directions to canonical FTQC resource quantities
- covers qubitization, symmetry-compressed double factorization, symmetry shifts with tensor factorizations, symmetry-adapted state preparation, and early-FTQC unitary-weight concentration
- updates the FTQC design notebook in English and Japanese to use the structured survey and assert the key quantity mappings
- adds tests that pin recent research signals to the quantity catalog

## Local review

No findings after reviewing the stacked diff against `codex/ftqc-block-encoding-quantity-catalog`.

Mechanical checks:

- `uv run ruff check qamomile/ tests/` passed
- `uv run ruff format --check qamomile/ tests/` passed
- `uv run zuban check qamomile/` passed

## Validation

- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run ruff check qamomile/circuit/estimator/algorithmic/ftqc_resources.py qamomile/circuit/estimator/algorithmic/__init__.py tests/circuit/estimator/test_ftqc_resources.py docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run zuban check qamomile/`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design'`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`