### PR TITLE
Track FTQC space-time resource quantities

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "36469083",
+   "id": "ec877556",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a38136b2",
+   "id": "200a699a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:38.714263Z",
-     "iopub.status.busy": "2026-06-22T21:25:38.714084Z",
-     "iopub.status.idle": "2026-06-22T21:25:38.718063Z",
-     "shell.execute_reply": "2026-06-22T21:25:38.717481Z"
+     "iopub.execute_input": "2026-06-22T21:59:19.878889Z",
+     "iopub.status.busy": "2026-06-22T21:59:19.878672Z",
+     "iopub.status.idle": "2026-06-22T21:59:19.885423Z",
+     "shell.execute_reply": "2026-06-22T21:59:19.883547Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b2028f61",
+   "id": "a6fb5bec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:38.720110Z",
-     "iopub.status.busy": "2026-06-22T21:25:38.719989Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.047716Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.047185Z"
+     "iopub.execute_input": "2026-06-22T21:59:19.888825Z",
+     "iopub.status.busy": "2026-06-22T21:59:19.888622Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.223216Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.222606Z"
     }
    },
    "outputs": [],
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5f96ad3",
+   "id": "4ecc9132",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6139d82",
+   "id": "a7eef40c",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -111,7 +111,7 @@
     "| Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |\n",
     "| Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |\n",
     "| Symmetry-adapted filtering can increase state-preparation success probability before QPE ([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)). | Track success probability, expected QPE repetitions, filtering overhead, T gates, and runtime. |\n",
-    "| Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |\n",
+    "| Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, logical space-time volume, physical qubits, runtime, physical qubit-seconds, and architecture knobs in addition to Toffoli-native qubitization costs. |\n",
     "\n",
     "These are modeling quantities. They should be validated against each paper's\n",
     "assumptions before being used as a molecule-specific resource claim."
@@ -120,13 +120,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "977295b2",
+   "id": "e1e85fec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.049105Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.049019Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.051805Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.051290Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.224576Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.224491Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.227055Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.226624Z"
     }
    },
    "outputs": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c32d3318",
+   "id": "0e7a5d56",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -169,13 +169,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "cfbce740",
+   "id": "db0b891d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.052784Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.052728Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.056037Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.055621Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.228008Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.227939Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.231139Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.230746Z"
     }
    },
    "outputs": [
@@ -204,11 +204,13 @@
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
       "logical_depth logical layers logical\n",
+      "logical_spacetime_volume logical qubit-layers logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "clifford_gates Clifford gates logical\n",
       "physical_qubits physical qubits physical\n",
       "runtime_seconds seconds physical\n",
+      "physical_qubit_seconds physical qubit-seconds physical\n",
       "logical_error_rate probability physical\n",
       "target_logical_failure_probability probability architecture\n",
       "logical_operation_budget operations architecture\n",
@@ -253,7 +255,13 @@
     "    row[\"quantity\"] for row in catalog\n",
     "}\n",
     "assert FTQCResourceQuantity.TOFFOLI_GATES.value in {row[\"quantity\"] for row in catalog}\n",
+    "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
     "assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS.value in {\n",
     "    row[\"quantity\"] for row in catalog\n",
     "}\n",
     "assert FTQCResourceQuantity.CODE_DISTANCE.value in {row[\"quantity\"] for row in catalog}"
@@ -261,7 +269,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111ea04f",
+   "id": "6760ea0e",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -274,13 +282,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c908ac19",
+   "id": "24d7bc15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.057022Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.056968Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.084838Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.084370Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.232202Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.232151Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.264078Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.263679Z"
     }
    },
    "outputs": [
@@ -292,7 +300,9 @@
       "{'target_precision': '0.00160000000000000', 'truncation_error': '0.000100000000000000', 'safety_margin': '0', 'qpe_precision': '0.00150000000000000'}\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.276 reduction: -1.276\n"
+      "Logical space-time volume ratio: 1.650 reduction: -0.6500\n",
+      "Physical qubits ratio: 2.276 reduction: -1.276\n",
+      "Physical qubit-seconds ratio: 1.252 reduction: -0.2520\n"
      ]
     }
    ],
@@ -390,7 +400,13 @@
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
     "    compressed,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in comparison:\n",
@@ -398,12 +414,16 @@
     "\n",
     "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
     "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
