### PR TITLE
Accept FTQC resource profiles in comparisons

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "16d37215",
+   "id": "3682cc18",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6f1b423f",
+   "id": "6b78f2a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.214132Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.213857Z",
-     "iopub.status.idle": "2026-06-23T02:23:33.218351Z",
-     "shell.execute_reply": "2026-06-23T02:23:33.217399Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.111150Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.110841Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.117872Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.116484Z"
     }
    },
    "outputs": [],
@@ -40,13 +40,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "54b52bfa",
+   "id": "66a40154",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.221095Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.220927Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.939655Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.939132Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.121254Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.121054Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.870767Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.870335Z"
     }
    },
    "outputs": [],
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18026299",
+   "id": "79b23658",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b10fcb5",
+   "id": "a3f85454",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -130,13 +130,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7b2d534e",
+   "id": "36890291",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.941447Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.941227Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.945487Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.945051Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.872274Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.872131Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.876031Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.875705Z"
     }
    },
    "outputs": [],
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca5cdb42",
+   "id": "c267714b",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -187,13 +187,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "4c42250a",
+   "id": "e2cead08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.946687Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.946632Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.949351Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.948967Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.877866Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.877752Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.880590Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.880198Z"
     }
    },
    "outputs": [
@@ -264,24 +264,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8d04e59",
+   "id": "dfb944f7",
    "metadata": {},
    "source": [
     "Qamomile also provides standard review profiles: small reusable bundles of\n",
     "quantities for common audit questions. The profile does not compute new\n",
-    "resources; it names the columns to compare."
+    "resources; it names the columns to compare and can be passed directly to\n",
+    "comparison helpers."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "87786d52",
+   "id": "1e036d9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.950591Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.950527Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.952789Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.952320Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.882017Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.881932Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.884156Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.883798Z"
     }
    },
    "outputs": [
@@ -315,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee0fe7cb",
+   "id": "f1f05ad6",
    "metadata": {},
    "source": [
     "The research-signal catalog maps recent papers to the quantities they ask a\n",
@@ -326,13 +327,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "15a5e53a",
+   "id": "ea6757a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.953955Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.953893Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.956194Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.955731Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.885358Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.885285Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.887853Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.887124Z"
     }
    },
    "outputs": [
@@ -366,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47be9d85",
+   "id": "1f2b81a8",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -379,13 +380,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "900d0084",
+   "id": "dfc17b0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.957311Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.957251Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.960171Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.959728Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.888873Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.888808Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.891476Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.891040Z"
     }
    },
    "outputs": [],
@@ -408,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c23575d9",
+   "id": "de1f0298",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -420,13 +421,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "fe106619",
+   "id": "b67eb1fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.961326Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.961249Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.963794Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.963289Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.892682Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.892607Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.894913Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.894590Z"
     }
    },
    "outputs": [],
