### PR TITLE
Plan block-encoding QPE resources

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bf895307",
+   "id": "9e787469",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "668d4fdb",
+   "id": "6a88d964",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:00.780557Z",
-     "iopub.status.busy": "2026-06-23T04:51:00.780182Z",
-     "iopub.status.idle": "2026-06-23T04:51:00.786094Z",
-     "shell.execute_reply": "2026-06-23T04:51:00.784704Z"
+     "iopub.execute_input": "2026-06-23T05:10:13.436273Z",
+     "iopub.status.busy": "2026-06-23T05:10:13.436100Z",
+     "iopub.status.idle": "2026-06-23T05:10:13.441311Z",
+     "shell.execute_reply": "2026-06-23T05:10:13.440193Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "845dfce5",
+   "id": "be3c78f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:00.788529Z",
-     "iopub.status.busy": "2026-06-23T04:51:00.788339Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.217882Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.217258Z"
+     "iopub.execute_input": "2026-06-23T05:10:13.444666Z",
+     "iopub.status.busy": "2026-06-23T05:10:13.444414Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.156562Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.155782Z"
     }
    },
    "outputs": [],
@@ -53,6 +53,7 @@
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    BlockEncodingResource,\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
     "    FTQCAccuracyBudget,\n",
@@ -75,6 +76,7 @@
     "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_profile_specs,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
+    "    plan_qubitized_qpe_from_block_encoding,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -82,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c11d3ea",
+   "id": "73dd5419",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -107,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102ab04e",
+   "id": "29b2b65c",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -130,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2cfecf05",
+   "id": "8943a315",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.219570Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.219453Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.222247Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.221589Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.159235Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.159040Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.163251Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.162555Z"
     }
    },
    "outputs": [
@@ -167,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71f230b2",
+   "id": "f5c7ec7a",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -179,13 +181,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b4520586",
+   "id": "aa2bcfb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.223255Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.223187Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.226507Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.226056Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.165795Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.165662Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.171068Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.170478Z"
     }
    },
    "outputs": [
@@ -279,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f6bc7de",
+   "id": "7f08dd3b",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -290,13 +292,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3e58425f",
+   "id": "00477e4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.227584Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.227531Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.229641Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.229230Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.173075Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.172945Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.177376Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.176053Z"
     }
    },
    "outputs": [
@@ -326,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc3417aa",
+   "id": "e8948b53",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -341,13 +343,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "73271707",
+   "id": "e652ff01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.230719Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.230660Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.235074Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.234494Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.179957Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.179816Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.189457Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.188624Z"
     }
    },
    "outputs": [
@@ -407,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23587811",
+   "id": "018e68ec",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -419,13 +421,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7d11de8a",
+   "id": "d7137ec4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.236086Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.236035Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.238558Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.238159Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.191498Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.191336Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.195764Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.195120Z"
     }
    },
    "outputs": [],