-    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")"
+    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
+    "assert comparison[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "assert compressed.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (\n",
+    "    compressed.physical_qubits * compressed.runtime_seconds\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2ff2d256",
+   "id": "a29c1198",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -414,13 +434,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "953ad3a0",
+   "id": "32c09213",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.085885Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.085829Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.088698Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.088297Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.265290Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.265231Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.268669Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.268343Z"
     }
    },
    "outputs": [
@@ -430,7 +450,9 @@
      "text": [
       "smaller: QPE iterations by 0.5000\n",
       "smaller: Toffoli gates by 0.4500\n",
-      "larger: Physical qubits by 1.276\n"
+      "larger: Physical qubits by 1.276\n",
+      "larger: Logical space-time volume by 0.6500\n",
+      "larger: Physical qubit-seconds by 0.2520\n"
      ]
     }
    ],
@@ -438,7 +460,13 @@
     "comparison_summary = summarize_ftqc_resource_comparison(\n",
     "    baseline,\n",
     "    compressed,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in comparison_summary.smaller:\n",
@@ -453,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06979bdb",
+   "id": "16c124bc",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -467,13 +495,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "0f14b917",
+   "id": "99d5c2fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.089605Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.089553Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.091676Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.091387Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.269752Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.269699Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.272051Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.271650Z"
     }
    },
    "outputs": [
@@ -499,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e15fb60e",
+   "id": "a6e7e361",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -513,13 +541,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "55f78a98",
+   "id": "9800280d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.092657Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.092601Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.095268Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.094857Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.273165Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.273099Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.276170Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.275770Z"
     }
    },
    "outputs": [
@@ -552,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33ee5dec",
+   "id": "3948d781",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -566,13 +594,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9080fa84",
+   "id": "69223622",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.096400Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.096343Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.098831Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.098450Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.277299Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.277228Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.279367Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.278908Z"
     }
    },
    "outputs": [
@@ -608,7 +636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6198ce0",
+   "id": "55456d13",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -620,13 +648,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e0777e8d",
+   "id": "63462c53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.099967Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.099910Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.103783Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.103464Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.280406Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.280324Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.284390Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.283929Z"
     }
    },
    "outputs": [
@@ -673,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ebfcd33",
+   "id": "d6df722e",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -685,13 +713,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "56e9708b",
+   "id": "b14f8f15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.104815Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.104754Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.111647Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.111243Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.285407Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.285347Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.292282Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.291915Z"
     }
    },
    "outputs": [
@@ -739,7 +767,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b106dcaf",
+   "id": "d0df5f93",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -764,7 +792,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "497a020a",
+   "id": "74cac210",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -773,7 +801,8 @@
     "\n",
     "- Recent FTQC chemistry work motivates tracking Hamiltonian normalization,\n",
     "  target precision, truncation error, QPE iterations, non-Clifford counts,\n",
-    "  logical depth, physical qubits, and runtime separately.\n",
+    "  logical depth, logical space-time volume, physical qubits, runtime, and\n",
+    "  physical qubit-seconds separately.\n",
     "- `iter_ftqc_research_signals` maps research directions to the canonical\n",
     "  quantities that Qamomile reports.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -81,7 +81,7 @@ from qamomile.circuit.estimator.algorithmic import (
 # | Symmetry-compressed double factorization reduces the Hamiltonian 1-norm and Toffoli count for qubitized chemistry QPE ([arXiv:2403.03502](https://arxiv.org/abs/2403.03502)). | Track `lambda_norm`, QPE iterations, per-walk Toffoli cost, and total Toffoli count separately. |
 # | Simultaneous symmetry shifts and tensor factorizations reduce the block-encoding scaling constant for electronic Hamiltonians ([arXiv:2412.01338](https://arxiv.org/abs/2412.01338)). | Treat Hamiltonian normalization as representation metadata, not as an emitted-circuit property. |
 # | Symmetry-adapted filtering can increase state-preparation success probability before QPE ([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)). | Track success probability, expected QPE repetitions, filtering overhead, T gates, and runtime. |
-# | Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, physical qubits, runtime, and architecture knobs in addition to Toffoli-native qubitization costs. |
+# | Early-FTQC single-ancilla QPE with unitary weight concentration targets smaller physical-qubit budgets and limited depth ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). | Track T gates, logical depth, logical space-time volume, physical qubits, runtime, physical qubit-seconds, and architecture knobs in addition to Toffoli-native qubitization costs. |
 #
 # These are modeling quantities. They should be validated against each paper's
 # assumptions before being used as a molecule-specific resource claim.
@@ -129,7 +129,13 @@ assert FTQCResourceQuantity.TRUNCATION_ERROR.value in {
     row["quantity"] for row in catalog
 }
 assert FTQCResourceQuantity.TOFFOLI_GATES.value in {row["quantity"] for row in catalog}
+assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME.value in {
+    row["quantity"] for row in catalog
+}
 assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS.value in {
     row["quantity"] for row in catalog
 }
 assert FTQCResourceQuantity.CODE_DISTANCE.value in {row["quantity"] for row in catalog}
@@ -235,7 +241,13 @@ assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR]
 comparison = compare_ftqc_resource_estimates(
     baseline,
     compressed,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in comparison:
@@ -244,6 +256,10 @@ for row in comparison:
 assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
 assert comparison[0].ratio == sp.Float("0.5")
 assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
+assert comparison[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+assert compressed.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (
+    compressed.physical_qubits * compressed.runtime_seconds
+)
 
 # %% [markdown]
 # For design reviews, the summary helper groups the same rows by whether the
@@ -254,7 +270,13 @@ assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 comparison_summary = summarize_ftqc_resource_comparison(
     baseline,
     compressed,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in comparison_summary.smaller:
@@ -426,7 +448,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #
 # - Recent FTQC chemistry work motivates tracking Hamiltonian normalization,
 #   target precision, truncation error, QPE iterations, non-Clifford counts,
-#   logical depth, physical qubits, and runtime separately.
+#   logical depth, logical space-time volume, physical qubits, runtime, and
+#   physical qubit-seconds separately.
 # - `iter_ftqc_research_signals` maps research directions to the canonical
 #   quantities that Qamomile reports.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4105f4a6",
+   "id": "d1025b88",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a13f8661",
+   "id": "72c965fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:38.733900Z",
-     "iopub.status.busy": "2026-06-22T21:25:38.733781Z",
-     "iopub.status.idle": "2026-06-22T21:25:38.737005Z",
-     "shell.execute_reply": "2026-06-22T21:25:38.736436Z"
+     "iopub.execute_input": "2026-06-22T21:59:19.878777Z",
+     "iopub.status.busy": "2026-06-22T21:59:19.878555Z",
+     "iopub.status.idle": "2026-06-22T21:59:19.885433Z",
+     "shell.execute_reply": "2026-06-22T21:59:19.883536Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "dac88f6d",
+   "id": "52f18f25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:38.738777Z",
-     "iopub.status.busy": "2026-06-22T21:25:38.738652Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.047670Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.047202Z"
+     "iopub.execute_input": "2026-06-22T21:59:19.888801Z",
+     "iopub.status.busy": "2026-06-22T21:59:19.888611Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.223163Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.222607Z"
     }
    },
    "outputs": [],
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed6b20f7",
+   "id": "34b8b71c",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ded925c4",
+   "id": "4b6dbe03",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -98,7 +98,7 @@
     "| Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |\n",
     "| Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |\n",
     "| Symmetry-adapted filteringはQPE前のstate-preparation success probabilityを高める場合があります([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))。 | success probability、期待QPE repetition、filtering overhead、T gates、runtimeを追跡します。 |\n",
-    "| Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |\n",
+    "| Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-seconds、architecture knobを追跡します。 |\n",
     "\n",
     "これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。"
    ]
