### PR TITLE
Teach FTQC chemistry space-time resources

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "522e6db9",
+   "id": "da2db3ab",
    "metadata": {},
    "source": [
     "---\n",
@@ -15,19 +15,20 @@
     "models with Qamomile. It focuses on algorithm-level quantities that matter\n",
     "before a full logical circuit is available: Hamiltonian normalization,\n",
     "phase-estimation iterations, Toffoli or T counts, logical qubits, physical\n",
-    "qubits, and runtime proxies."
+    "qubits, logical space-time volume, physical qubit-seconds, and runtime\n",
+    "proxies."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2ba5254e",
+   "id": "50c20c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:55.525695Z",
-     "iopub.status.busy": "2026-06-22T20:19:55.525286Z",
-     "iopub.status.idle": "2026-06-22T20:19:55.531521Z",
-     "shell.execute_reply": "2026-06-22T20:19:55.530933Z"
+     "iopub.execute_input": "2026-06-22T22:45:10.093618Z",
+     "iopub.status.busy": "2026-06-22T22:45:10.093376Z",
+     "iopub.status.idle": "2026-06-22T22:45:10.097668Z",
+     "shell.execute_reply": "2026-06-22T22:45:10.096703Z"
     }
    },
    "outputs": [],
@@ -39,13 +40,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "79f438b7",
+   "id": "e9816282",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:55.533779Z",
-     "iopub.status.busy": "2026-06-22T20:19:55.533627Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.976825Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.975956Z"
+     "iopub.execute_input": "2026-06-22T22:45:10.100074Z",
+     "iopub.status.busy": "2026-06-22T22:45:10.099923Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.810731Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.810251Z"
     }
    },
    "outputs": [],
@@ -66,6 +67,7 @@
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_openfermion_qubit_operator,\n",
@@ -75,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4ebd3de",
+   "id": "cd245c32",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -95,15 +97,17 @@
     "([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). State-preparation\n",
     "improvements such as symmetry-adapted filtering\n",
     "([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)) can also change the\n",
-    "expected number of QPE attempts. The estimators below are deliberately\n",
-    "symbolic. They let you test how a proposed representation changes the\n",
-    "cost-driving quantities before committing to a concrete Hamiltonian-loading\n",
-    "circuit."
+    "expected number of QPE attempts. Because these proposals trade algorithmic\n",
+    "work, logical depth, logical qubits, and hardware runtime differently,\n",
+    "space-time quantities such as logical qubit-layers and physical qubit-seconds\n",
+    "are useful review targets. The estimators below are deliberately symbolic.\n",
+    "They let you test how a proposed representation changes the cost-driving\n",
+    "quantities before committing to a concrete Hamiltonian-loading circuit."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4be9b576",
+   "id": "118d87bf",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -123,13 +127,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "80f3e417",
+   "id": "d5f48005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.978786Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.978597Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.983299Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.982721Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.812275Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.812112Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.816480Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.816057Z"
     }
    },
    "outputs": [],
@@ -166,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9ca7bd8",
+   "id": "57b91192",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -180,13 +184,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6ace9980",
+   "id": "3476a3ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.984784Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.984721Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.987920Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.987387Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.817523Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.817466Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.820196Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.819826Z"
     }
    },
    "outputs": [
@@ -200,10 +204,12 @@
       "qpe_repetitions runs algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
+      "logical_spacetime_volume logical qubit-layers logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "physical_qubits physical qubits physical\n",
       "runtime_seconds seconds physical\n",
+      "physical_qubit_seconds physical qubit-seconds physical\n",
       "logical_error_rate probability physical\n",
       "code_distance distance architecture\n"
      ]
@@ -223,7 +229,9 @@
     "        \"toffoli_gates\",\n",
     "        \"t_gates\",\n",
     "        \"logical_qubits\",\n",
+    "        \"logical_spacetime_volume\",\n",
     "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
     "        \"runtime_seconds\",\n",
     "        \"logical_error_rate\",\n",
     "        \"code_distance\",\n",
@@ -242,7 +250,9 @@
     "    \"toffoli_gates\",\n",
     "    \"t_gates\",\n",
     "    \"logical_qubits\",\n",
+    "    \"logical_spacetime_volume\",\n",
     "    \"physical_qubits\",\n",
+    "    \"physical_qubit_seconds\",\n",
     "    \"runtime_seconds\",\n",
     "    \"logical_error_rate\",\n",
     "    \"code_distance\",\n",
@@ -251,7 +261,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "804c5bb7",
+   "id": "88fae61f",
+   "metadata": {},
+   "source": [
+    "The research-signal catalog maps recent papers to the quantities they ask a\n",
+    "Qamomile model to expose. This keeps the tutorial grounded in a small,\n",
+    "inspectable contract instead of prose-only claims."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "793ce016",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T22:45:11.821213Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.821159Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.823546Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.823226Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Symmetry-compressed double factorization for fault-tolerant chemistry simulation\n",
+      "['lambda_norm', 'qpe_iterations', 'walk_cost_toffoli', 'toffoli_gates', 'logical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "Chemically accurate QPE in the early fault-tolerant regime\n",
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+     ]
+    }
+   ],
+   "source": [
+    "signal_by_key = {\n",
+    "    signal.reference_key: signal for signal in iter_ftqc_research_signals()\n",
+    "}\n",
+    "scdf_signal = signal_by_key[\"arXiv:2403.03502\"]\n",
+    "early_ftqc_signal = signal_by_key[\"arXiv:2603.22778\"]\n",
+    "\n",
+    "print(scdf_signal.title)\n",
+    "print([quantity.value for quantity in scdf_signal.quantities])\n",
+    "print(early_ftqc_signal.title)\n",
+    "print([quantity.value for quantity in early_ftqc_signal.quantities])\n",
+    "\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities\n",
+    "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dfeae23",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -263,14 +324,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "2f05dffc",
+   "execution_count": 6,
+   "id": "9d7ba2bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.989184Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.989121Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.992379Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.991731Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.824788Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.824731Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.827677Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.827191Z"
     }
    },
    "outputs": [],
@@ -293,7 +354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c8491ff",
+   "id": "97f1bd95",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -304,14 +365,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "2a3ef93f",
+   "execution_count": 7,
+   "id": "fc59540e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.993524Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.993458Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.995816Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.995358Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.828760Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.828692Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.831024Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.830670Z"
     }
    },
    "outputs": [],
@@ -334,7 +395,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d07c088",
+   "id": "72fe8a85",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -355,14 +416,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "fcbbda86",
+   "execution_count": 8,
+   "id": "ae51b46e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.997073Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.997016Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.023199Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.022784Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.832176Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.832109Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.857125Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.856725Z"
     }
    },
    "outputs": [
@@ -377,9 +438,13 @@
       "Physical qubits 125840 physical qubits\n",
       "Toffoli gates 293333333333.333 Toffoli gates\n",
       "QPE iterations 66666666.6666667 iterations\n",
+      "Logical space-time volume 35200000000000.0 logical qubit-layers\n",
+      "Physical qubit-seconds 38758720000.0000 physical qubit-seconds\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.276 reduction: -1.276\n"
+      "Logical space-time volume ratio: 1.650 reduction: -0.6500\n",
+      "Physical qubits ratio: 2.276 reduction: -1.276\n",
+      "Physical qubit-seconds ratio: 1.252 reduction: -0.2520\n"
      ]
     }
    ],