@@ -450,7 +452,69 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0c42f8b",
+   "id": "c52969c6",
+   "metadata": {},
+   "source": [
+    "A block-encoding model can also produce a plan directly. The plan separates\n",
+    "the reusable block-encoding contract from the repeated qubitized-walk step,\n",
+    "so reviewers can inspect PREPARE, SELECT, reflection, walk cost, and QPE\n",
+    "iterations before a loader circuit exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "96c793c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:10:14.197604Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.197495Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.206125Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.205245Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block_encoding_contract 1\n",
+      "qubitized_walk_qpe 133333333.333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "block_encoding = BlockEncodingResource(\n",
+    "    system_qubits=40,\n",
+    "    normalization=sp.Float(\"2.0e5\"),\n",
+    "    select_cost_toffoli=4_000,\n",
+    "    prepare_cost_toffoli=500,\n",
+    "    reflection_cost_toffoli=100,\n",
+    "    ancilla_qubits=80,\n",
+    "    name=\"toy_lcu_loader\",\n",
+    ")\n",
+    "block_plan = plan_qubitized_qpe_from_block_encoding(\n",
+    "    block_encoding,\n",
+    "    precision=sp.Float(\"0.0015\"),\n",
+    "    qpe_register_qubits=12,\n",
+    ")\n",
+    "block_plan_values = block_plan.resource_values()\n",
+    "\n",
+    "for step in block_plan.to_dict()[\"steps\"]:\n",
+    "    print(step[\"name\"], step[\"repetitions\"])\n",
+    "\n",
+    "assert block_plan.steps[0].name == \"block_encoding_contract\"\n",
+    "assert block_plan.steps[1].name == \"qubitized_walk_qpe\"\n",
+    "assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100\n",
+    "assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132\n",
+    "assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
+    "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcb608cf",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -462,14 +526,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "aa3ac838",
+   "execution_count": 9,
+   "id": "86b4afd7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.239570Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.239514Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.272144Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.271720Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.208584Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.208455Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.285694Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.282121Z"
     }
    },
    "outputs": [
@@ -605,7 +669,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73d1f2a5",
+   "id": "e7870e24",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -615,14 +679,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "e9d1b9dd",
+   "execution_count": 10,
+   "id": "38ada641",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.273359Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.273298Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.277372Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.276874Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.289541Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.289384Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.299681Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.297245Z"
     }
    },
    "outputs": [
@@ -668,7 +732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e1df2ad",
+   "id": "15219776",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -679,14 +743,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "6fce89da",
+   "execution_count": 11,
+   "id": "a6bec258",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.278436Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.278375Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.283668Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.283252Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.302105Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.301955Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.316782Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.314478Z"
     }
    },
    "outputs": [
@@ -737,7 +801,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b52d3fc",
+   "id": "4a2e9a84",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -750,14 +814,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f97a52eb",
+   "execution_count": 12,
+   "id": "026e383a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.284774Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.284697Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.287152Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.286814Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.319262Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.318992Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.327126Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.326047Z"
     }
    },
    "outputs": [
@@ -783,7 +847,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "caf79646",
+   "id": "9bb22386",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -796,14 +860,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "d3823fef",
+   "execution_count": 13,
+   "id": "ccd4b3af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.288282Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.288217Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.290897Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.290520Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.329522Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.329266Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.337139Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.336110Z"
     }
    },
    "outputs": [
@@ -836,7 +900,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "045505ac",
+   "id": "ab852bf3",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -849,14 +913,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "5cee2c03",
+   "execution_count": 14,
+   "id": "0c6e591b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.292227Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.292162Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.294240Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.293889Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.339337Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.339221Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.345142Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.343874Z"
     }
    },
    "outputs": [
@@ -892,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "251b1bb9",
+   "id": "a3cc0fb3",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -903,14 +967,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "9e9e3b61",
+   "execution_count": 15,
+   "id": "fa1f6132",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.295451Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.295377Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.299187Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.298769Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.349768Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.348754Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.360898Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.360062Z"
     }
    },
    "outputs": [
@@ -957,7 +1021,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53ffe2c8",
+   "id": "efea0790",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -968,14 +1032,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "6a022352",
+   "execution_count": 16,
+   "id": "a0d47a73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.300314Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.300264Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.307064Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.306789Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.363185Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.363057Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.386959Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.385782Z"
     }
    },
    "outputs": [
@@ -1023,7 +1087,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7445c19b",
+   "id": "89573d3f",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1036,14 +1100,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "4f88ad0e",
+   "execution_count": 17,
+   "id": "6dbd854e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.308390Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.308330Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.311408Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.311032Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.390028Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.389877Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.396774Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.395712Z"
     }
    },
    "outputs": [
@@ -1094,7 +1158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7b9b4a5",
+   "id": "d8f78f18",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1119,7 +1183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cba2489",
+   "id": "2b748e12",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1136,6 +1200,8 @@
     "  space-time profile and can be passed directly to comparison helpers.\n",
     "- `FTQCResourcePlan` composes abstract FTQC subroutines before a concrete\n",
     "  circuit implementation exists.\n",
+    "- `plan_qubitized_qpe_from_block_encoding` turns a block-encoding contract\n",
+    "  into a PREPARE/SELECT/reflection/QPE resource plan.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
     "  remains backend-neutral.\n",
     "- Accuracy budgets split a total target precision into representation\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -33,6 +33,7 @@ import sympy as sp
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
+    BlockEncodingResource,
     ChemistryQPEMethod,
     ChemistryQPEModel,
     FTQCAccuracyBudget,
@@ -55,6 +56,7 @@ from qamomile.circuit.estimator.algorithmic import (
     iter_ftqc_research_signals,
     iter_ftqc_resource_profile_specs,
     iter_ftqc_resource_quantity_specs,
+    plan_qubitized_qpe_from_block_encoding,
     summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
 )
@@ -241,6 +243,40 @@ plan_budget = evaluate_ftqc_resource_constraints(
 assert parallel_runtime_plan.resource_values()[FTQCResourceQuantity.RUNTIME_SECONDS] == 40
 assert plan_budget.satisfied[0].quantity == FTQCResourceQuantity.LOGICAL_QUBITS
 assert plan_budget.violated[0].quantity == FTQCResourceQuantity.TOFFOLI_GATES
+
+# %% [markdown]
+# A block-encoding model can also produce a plan directly. The plan separates
+# the reusable block-encoding contract from the repeated qubitized-walk step,
+# so reviewers can inspect PREPARE, SELECT, reflection, walk cost, and QPE
+# iterations before a loader circuit exists.
+
+# %%
+block_encoding = BlockEncodingResource(
+    system_qubits=40,
+    normalization=sp.Float("2.0e5"),
+    select_cost_toffoli=4_000,
+    prepare_cost_toffoli=500,
+    reflection_cost_toffoli=100,
+    ancilla_qubits=80,
+    name="toy_lcu_loader",
+)
+block_plan = plan_qubitized_qpe_from_block_encoding(
+    block_encoding,
+    precision=sp.Float("0.0015"),
+    qpe_register_qubits=12,
+)
+block_plan_values = block_plan.resource_values()
+
+for step in block_plan.to_dict()["steps"]:
+    print(step["name"], step["repetitions"])
+
+assert block_plan.steps[0].name == "block_encoding_contract"
+assert block_plan.steps[1].name == "qubitized_walk_qpe"
+assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100
+assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132
+assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
+    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100
+)
 
 # %% [markdown]
 # ## Minimal Example
@@ -637,6 +673,8 @@ assert budget_report.to_dict()["counts"] == {
 #   space-time profile and can be passed directly to comparison helpers.
 # - `FTQCResourcePlan` composes abstract FTQC subroutines before a concrete
 #   circuit implementation exists.
+# - `plan_qubitized_qpe_from_block_encoding` turns a block-encoding contract
+#   into a PREPARE/SELECT/reflection/QPE resource plan.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
 #   remains backend-neutral.
 # - Accuracy budgets split a total target precision into representation

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6efee5b1",
+   "id": "fc52cdc1",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "584bbbe3",
+   "id": "15708445",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:00.779126Z",
-     "iopub.status.busy": "2026-06-23T04:51:00.778892Z",
-     "iopub.status.idle": "2026-06-23T04:51:00.786025Z",
-     "shell.execute_reply": "2026-06-23T04:51:00.784696Z"
+     "iopub.execute_input": "2026-06-23T05:10:13.436638Z",
+     "iopub.status.busy": "2026-06-23T05:10:13.436490Z",
+     "iopub.status.idle": "2026-06-23T05:10:13.441026Z",
+     "shell.execute_reply": "2026-06-23T05:10:13.439953Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e18c8872",
+   "id": "14c63a4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:00.788847Z",
-     "iopub.status.busy": "2026-06-23T04:51:00.788653Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.218046Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.217428Z"
+     "iopub.execute_input": "2026-06-23T05:10:13.444521Z",
+     "iopub.status.busy": "2026-06-23T05:10:13.444243Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.156505Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.155777Z"
     }
    },
    "outputs": [],