@@ -106,13 +106,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "811a28c7",
+   "id": "5a3dbd53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.049117Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.049029Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.051691Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.051311Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.224574Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.224482Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.226936Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.226597Z"
     }
    },
    "outputs": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5046ad7e",
+   "id": "a648cd41",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -154,13 +154,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1f5ca832",
+   "id": "5273f590",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.052709Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.052653Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.055923Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.055520Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.227954Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.227886Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.231183Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.230783Z"
     }
    },
    "outputs": [
@@ -189,11 +189,13 @@
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
       "logical_depth logical layers logical\n",
+      "logical_spacetime_volume logical qubit-layers logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "clifford_gates Clifford gates logical\n",
       "physical_qubits physical qubits physical\n",
       "runtime_seconds seconds physical\n",
+      "physical_qubit_seconds physical qubit-seconds physical\n",
       "logical_error_rate probability physical\n",
       "target_logical_failure_probability probability architecture\n",
       "logical_operation_budget operations architecture\n",
@@ -238,7 +240,13 @@
     "    row[\"quantity\"] for row in catalog\n",
     "}\n",
     "assert FTQCResourceQuantity.TOFFOLI_GATES.value in {row[\"quantity\"] for row in catalog}\n",
+    "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
     "assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {\n",
+    "    row[\"quantity\"] for row in catalog\n",
+    "}\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS.value in {\n",
     "    row[\"quantity\"] for row in catalog\n",
     "}\n",
     "assert FTQCResourceQuantity.CODE_DISTANCE.value in {row[\"quantity\"] for row in catalog}"
@@ -246,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6dd0f192",
+   "id": "503621d3",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -257,13 +265,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "739792be",
+   "id": "78d8a724",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.056898Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.056843Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.084433Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.084035Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.232220Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.232161Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.264059Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.263568Z"
     }
    },
    "outputs": [
@@ -275,7 +283,9 @@
       "{'target_precision': '0.00160000000000000', 'truncation_error': '0.000100000000000000', 'safety_margin': '0', 'qpe_precision': '0.00150000000000000'}\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.276 reduction: -1.276\n"
+      "Logical space-time volume ratio: 1.650 reduction: -0.6500\n",
+      "Physical qubits ratio: 2.276 reduction: -1.276\n",
+      "Physical qubit-seconds ratio: 1.252 reduction: -0.2520\n"
      ]
     }
    ],