@@ -427,13 +492,25 @@
     "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)\n",
     "\n",
     "for row in scdf.to_quantity_table():\n",
-    "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
+    "    if row[\"quantity\"] in {\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    }:\n",
     "        print(row[\"label\"], row[\"value\"], row[\"unit\"])\n",
     "\n",
     "qubitized_savings = compare_ftqc_resource_estimates(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "for row in qubitized_savings:\n",
     "    print(\n",
@@ -447,11 +524,18 @@
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
     "assert sp.Abs(qubitized_savings[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
+    "assert qubitized_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
     "\n",
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
@@ -460,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "683ffd38",
+   "id": "40616de9",
    "metadata": {},
    "source": [
     "## State-Preparation Success Budget\n",
@@ -474,14 +558,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "f676332b",
+   "execution_count": 9,
+   "id": "f1ce117f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.024772Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.024702Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.038873Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.038179Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.858225Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.858166Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.871727Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.871309Z"
     }
    },
    "outputs": [
@@ -492,7 +576,9 @@
       "QPE repetitions ratio: 0.2500 reduction: 0.7500\n",
       "QPE iterations ratio: 0.2500 reduction: 0.7500\n",
       "Toffoli gates ratio: 0.2500 reduction: 0.7500\n",
-      "Runtime ratio: 0.2500 reduction: 0.7500\n"
+      "Logical space-time volume ratio: 0.2500 reduction: 0.7500\n",
+      "Runtime ratio: 0.2500 reduction: 0.7500\n",
+      "Physical qubit-seconds ratio: 0.2500 reduction: 0.7500\n"
      ]
     }
    ],
@@ -514,7 +600,14 @@
     "preparation_savings = compare_ftqc_resource_estimates(\n",
     "    weak_overlap_scdf,\n",
     "    symmetry_filtered_scdf,\n",
-    "    quantities=(\"qpe_repetitions\", \"qpe_iterations\", \"toffoli_gates\", \"runtime_seconds\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_repetitions\",\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"runtime_seconds\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in preparation_savings:\n",
@@ -524,6 +617,9 @@
     "assert (\n",
     "    symmetry_filtered_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS] == 2\n",
     ")\n",
+    "assert symmetry_filtered_scdf.resource_values()[\n",
+    "    FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "] == (symmetry_filtered_scdf.logical_qubits * symmetry_filtered_scdf.logical_depth)\n",
     "assert symmetry_filtered_scdf.qpe_iterations == scdf.qpe_iterations * 2\n",
     "assert symmetry_filtered_scdf.toffoli_gates < weak_overlap_scdf.toffoli_gates\n",
     "assert \"state_preparation_success_probability\" in symmetry_filtered_scdf.to_dict()[\n",
@@ -533,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c98360a7",
+   "id": "6bc03876",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -544,14 +640,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "05451b4f",
+   "execution_count": 10,
+   "id": "a66288fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.040129Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.040062Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.045706Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.044852Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.872801Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.872730Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.876359Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.875958Z"
     }
    },
    "outputs": [
@@ -585,7 +681,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae1b8043",
+   "id": "3e79e6e9",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -599,14 +695,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "a093da5e",
+   "execution_count": 11,
+   "id": "43fb4790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.047649Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.047489Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.055841Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.055353Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.877358Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.877298Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.884860Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.884455Z"
     }
    },
    "outputs": [
@@ -618,7 +714,8 @@
       "UWC-style Trotter QPE depth proxy: 1.365e+10\n",
       "UWC-style T gates: 4.096e+10\n",
       "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
-      "Logical depth ratio: 0.05000 reduction: 0.9500\n"
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n",
+      "Logical space-time volume ratio: 0.05000 reduction: 0.9500\n"
      ]
     }
    ],
@@ -652,7 +749,7 @@
     "trotter_savings = compare_ftqc_resource_estimates(\n",
     "    plain_trotter,\n",
     "    uwc_trotter,\n",
-    "    quantities=(\"qpe_iterations\", \"logical_depth\"),\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\", \"logical_spacetime_volume\"),\n",
     ")\n",
     "for row in trotter_savings:\n",
     "    print(\n",
@@ -664,12 +761,13 @@
     "    )\n",
     "\n",
     "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
-    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")"
+    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")\n",
+    "assert trotter_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3f37c32a",
+   "id": "b94ac5a7",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -677,19 +775,20 @@
     "We can put the estimates into a compact table. The important point is that\n",
     "each column has a distinct design meaning: changing the Hamiltonian\n",
     "representation should affect `qpe_iterations` and per-step cost, while\n",
-    "changing the hardware model should affect `physical_qubits` and runtime."
+    "changing the hardware model should affect `physical_qubits`, runtime, and\n",
+    "physical qubit-seconds."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "721ed6fa",
+   "execution_count": 12,
+   "id": "71a54250",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.057161Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.057085Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.060910Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.060198Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.885949Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.885876Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.889554Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.889232Z"
     }
    },
    "outputs": [
@@ -697,10 +796,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'runtime_seconds': 5.600e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'runtime_seconds': 3.080e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'runtime_seconds': 2.867e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'runtime_seconds': 2.150e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'logical_spacetime_volume': 2.133e+13, 'runtime_seconds': 5.600e+5, 'physical_qubit_seconds': 3.096e+10}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'logical_spacetime_volume': 3.520e+13, 'runtime_seconds': 3.080e+5, 'physical_qubit_seconds': 3.876e+10}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'logical_spacetime_volume': 1.120e+13, 'runtime_seconds': 2.867e+5, 'physical_qubit_seconds': 1.610e+10}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'logical_spacetime_volume': 5.598e+11, 'runtime_seconds': 2.150e+4, 'physical_qubit_seconds': 1.208e+9}\n"
      ]
     }
    ],
@@ -721,17 +820,28 @@
     "            \"qpe_iterations\": sp.N(estimate.qpe_iterations, 4),\n",
     "            \"toffoli_gates\": sp.N(estimate.toffoli_gates, 4),\n",
     "            \"t_gates\": sp.N(estimate.t_gates, 4),\n",
+    "            \"logical_spacetime_volume\": sp.N(\n",
+    "                estimate.resource_values()[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],\n",
+    "                4,\n",
+    "            ),\n",
     "            \"runtime_seconds\": sp.N(estimate.runtime_seconds, 4),\n",
+    "            \"physical_qubit_seconds\": sp.N(\n",
+    "                estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS],\n",
+    "                4,\n",
+    "            ),\n",
     "        },\n",
     "    )\n",
     "\n",
     "assert scdf.physical_qubits > thc.physical_qubits\n",