@@ -50,6 +50,7 @@
     "\n",
     "import qamomile.observable as qm_o\n",
     "from qamomile.circuit.estimator.algorithmic import (\n",
+    "    BlockEncodingResource,\n",
     "    ChemistryQPEMethod,\n",
     "    ChemistryQPEModel,\n",
     "    FTQCAccuracyBudget,\n",
@@ -72,6 +73,7 @@
     "    iter_ftqc_research_signals,\n",
     "    iter_ftqc_resource_profile_specs,\n",
     "    iter_ftqc_resource_quantity_specs,\n",
+    "    plan_qubitized_qpe_from_block_encoding,\n",
     "    summarize_ftqc_resource_comparison,\n",
     "    summarize_pauli_hamiltonian,\n",
     ")"
@@ -79,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "561a2f60",
+   "id": "f490df45",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -96,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c5200b3",
+   "id": "2ff112a6",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -116,13 +118,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2c689022",
+   "id": "fc2d498a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.219695Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.219587Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.222087Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.221561Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.159514Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.159319Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.163834Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.162740Z"
     }
    },
    "outputs": [
@@ -153,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "089a2185",
+   "id": "235ac924",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -164,13 +166,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "87fc79de",
+   "id": "03015856",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.223203Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.223135Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.226410Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.226013Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.166260Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.166139Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.171723Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.171154Z"
     }
    },
    "outputs": [
@@ -264,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee86f56e",
+   "id": "f89112e0",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -273,13 +275,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d5ce2bb7",
+   "id": "c146f4b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.227426Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.227370Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.229585Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.229222Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.173589Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.173468Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.178587Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.177744Z"
     }
    },
    "outputs": [
@@ -309,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50412aa3",
+   "id": "639aceb9",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -320,13 +322,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a454d2ac",
+   "id": "45c5a56f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.230709Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.230650Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.234808Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.234474Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.181406Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.181195Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.190354Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.189587Z"
     }
    },
    "outputs": [
@@ -386,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18bc0b45",
+   "id": "8adc94c2",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -395,13 +397,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a59136c3",
+   "id": "3cbb095e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.236124Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.236072Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.238610Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.238164Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.192218Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.192078Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.196398Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.195829Z"
     }
    },
    "outputs": [],