@@ -373,7 +383,13 @@
     "comparison = compare_ftqc_resource_estimates(\n",
     "    baseline,\n",
     "    compressed,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in comparison:\n",
@@ -381,12 +397,16 @@
     "\n",
     "assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
     "assert comparison[0].ratio == sp.Float(\"0.5\")\n",
-    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")"
+    "assert sp.Abs(comparison[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
+    "assert comparison[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "assert compressed.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (\n",
+    "    compressed.physical_qubits * compressed.runtime_seconds\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "74345e5b",
+   "id": "35d1f4dc",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -395,13 +415,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9ff6daf4",
+   "id": "8c68a0e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.085519Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.085459Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.088159Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.087785Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.265126Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.265069Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.268453Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.268120Z"
     }
    },
    "outputs": [
@@ -411,7 +431,9 @@
      "text": [
       "smaller: QPE iterations by 0.5000\n",
       "smaller: Toffoli gates by 0.4500\n",
-      "larger: Physical qubits by 1.276\n"
+      "larger: Physical qubits by 1.276\n",
+      "larger: Logical space-time volume by 0.6500\n",
+      "larger: Physical qubit-seconds by 0.2520\n"
      ]
     }
    ],
@@ -419,7 +441,13 @@
     "comparison_summary = summarize_ftqc_resource_comparison(\n",
     "    baseline,\n",
     "    compressed,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in comparison_summary.smaller:\n",