-    "assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits"
+    "assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits\n",
+    "assert uwc_trotter.resource_values()[\n",
+    "    FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS\n",
+    "] < plain_trotter.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a6ca3570",
+   "id": "363601d0",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -740,7 +850,8 @@
     "\n",
     "- Separated FTQC chemistry resource quantities into Hamiltonian\n",
     "  normalization, QPE iterations, non-Clifford counts, logical qubits,\n",
-    "  physical qubits, and runtime proxies.\n",
+    "  logical space-time volume, physical qubits, runtime proxies, and physical\n",
+    "  qubit-seconds.\n",
     "- Allocated a total target precision into truncation error and QPE precision\n",
     "  before building comparable estimates.\n",
     "- Modeled state-preparation success probability as an explicit expected\n",
@@ -754,7 +865,9 @@
     "- Converted a chemistry QPE model into a block-encoding contract so PREPARE,\n",
     "  SELECT, reflection, and workspace costs can be reviewed separately.\n",
     "- Demonstrated how a unitary-weight concentration factor can be modeled as a\n",
-    "  cost-driver reduction for early-FTQC single-ancilla Trotter QPE."
+    "  cost-driver reduction for early-FTQC single-ancilla Trotter QPE.\n",
+    "- Connected recent FTQC chemistry research signals to the canonical\n",
+    "  quantities that the tutorial compares."
    ]
   }
  ],

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -23,7 +23,8 @@
 # models with Qamomile. It focuses on algorithm-level quantities that matter
 # before a full logical circuit is available: Hamiltonian normalization,
 # phase-estimation iterations, Toffoli or T counts, logical qubits, physical
-# qubits, and runtime proxies.
+# qubits, logical space-time volume, physical qubit-seconds, and runtime
+# proxies.
 
 # %%
 # Install the latest Qamomile through pip!
@@ -46,6 +47,7 @@ from qamomile.circuit.estimator.algorithmic import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_qubitized_qpe_from_block_encoding,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
     summarize_openfermion_qubit_operator,