@@ -426,7 +428,66 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34a44aef",
+   "id": "9369325b",
+   "metadata": {},
+   "source": [
+    "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dbb4340d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:10:14.198713Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.198600Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.207049Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.206174Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "block_encoding_contract 1\n",
+      "qubitized_walk_qpe 133333333.333333\n"
+     ]
+    }
+   ],
+   "source": [
+    "block_encoding = BlockEncodingResource(\n",
+    "    system_qubits=40,\n",
+    "    normalization=sp.Float(\"2.0e5\"),\n",
+    "    select_cost_toffoli=4_000,\n",
+    "    prepare_cost_toffoli=500,\n",
+    "    reflection_cost_toffoli=100,\n",
+    "    ancilla_qubits=80,\n",
+    "    name=\"toy_lcu_loader\",\n",
+    ")\n",
+    "block_plan = plan_qubitized_qpe_from_block_encoding(\n",
+    "    block_encoding,\n",
+    "    precision=sp.Float(\"0.0015\"),\n",
+    "    qpe_register_qubits=12,\n",
+    ")\n",
+    "block_plan_values = block_plan.resource_values()\n",
+    "\n",
+    "for step in block_plan.to_dict()[\"steps\"]:\n",
+    "    print(step[\"name\"], step[\"repetitions\"])\n",
+    "\n",
+    "assert block_plan.steps[0].name == \"block_encoding_contract\"\n",
+    "assert block_plan.steps[1].name == \"qubitized_walk_qpe\"\n",
+    "assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100\n",
+    "assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132\n",
+    "assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
+    "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a50e5b0",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -436,14 +497,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "0c364d06",
+   "execution_count": 9,
+   "id": "e9125e27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.239656Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.239601Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.272110Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.271677Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.209811Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.209600Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.285120Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.282845Z"
     }
    },
    "outputs": [
@@ -579,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52b74dbf",
+   "id": "1fde38cd",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -587,14 +648,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "00b930d9",
+   "execution_count": 10,
+   "id": "7644bc86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.273227Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.273166Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.277439Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.276919Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.289235Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.288928Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.299669Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.297236Z"
     }
    },
    "outputs": [
@@ -640,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48b716da",
+   "id": "4547fd43",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -648,14 +709,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "190a56c4",
+   "execution_count": 11,
+   "id": "f2dd0ab3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.278487Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.278422Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.283684Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.283252Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.301908Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.301781Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.315570Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.313852Z"
     }
    },
    "outputs": [
@@ -706,7 +767,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "939e1337",
+   "id": "0213db5d",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -716,14 +777,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "8dcdd5b4",
+   "execution_count": 12,
+   "id": "9580d873",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.284937Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.284878Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.287280Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.286985Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.318840Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.318554Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.325068Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.323970Z"
     }
    },
    "outputs": [
@@ -749,7 +810,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbd26563",
+   "id": "e2bc2eb6",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -759,14 +820,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "3e1864ec",
+   "execution_count": 13,
+   "id": "ab8feacb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.288498Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.288437Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.291203Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.290847Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.328144Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.327998Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.335647Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.334647Z"
     }
    },
    "outputs": [
@@ -799,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "edf40ac4",
+   "id": "0dfcc3a1",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -809,14 +870,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "f9c4d77d",
+   "execution_count": 14,
+   "id": "79f4fa48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.292515Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.292458Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.294672Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.294291Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.338129Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.337987Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.343259Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.341506Z"
     }
    },
    "outputs": [
@@ -852,7 +913,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563ac247",
+   "id": "23a9b35a",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -862,14 +923,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "d78f163a",
+   "execution_count": 15,
+   "id": "d5c66ffe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.295842Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.295770Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.299566Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.299150Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.347081Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.346852Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.359904Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.358894Z"
     }
    },
    "outputs": [
@@ -916,7 +977,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fb8c7ce",
+   "id": "51820428",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -926,14 +987,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "04ed2fd1",
+   "execution_count": 16,
+   "id": "d84de2a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.300585Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.300527Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.307626Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.307309Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.362376Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.362250Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.387280Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.386285Z"
     }
    },
    "outputs": [
@@ -981,7 +1042,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56834834",
+   "id": "98e59ac7",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -991,14 +1052,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "efcdd93b",
+   "execution_count": 17,
+   "id": "4d44826b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T04:51:01.308862Z",
-     "iopub.status.busy": "2026-06-23T04:51:01.308804Z",
-     "iopub.status.idle": "2026-06-23T04:51:01.311842Z",
-     "shell.execute_reply": "2026-06-23T04:51:01.311525Z"
+     "iopub.execute_input": "2026-06-23T05:10:14.390288Z",
+     "iopub.status.busy": "2026-06-23T05:10:14.390123Z",
+     "iopub.status.idle": "2026-06-23T05:10:14.397208Z",
+     "shell.execute_reply": "2026-06-23T05:10:14.396227Z"
     }
    },
    "outputs": [
@@ -1049,7 +1110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86bc396a",
+   "id": "515c57ba",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1068,7 +1129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d512b0e",
+   "id": "454ee38d",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1079,6 +1140,7 @@
     "- `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。\n",
     "- `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。\n",
     "- `FTQCResourcePlan`を使うと、具体的な回路実装ができる前に抽象的なFTQC subroutineを合成できます。\n",
+    "- `plan_qubitized_qpe_from_block_encoding`は、block-encoding contractをPREPARE/SELECT/reflection/QPE resource planへ変換します。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",
     "- Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -30,6 +30,7 @@ import sympy as sp
 
 import qamomile.observable as qm_o
 from qamomile.circuit.estimator.algorithmic import (
+    BlockEncodingResource,
     ChemistryQPEMethod,
     ChemistryQPEModel,
     FTQCAccuracyBudget,
@@ -52,6 +53,7 @@ from qamomile.circuit.estimator.algorithmic import (
     iter_ftqc_research_signals,
     iter_ftqc_resource_profile_specs,
     iter_ftqc_resource_quantity_specs,
+    plan_qubitized_qpe_from_block_encoding,
     summarize_ftqc_resource_comparison,
     summarize_pauli_hamiltonian,
 )
@@ -217,6 +219,37 @@ plan_budget = evaluate_ftqc_resource_constraints(
 assert parallel_runtime_plan.resource_values()[FTQCResourceQuantity.RUNTIME_SECONDS] == 40
 assert plan_budget.satisfied[0].quantity == FTQCResourceQuantity.LOGICAL_QUBITS
 assert plan_budget.violated[0].quantity == FTQCResourceQuantity.TOFFOLI_GATES
+
+# %% [markdown]
+# block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。
+
+# %%
+block_encoding = BlockEncodingResource(
+    system_qubits=40,
+    normalization=sp.Float("2.0e5"),
+    select_cost_toffoli=4_000,
+    prepare_cost_toffoli=500,
+    reflection_cost_toffoli=100,
+    ancilla_qubits=80,
+    name="toy_lcu_loader",
+)
+block_plan = plan_qubitized_qpe_from_block_encoding(
+    block_encoding,
+    precision=sp.Float("0.0015"),
+    qpe_register_qubits=12,
+)
+block_plan_values = block_plan.resource_values()
+
+for step in block_plan.to_dict()["steps"]:
+    print(step["name"], step["repetitions"])
+
+assert block_plan.steps[0].name == "block_encoding_contract"
+assert block_plan.steps[1].name == "qubitized_walk_qpe"
+assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100
+assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132
+assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
+    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100
+)
 
 # %% [markdown]
 # ## 最小例
@@ -580,6 +613,7 @@ assert budget_report.to_dict()["counts"] == {
 # - `iter_ftqc_research_signals`は、研究方向をQamomileがreportするcanonical quantityへ対応づけます。
 # - `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。
 # - `FTQCResourcePlan`を使うと、具体的な回路実装ができる前に抽象的なFTQC subroutineを合成できます。
+# - `plan_qubitized_qpe_from_block_encoding`は、block-encoding contractをPREPARE/SELECT/reflection/QPE resource planへ変換します。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。
 # - Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。

--- a/qamomile/circuit/estimator/algorithmic/__init__.py
+++ b/qamomile/circuit/estimator/algorithmic/__init__.py
@@ -15,6 +15,7 @@ from qamomile.circuit.estimator.algorithmic.ftqc_block_encoding import (
     BlockEncodingResource,
     block_encoding_from_chemistry_model,
     estimate_qubitized_qpe_from_block_encoding,
+    plan_qubitized_qpe_from_block_encoding,
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
     ChemistryQPEMethod,
@@ -124,6 +125,7 @@ __all__ = [
     "estimate_qubitized_chemistry_qpe",
     "estimate_qubitized_qpe_from_block_encoding",
     "estimate_qubitized_chemistry_qpe_from_model",
+    "plan_qubitized_qpe_from_block_encoding",
     "estimate_single_ancilla_trotter_qpe",
     "estimate_single_ancilla_trotter_qpe_from_hamiltonian",
     "hamiltonian_from_openfermion_qubit_operator",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -17,6 +17,8 @@ from qamomile.circuit.estimator.algorithmic.ftqc_chemistry import (
 )
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceFormula,
+    FTQCResourcePlan,
+    FTQCResourcePlanStep,
     FTQCResourceQuantity,
 )
 
@@ -362,6 +364,110 @@ class BlockEncodingResource:
             sp.Expr: Converted ancilla-qubit count.
         """
         return _as_expr(self.ancilla_qubits, "ancilla_qubits")
+
+
+def plan_qubitized_qpe_from_block_encoding(
+    block_encoding: BlockEncodingResource,
+    precision: _SympyLike,
+    *,
+    qpe_register_qubits: _SympyLike = 0,
+    title: str | None = None,
+) -> FTQCResourcePlan:
+    """Build an abstract resource plan for block-encoding QPE.
+
+    The plan exposes the reusable block-encoding contract separately from the
+    repeated qubitized-walk step. This gives design reviews a subroutine-level
+    view of PREPARE, SELECT, reflection, walk cost, QPE iterations, and logical
+    footprint before any loader is lowered into concrete Qamomile IR.
+
+    Args:
+        block_encoding (BlockEncodingResource): Block-encoding subroutine
+            metadata, including normalization and per-walk costs.
+        precision (sp.Expr | int | float): Target energy precision in the
+            same units as ``block_encoding.normalization``.
+        qpe_register_qubits (sp.Expr | int | float): Optional readout qubits
+            used by an explicit QPE circuit. Defaults to zero.
+        title (str | None): Optional reader-facing plan title. Defaults to a
+            label derived from ``block_encoding.name``.
+
+    Returns:
+        FTQCResourcePlan: Abstract resource plan whose aggregate logical
+            quantities match the corresponding block-encoding QPE estimate
+            before architecture lifting.
+
+    Raises:
+        TypeError: If ``precision`` or ``qpe_register_qubits`` cannot be
+            converted to SymPy expressions.
+        ValueError: If ``precision`` is non-positive or
+            ``qpe_register_qubits`` is negative.
+
+    Example:
+        >>> block = BlockEncodingResource(
+        ...     system_qubits=4,
+        ...     normalization=100,
+        ...     select_cost_toffoli=20,
+        ...     prepare_cost_toffoli=5,
+        ... )
+        >>> plan = plan_qubitized_qpe_from_block_encoding(block, precision=2)
+        >>> plan.resource_values()[FTQCResourceQuantity.QPE_ITERATIONS]
+        50
+    """
+    precision_expr = _as_expr(precision, "precision")
+    qpe_qubits = _as_expr(qpe_register_qubits, "qpe_register_qubits")
+    _validate_positive(precision_expr, "precision")
+    _validate_nonnegative(qpe_qubits, "qpe_register_qubits")
+
+    qpe_iterations = sp.simplify(block_encoding._normalization / precision_expr)
+    logical_qubits = sp.simplify(block_encoding.logical_qubits + qpe_qubits)
+    walk_spacetime = sp.simplify(logical_qubits * block_encoding.walk_cost_toffoli)
+
+    return FTQCResourcePlan(
+        (
+            FTQCResourcePlanStep(
+                "block_encoding_contract",
+                {
+                    FTQCResourceQuantity.SYSTEM_QUBITS: block_encoding._system_qubits,
+                    FTQCResourceQuantity.LAMBDA_NORM: block_encoding._normalization,
+                    FTQCResourceQuantity.TARGET_PRECISION: precision_expr,
+                    FTQCResourceQuantity.BLOCK_ENCODING_ANCILLA_QUBITS: (
+                        block_encoding._ancilla_qubits
+                    ),
+                    FTQCResourceQuantity.QPE_REGISTER_QUBITS: qpe_qubits,
+                    FTQCResourceQuantity.PREPARE_COST_TOFFOLI: (
+                        block_encoding._prepare_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.SELECT_COST_TOFFOLI: (
+                        block_encoding._select_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.REFLECTION_COST_TOFFOLI: (
+                        block_encoding._reflection_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.WALK_COST_TOFFOLI: (
+                        block_encoding.walk_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.LOGICAL_QUBITS: logical_qubits,
+                },
+                label="Block-encoding contract",
+            ),
+            FTQCResourcePlanStep(
+                "qubitized_walk_qpe",
+                {
+                    FTQCResourceQuantity.QPE_ITERATIONS: 1,
+                    FTQCResourceQuantity.TOFFOLI_GATES: (
+                        block_encoding.walk_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.LOGICAL_DEPTH: (
+                        block_encoding.walk_cost_toffoli
+                    ),
+                    FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME: walk_spacetime,
+                    FTQCResourceQuantity.LOGICAL_QUBITS: logical_qubits,
+                },
+                repetitions=qpe_iterations,
+                label="Repeated qubitized walk",
+            ),
+        ),
+        title=title or f"Qubitized QPE plan: {block_encoding.name}",
+    )
 
 
 def estimate_qubitized_qpe_from_block_encoding(

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -49,6 +49,7 @@ from qamomile.circuit.estimator.algorithmic import (
 from qamomile.circuit.estimator.algorithmic.ftqc_block_encoding import (
     BlockEncodingResource,
     estimate_qubitized_qpe_from_block_encoding,
+    plan_qubitized_qpe_from_block_encoding,
 )
 
 
@@ -464,6 +465,64 @@ def test_block_encoding_estimates_expose_formula_provenance():
     assert formulas[FTQCResourceQuantity.QPE_ITERATIONS].reference_keys == (
         "arXiv:1610.06546",
     )
+
+
+def test_block_encoding_qpe_plan_matches_logical_estimate_resources():
+    """Block-encoding plans expose subroutines matching logical estimates."""
+    block = BlockEncodingResource(
+        system_qubits=4,
+        normalization=100,
+        select_cost_toffoli=7,
+        prepare_cost_toffoli=5,
+        reflection_cost_toffoli=3,
+        ancilla_qubits=2,
+        name="toy_block",
+    )
+
+    plan = plan_qubitized_qpe_from_block_encoding(
+        block,
+        precision=2,
+        qpe_register_qubits=3,
+    )
+    estimate = estimate_qubitized_qpe_from_block_encoding(
+        block,
+        precision=2,
+        qpe_register_qubits=3,
+    )
+    plan_values = plan.resource_values()
+
+    assert len(plan.steps) == 2
+    assert plan.steps[0].name == "block_encoding_contract"
+    assert plan.steps[1].name == "qubitized_walk_qpe"
+    assert plan.steps[1].repetitions == 50
+    assert plan_values[FTQCResourceQuantity.QPE_ITERATIONS] == (estimate.qpe_iterations)
+    assert plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == estimate.toffoli_gates
+    assert plan_values[FTQCResourceQuantity.LOGICAL_DEPTH] == estimate.logical_depth
+    assert plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == (estimate.logical_qubits)
+    assert plan_values[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME] == (
+        estimate.logical_qubits * estimate.logical_depth
+    )
+    assert plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 20
+    assert plan.to_dict()["steps"][1]["label"] == "Repeated qubitized walk"
+
+
+def test_block_encoding_qpe_plan_rejects_invalid_precision_inputs():
+    """Block-encoding QPE plans reject invalid precision and readout sizes."""
+    block = BlockEncodingResource(
+        system_qubits=4,
+        normalization=100,
+        select_cost_toffoli=7,
+    )
+
+    with pytest.raises(ValueError, match="precision"):
+        plan_qubitized_qpe_from_block_encoding(block, precision=0)
+
+    with pytest.raises(ValueError, match="qpe_register_qubits"):
+        plan_qubitized_qpe_from_block_encoding(
+            block,
+            precision=1,
+            qpe_register_qubits=-1,
+        )
 
 
 def test_surface_code_model_exposes_raw_and_derived_resource_values():


### PR DESCRIPTION
## Summary
- Add a block-encoding QPE resource-plan builder that separates the block-encoding contract from the repeated qubitized-walk step.
- Re-export the helper from the algorithmic estimator API.
- Extend the FTQC resource-estimation design notebook in English and Japanese with the block-encoding plan workflow.

## Checks
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- uv run python docs/en/usage/ftqc_resource_estimation_design.py
- uv run python docs/ja/usage/ftqc_resource_estimation_design.py
- uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design'
- uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py
- git diff --check

Note: the local-review skill still lists an older zuban invocation, uv run zuban qamomile/, which the current CLI rejects. The repository-standard uv run zuban check qamomile/ command passed.