@@ -434,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adf00a14",
+   "id": "378f51d9",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -445,13 +473,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3e3932f6",
+   "id": "44be8a0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.089071Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.089017Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.091263Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.090896Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.269535Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.269483Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.271841Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.271385Z"
     }
    },
    "outputs": [
@@ -477,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68f13f1d",
+   "id": "a39ba87c",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -488,13 +516,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "75b9bd48",
+   "id": "cd3a935e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.092264Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.092210Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.094735Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.094404Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.272905Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.272851Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.275800Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.275422Z"
     }
    },
    "outputs": [
@@ -527,7 +555,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deddaeaf",
+   "id": "02daa296",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -538,13 +566,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "8ca60f14",
+   "id": "d6e6a04a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.095837Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.095778Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.097843Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.097577Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.276911Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.276854Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.279216Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.278829Z"
     }
    },
    "outputs": [
@@ -580,7 +608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f592db93",
+   "id": "e431df09",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -591,13 +619,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "1de2ae96",
+   "id": "03127619",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.098994Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.098945Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.102839Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.102479Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.280359Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.280283Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.284344Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.283906Z"
     }
    },
    "outputs": [
@@ -644,7 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6741588",
+   "id": "53efbe35",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -655,13 +683,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "779c0352",
+   "id": "bbce48b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T21:25:39.103919Z",
-     "iopub.status.busy": "2026-06-22T21:25:39.103867Z",
-     "iopub.status.idle": "2026-06-22T21:25:39.110619Z",
-     "shell.execute_reply": "2026-06-22T21:25:39.110230Z"
+     "iopub.execute_input": "2026-06-22T21:59:20.285407Z",
+     "iopub.status.busy": "2026-06-22T21:59:20.285352Z",
+     "iopub.status.idle": "2026-06-22T21:59:20.292413Z",
+     "shell.execute_reply": "2026-06-22T21:59:20.292035Z"
     }
    },
    "outputs": [
@@ -709,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80d1cd31",
+   "id": "13f18816",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -728,14 +756,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb478845",
+   "id": "7a3fe338",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
     "このnotebookでは、次のことを学びました。\n",
     "\n",
-    "- 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。\n",
+    "- 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-secondsを分けて追跡する必要があることがわかります。\n",
     "- `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -68,7 +68,7 @@ from qamomile.circuit.estimator.algorithmic import (
 # | Symmetry-compressed double factorizationはqubitized chemistry QPEのHamiltonian 1-normとToffoli countを削減します([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))。 | `lambda_norm`、QPE反復回数、walkあたりのToffoli cost、総Toffoli countを別々に追跡します。 |
 # | Simultaneous symmetry shiftsとtensor factorizationsは、electronic Hamiltonianのblock-encoding scaling constantを削減します([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))。 | Hamiltonian normalizationを、emit済み回路の性質ではなく表現メタデータとして扱います。 |
 # | Symmetry-adapted filteringはQPE前のstate-preparation success probabilityを高める場合があります([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))。 | success probability、期待QPE repetition、filtering overhead、T gates、runtimeを追跡します。 |
-# | Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、physical量子ビット、runtime、architecture knobを追跡します。 |
+# | Unitary weight concentrationを使うearly-FTQC single-ancilla QPEは、より小さいphysical量子ビットbudgetと限られたdepthを目標にします([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))。 | Toffoli-nativeなqubitization costに加えて、T gates、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-seconds、architecture knobを追跡します。 |
 #
 # これらはmodeling上の量です。特定の分子についてリソースを主張する前に、それぞれの論文の仮定に照らして検証する必要があります。
 
@@ -114,7 +114,13 @@ assert FTQCResourceQuantity.TRUNCATION_ERROR.value in {
     row["quantity"] for row in catalog
 }
 assert FTQCResourceQuantity.TOFFOLI_GATES.value in {row["quantity"] for row in catalog}
+assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME.value in {
+    row["quantity"] for row in catalog
+}
 assert FTQCResourceQuantity.RUNTIME_SECONDS.value in {
+    row["quantity"] for row in catalog
+}
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS.value in {
     row["quantity"] for row in catalog
 }
 assert FTQCResourceQuantity.CODE_DISTANCE.value in {row["quantity"] for row in catalog}
@@ -218,7 +224,13 @@ assert compressed_model.resource_values()[FTQCResourceQuantity.TRUNCATION_ERROR]
 comparison = compare_ftqc_resource_estimates(
     baseline,
     compressed,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in comparison:
@@ -227,6 +239,10 @@ for row in comparison:
 assert comparison[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
 assert comparison[0].ratio == sp.Float("0.5")
 assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
+assert comparison[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+assert compressed.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (
+    compressed.physical_qubits * compressed.runtime_seconds
+)
 
 # %% [markdown]
 # 設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。
@@ -235,7 +251,13 @@ assert sp.Abs(comparison[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
 comparison_summary = summarize_ftqc_resource_comparison(
     baseline,
     compressed,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in comparison_summary.smaller:
@@ -388,7 +410,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #
 # このnotebookでは、次のことを学びました。
 #
-# - 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、physical量子ビット、runtimeを分けて追跡する必要があることがわかります。
+# - 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-secondsを分けて追跡する必要があることがわかります。
 # - `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -77,6 +77,8 @@ def _block_encoding_qpe_formulas() -> tuple[FTQCResourceFormula, ...]:
     toffoli_gates = _nonnegative_symbol(FTQCResourceQuantity.TOFFOLI_GATES.value)
     logical_qubits = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_QUBITS.value)
     logical_depth = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_DEPTH.value)
+    physical_qubits = _nonnegative_symbol(FTQCResourceQuantity.PHYSICAL_QUBITS.value)
+    runtime_seconds = _nonnegative_symbol(FTQCResourceQuantity.RUNTIME_SECONDS.value)
     physical_qubits_per_logical = _positive_symbol(
         FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL.value
     )
@@ -154,6 +156,27 @@ def _block_encoding_qpe_formulas() -> tuple[FTQCResourceFormula, ...]:
             description=(
                 "Use the slower of logical-cycle execution and factory "
                 "throughput as the runtime proxy."
+            ),
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+            expression=logical_qubits * logical_depth,
+            depends_on=(
+                FTQCResourceQuantity.LOGICAL_QUBITS,
+                FTQCResourceQuantity.LOGICAL_DEPTH,
+            ),
+            description="Multiply logical qubits by logical-depth proxy.",
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+            expression=physical_qubits * runtime_seconds,
+            depends_on=(
+                FTQCResourceQuantity.PHYSICAL_QUBITS,
+                FTQCResourceQuantity.RUNTIME_SECONDS,
+            ),
+            description=(
+                "Multiply physical qubits by runtime as a hardware "
+                "space-time cost proxy."
             ),
         ),
     )

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -1042,7 +1042,13 @@ class FTQCResourceEstimate:
             FTQCResourceQuantity.QPE_ITERATIONS: self.qpe_iterations,
             FTQCResourceQuantity.TARGET_PRECISION: self.target_precision,
             FTQCResourceQuantity.LOGICAL_DEPTH: self.logical_depth,
+            FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME: sp.simplify(
+                self.logical_qubits * self.logical_depth
+            ),
             FTQCResourceQuantity.RUNTIME_SECONDS: self.runtime_seconds,
+            FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS: sp.simplify(
+                self.physical_qubits * self.runtime_seconds
+            ),
         }
         values.update(self.algorithm_values)
         values.update(self.architecture_values)
@@ -2468,6 +2474,8 @@ def _architecture_formulas(
     logical_qubits = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_QUBITS.value)
     logical_depth = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_DEPTH.value)
     non_clifford = _nonnegative_symbol(non_clifford_quantity.value)
+    physical_qubits = _nonnegative_symbol(FTQCResourceQuantity.PHYSICAL_QUBITS.value)
+    runtime_seconds = _nonnegative_symbol(FTQCResourceQuantity.RUNTIME_SECONDS.value)
     physical_qubits_per_logical = _positive_symbol(
         FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL.value
     )
@@ -2507,6 +2515,27 @@ def _architecture_formulas(
             description=(
                 "Use the slower of logical-cycle execution and factory "
                 "throughput as the runtime proxy."
+            ),
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+            expression=logical_qubits * logical_depth,
+            depends_on=(
+                FTQCResourceQuantity.LOGICAL_QUBITS,
+                FTQCResourceQuantity.LOGICAL_DEPTH,
+            ),
+            description="Multiply logical qubits by logical-depth proxy.",
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+            expression=physical_qubits * runtime_seconds,
+            depends_on=(
+                FTQCResourceQuantity.PHYSICAL_QUBITS,
+                FTQCResourceQuantity.RUNTIME_SECONDS,
+            ),
+            description=(
+                "Multiply physical qubits by runtime as a hardware "
+                "space-time cost proxy."
             ),
         ),
     )