@@ -70,10 +72,12 @@ from qamomile.circuit.estimator.algorithmic import (
 # ([arXiv:2603.22778](https://arxiv.org/abs/2603.22778)). State-preparation
 # improvements such as symmetry-adapted filtering
 # ([arXiv:2601.08533](https://arxiv.org/abs/2601.08533)) can also change the
-# expected number of QPE attempts. The estimators below are deliberately
-# symbolic. They let you test how a proposed representation changes the
-# cost-driving quantities before committing to a concrete Hamiltonian-loading
-# circuit.
+# expected number of QPE attempts. Because these proposals trade algorithmic
+# work, logical depth, logical qubits, and hardware runtime differently,
+# space-time quantities such as logical qubit-layers and physical qubit-seconds
+# are useful review targets. The estimators below are deliberately symbolic.
+# They let you test how a proposed representation changes the cost-driving
+# quantities before committing to a concrete Hamiltonian-loading circuit.
 
 # %% [markdown]
 # ## Problem Settings
@@ -141,7 +145,9 @@ quantity_catalog = [
         "toffoli_gates",
         "t_gates",
         "logical_qubits",
+        "logical_spacetime_volume",
         "physical_qubits",
+        "physical_qubit_seconds",
         "runtime_seconds",
         "logical_error_rate",
         "code_distance",
@@ -160,11 +166,34 @@ assert {row["quantity"] for row in quantity_catalog} == {
     "toffoli_gates",
     "t_gates",
     "logical_qubits",
+    "logical_spacetime_volume",
     "physical_qubits",
+    "physical_qubit_seconds",
     "runtime_seconds",
     "logical_error_rate",
     "code_distance",
 }
+
+# %% [markdown]
+# The research-signal catalog maps recent papers to the quantities they ask a
+# Qamomile model to expose. This keeps the tutorial grounded in a small,
+# inspectable contract instead of prose-only claims.
+
+# %%
+signal_by_key = {
+    signal.reference_key: signal for signal in iter_ftqc_research_signals()
+}
+scdf_signal = signal_by_key["arXiv:2403.03502"]
+early_ftqc_signal = signal_by_key["arXiv:2603.22778"]
+
+print(scdf_signal.title)
+print([quantity.value for quantity in scdf_signal.quantities])
+print(early_ftqc_signal.title)
+print([quantity.value for quantity in early_ftqc_signal.quantities])
+
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities
+assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities
 
 # %% [markdown]
 # We start from a small Qamomile observable so the workflow has the same shape
@@ -271,13 +300,25 @@ print("Toy Pauli terms:", toy_summary.n_pauli_terms)
 print("SCDF-style logical qubits:", scdf.logical_qubits)
 
 for row in scdf.to_quantity_table():
-    if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
+    if row["quantity"] in {
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    }:
         print(row["label"], row["value"], row["unit"])
 
 qubitized_savings = compare_ftqc_resource_estimates(
     thc,
     scdf,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 for row in qubitized_savings:
     print(
@@ -291,11 +332,18 @@ for row in qubitized_savings:
 assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
 assert sp.Abs(qubitized_savings[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
+assert qubitized_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
 
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
     scdf,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
@@ -328,7 +376,14 @@ symmetry_filtered_scdf = symmetry_filtered_budget.apply(scdf)
 preparation_savings = compare_ftqc_resource_estimates(
     weak_overlap_scdf,
     symmetry_filtered_scdf,
-    quantities=("qpe_repetitions", "qpe_iterations", "toffoli_gates", "runtime_seconds"),
+    quantities=(
+        "qpe_repetitions",
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "runtime_seconds",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in preparation_savings:
@@ -338,6 +393,9 @@ assert weak_overlap_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS]
 assert (
     symmetry_filtered_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS] == 2
 )
+assert symmetry_filtered_scdf.resource_values()[
+    FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+] == (symmetry_filtered_scdf.logical_qubits * symmetry_filtered_scdf.logical_depth)
 assert symmetry_filtered_scdf.qpe_iterations == scdf.qpe_iterations * 2
 assert symmetry_filtered_scdf.toffoli_gates < weak_overlap_scdf.toffoli_gates
 assert "state_preparation_success_probability" in symmetry_filtered_scdf.to_dict()[
@@ -408,7 +466,7 @@ print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
 trotter_savings = compare_ftqc_resource_estimates(
     plain_trotter,
     uwc_trotter,
-    quantities=("qpe_iterations", "logical_depth"),
+    quantities=("qpe_iterations", "logical_depth", "logical_spacetime_volume"),
 )
 for row in trotter_savings:
     print(
@@ -421,6 +479,7 @@ for row in trotter_savings:
 
 assert trotter_savings[0].ratio == sp.Float("0.1")
 assert trotter_savings[1].ratio == sp.Float("0.05")
+assert trotter_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
 
 # %% [markdown]
 # ## Result
@@ -428,7 +487,8 @@ assert trotter_savings[1].ratio == sp.Float("0.05")
 # We can put the estimates into a compact table. The important point is that
 # each column has a distinct design meaning: changing the Hamiltonian
 # representation should affect `qpe_iterations` and per-step cost, while
-# changing the hardware model should affect `physical_qubits` and runtime.
+# changing the hardware model should affect `physical_qubits`, runtime, and
+# physical qubit-seconds.
 
 # %%
 rows = [
@@ -447,12 +507,23 @@ for name, estimate in rows:
             "qpe_iterations": sp.N(estimate.qpe_iterations, 4),
             "toffoli_gates": sp.N(estimate.toffoli_gates, 4),
             "t_gates": sp.N(estimate.t_gates, 4),
+            "logical_spacetime_volume": sp.N(
+                estimate.resource_values()[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],
+                4,
+            ),
             "runtime_seconds": sp.N(estimate.runtime_seconds, 4),
+            "physical_qubit_seconds": sp.N(
+                estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS],
+                4,
+            ),
         },
     )
 
 assert scdf.physical_qubits > thc.physical_qubits
 assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
+assert uwc_trotter.resource_values()[
+    FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS
+] < plain_trotter.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS]
 
 # %% [markdown]
 # ## Summary
@@ -461,7 +532,8 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 #
 # - Separated FTQC chemistry resource quantities into Hamiltonian
 #   normalization, QPE iterations, non-Clifford counts, logical qubits,
-#   physical qubits, and runtime proxies.
+#   logical space-time volume, physical qubits, runtime proxies, and physical
+#   qubit-seconds.
 # - Allocated a total target precision into truncation error and QPE precision
 #   before building comparable estimates.
 # - Modeled state-preparation success probability as an explicit expected
@@ -476,3 +548,5 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 #   SELECT, reflection, and workspace costs can be reviewed separately.
 # - Demonstrated how a unitary-weight concentration factor can be modeled as a
 #   cost-driver reduction for early-FTQC single-ancilla Trotter QPE.
+# - Connected recent FTQC chemistry research signals to the canonical
+#   quantities that the tutorial compares.

--- a/docs/en/algorithm/index.md
+++ b/docs/en/algorithm/index.md
@@ -12,7 +12,7 @@ Concrete quantum algorithm examples built with Qamomile.
 - [QAOA for Graph Partitioning](qaoa_graph_partition) — End-to-end optimization example using OMMX, JijModeling, and `QAOAConverter`
 - [VQE for the Hydrogen Molecule](vqe_for_hydrogen) — Build a molecular Hamiltonian with OpenFermion and find the ground state energy via VQE
 - [Quantum Phase Estimation as an FTQC Building Block](phase_estimation) — Build a minimal QPE kernel, verify the decoded phase, and connect precision to symbolic resources
-- [FTQC Chemistry Resource Estimation](ftqc_chemistry_resource_estimation) — Compare qubitized QPE and early-FTQC Trotter QPE cost drivers for chemistry workloads
+- [FTQC Chemistry Resource Estimation](ftqc_chemistry_resource_estimation) — Compare qubitized QPE and early-FTQC Trotter QPE cost drivers, including space-time resource proxies
 - [Hamiltonian Simulation with Suzuki–Trotter](hamiltonian_simulation) — Trotter–Suzuki product formulas on the Rabi model with empirical convergence orders
 - [Introduction to Quantum Error Correction](quantum_error_correction) — 3-qubit bit-flip/phase-flip codes, Shor's 9-qubit code, and stabilizers
 - [Steane [[7,1,3]] Code](steane_code) — CSS construction, syndrome decoding, and transversal Hadamard

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "68bb8a76",
+   "id": "9c573401",
    "metadata": {},
    "source": [
     "---\n",
@@ -11,19 +11,19 @@
     "\n",
     "# FTQC化学計算のリソース推定\n",
     "\n",
-    "このノートブックでは、Qamomileでfault-tolerantな量子化学計算のリソースモデルを比較する方法を示します。完全な論理回路がまだない段階で重要になる、Hamiltonian normalization、phase-estimation iterations、ToffoliまたはT counts、論理量子ビット、物理量子ビット、runtime proxiesに注目します。"
+    "このノートブックでは、Qamomileでfault-tolerantな量子化学計算のリソースモデルを比較する方法を示します。完全な論理回路がまだない段階で重要になる、Hamiltonian normalization、phase-estimation iterations、ToffoliまたはT counts、論理量子ビット、物理量子ビット、logical space-time volume、physical qubit-seconds、runtime proxiesに注目します。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "318424a6",
+   "id": "636b1ca1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:55.547019Z",
-     "iopub.status.busy": "2026-06-22T20:19:55.546866Z",
-     "iopub.status.idle": "2026-06-22T20:19:55.550369Z",
-     "shell.execute_reply": "2026-06-22T20:19:55.549742Z"
+     "iopub.execute_input": "2026-06-22T22:45:10.092070Z",
+     "iopub.status.busy": "2026-06-22T22:45:10.091851Z",
+     "iopub.status.idle": "2026-06-22T22:45:10.097440Z",
+     "shell.execute_reply": "2026-06-22T22:45:10.096356Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b339aff1",
+   "id": "9cfa0c1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:55.552101Z",
-     "iopub.status.busy": "2026-06-22T20:19:55.551981Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.940250Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.938555Z"
+     "iopub.execute_input": "2026-06-22T22:45:10.099793Z",
+     "iopub.status.busy": "2026-06-22T22:45:10.099632Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.810830Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.810284Z"
     }
    },
    "outputs": [],
@@ -62,6 +62,7 @@
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
     "    estimate_single_ancilla_trotter_qpe_from_hamiltonian,\n",
+    "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_openfermion_qubit_operator,\n",
@@ -71,19 +72,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "157b2eae",
+   "id": "5f6d881a",
    "metadata": {},
    "source": [
     "## Background\n",
     "\n",
     "Fault-tolerantな化学計算アルゴリズムは、NISQのvariationalな例とは異なるリソース量で比較されることが多くあります。qubitized QPEでは、Hamiltonian block-encoding normalizationがwalk callsの回数を決め、per-walk implementationがToffoli countを決めます。近年の化学計算向け提案では、backend-levelのgate decompositionだけを変えるのではなく、Hamiltonian representationを変えることでこれらのコストを下げようとします。\n",
     "\n",
-    "例として、symmetry-compressed double factorization([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))、simultaneous symmetry shifts and tensor factorizations([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))、unitary weight concentrationを使うearly-FTQC single-ancilla QPE([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))があります。symmetry-adapted filtering([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))のようなstate-preparation改善も、期待されるQPE試行回数を変えます。以下のEstimatorは意図的にsymbolicです。具体的なHamiltonian-loading circuitに進む前に、提案したrepresentationがコストを支配する量をどう変えるかを確認できます。"
+    "例として、symmetry-compressed double factorization([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))、simultaneous symmetry shifts and tensor factorizations([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))、unitary weight concentrationを使うearly-FTQC single-ancilla QPE([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))があります。symmetry-adapted filtering([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))のようなstate-preparation改善も、期待されるQPE試行回数を変えます。これらの提案はalgorithmic work、logical depth、論理量子ビット、hardware runtimeをそれぞれ異なる形で交換するため、logical qubit-layersやphysical qubit-secondsのようなspace-time量がレビュー対象として役立ちます。以下のEstimatorは意図的にsymbolicです。具体的なHamiltonian-loading circuitに進む前に、提案したrepresentationがコストを支配する量をどう変えるかを確認できます。"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d21e8723",
+   "id": "e10cbf85",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -100,13 +101,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ef2c3320",
+   "id": "dd5cc8ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.965168Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.964792Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.970302Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.969931Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.812270Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.812101Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.816356Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.816014Z"
     }
    },
    "outputs": [],
@@ -143,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a848fd72",
+   "id": "dd3f2abf",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -157,13 +158,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8a4445be",
+   "id": "a5c53283",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.971899Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.971832Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.975188Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.974323Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.817645Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.817589Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.820219Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.819924Z"
     }
    },
    "outputs": [
@@ -177,10 +178,12 @@
       "qpe_repetitions runs algorithm\n",
       "qpe_iterations iterations algorithm\n",
       "logical_qubits logical qubits logical\n",
+      "logical_spacetime_volume logical qubit-layers logical\n",
       "toffoli_gates Toffoli gates logical\n",
       "t_gates T gates logical\n",
       "physical_qubits physical qubits physical\n",
       "runtime_seconds seconds physical\n",
+      "physical_qubit_seconds physical qubit-seconds physical\n",
       "logical_error_rate probability physical\n",
       "code_distance distance architecture\n"
      ]
@@ -200,7 +203,9 @@
     "        \"toffoli_gates\",\n",
     "        \"t_gates\",\n",
     "        \"logical_qubits\",\n",
+    "        \"logical_spacetime_volume\",\n",
     "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
     "        \"runtime_seconds\",\n",
     "        \"logical_error_rate\",\n",
     "        \"code_distance\",\n",
@@ -219,7 +224,9 @@
     "    \"toffoli_gates\",\n",
     "    \"t_gates\",\n",
     "    \"logical_qubits\",\n",
+    "    \"logical_spacetime_volume\",\n",
     "    \"physical_qubits\",\n",
+    "    \"physical_qubit_seconds\",\n",
     "    \"runtime_seconds\",\n",
     "    \"logical_error_rate\",\n",
     "    \"code_distance\",\n",
@@ -228,7 +235,56 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6f7be50",
+   "id": "28cde6a4",
+   "metadata": {},
+   "source": [
+    "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "53548945",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T22:45:11.821432Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.821378Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.823737Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.823270Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Symmetry-compressed double factorization for fault-tolerant chemistry simulation\n",
+      "['lambda_norm', 'qpe_iterations', 'walk_cost_toffoli', 'toffoli_gates', 'logical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "Chemically accurate QPE in the early fault-tolerant regime\n",
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+     ]
+    }
+   ],
+   "source": [
+    "signal_by_key = {\n",
+    "    signal.reference_key: signal for signal in iter_ftqc_research_signals()\n",
+    "}\n",
+    "scdf_signal = signal_by_key[\"arXiv:2403.03502\"]\n",
+    "early_ftqc_signal = signal_by_key[\"arXiv:2603.22778\"]\n",
+    "\n",
+    "print(scdf_signal.title)\n",
+    "print([quantity.value for quantity in scdf_signal.quantities])\n",
+    "print(early_ftqc_signal.title)\n",
+    "print([quantity.value for quantity in early_ftqc_signal.quantities])\n",
+    "\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities\n",
+    "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities\n",
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "487c7fca",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -236,14 +292,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "a91ace1a",
+   "execution_count": 6,
+   "id": "4573e220",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.977480Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.977397Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.980416Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.979814Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.824799Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.824741Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.827635Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.827136Z"
     }
    },
    "outputs": [],