@@ -449,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6fdabe5",
+   "id": "0054a08c",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -471,13 +472,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f6b5edfd",
+   "id": "fdd4612a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.964880Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.964822Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.989182Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.988832Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.896114Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.896046Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.920075Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.919595Z"
     }
    },
    "outputs": [
@@ -564,7 +565,11 @@
     "qubitized_savings = compare_ftqc_resource_estimates(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=qubitized_quantities,\n",
+    "    quantities=(\n",
+    "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
+    "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
+    "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "for row in qubitized_savings:\n",
     "    print(\n",
@@ -583,7 +588,11 @@
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=qubitized_quantities,\n",
+    "    quantities=(\n",
+    "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
+    "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
+    "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
@@ -596,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37c1159c",
+   "id": "0d429a2d",
    "metadata": {},
    "source": [
     "## State-Preparation Success Budget\n",
@@ -611,13 +620,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0c48372d",
+   "id": "8c4a7fb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.990459Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.990396Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.003630Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.003231Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.921302Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.921246Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.934708Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.934256Z"
     }
    },
    "outputs": [
@@ -659,8 +668,8 @@
     "        FTQCResourceQuantity.QPE_REPETITIONS,\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in preparation_savings:\n",
@@ -682,7 +691,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1c25dc8",
+   "id": "b2309057",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -694,13 +703,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a1d255aa",
+   "id": "21198316",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.004794Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.004731Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.008698Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.008369Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.935904Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.935824Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.939666Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.939282Z"
     }
    },
    "outputs": [
@@ -734,7 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bc49ada",
+   "id": "5d8e1826",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -749,13 +758,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f415d2cd",
+   "id": "f46fee18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.009848Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.009794Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.017973Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.017532Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.940686Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.940623Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.948436Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.948014Z"
     }
    },
    "outputs": [
@@ -806,7 +815,8 @@
     "trotter_savings = compare_ftqc_resource_estimates(\n",
     "    plain_trotter,\n",
     "    uwc_trotter,\n",
-    "    quantities=(FTQCResourceQuantity.QPE_ITERATIONS, *space_time_quantities),\n",
+    "    quantities=(FTQCResourceQuantity.QPE_ITERATIONS,),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "for row in trotter_savings:\n",
     "    print(\n",
@@ -824,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "121682b7",
+   "id": "0c264cfe",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -839,13 +849,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b0eda84d",
+   "id": "3a7ee08d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.018984Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.018911Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.022679Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.022275Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.949517Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.949444Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.953144Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.952628Z"
     }
    },
    "outputs": [
@@ -898,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccbc1196",
+   "id": "711bae59",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -180,7 +180,8 @@ assert {row["quantity"] for row in quantity_catalog} == {
 # %% [markdown]
 # Qamomile also provides standard review profiles: small reusable bundles of
 # quantities for common audit questions. The profile does not compute new
-# resources; it names the columns to compare.
+# resources; it names the columns to compare and can be passed directly to
+# comparison helpers.
 
 # %%
 profile_catalog = {
@@ -339,7 +340,11 @@ for row in scdf.to_quantity_table():
 qubitized_savings = compare_ftqc_resource_estimates(
     thc,
     scdf,
-    quantities=qubitized_quantities,
+    quantities=(
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+    ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 for row in qubitized_savings:
     print(
@@ -358,7 +363,11 @@ assert qubitized_savings[4].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_V
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
     scdf,
-    quantities=qubitized_quantities,
+    quantities=(
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+    ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
@@ -399,8 +408,8 @@ preparation_savings = compare_ftqc_resource_estimates(
         FTQCResourceQuantity.QPE_REPETITIONS,
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in preparation_savings:
@@ -483,7 +492,8 @@ print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
 trotter_savings = compare_ftqc_resource_estimates(
     plain_trotter,
     uwc_trotter,
-    quantities=(FTQCResourceQuantity.QPE_ITERATIONS, *space_time_quantities),
+    quantities=(FTQCResourceQuantity.QPE_ITERATIONS,),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 for row in trotter_savings:
     print(

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f0ca7807",
+   "id": "1631ff25",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "270cd9e1",
+   "id": "8746c5df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.213993Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.213703Z",
-     "iopub.status.idle": "2026-06-23T02:23:33.218743Z",
-     "shell.execute_reply": "2026-06-23T02:23:33.217624Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.112581Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.111932Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.118877Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.117534Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a83c0b9b",
+   "id": "bd0bf11b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.221501Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.221312Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.221087Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.218264Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.121843Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.121668Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.495370Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.494856Z"
     }
    },
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82226c8d",
+   "id": "9712bcbd",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffcd99db",
+   "id": "d6873154",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -123,13 +123,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "cf421764",
+   "id": "8326355f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.225504Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.224620Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.236713Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.235504Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.497069Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.496956Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.499854Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.499201Z"
     }
    },
    "outputs": [
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00f30a8a",
+   "id": "5e343914",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -172,13 +172,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6b173271",
+   "id": "83592367",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.240733Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.240536Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.247167Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.246088Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.501709Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.501630Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.505382Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.504725Z"
     }
    },
    "outputs": [
@@ -272,24 +272,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1793b9eb",
+   "id": "c5cc891f",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
     "questions such as \"what is the space-time footprint?\" They keep reports from\n",
-    "hand-copying ad hoc column lists while leaving comparison functions generic."
+    "hand-copying ad hoc column lists, and comparison helpers accept them directly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "eadf301c",
+   "id": "6b2ecb6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.255200Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.255041Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.258086Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.257236Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.506791Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.506737Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.509190Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.508557Z"
     }
    },
    "outputs": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10cb0aee",
+   "id": "fb2860bf",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -332,13 +332,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d61491f9",
+   "id": "3f900096",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.260409Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.260334Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.351832Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.351362Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.510406Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.510352Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.543494Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.542668Z"
     }
    },
    "outputs": [
@@ -456,8 +456,8 @@
     "    quantities=(\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in comparison:\n",
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc06ba2a",
+   "id": "3e392fc7",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -485,13 +485,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "71a93ba4",
+   "id": "e953bf3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.353248Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.353184Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.357579Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.357135Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.544773Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.544693Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.549054Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.548370Z"
     }
    },
    "outputs": [
@@ -517,8 +517,8 @@
     "    quantities=(\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in comparison_summary.smaller:\n",
@@ -537,7 +537,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9df8b39",
+   "id": "3788e66b",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -551,13 +551,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c3379491",
+   "id": "f988d3af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.358854Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.358793Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.361765Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.361114Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.550475Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.550409Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.553303Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.552811Z"
     }
    },
    "outputs": [
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fff022e",
+   "id": "5ce8bca0",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -597,13 +597,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "6b9d18b5",
+   "id": "4ab8f475",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.363070Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.362990Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.366307Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.365465Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.554515Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.554462Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.557389Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.557029Z"
     }
    },
    "outputs": [
@@ -636,7 +636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32310793",
+   "id": "657f11f7",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -650,13 +650,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a0d5f3e2",
+   "id": "d38cf4f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.367739Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.367604Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.370627Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.369966Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.558890Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.558821Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.561472Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.560828Z"
     }
    },
    "outputs": [
@@ -692,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93069e29",
+   "id": "f6db41aa",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -704,13 +704,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c28067c1",
+   "id": "4316ef22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.371878Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.371821Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.376939Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.376156Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.562753Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.562680Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.568001Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.567037Z"
     }
    },
    "outputs": [
@@ -757,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0945c985",
+   "id": "148aadc3",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -769,13 +769,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "482a6673",
+   "id": "9e0a9ee1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.379856Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.379765Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.393420Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.391935Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.569257Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.569175Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.578029Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.577246Z"
     }
    },
    "outputs": [
@@ -823,7 +823,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d96debd6",
+   "id": "a63ce8c8",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -848,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deb3d52e",
+   "id": "6b3f172b",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -861,8 +861,8 @@
     "  physical qubit-seconds separately.\n",
     "- `iter_ftqc_research_signals` maps research directions to the canonical\n",
     "  quantities that Qamomile reports.\n",
-    "- `ftqc_resource_profile_quantities` gives reusable quantity bundles such as\n",
-    "  the space-time profile for design reviews.\n",
+    "- `FTQCResourceProfile` gives reusable quantity bundles such as the\n",
+    "  space-time profile and can be passed directly to comparison helpers.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
     "  remains backend-neutral.\n",
     "- Accuracy budgets split a total target precision into representation\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -146,7 +146,7 @@ assert FTQCResourceQuantity.CODE_DISTANCE.value in {row["quantity"] for row in c
 # %% [markdown]
 # Standard review profiles provide reusable quantity bundles for recurring
 # questions such as "what is the space-time footprint?" They keep reports from
-# hand-copying ad hoc column lists while leaving comparison functions generic.
+# hand-copying ad hoc column lists, and comparison helpers accept them directly.
 
 # %%
 profile_catalog = {
@@ -266,8 +266,8 @@ comparison = compare_ftqc_resource_estimates(
     quantities=(
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in comparison:
@@ -293,8 +293,8 @@ comparison_summary = summarize_ftqc_resource_comparison(
     quantities=(
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in comparison_summary.smaller:
@@ -474,8 +474,8 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #   physical qubit-seconds separately.
 # - `iter_ftqc_research_signals` maps research directions to the canonical
 #   quantities that Qamomile reports.
-# - `ftqc_resource_profile_quantities` gives reusable quantity bundles such as
-#   the space-time profile for design reviews.
+# - `FTQCResourceProfile` gives reusable quantity bundles such as the
+#   space-time profile and can be passed directly to comparison helpers.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
 #   remains backend-neutral.
 # - Accuracy budgets split a total target precision into representation

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4301fed1",
+   "id": "641f7549",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "0c1db98d",
+   "id": "9bb76ba7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.214339Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.214063Z",
-     "iopub.status.idle": "2026-06-23T02:23:33.219217Z",
-     "shell.execute_reply": "2026-06-23T02:23:33.218063Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.110837Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.110538Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.118982Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.117295Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d5c21973",
+   "id": "70c437ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.221728Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.221560Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.940337Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.939842Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.121923Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.121736Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.870819Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.870320Z"
     }
    },
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3ae76e0",
+   "id": "9adae759",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a041785e",
+   "id": "c452f17e",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -104,13 +104,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4251022b",
+   "id": "b088f52d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.941983Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.941801Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.946127Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.945641Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.872298Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.872142Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.876152Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.875704Z"
     }
    },
    "outputs": [],
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca0b2365",
+   "id": "7655dd44",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -161,13 +161,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a829cb29",
+   "id": "2fdf90a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.947282Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.947217Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.949763Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.949444Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.877612Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.877532Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.880691Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.880019Z"
     }
    },
    "outputs": [
@@ -238,22 +238,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2763726",
+   "id": "84f96347",
    "metadata": {},
    "source": [
-    "Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付けます。"
+    "Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付け、comparison helperへ直接渡せます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f9829b13",
+   "id": "037400ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.951038Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.950974Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.953231Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.952833Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.881915Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.881814Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.884109Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.883703Z"
     }
    },
    "outputs": [
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6708f073",
+   "id": "50b6a072",
    "metadata": {},
    "source": [
     "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
@@ -296,13 +296,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e2a8d955",
+   "id": "4e5ca20d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.954319Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.954256Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.956534Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.956124Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.885217Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.885132Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.887602Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.887085Z"
     }
    },
    "outputs": [
@@ -336,7 +336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a1e5779",
+   "id": "1923345f",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -345,13 +345,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "9c21f701",
+   "id": "deb2d563",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.957571Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.957510Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.960215Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.959858Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.888747Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.888677Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.891497Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.891035Z"
     }
    },
    "outputs": [],
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "380f4bef",
+   "id": "0eb88b28",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -386,13 +386,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4fa74082",
+   "id": "7228b542",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.961398Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.961334Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.963674Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.963294Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.892622Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.892553Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.894554Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.894199Z"
     }
    },
    "outputs": [],
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eafe65ec",
+   "id": "0c48a049",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -433,13 +433,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d015cf51",
+   "id": "0f4771af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.964831Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.964771Z",
-     "iopub.status.idle": "2026-06-23T02:39:01.989309Z",
-     "shell.execute_reply": "2026-06-23T02:39:01.988827Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.895889Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.895814Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.920309Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.919717Z"
     }
    },
    "outputs": [
@@ -526,7 +526,11 @@
     "qubitized_savings = compare_ftqc_resource_estimates(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=qubitized_quantities,\n",
+    "    quantities=(\n",
+    "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
+    "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
+    "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "for row in qubitized_savings:\n",
     "    print(\n",
@@ -545,7 +549,11 @@
     "qubitized_summary = summarize_ftqc_resource_comparison(\n",
     "    thc,\n",
     "    scdf,\n",
-    "    quantities=qubitized_quantities,\n",
+    "    quantities=(\n",
+    "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
+    "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
+    "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS\n",
@@ -558,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c619a12a",
+   "id": "1abfa48c",
    "metadata": {},
    "source": [
     "## State-preparation success budget\n",
@@ -569,13 +577,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f2013f04",
+   "id": "63716203",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:01.990504Z",
-     "iopub.status.busy": "2026-06-23T02:39:01.990441Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.003578Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.003234Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.921539Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.921476Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.934833Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.934335Z"
     }
    },
    "outputs": [
@@ -617,8 +625,8 @@
     "        FTQCResourceQuantity.QPE_REPETITIONS,\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in preparation_savings:\n",
@@ -640,7 +648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da6b39b9",
+   "id": "90dedcd2",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -649,13 +657,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "965ac3bf",
+   "id": "12193753",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.004876Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.004803Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.008793Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.008376Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.935947Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.935871Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.939675Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.939193Z"
     }
    },
    "outputs": [
@@ -689,7 +697,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b853675",
+   "id": "b275604a",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -700,13 +708,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a5d80d94",
+   "id": "4dffd214",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.009838Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.009779Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.017902Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.017532Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.940682Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.940620Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.948133Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.947736Z"
     }
    },
    "outputs": [
@@ -757,7 +765,8 @@
     "trotter_savings = compare_ftqc_resource_estimates(\n",
     "    plain_trotter,\n",
     "    uwc_trotter,\n",
-    "    quantities=(FTQCResourceQuantity.QPE_ITERATIONS, *space_time_quantities),\n",
+    "    quantities=(FTQCResourceQuantity.QPE_ITERATIONS,),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "for row in trotter_savings:\n",
     "    print(\n",
@@ -775,7 +784,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00546a0c",
+   "id": "f314b11b",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -786,13 +795,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "8f499552",
+   "id": "4f3ff645",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:02.018948Z",
-     "iopub.status.busy": "2026-06-23T02:39:02.018881Z",
-     "iopub.status.idle": "2026-06-23T02:39:02.022671Z",
-     "shell.execute_reply": "2026-06-23T02:39:02.022186Z"
+     "iopub.execute_input": "2026-06-23T03:35:03.949348Z",
+     "iopub.status.busy": "2026-06-23T03:35:03.949273Z",
+     "iopub.status.idle": "2026-06-23T03:35:03.952903Z",
+     "shell.execute_reply": "2026-06-23T03:35:03.952491Z"
     }
    },
    "outputs": [
@@ -845,7 +854,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09968322",
+   "id": "7e5f599c",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -152,7 +152,7 @@ assert {row["quantity"] for row in quantity_catalog} == {
 }
 
 # %% [markdown]
-# Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付けます。
+# Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付け、comparison helperへ直接渡せます。
 
 # %%
 profile_catalog = {
@@ -301,7 +301,11 @@ for row in scdf.to_quantity_table():
 qubitized_savings = compare_ftqc_resource_estimates(
     thc,
     scdf,
-    quantities=qubitized_quantities,
+    quantities=(
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+    ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 for row in qubitized_savings:
     print(
@@ -320,7 +324,11 @@ assert qubitized_savings[4].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_V
 qubitized_summary = summarize_ftqc_resource_comparison(
     thc,
     scdf,
-    quantities=qubitized_quantities,
+    quantities=(
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+    ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 assert qubitized_summary.smaller[0].quantity == FTQCResourceQuantity.QPE_ITERATIONS
@@ -357,8 +365,8 @@ preparation_savings = compare_ftqc_resource_estimates(
         FTQCResourceQuantity.QPE_REPETITIONS,
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in preparation_savings:
@@ -434,7 +442,8 @@ print("UWC-style T gates:", sp.N(uwc_trotter.t_gates, 4))
 trotter_savings = compare_ftqc_resource_estimates(
     plain_trotter,
     uwc_trotter,
-    quantities=(FTQCResourceQuantity.QPE_ITERATIONS, *space_time_quantities),
+    quantities=(FTQCResourceQuantity.QPE_ITERATIONS,),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 for row in trotter_savings:
     print(

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "044dae34",
+   "id": "e93d2018",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f58823df",
+   "id": "f380f02b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.215097Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.214874Z",
-     "iopub.status.idle": "2026-06-23T02:23:33.219374Z",
-     "shell.execute_reply": "2026-06-23T02:23:33.218250Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.111137Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.110826Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.117988Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.116517Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f2d8148b",
+   "id": "dc742bab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:23:33.222361Z",
-     "iopub.status.busy": "2026-06-23T02:23:33.222183Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.220081Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.218343Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.120986Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.120762Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.495384Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.494856Z"
     }
    },
    "outputs": [],
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bcea37cc",
+   "id": "01d7152e",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "505e561a",
+   "id": "8cf19ff7",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -109,13 +109,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2dd0fa5f",
+   "id": "2dffc736",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.225773Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.225089Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.236382Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.235142Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.497079Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.496966Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.499607Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.499224Z"
     }
    },
    "outputs": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "425c35c4",
+   "id": "1ccdf60e",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -157,13 +157,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7a69109b",
+   "id": "62fda68a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.240805Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.240628Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.245683Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.244558Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.501759Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.501684Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.505770Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.504918Z"
     }
    },
    "outputs": [
@@ -257,22 +257,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6534f2d",
+   "id": "4aa82ca5",
    "metadata": {},
    "source": [
-    "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らしつつ、comparison関数はgenericなまま保てます。"
+    "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d51ec718",
+   "id": "3d3609bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.248522Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.248223Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.257072Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.256313Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.506946Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.506890Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.509553Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.508737Z"
     }
    },
    "outputs": [
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6c4fe4f",
+   "id": "a5bf0bc1",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -313,13 +313,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b0c1f5e9",
+   "id": "3d28a85b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.259344Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.259203Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.352390Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.351995Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.510706Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.510646Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.543295Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.542600Z"
     }
    },
    "outputs": [
@@ -437,8 +437,8 @@
     "    quantities=(\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in comparison:\n",
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ceacb98",
+   "id": "84bc2621",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -464,13 +464,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "153e79bf",
+   "id": "2a63ed66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.353988Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.353924Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.358298Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.357909Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.544814Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.544736Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.549358Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.548621Z"
     }
    },
    "outputs": [
@@ -496,8 +496,8 @@
     "    quantities=(\n",
     "        FTQCResourceQuantity.QPE_ITERATIONS,\n",
     "        FTQCResourceQuantity.TOFFOLI_GATES,\n",
-    "        *space_time_quantities,\n",
     "    ),\n",
+    "    profile=FTQCResourceProfile.SPACETIME,\n",
     ")\n",
     "\n",
     "for row in comparison_summary.smaller:\n",
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6644fd32",
+   "id": "8019303c",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -527,13 +527,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "63db6800",
+   "id": "ce0f4ce9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.359432Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.359355Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.361974Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.361465Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.550532Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.550470Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.553342Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.552860Z"
     }
    },
    "outputs": [
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37ce7645",
+   "id": "12584d02",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -570,13 +570,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e6ed4b13",
+   "id": "01ccb6fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.363357Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.363282Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.366344Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.365705Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.554478Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.554423Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.557577Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.556933Z"
     }
    },
    "outputs": [
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b5637c3",
+   "id": "31c8959f",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -620,13 +620,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f8020780",
+   "id": "2d211c46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.367752Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.367623Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.370361Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.369757Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.558892Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.558824Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.561324Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.560764Z"
     }
    },
    "outputs": [
@@ -662,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14b5101b",
+   "id": "3bb7cec1",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -673,13 +673,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "52b7cba0",
+   "id": "4b84afa8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.371715Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.371657Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.376761Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.375870Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.562612Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.562538Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.567559Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.566905Z"
     }
    },
    "outputs": [
@@ -726,7 +726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26801abc",
+   "id": "ff0048cd",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -737,13 +737,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "03491161",
+   "id": "e6c8f6dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T02:39:00.379830Z",
-     "iopub.status.busy": "2026-06-23T02:39:00.379740Z",
-     "iopub.status.idle": "2026-06-23T02:39:00.393345Z",
-     "shell.execute_reply": "2026-06-23T02:39:00.391948Z"
+     "iopub.execute_input": "2026-06-23T03:35:02.569226Z",
+     "iopub.status.busy": "2026-06-23T03:35:02.569143Z",
+     "iopub.status.idle": "2026-06-23T03:35:02.577567Z",
+     "shell.execute_reply": "2026-06-23T03:35:02.576918Z"
     }
    },
    "outputs": [
@@ -791,7 +791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dda23ae0",
+   "id": "a459ba5d",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -810,7 +810,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80c0f5c1",
+   "id": "99ac994d",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -819,7 +819,7 @@
     "\n",
     "- 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-secondsを分けて追跡する必要があることがわかります。\n",
     "- `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。\n",
-    "- `ftqc_resource_profile_quantities`を使うと、space-time profileのような再利用可能なquantity bundleを設計レビューに使えます。\n",
+    "- `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",
     "- Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -129,7 +129,7 @@ assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS.value in {
 assert FTQCResourceQuantity.CODE_DISTANCE.value in {row["quantity"] for row in catalog}
 
 # %% [markdown]
-# 標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らしつつ、comparison関数はgenericなまま保てます。
+# 標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。
 
 # %%
 profile_catalog = {
@@ -247,8 +247,8 @@ comparison = compare_ftqc_resource_estimates(
     quantities=(
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in comparison:
@@ -272,8 +272,8 @@ comparison_summary = summarize_ftqc_resource_comparison(
     quantities=(
         FTQCResourceQuantity.QPE_ITERATIONS,
         FTQCResourceQuantity.TOFFOLI_GATES,
-        *space_time_quantities,
     ),
+    profile=FTQCResourceProfile.SPACETIME,
 )
 
 for row in comparison_summary.smaller:
@@ -432,7 +432,7 @@ assert trotter_comparison[1].ratio == sp.Float("0.05")
 #
 # - 近年のFTQC化学計算研究から、Hamiltonian normalization、target precision、truncation error、QPE反復回数、non-Clifford count、logical depth、logical space-time volume、physical量子ビット、runtime、physical qubit-secondsを分けて追跡する必要があることがわかります。
 # - `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。
-# - `ftqc_resource_profile_quantities`を使うと、space-time profileのような再利用可能なquantity bundleを設計レビューに使えます。
+# - `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。
 # - Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -1176,6 +1176,7 @@ def compare_ftqc_resource_estimates(
     candidate: SupportsFTQCResourceValues,
     *,
     quantities: tuple[str | FTQCResourceQuantity, ...] | None = None,
+    profile: str | FTQCResourceProfile | None = None,
 ) -> tuple[FTQCResourceComparisonRow, ...]:
     """Compare canonical FTQC quantities between two estimates.
 
@@ -1185,8 +1186,12 @@ def compare_ftqc_resource_estimates(
         candidate (SupportsFTQCResourceValues): Candidate estimate, model, or
             summary exposing ``resource_values()``.
         quantities (tuple[str | FTQCResourceQuantity, ...] | None): Quantities
-            to compare. Defaults to the intersection of quantities exposed by
-            both inputs, ordered by the canonical quantity catalog.
+            to compare before any profile quantities. Defaults to the
+            intersection of quantities exposed by both inputs when ``profile``
+            is None.
+        profile (str | FTQCResourceProfile | None): Optional standard review
+            profile whose quantities are appended after ``quantities`` with
+            duplicates removed. Defaults to None.
 
     Returns:
         tuple[FTQCResourceComparisonRow, ...]: Comparison rows containing
@@ -1199,10 +1204,11 @@ def compare_ftqc_resource_estimates(
     """
     baseline_values = baseline.resource_values()
     candidate_values = candidate.resource_values()
-    selected = _normalize_comparison_quantities(
+    selected = _select_comparison_quantities(
         baseline_values,
         candidate_values,
         quantities,
+        profile,
     )
 
     rows = []
@@ -1236,6 +1242,7 @@ def summarize_ftqc_resource_comparison(
     candidate: SupportsFTQCResourceValues,
     *,
     quantities: tuple[str | FTQCResourceQuantity, ...] | None = None,
+    profile: str | FTQCResourceProfile | None = None,
 ) -> FTQCResourceComparisonSummary:
     """Summarize FTQC resource changes between two estimates.
 
@@ -1249,8 +1256,12 @@ def summarize_ftqc_resource_comparison(
         candidate (SupportsFTQCResourceValues): Candidate estimate, model, or
             summary exposing ``resource_values()``.
         quantities (tuple[str | FTQCResourceQuantity, ...] | None): Quantities
-            to compare. Defaults to the intersection of quantities exposed by
-            both inputs, ordered by the canonical quantity catalog.
+            to compare before any profile quantities. Defaults to the
+            intersection of quantities exposed by both inputs when ``profile``
+            is None.
+        profile (str | FTQCResourceProfile | None): Optional standard review
+            profile whose quantities are appended after ``quantities`` with
+            duplicates removed. Defaults to None.
 
     Returns:
         FTQCResourceComparisonSummary: Grouped comparison rows.
@@ -1264,7 +1275,53 @@ def summarize_ftqc_resource_comparison(
             baseline,
             candidate,
             quantities=quantities,
+            profile=profile,
         )
+    )
+
+
+def _select_comparison_quantities(
+    baseline_values: dict[FTQCResourceQuantity, sp.Expr],
+    candidate_values: dict[FTQCResourceQuantity, sp.Expr],
+    quantities: tuple[str | FTQCResourceQuantity, ...] | None,
+    profile: str | FTQCResourceProfile | None,
+) -> tuple[FTQCResourceQuantity, ...]:
+    """Select quantities from explicit requests and optional review profile.
+
+    Args:
+        baseline_values (dict[FTQCResourceQuantity, sp.Expr]): Baseline
+            resource values.
+        candidate_values (dict[FTQCResourceQuantity, sp.Expr]): Candidate
+            resource values.
+        quantities (tuple[str | FTQCResourceQuantity, ...] | None): Explicit
+            requested quantities.
+        profile (str | FTQCResourceProfile | None): Optional standard review
+            profile to append after explicit quantities.
+
+    Returns:
+        tuple[FTQCResourceQuantity, ...]: Normalized quantities.
+
+    Raises:
+        ValueError: If a requested quantity is absent from either value map, or
+            if ``profile`` is not a known FTQC resource profile.
+    """
+    if profile is None:
+        return _normalize_comparison_quantities(
+            baseline_values,
+            candidate_values,
+            quantities,
+        )
+
+    profile_quantities = ftqc_resource_profile_quantities(profile)
+    if quantities is None:
+        selected = profile_quantities
+    else:
+        selected = (*quantities, *profile_quantities)
+
+    return _normalize_comparison_quantities(
+        baseline_values,
+        candidate_values,
+        selected,
     )
 
 
@@ -1297,8 +1354,8 @@ def _normalize_comparison_quantities(
             if spec.quantity in common
         )
 
-    normalized = tuple(
-        _normalize_resource_quantity(quantity) for quantity in quantities
+    normalized = _dedupe_resource_quantities(
+        tuple(_normalize_resource_quantity(quantity) for quantity in quantities)
     )
     missing = [
         quantity.value
@@ -1312,6 +1369,28 @@ def _normalize_comparison_quantities(
             + "."
         )
     return normalized
+
+
+def _dedupe_resource_quantities(
+    quantities: tuple[FTQCResourceQuantity, ...],
+) -> tuple[FTQCResourceQuantity, ...]:
+    """Remove duplicate resource quantities while preserving input order.
+
+    Args:
+        quantities (tuple[FTQCResourceQuantity, ...]): Normalized resource
+            quantities.
+
+    Returns:
+        tuple[FTQCResourceQuantity, ...]: First occurrence of each quantity.
+    """
+    seen: set[FTQCResourceQuantity] = set()
+    deduped = []
+    for quantity in quantities:
+        if quantity in seen:
+            continue
+        seen.add(quantity)
+        deduped.append(quantity)
+    return tuple(deduped)
 
 
 def _normalize_resource_quantity(

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -393,8 +393,8 @@ def test_compare_ftqc_resource_estimates_reports_ratios_and_reductions():
     assert rows[1].to_dict()["unit"] == "Toffoli gates"
 
 
-def test_compare_ftqc_resource_estimates_accepts_profile_quantities():
-    """Comparison helpers accept quantities returned by standard profiles."""
+def test_compare_ftqc_resource_estimates_accepts_profile():
+    """Comparison helpers accept standard profiles directly."""
     baseline = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
     candidate = baseline.with_lambda_scale(sp.Rational(1, 2), source="compressed")
     cost = FTQCCostModel(
@@ -425,7 +425,7 @@ def test_compare_ftqc_resource_estimates_accepts_profile_quantities():
     rows = compare_ftqc_resource_estimates(
         baseline_estimate,
         candidate_estimate,
-        quantities=ftqc_resource_profile_quantities(FTQCResourceProfile.SPACETIME),
+        profile=FTQCResourceProfile.SPACETIME,
     )
 
     assert [row.quantity for row in rows] == list(
@@ -433,6 +433,56 @@ def test_compare_ftqc_resource_estimates_accepts_profile_quantities():
     )
     assert rows[2].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
     assert rows[-1].quantity == FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS
+
+
+def test_compare_ftqc_resource_estimates_appends_profile_without_duplicates():
+    """Explicit quantities are kept before profile quantities without repeats."""
+    baseline = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    candidate = baseline.with_lambda_scale(sp.Rational(1, 2), source="compressed")
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e5"),
+    )
+    baseline_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=baseline,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=10,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+    candidate_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=candidate,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=11,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+
+    rows = compare_ftqc_resource_estimates(
+        baseline_estimate,
+        candidate_estimate,
+        quantities=(
+            FTQCResourceQuantity.QPE_ITERATIONS,
+            FTQCResourceQuantity.LOGICAL_QUBITS,
+        ),
+        profile="spacetime",
+    )
+
+    assert [row.quantity for row in rows] == [
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.LOGICAL_QUBITS,
+        FTQCResourceQuantity.LOGICAL_DEPTH,
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+        FTQCResourceQuantity.PHYSICAL_QUBITS,
+        FTQCResourceQuantity.RUNTIME_SECONDS,
+        FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+    ]
 
 
 def test_compare_ftqc_resource_estimates_defaults_to_common_quantities():
@@ -527,6 +577,45 @@ def test_summarize_ftqc_resource_comparison_groups_review_drivers():
         "unchanged": 1,
         "symbolic": 0,
     }
+
+
+def test_summarize_ftqc_resource_comparison_accepts_profile():
+    """Comparison summaries accept standard review profiles directly."""
+    baseline = summarize_pauli_hamiltonian(2 * qm_o.Z(0) + 3 * qm_o.X(1))
+    candidate = baseline.with_lambda_scale(sp.Rational(1, 2), source="compressed")
+    cost = FTQCCostModel(
+        physical_qubits_per_logical=100,
+        logical_cycle_time_seconds=sp.Float("1e-6"),
+        factory_qubits=10,
+        toffoli_throughput_per_second=sp.Float("1e5"),
+    )
+    baseline_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=baseline,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=10,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+    candidate_estimate = estimate_qubitized_chemistry_qpe_from_model(
+        ChemistryQPEModel(
+            hamiltonian=candidate,
+            method=ChemistryQPEMethod.SPARSE,
+            walk_cost_toffoli=11,
+        ),
+        precision=1,
+        cost_model=cost,
+    )
+
+    summary = summarize_ftqc_resource_comparison(
+        baseline_estimate,
+        candidate_estimate,
+        profile=FTQCResourceProfile.SPACETIME,
+    )
+
+    assert summary.rows[0].quantity == FTQCResourceQuantity.LOGICAL_QUBITS
+    assert summary.rows[-1].quantity == FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS
 
 
 def test_comparison_summary_keeps_undecidable_symbolic_changes_separate():


### PR DESCRIPTION
## Summary

- Let `compare_ftqc_resource_estimates` and `summarize_ftqc_resource_comparison` accept an optional `profile` argument.
- Append profile quantities after explicit comparison quantities while preserving order and removing duplicates.
- Update EN/JA FTQC resource-estimation docs and executed notebooks to pass the space-time profile directly into comparison helpers.

## Verification

- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run python docs/en/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run python docs/ja/algorithm/ftqc_chemistry_resource_estimation.py`
- `uv run python docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run python docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_chemistry_resource_estimation or ftqc_resource_estimation_design'`
- `uv run jupytext --to ipynb --test docs/en/algorithm/ftqc_chemistry_resource_estimation.py docs/ja/algorithm/ftqc_chemistry_resource_estimation.py docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `git diff --check`