@@ -2621,6 +2650,9 @@ def _qpe_state_preparation_formulas() -> tuple[FTQCResourceFormula, ...]:
     base_t_gates = _nonnegative_symbol("base_t_gates")
     base_depth = _nonnegative_symbol("base_logical_depth")
     logical_qubits = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_QUBITS.value)
+    logical_depth = _nonnegative_symbol(FTQCResourceQuantity.LOGICAL_DEPTH.value)
+    physical_qubits = _nonnegative_symbol(FTQCResourceQuantity.PHYSICAL_QUBITS.value)
+    runtime_seconds = _nonnegative_symbol(FTQCResourceQuantity.RUNTIME_SECONDS.value)
     physical_qubits_per_logical = _positive_symbol(
         FTQCResourceQuantity.PHYSICAL_QUBITS_PER_LOGICAL.value
     )
@@ -2732,6 +2764,27 @@ def _qpe_state_preparation_formulas() -> tuple[FTQCResourceFormula, ...]:
             description=(
                 "Use the slower of repeated logical-depth execution and "
                 "factory throughput for repeated Toffoli plus T work."
+            ),
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+            expression=logical_qubits * logical_depth,
+            depends_on=(
+                FTQCResourceQuantity.LOGICAL_QUBITS,
+                FTQCResourceQuantity.LOGICAL_DEPTH,
+            ),
+            description="Multiply logical qubits by repeated logical-depth proxy.",
+        ),
+        FTQCResourceFormula(
+            quantity=FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+            expression=physical_qubits * runtime_seconds,
+            depends_on=(
+                FTQCResourceQuantity.PHYSICAL_QUBITS,
+                FTQCResourceQuantity.RUNTIME_SECONDS,
+            ),
+            description=(
+                "Multiply physical qubits by runtime as a hardware "
+                "space-time cost proxy."
             ),
         ),
     )

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -69,11 +69,13 @@ class FTQCResourceQuantity(enum.StrEnum):
             calls.
         LOGICAL_QUBITS: Logical qubits required by an algorithm.
         LOGICAL_DEPTH: Logical-depth proxy.
+        LOGICAL_SPACETIME_VOLUME: Logical qubit-layer volume proxy.
         TOFFOLI_GATES: Toffoli or Toffoli-equivalent non-Clifford count.
         T_GATES: T-gate or T-equivalent count.
         CLIFFORD_GATES: Clifford gate count.
         PHYSICAL_QUBITS: Physical qubits under an architecture model.
         RUNTIME_SECONDS: Runtime proxy in seconds.