@@ -266,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1f39897",
+   "id": "e5420b95",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -277,14 +333,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "f76134f7",
+   "execution_count": 7,
+   "id": "8bc33447",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.981653Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.981589Z",
-     "iopub.status.idle": "2026-06-22T20:19:57.984416Z",
-     "shell.execute_reply": "2026-06-22T20:19:57.983883Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.828722Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.828657Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.831132Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.830741Z"
     }
    },
    "outputs": [],
@@ -307,7 +363,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68d6a4d5",
+   "id": "1c4c13b6",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -324,14 +380,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "d060fa2e",
+   "execution_count": 8,
+   "id": "09ad6d1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:57.985627Z",
-     "iopub.status.busy": "2026-06-22T20:19:57.985571Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.015492Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.015066Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.832252Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.832188Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.857413Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.856991Z"
     }
    },
    "outputs": [
@@ -346,9 +402,13 @@
       "Physical qubits 125840 physical qubits\n",
       "Toffoli gates 293333333333.333 Toffoli gates\n",
       "QPE iterations 66666666.6666667 iterations\n",
+      "Logical space-time volume 35200000000000.0 logical qubit-layers\n",
+      "Physical qubit-seconds 38758720000.0000 physical qubit-seconds\n",
       "QPE iterations ratio: 0.5000 reduction: 0.5000\n",
       "Toffoli gates ratio: 0.5500 reduction: 0.4500\n",
-      "Physical qubits ratio: 2.276 reduction: -1.276\n"
+      "Logical space-time volume ratio: 1.650 reduction: -0.6500\n",
+      "Physical qubits ratio: 2.276 reduction: -1.276\n",
+      "Physical qubit-seconds ratio: 1.252 reduction: -0.2520\n"
      ]
     }
    ],
@@ -396,13 +456,25 @@
     "print(\"SCDF-style logical qubits:\", scdf.logical_qubits)\n",
     "\n",
     "for row in scdf.to_quantity_table():\n",
-    "    if row[\"quantity\"] in {\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"}:\n",
+    "    if row[\"quantity\"] in {\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    }:\n",
     "        print(row[\"label\"], row[\"value\"], row[\"unit\"])\n",
     "\n",
     "qubitized_savings = compare_ftqc_resource_estimates(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "for row in qubitized_savings:\n",
     "    print(\n",
@@ -416,11 +488,18 @@
     "assert qubitized_savings[0].quantity.value == \"qpe_iterations\"\n",
     "assert qubitized_savings[0].ratio == sp.Float(\"0.5\")\n",
     "assert sp.Abs(qubitized_savings[1].ratio - sp.Float(\"0.55\")) < sp.Float(\"1e-12\")\n",
+    "assert qubitized_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
     "\n",
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=(\"qpe_iterations\", \"toffoli_gates\", \"physical_qubits\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"physical_qubits\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
@@ -429,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "194e8718",
+   "id": "659216ed",
    "metadata": {},
    "source": [
     "## State-preparation success budget\n",
@@ -439,14 +518,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c64d4bbe",
+   "execution_count": 9,
+   "id": "bfca7589",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.016889Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.016822Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.030202Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.029589Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.858444Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.858386Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.871561Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.871136Z"
     }
    },
    "outputs": [
@@ -457,7 +536,9 @@
       "QPE repetitions ratio: 0.2500 reduction: 0.7500\n",
       "QPE iterations ratio: 0.2500 reduction: 0.7500\n",
       "Toffoli gates ratio: 0.2500 reduction: 0.7500\n",
-      "Runtime ratio: 0.2500 reduction: 0.7500\n"
+      "Logical space-time volume ratio: 0.2500 reduction: 0.7500\n",
+      "Runtime ratio: 0.2500 reduction: 0.7500\n",
+      "Physical qubit-seconds ratio: 0.2500 reduction: 0.7500\n"
      ]
     }
    ],