+        PHYSICAL_QUBIT_SECONDS: Physical qubit-seconds space-time cost.
         LOGICAL_ERROR_RATE: Logical error-rate proxy per operation or cycle.
         TARGET_LOGICAL_FAILURE_PROBABILITY: Total allowed logical failure
             probability for an architecture budget.
@@ -123,11 +125,13 @@ class FTQCResourceQuantity(enum.StrEnum):
     QPE_ITERATIONS = "qpe_iterations"
     LOGICAL_QUBITS = "logical_qubits"
     LOGICAL_DEPTH = "logical_depth"
+    LOGICAL_SPACETIME_VOLUME = "logical_spacetime_volume"
     TOFFOLI_GATES = "toffoli_gates"
     T_GATES = "t_gates"
     CLIFFORD_GATES = "clifford_gates"
     PHYSICAL_QUBITS = "physical_qubits"
     RUNTIME_SECONDS = "runtime_seconds"
+    PHYSICAL_QUBIT_SECONDS = "physical_qubit_seconds"
     LOGICAL_ERROR_RATE = "logical_error_rate"
     TARGET_LOGICAL_FAILURE_PROBABILITY = "target_logical_failure_probability"
     LOGICAL_OPERATION_BUDGET = "logical_operation_budget"
@@ -650,6 +654,13 @@ FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
         "Logical circuit-depth proxy after algorithmic repetition factors.",
     ),
     FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+        "Logical space-time volume",
+        "logical qubit-layers",
+        FTQCResourceCategory.LOGICAL,
+        "Product of logical qubits and logical-depth proxy.",
+    ),
+    FTQCResourceQuantitySpec(
         FTQCResourceQuantity.TOFFOLI_GATES,
         "Toffoli gates",
         "Toffoli gates",
@@ -683,6 +694,13 @@ FTQC_RESOURCE_QUANTITY_SPECS: tuple[FTQCResourceQuantitySpec, ...] = (
         "seconds",
         FTQCResourceCategory.PHYSICAL,
         "Wall-clock runtime proxy under the selected architecture model.",
+    ),
+    FTQCResourceQuantitySpec(
+        FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+        "Physical qubit-seconds",
+        "physical qubit-seconds",
+        FTQCResourceCategory.PHYSICAL,
+        "Product of physical qubits and wall-clock runtime proxy.",
     ),
     FTQCResourceQuantitySpec(
         FTQCResourceQuantity.LOGICAL_ERROR_RATE,
@@ -842,6 +860,7 @@ FTQC_RESEARCH_SIGNALS = (
             FTQCResourceQuantity.TOFFOLI_GATES,
             FTQCResourceQuantity.LOGICAL_QUBITS,
             FTQCResourceQuantity.RUNTIME_SECONDS,
+            FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
         ),
         design_note=(
             "Keep factorization ranks, normalization, and walk cost on the "
@@ -905,8 +924,10 @@ FTQC_RESEARCH_SIGNALS = (
             FTQCResourceQuantity.QPE_ITERATIONS,
             FTQCResourceQuantity.T_GATES,
             FTQCResourceQuantity.LOGICAL_DEPTH,
+            FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
             FTQCResourceQuantity.PHYSICAL_QUBITS,
             FTQCResourceQuantity.RUNTIME_SECONDS,
+            FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
         ),
         design_note=(
             "Track T gates, logical depth, and architecture knobs alongside "

--- a/tests/circuit/estimator/test_ftqc_block_encoding.py
+++ b/tests/circuit/estimator/test_ftqc_block_encoding.py
@@ -87,6 +87,9 @@ def test_qubitized_qpe_from_block_encoding_tracks_walk_calls_and_costs():
     assert estimate.qpe_iterations == 50
     assert estimate.target_precision == 2
     assert estimate.resource_values()[FTQCResourceQuantity.TARGET_PRECISION] == 2
+    assert estimate.resource_values()[
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+    ] == (13 * 4750)
     assert estimate.resource_values()[FTQCResourceQuantity.SYSTEM_QUBITS] == 6
     assert estimate.resource_values()[FTQCResourceQuantity.PREPARE_COST_TOFFOLI] == 20
     assert estimate.resource_values()[FTQCResourceQuantity.SELECT_COST_TOFFOLI] == 50
@@ -95,6 +98,10 @@ def test_qubitized_qpe_from_block_encoding_tracks_walk_calls_and_costs():
     assert estimate.toffoli_gates == 4750
     assert estimate.physical_qubits == 1310
     assert sp.Abs(estimate.runtime_seconds - sp.Float("0.00475")) < sp.Float("1e-12")
+    assert sp.Abs(
+        estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS]
+        - sp.Float("6.2225")
+    ) < sp.Float("1e-12")
     assert estimate.assumptions["block_encoding"] == "toy_lcu"
     assert estimate.to_dict()["algorithm_values"]["prepare_cost_toffoli"] == "20"
     assert any(reference.key == "arXiv:1610.06546" for reference in estimate.references)

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -249,6 +249,12 @@ def test_state_preparation_budget_scales_expected_qpe_work():
     assert repeated.physical_qubits == estimate.physical_qubits
     assert sp.Abs(repeated.runtime_seconds - sp.Float("0.00296")) < sp.Float("1e-12")
     assert repeated.resource_values()[
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+    ] == (repeated.logical_qubits * repeated.logical_depth)
+    assert repeated.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (
+        repeated.physical_qubits * repeated.runtime_seconds
+    )
+    assert repeated.resource_values()[
         FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY
     ] == sp.Rational(1, 4)
     assert repeated.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS] == 4

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -50,7 +50,9 @@ def test_ftqc_quantity_specs_cover_core_resource_layers():
     assert FTQCResourceQuantity.PREPARE_COST_TOFFOLI in quantities
     assert FTQCResourceQuantity.SELECT_COST_TOFFOLI in quantities
     assert FTQCResourceQuantity.REFLECTION_COST_TOFFOLI in quantities
+    assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in quantities
     assert FTQCResourceQuantity.TOFFOLI_GATES in quantities
+    assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in quantities
     assert FTQCResourceQuantity.LOGICAL_ERROR_RATE in quantities
     assert FTQCResourceQuantity.PHYSICAL_ERROR_RATE in quantities
     assert FTQCResourceQuantity.THRESHOLD_ERROR_RATE in quantities
@@ -83,6 +85,7 @@ def test_ftqc_research_signals_map_sources_to_quantity_catalog():
     scdf = signal_by_key["arXiv:2403.03502"]
     assert FTQCResourceQuantity.LAMBDA_NORM in scdf.quantities
     assert FTQCResourceQuantity.TOFFOLI_GATES in scdf.quantities
+    assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf.quantities
 
     state_preparation = signal_by_key["arXiv:2601.08533"]
     assert (
@@ -93,6 +96,8 @@ def test_ftqc_research_signals_map_sources_to_quantity_catalog():
     assert state_preparation.to_dict()["quantities"][0] == (
         "state_preparation_success_probability"
     )
+    early_ftqc = signal_by_key["arXiv:2603.22778"]
+    assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc.quantities
 
 
 def test_ftqc_resource_formula_serializes_symbolic_derivations():
@@ -178,6 +183,12 @@ def test_ftqc_models_expose_canonical_resource_values():
         == 0
     )
     assert estimate.resource_values()[FTQCResourceQuantity.TARGET_PRECISION] == 1
+    assert estimate.resource_values()[
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+    ] == (estimate.logical_qubits * estimate.logical_depth)
+    assert estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS] == (
+        estimate.physical_qubits * estimate.runtime_seconds
+    )
     assert estimate.to_quantity_table()[0]["quantity"] == "logical_qubits"
 
     formula_table = estimate.to_formula_table()
@@ -189,6 +200,14 @@ def test_ftqc_models_expose_canonical_resource_values():
     assert formula_by_quantity["toffoli_gates"]["depends_on"] == [
         "qpe_iterations",
         "walk_cost_toffoli",
+    ]
+    assert formula_by_quantity["logical_spacetime_volume"]["depends_on"] == [
+        "logical_qubits",
+        "logical_depth",
+    ]
+    assert formula_by_quantity["physical_qubit_seconds"]["depends_on"] == [
+        "physical_qubits",
+        "runtime_seconds",
     ]
     assert estimate.to_dict()["formulas"][0]["quantity"] == "qpe_iterations"
 


### PR DESCRIPTION
## Summary

- Add canonical FTQC quantities for logical space-time volume and physical qubit-seconds.
- Thread those quantities through chemistry, state-preparation, and block-encoding resource formula tables.
- Update EN/JA FTQC resource-estimation tutorials and executed notebooks to compare these space-time proxies.

## Validation

- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_ftqc_block_encoding.py tests/circuit/estimator/test_ftqc_chemistry.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k ftqc_resource_estimation_design`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`