@@ -479,7 +560,14 @@
     "preparation_savings = compare_ftqc_resource_estimates(\n",
     "    weak_overlap_scdf,\n",
     "    symmetry_filtered_scdf,\n",
-    "    quantities=(\"qpe_repetitions\", \"qpe_iterations\", \"toffoli_gates\", \"runtime_seconds\"),\n",
+    "    quantities=(\n",
+    "        \"qpe_repetitions\",\n",
+    "        \"qpe_iterations\",\n",
+    "        \"toffoli_gates\",\n",
+    "        \"logical_spacetime_volume\",\n",
+    "        \"runtime_seconds\",\n",
+    "        \"physical_qubit_seconds\",\n",
+    "    ),\n",
     ")\n",
     "\n",
     "for row in preparation_savings:\n",
@@ -489,6 +577,9 @@
     "assert (\n",
     "    symmetry_filtered_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS] == 2\n",
     ")\n",
+    "assert symmetry_filtered_scdf.resource_values()[\n",
+    "    FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "] == (symmetry_filtered_scdf.logical_qubits * symmetry_filtered_scdf.logical_depth)\n",
     "assert symmetry_filtered_scdf.qpe_iterations == scdf.qpe_iterations * 2\n",
     "assert symmetry_filtered_scdf.toffoli_gates < weak_overlap_scdf.toffoli_gates\n",
     "assert \"state_preparation_success_probability\" in symmetry_filtered_scdf.to_dict()[\n",
@@ -498,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f769637",
+   "id": "ff4f7dce",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -506,14 +597,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a2faa074",
+   "execution_count": 10,
+   "id": "f500197f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.031557Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.031475Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.035601Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.034986Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.872726Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.872640Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.876061Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.875746Z"
     }
    },
    "outputs": [
@@ -547,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f9e8e4d",
+   "id": "f8911d7d",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -557,14 +648,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "47b9b23b",
+   "execution_count": 11,
+   "id": "b3ccaa98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.037224Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.037165Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.045727Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.045088Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.877189Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.877120Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.884602Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.884090Z"
     }
    },
    "outputs": [
@@ -576,7 +667,8 @@
       "UWC-style Trotter QPE depth proxy: 1.365e+10\n",
       "UWC-style T gates: 4.096e+10\n",
       "QPE iterations ratio: 0.1000 reduction: 0.9000\n",
-      "Logical depth ratio: 0.05000 reduction: 0.9500\n"
+      "Logical depth ratio: 0.05000 reduction: 0.9500\n",
+      "Logical space-time volume ratio: 0.05000 reduction: 0.9500\n"
      ]
     }
    ],
@@ -610,7 +702,7 @@
     "trotter_savings = compare_ftqc_resource_estimates(\n",
     "    plain_trotter,\n",
     "    uwc_trotter,\n",
-    "    quantities=(\"qpe_iterations\", \"logical_depth\"),\n",
+    "    quantities=(\"qpe_iterations\", \"logical_depth\", \"logical_spacetime_volume\"),\n",
     ")\n",
     "for row in trotter_savings:\n",
     "    print(\n",
@@ -622,29 +714,30 @@
     "    )\n",
     "\n",
     "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
-    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")"
+    "assert trotter_savings[1].ratio == sp.Float(\"0.05\")\n",
+    "assert trotter_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bbb0a175",
+   "id": "053d2beb",
    "metadata": {},
    "source": [
     "## Result\n",
     "\n",
-    "推定結果を小さな表にまとめます。重要なのは、各列が別々の設計上の意味を持つことです。Hamiltonian representationの変更は`qpe_iterations`とper-step costに効くべきで、hardware modelの変更は`physical_qubits`とruntimeに効くべきです。"
+    "推定結果を小さな表にまとめます。重要なのは、各列が別々の設計上の意味を持つことです。Hamiltonian representationの変更は`qpe_iterations`とper-step costに効くべきで、hardware modelの変更は`physical_qubits`、runtime、physical qubit-secondsに効くべきです。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "9ccc1e61",
+   "execution_count": 12,
+   "id": "17632178",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-22T20:19:58.047622Z",
-     "iopub.status.busy": "2026-06-22T20:19:58.047553Z",
-     "iopub.status.idle": "2026-06-22T20:19:58.050644Z",
-     "shell.execute_reply": "2026-06-22T20:19:58.050031Z"
+     "iopub.execute_input": "2026-06-22T22:45:11.885704Z",
+     "iopub.status.busy": "2026-06-22T22:45:11.885617Z",
+     "iopub.status.idle": "2026-06-22T22:45:11.889504Z",
+     "shell.execute_reply": "2026-06-22T22:45:11.889065Z"
     }
    },
    "outputs": [
@@ -652,10 +745,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'runtime_seconds': 5.600e+5}\n",
-      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'runtime_seconds': 3.080e+5}\n",
-      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'runtime_seconds': 2.867e+5}\n",
-      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'runtime_seconds': 2.150e+4}\n"
+      "THC qubitized QPE {'logical_qubits': 40.00, 'physical_qubits': 5.528e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 5.333e+11, 't_gates': 0, 'logical_spacetime_volume': 2.133e+13, 'runtime_seconds': 5.600e+5, 'physical_qubit_seconds': 3.096e+10}\n",
+      "SCDF-style qubitized QPE {'logical_qubits': 120.0, 'physical_qubits': 1.258e+5, 'qpe_iterations': 6.667e+7, 'toffoli_gates': 2.933e+11, 't_gates': 0, 'logical_spacetime_volume': 3.520e+13, 'runtime_seconds': 3.080e+5, 'physical_qubit_seconds': 3.876e+10}\n",
+      "Plain Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+8, 'toffoli_gates': 0, 't_gates': 2.731e+11, 'logical_spacetime_volume': 1.120e+13, 'runtime_seconds': 2.867e+5, 'physical_qubit_seconds': 1.610e+10}\n",
+      "UWC-style Trotter QPE {'logical_qubits': 41.00, 'physical_qubits': 5.616e+4, 'qpe_iterations': 1.333e+7, 'toffoli_gates': 0, 't_gates': 4.096e+10, 'logical_spacetime_volume': 5.598e+11, 'runtime_seconds': 2.150e+4, 'physical_qubit_seconds': 1.208e+9}\n"
      ]
     }
    ],
@@ -676,31 +769,43 @@
     "            \"qpe_iterations\": sp.N(estimate.qpe_iterations, 4),\n",
     "            \"toffoli_gates\": sp.N(estimate.toffoli_gates, 4),\n",
     "            \"t_gates\": sp.N(estimate.t_gates, 4),\n",
+    "            \"logical_spacetime_volume\": sp.N(\n",
+    "                estimate.resource_values()[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],\n",
+    "                4,\n",
+    "            ),\n",
     "            \"runtime_seconds\": sp.N(estimate.runtime_seconds, 4),\n",
+    "            \"physical_qubit_seconds\": sp.N(\n",
+    "                estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS],\n",
+    "                4,\n",
+    "            ),\n",
     "        },\n",
     "    )\n",
     "\n",
     "assert scdf.physical_qubits > thc.physical_qubits\n",
-    "assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits"
+    "assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits\n",
+    "assert uwc_trotter.resource_values()[\n",
+    "    FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS\n",
+    "] < plain_trotter.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6d54385b",
+   "id": "70749a4c",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
     "このノートブックでは、次のことを確認しました。\n",
     "\n",
-    "- FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。\n",
+    "- FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、logical space-time volume、物理量子ビット、runtime proxies、physical qubit-secondsに分けて扱いました。\n",
     "- comparableなestimateを作る前に、total target precisionをtruncation errorとQPE precisionへ割り当てました。\n",
     "- state-preparation success probabilityを、QPE resourceの明示的な期待repetition factorとしてモデル化しました。\n",
     "- Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。\n",
     "- logical failure budgetからsurface-code distanceを選び、logical resourceをphysical resourceへliftしました。\n",
     "- code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。\n",
     "- chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。\n",
-    "- unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。"
+    "- unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。\n",
+    "- 近年のFTQC化学計算のresearch signalを、このチュートリアルで比較するcanonical quantitiesへ結びつけました。"
    ]
   }
  ],

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -19,7 +19,7 @@
 #
 # # FTQC化学計算のリソース推定
 #
-# このノートブックでは、Qamomileでfault-tolerantな量子化学計算のリソースモデルを比較する方法を示します。完全な論理回路がまだない段階で重要になる、Hamiltonian normalization、phase-estimation iterations、ToffoliまたはT counts、論理量子ビット、物理量子ビット、runtime proxiesに注目します。
+# このノートブックでは、Qamomileでfault-tolerantな量子化学計算のリソースモデルを比較する方法を示します。完全な論理回路がまだない段階で重要になる、Hamiltonian normalization、phase-estimation iterations、ToffoliまたはT counts、論理量子ビット、物理量子ビット、logical space-time volume、physical qubit-seconds、runtime proxiesに注目します。
 
 # %%
 # 最新のQamomileをpipでインストールします！
@@ -42,6 +42,7 @@ from qamomile.circuit.estimator.algorithmic import (
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_qubitized_qpe_from_block_encoding,
     estimate_single_ancilla_trotter_qpe_from_hamiltonian,
+    iter_ftqc_research_signals,
     iter_ftqc_resource_quantity_specs,
     summarize_ftqc_resource_comparison,
     summarize_openfermion_qubit_operator,
@@ -53,7 +54,7 @@ from qamomile.circuit.estimator.algorithmic import (
 #
 # Fault-tolerantな化学計算アルゴリズムは、NISQのvariationalな例とは異なるリソース量で比較されることが多くあります。qubitized QPEでは、Hamiltonian block-encoding normalizationがwalk callsの回数を決め、per-walk implementationがToffoli countを決めます。近年の化学計算向け提案では、backend-levelのgate decompositionだけを変えるのではなく、Hamiltonian representationを変えることでこれらのコストを下げようとします。
 #
-# 例として、symmetry-compressed double factorization([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))、simultaneous symmetry shifts and tensor factorizations([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))、unitary weight concentrationを使うearly-FTQC single-ancilla QPE([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))があります。symmetry-adapted filtering([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))のようなstate-preparation改善も、期待されるQPE試行回数を変えます。以下のEstimatorは意図的にsymbolicです。具体的なHamiltonian-loading circuitに進む前に、提案したrepresentationがコストを支配する量をどう変えるかを確認できます。
+# 例として、symmetry-compressed double factorization([arXiv:2403.03502](https://arxiv.org/abs/2403.03502))、simultaneous symmetry shifts and tensor factorizations([arXiv:2412.01338](https://arxiv.org/abs/2412.01338))、unitary weight concentrationを使うearly-FTQC single-ancilla QPE([arXiv:2603.22778](https://arxiv.org/abs/2603.22778))があります。symmetry-adapted filtering([arXiv:2601.08533](https://arxiv.org/abs/2601.08533))のようなstate-preparation改善も、期待されるQPE試行回数を変えます。これらの提案はalgorithmic work、logical depth、論理量子ビット、hardware runtimeをそれぞれ異なる形で交換するため、logical qubit-layersやphysical qubit-secondsのようなspace-time量がレビュー対象として役立ちます。以下のEstimatorは意図的にsymbolicです。具体的なHamiltonian-loading circuitに進む前に、提案したrepresentationがコストを支配する量をどう変えるかを確認できます。
 
 # %% [markdown]
 # ## Problem Settings
@@ -118,7 +119,9 @@ quantity_catalog = [
         "toffoli_gates",
         "t_gates",
         "logical_qubits",
+        "logical_spacetime_volume",
         "physical_qubits",
+        "physical_qubit_seconds",
         "runtime_seconds",
         "logical_error_rate",
         "code_distance",
@@ -137,11 +140,32 @@ assert {row["quantity"] for row in quantity_catalog} == {
     "toffoli_gates",
     "t_gates",
     "logical_qubits",
+    "logical_spacetime_volume",
     "physical_qubits",
+    "physical_qubit_seconds",
     "runtime_seconds",
     "logical_error_rate",
     "code_distance",
 }
+
+# %% [markdown]
+# research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。
+
+# %%
+signal_by_key = {
+    signal.reference_key: signal for signal in iter_ftqc_research_signals()
+}
+scdf_signal = signal_by_key["arXiv:2403.03502"]
+early_ftqc_signal = signal_by_key["arXiv:2603.22778"]
+
+print(scdf_signal.title)
+print([quantity.value for quantity in scdf_signal.quantities])
+print(early_ftqc_signal.title)
+print([quantity.value for quantity in early_ftqc_signal.quantities])
+
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities
+assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities
+assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities
 
 # %% [markdown]
 # 小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。
@@ -240,13 +264,25 @@ print("Toy Pauli terms:", toy_summary.n_pauli_terms)
 print("SCDF-style logical qubits:", scdf.logical_qubits)
 
 for row in scdf.to_quantity_table():
-    if row["quantity"] in {"qpe_iterations", "toffoli_gates", "physical_qubits"}:
+    if row["quantity"] in {
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    }:
         print(row["label"], row["value"], row["unit"])
 
 qubitized_savings = compare_ftqc_resource_estimates(
     thc,
     scdf,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 for row in qubitized_savings:
     print(
@@ -260,11 +296,18 @@ for row in qubitized_savings:
 assert qubitized_savings[0].quantity.value == "qpe_iterations"
 assert qubitized_savings[0].ratio == sp.Float("0.5")
 assert sp.Abs(qubitized_savings[1].ratio - sp.Float("0.55")) < sp.Float("1e-12")
+assert qubitized_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
 
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
     scdf,
-    quantities=("qpe_iterations", "toffoli_gates", "physical_qubits"),
+    quantities=(
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "physical_qubits",
+        "physical_qubit_seconds",
+    ),
 )
 
 assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
@@ -293,7 +336,14 @@ symmetry_filtered_scdf = symmetry_filtered_budget.apply(scdf)
 preparation_savings = compare_ftqc_resource_estimates(
     weak_overlap_scdf,
     symmetry_filtered_scdf,
-    quantities=("qpe_repetitions", "qpe_iterations", "toffoli_gates", "runtime_seconds"),
+    quantities=(
+        "qpe_repetitions",
+        "qpe_iterations",
+        "toffoli_gates",
+        "logical_spacetime_volume",
+        "runtime_seconds",
+        "physical_qubit_seconds",
+    ),
 )
 
 for row in preparation_savings:
@@ -303,6 +353,9 @@ assert weak_overlap_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS]
 assert (
     symmetry_filtered_scdf.resource_values()[FTQCResourceQuantity.QPE_REPETITIONS] == 2
 )
+assert symmetry_filtered_scdf.resource_values()[
+    FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+] == (symmetry_filtered_scdf.logical_qubits * symmetry_filtered_scdf.logical_depth)
 assert symmetry_filtered_scdf.qpe_iterations == scdf.qpe_iterations * 2
 assert symmetry_filtered_scdf.toffoli_gates < weak_overlap_scdf.toffoli_gates
 assert "state_preparation_success_probability" in symmetry_filtered_scdf.to_dict()[
@@ -366,7 +419,7 @@ print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
 trotter_savings = compare_ftqc_resource_estimates(
     plain_trotter,
     uwc_trotter,
-    quantities=("qpe_iterations", "logical_depth"),
+    quantities=("qpe_iterations", "logical_depth", "logical_spacetime_volume"),
 )
 for row in trotter_savings:
     print(
@@ -379,11 +432,12 @@ for row in trotter_savings:
 
 assert trotter_savings[0].ratio == sp.Float("0.1")
 assert trotter_savings[1].ratio == sp.Float("0.05")
+assert trotter_savings[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
 
 # %% [markdown]
 # ## Result
 #
-# 推定結果を小さな表にまとめます。重要なのは、各列が別々の設計上の意味を持つことです。Hamiltonian representationの変更は`qpe_iterations`とper-step costに効くべきで、hardware modelの変更は`physical_qubits`とruntimeに効くべきです。
+# 推定結果を小さな表にまとめます。重要なのは、各列が別々の設計上の意味を持つことです。Hamiltonian representationの変更は`qpe_iterations`とper-step costに効くべきで、hardware modelの変更は`physical_qubits`、runtime、physical qubit-secondsに効くべきです。
 
 # %%
 rows = [
@@ -402,19 +456,30 @@ for name, estimate in rows:
             "qpe_iterations": sp.N(estimate.qpe_iterations, 4),
             "toffoli_gates": sp.N(estimate.toffoli_gates, 4),
             "t_gates": sp.N(estimate.t_gates, 4),
+            "logical_spacetime_volume": sp.N(
+                estimate.resource_values()[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],
+                4,
+            ),
             "runtime_seconds": sp.N(estimate.runtime_seconds, 4),
+            "physical_qubit_seconds": sp.N(
+                estimate.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS],
+                4,
+            ),
         },
     )
 
 assert scdf.physical_qubits > thc.physical_qubits
 assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
+assert uwc_trotter.resource_values()[
+    FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS
+] < plain_trotter.resource_values()[FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS]
 
 # %% [markdown]
 # ## Summary
 #
 # このノートブックでは、次のことを確認しました。
 #
-# - FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、物理量子ビット、runtime proxiesに分けて扱いました。
+# - FTQC化学計算のリソース量を、Hamiltonian normalization、QPE iterations、non-Clifford counts、論理量子ビット、logical space-time volume、物理量子ビット、runtime proxies、physical qubit-secondsに分けて扱いました。
 # - comparableなestimateを作る前に、total target precisionをtruncation errorとQPE precisionへ割り当てました。
 # - state-preparation success probabilityを、QPE resourceの明示的な期待repetition factorとしてモデル化しました。
 # - Qamomile IRをbackend-specificなchemistry loading circuitsへloweringせずに、qubitized QPE representationsを比較しました。
@@ -422,3 +487,4 @@ assert uwc_trotter.physical_qubits == plain_trotter.physical_qubits
 # - code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。
 # - chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。
 # - unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。
+# - 近年のFTQC化学計算のresearch signalを、このチュートリアルで比較するcanonical quantitiesへ結びつけました。

--- a/docs/ja/algorithm/index.md
+++ b/docs/ja/algorithm/index.md
@@ -12,7 +12,7 @@ Qamomileで実装した具体的な量子アルゴリズム例です。
 - [QAOAによるグラフ分割](qaoa_graph_partition) — OMMX・JijModeling・`QAOAConverter`を使ったend-to-endの最適化例
 - [水素分子のためのVQE](vqe_for_hydrogen) — OpenFermionで分子ハミルトニアンを構築し、VQEで基底状態エネルギーを求める
 - [FTQCのbuilding blockとしての量子位相推定](phase_estimation) — 最小のQPE量子カーネルを構築し、decodeされたphaseを確認してprecisionをsymbolic resourceへ接続する
-- [FTQC化学計算のリソース推定](ftqc_chemistry_resource_estimation) — 化学計算workloadについて、qubitized QPEとearly-FTQC Trotter QPEのcost driverを比較する
+- [FTQC化学計算のリソース推定](ftqc_chemistry_resource_estimation) — 化学計算workloadについて、qubitized QPEとearly-FTQC Trotter QPEのcost driverをspace-time resource proxiesまで含めて比較する
 - [Suzuki–Trotterによるハミルトニアンシミュレーション](hamiltonian_simulation) — RabiモデルでのTrotter–Suzuki積公式と収束次数の実験
 - [量子誤り訂正入門](quantum_error_correction) — 3量子ビットbit-flip/phase-flip符号からShor 9量子ビット符号、スタビライザー形式まで
 - [Steane [[7,1,3]] 符号](steane_code) — Hamming [7,4,3] 符号からのCSS構成、6スタビライザー、横断的Hadamard


### PR DESCRIPTION
## Summary

- Extend the FTQC chemistry algorithm tutorial to include logical space-time volume and physical qubit-seconds.
- Show the structured FTQC research-signal catalog in the tutorial, including recent chemistry and early-FTQC signals.
- Update EN/JA paired notebooks and algorithm index descriptions.

## Validation

- `uv run python docs/en/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run python docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k ftqc_chemistry_resource_estimation`
- `uv run jupytext --to ipynb --test docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`