### PR TITLE
Preserve FTQC resource plan provenance

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9e787469",
+   "id": "a593d9ea",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6a88d964",
+   "id": "b4fc6968",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:13.436273Z",
-     "iopub.status.busy": "2026-06-23T05:10:13.436100Z",
-     "iopub.status.idle": "2026-06-23T05:10:13.441311Z",
-     "shell.execute_reply": "2026-06-23T05:10:13.440193Z"
+     "iopub.execute_input": "2026-06-23T05:27:59.822317Z",
+     "iopub.status.busy": "2026-06-23T05:27:59.821273Z",
+     "iopub.status.idle": "2026-06-23T05:27:59.832130Z",
+     "shell.execute_reply": "2026-06-23T05:27:59.831136Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "be3c78f0",
+   "id": "ed0d924c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:13.444666Z",
-     "iopub.status.busy": "2026-06-23T05:10:13.444414Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.156562Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.155782Z"
+     "iopub.execute_input": "2026-06-23T05:27:59.837796Z",
+     "iopub.status.busy": "2026-06-23T05:27:59.837574Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.105409Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.103471Z"
     }
    },
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73dd5419",
+   "id": "a1603bf0",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29b2b65c",
+   "id": "56ae7688",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -132,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8943a315",
+   "id": "c72c6459",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.159235Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.159040Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.163251Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.162555Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.113162Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.111726Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.123333Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.119094Z"
     }
    },
    "outputs": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5c7ec7a",
+   "id": "c4ae8fc6",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -181,13 +181,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "aa2bcfb0",
+   "id": "42d357d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.165795Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.165662Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.171068Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.170478Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.131992Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.131521Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.144139Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.140325Z"
     }
    },
    "outputs": [
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f08dd3b",
+   "id": "2cede022",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -292,13 +292,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "00477e4c",
+   "id": "5d5e9e40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.173075Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.172945Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.177376Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.176053Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.150195Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.149927Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.164951Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.156511Z"
     }
    },
    "outputs": [
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8948b53",
+   "id": "0fcbbf34",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -343,13 +343,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e652ff01",
+   "id": "564b99b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.179957Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.179816Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.189457Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.188624Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.172647Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.172182Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.216245Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.212783Z"
     }
    },
    "outputs": [
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "018e68ec",
+   "id": "0c52433e",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -421,13 +421,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "d7137ec4",
+   "id": "44d84c74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.191498Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.191336Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.195764Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.195120Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.221639Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.221426Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.238593Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.237549Z"
     }
    },
    "outputs": [],
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c52969c6",
+   "id": "f0ef2820",
    "metadata": {},
    "source": [
     "A block-encoding model can also produce a plan directly. The plan separates\n",
@@ -464,13 +464,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "96c793c5",
+   "id": "e7f96544",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.197604Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.197495Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.206125Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.205245Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.246423Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.246157Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.381682Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.377710Z"
     }
    },
    "outputs": [
@@ -478,8 +478,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "block_encoding_contract 1\n",
-      "qubitized_walk_qpe 133333333.333333\n"
+      "block_encoding_contract"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1\n",
+      "qubitized_walk_qpe 133333333.333333\n",
+      "walk_cost_toffoli <- prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "qpe_iterations <- lambda_norm, target_precision\n",
+      "toffoli_gates <- qpe_iterations, walk_cost_toffoli\n",
+      "logical_depth <- toffoli_gates\n",
+      "logical_spacetime_volume <- logical_qubits, logical_depth\n"
      ]
     }
    ],
@@ -503,18 +515,67 @@
     "for step in block_plan.to_dict()[\"steps\"]:\n",
     "    print(step[\"name\"], step[\"repetitions\"])\n",
     "\n",
+    "for formula in block_plan.to_dict()[\"formulas\"]:\n",
+    "    print(formula[\"quantity\"], \"<-\", \", \".join(formula[\"depends_on\"]))\n",
+    "\n",
     "assert block_plan.steps[0].name == \"block_encoding_contract\"\n",
     "assert block_plan.steps[1].name == \"qubitized_walk_qpe\"\n",
     "assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100\n",
     "assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132\n",
     "assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
     "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100\n",
-    ")"
+    ")\n",
+    "assert block_plan.reference_keys() == (\"arXiv:1610.06546\",)\n",
+    "assert block_plan.to_dict()[\"formulas\"][0][\"quantity\"] == \"walk_cost_toffoli\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dcb608cf",
+   "id": "948cf2c4",
+   "metadata": {},
+   "source": [
+    "Plan provenance is intentionally separate from circuit lowering. A review can\n",
+    "inspect derivation formulas and citation keys before deciding whether a\n",
+    "PREPARE/SELECT implementation should become a concrete Qamomile kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "84e16580",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:28:05.386336Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.385959Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.404801Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.402410Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:1610.06546']\n",
+      "Compose one qubitized walk from PREPARE, inverse PREPARE, SELECT, and reflection costs.\n"
+     ]
+    }
+   ],
+   "source": [
+    "block_plan_dict = block_plan.to_dict()\n",
+    "\n",
+    "print(block_plan_dict[\"reference_keys\"])\n",
+    "print(block_plan_dict[\"steps\"][0][\"formulas\"][0][\"description\"])\n",
+    "\n",
+    "assert block_plan_dict[\"reference_keys\"] == [\"arXiv:1610.06546\"]\n",
+    "assert block_plan_dict[\"steps\"][0][\"formulas\"][0][\"reference_keys\"] == [\n",
+    "    \"arXiv:1610.06546\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa999c09",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -526,14 +587,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "86b4afd7",
+   "execution_count": 10,
+   "id": "83a8dfeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.208584Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.208455Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.285694Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.282121Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.409798Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.409077Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.488972Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.488085Z"
     }
    },
    "outputs": [
@@ -669,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7870e24",
+   "id": "1d88b14a",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -679,14 +740,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "38ada641",
+   "execution_count": 11,
+   "id": "89fae04c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.289541Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.289384Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.299681Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.297245Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.497736Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.497423Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.517551Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.516533Z"
     }
    },
    "outputs": [
@@ -732,7 +793,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15219776",
+   "id": "7fa53b49",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -743,14 +804,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "a6bec258",
+   "execution_count": 12,
+   "id": "58369830",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.302105Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.301955Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.316782Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.314478Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.525460Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.523863Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.549298Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.546672Z"
     }
    },
    "outputs": [
@@ -801,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a2e9a84",
+   "id": "3cb76753",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -814,14 +875,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "026e383a",
+   "execution_count": 13,
+   "id": "68596631",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.319262Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.318992Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.327126Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.326047Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.553266Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.553053Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.567797Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.566503Z"
     }
    },
    "outputs": [
@@ -847,7 +908,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bb22386",
+   "id": "89609a87",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -860,14 +921,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "ccd4b3af",
+   "execution_count": 14,
+   "id": "61fed7c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.329522Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.329266Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.337139Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.336110Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.572717Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.572476Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.585389Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.584262Z"
     }
    },
    "outputs": [
@@ -875,7 +936,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QPE iterations = lambda_norm/target_precision\n",
+      "QPE iterations"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " = lambda_norm/target_precision\n",
       "Toffoli gates = qpe_iterations*walk_cost_toffoli\n",
       "Runtime = Max(logical_cycle_time_seconds*logical_depth, toffoli_gates/toffoli_throughput_per_second)\n"
      ]
@@ -900,7 +968,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab852bf3",
+   "id": "f01e61cd",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -913,14 +981,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "0c6e591b",
+   "execution_count": 15,
+   "id": "473962ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.339337Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.339221Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.345142Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.343874Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.590077Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.589512Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.603191Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.601691Z"
     }
    },
    "outputs": [
@@ -956,7 +1024,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3cc0fb3",
+   "id": "3621dc6f",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -967,14 +1035,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "fa1f6132",
+   "execution_count": 16,
+   "id": "6d76c02d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.349768Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.348754Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.360898Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.360062Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.607277Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.607033Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.632888Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.623261Z"
     }
    },
    "outputs": [
@@ -1021,7 +1089,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efea0790",
+   "id": "7719c4a4",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -1032,14 +1100,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "a0d47a73",
+   "execution_count": 17,
+   "id": "81aae241",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.363185Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.363057Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.386959Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.385782Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.636213Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.635705Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.673520Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.672235Z"
     }
    },
    "outputs": [
@@ -1087,7 +1155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89573d3f",
+   "id": "998ea498",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1100,14 +1168,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "6dbd854e",
+   "execution_count": 18,
+   "id": "56ec1542",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.390028Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.389877Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.396774Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.395712Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.682770Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.682457Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.700867Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.697387Z"
     }
    },
    "outputs": [
@@ -1158,7 +1226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8f78f18",
+   "id": "151c84ba",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1183,7 +1251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b748e12",
+   "id": "b174c98f",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -270,6 +270,9 @@ block_plan_values = block_plan.resource_values()
 for step in block_plan.to_dict()["steps"]:
     print(step["name"], step["repetitions"])
 
+for formula in block_plan.to_dict()["formulas"]:
+    print(formula["quantity"], "<-", ", ".join(formula["depends_on"]))
+
 assert block_plan.steps[0].name == "block_encoding_contract"
 assert block_plan.steps[1].name == "qubitized_walk_qpe"
 assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100
@@ -277,6 +280,24 @@ assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132
 assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
     block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100
 )
+assert block_plan.reference_keys() == ("arXiv:1610.06546",)
+assert block_plan.to_dict()["formulas"][0]["quantity"] == "walk_cost_toffoli"
+
+# %% [markdown]
+# Plan provenance is intentionally separate from circuit lowering. A review can
+# inspect derivation formulas and citation keys before deciding whether a
+# PREPARE/SELECT implementation should become a concrete Qamomile kernel.
+
+# %%
+block_plan_dict = block_plan.to_dict()
+
+print(block_plan_dict["reference_keys"])
+print(block_plan_dict["steps"][0]["formulas"][0]["description"])
+
+assert block_plan_dict["reference_keys"] == ["arXiv:1610.06546"]
+assert block_plan_dict["steps"][0]["formulas"][0]["reference_keys"] == [
+    "arXiv:1610.06546"
+]
 
 # %% [markdown]
 # ## Minimal Example

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fc52cdc1",
+   "id": "c2a93a02",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "15708445",
+   "id": "adcdb61f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:13.436638Z",
-     "iopub.status.busy": "2026-06-23T05:10:13.436490Z",
-     "iopub.status.idle": "2026-06-23T05:10:13.441026Z",
-     "shell.execute_reply": "2026-06-23T05:10:13.439953Z"
+     "iopub.execute_input": "2026-06-23T05:27:59.821355Z",
+     "iopub.status.busy": "2026-06-23T05:27:59.820730Z",
+     "iopub.status.idle": "2026-06-23T05:27:59.832726Z",
+     "shell.execute_reply": "2026-06-23T05:27:59.831351Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "14c63a4b",
+   "id": "5c50aa99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:13.444521Z",
-     "iopub.status.busy": "2026-06-23T05:10:13.444243Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.156505Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.155777Z"
+     "iopub.execute_input": "2026-06-23T05:27:59.838559Z",
+     "iopub.status.busy": "2026-06-23T05:27:59.838257Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.104901Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.103513Z"
     }
    },
    "outputs": [],
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f490df45",
+   "id": "2bb14d3e",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ff112a6",
+   "id": "fffcf4aa",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -118,13 +118,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fc2d498a",
+   "id": "6635f501",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.159514Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.159319Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.163834Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.162740Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.111660Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.111206Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.123357Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.119607Z"
     }
    },
    "outputs": [
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "235ac924",
+   "id": "f25ea3ff",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -166,13 +166,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "03015856",
+   "id": "6bea509b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.166260Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.166139Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.171723Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.171154Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.131788Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.131452Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.144897Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.140256Z"
     }
    },
    "outputs": [
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f89112e0",
+   "id": "2cccfb10",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -275,13 +275,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c146f4b5",
+   "id": "0a6172dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.173589Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.173468Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.178587Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.177744Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.150552Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.150277Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.167610Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.160821Z"
     }
    },
    "outputs": [
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "639aceb9",
+   "id": "6081d590",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -322,13 +322,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "45c5a56f",
+   "id": "3da6c0f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.181406Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.181195Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.190354Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.189587Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.173491Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.173201Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.216182Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.212605Z"
     }
    },
    "outputs": [
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8adc94c2",
+   "id": "2b7fb49b",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -397,13 +397,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3cbb095e",
+   "id": "70923a93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.192218Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.192078Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.196398Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.195829Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.221639Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.221411Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.238659Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.237521Z"
     }
    },
    "outputs": [],
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9369325b",
+   "id": "a4dbf5bf",
    "metadata": {},
    "source": [
     "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
@@ -437,13 +437,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "dbb4340d",
+   "id": "17e50a7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.198713Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.198600Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.207049Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.206174Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.246331Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.245920Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.382073Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.378012Z"
     }
    },
    "outputs": [
@@ -451,8 +451,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "block_encoding_contract 1\n",
-      "qubitized_walk_qpe 133333333.333333\n"
+      "block_encoding_contract"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1\n",
+      "qubitized_walk_qpe 133333333.333333\n",
+      "walk_cost_toffoli <- prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "qpe_iterations <- lambda_norm, target_precision\n",
+      "toffoli_gates <- qpe_iterations, walk_cost_toffoli\n",
+      "logical_depth <- toffoli_gates\n",
+      "logical_spacetime_volume <- logical_qubits, logical_depth\n"
      ]
     }
    ],
@@ -476,18 +488,65 @@
     "for step in block_plan.to_dict()[\"steps\"]:\n",
     "    print(step[\"name\"], step[\"repetitions\"])\n",
     "\n",
+    "for formula in block_plan.to_dict()[\"formulas\"]:\n",
+    "    print(formula[\"quantity\"], \"<-\", \", \".join(formula[\"depends_on\"]))\n",
+    "\n",
     "assert block_plan.steps[0].name == \"block_encoding_contract\"\n",
     "assert block_plan.steps[1].name == \"qubitized_walk_qpe\"\n",
     "assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100\n",
     "assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132\n",
     "assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
     "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100\n",
-    ")"
+    ")\n",
+    "assert block_plan.reference_keys() == (\"arXiv:1610.06546\",)\n",
+    "assert block_plan.to_dict()[\"formulas\"][0][\"quantity\"] == \"walk_cost_toffoli\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5a50e5b0",
+   "id": "a83b011b",
+   "metadata": {},
+   "source": [
+    "plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f0767a4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:28:05.386310Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.386049Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.404979Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.403030Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:1610.06546']\n",
+      "Compose one qubitized walk from PREPARE, inverse PREPARE, SELECT, and reflection costs.\n"
+     ]
+    }
+   ],
+   "source": [
+    "block_plan_dict = block_plan.to_dict()\n",
+    "\n",
+    "print(block_plan_dict[\"reference_keys\"])\n",
+    "print(block_plan_dict[\"steps\"][0][\"formulas\"][0][\"description\"])\n",
+    "\n",
+    "assert block_plan_dict[\"reference_keys\"] == [\"arXiv:1610.06546\"]\n",
+    "assert block_plan_dict[\"steps\"][0][\"formulas\"][0][\"reference_keys\"] == [\n",
+    "    \"arXiv:1610.06546\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2986b2f",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -497,14 +556,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "e9125e27",
+   "execution_count": 10,
+   "id": "72e5c926",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.209811Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.209600Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.285120Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.282845Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.409915Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.409067Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.487667Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.485935Z"
     }
    },
    "outputs": [
@@ -640,7 +699,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fde38cd",
+   "id": "7cfb3cd4",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -648,14 +707,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "7644bc86",
+   "execution_count": 11,
+   "id": "abbd047a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.289235Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.288928Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.299669Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.297236Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.493753Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.492840Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.515709Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.513824Z"
     }
    },
    "outputs": [
@@ -701,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4547fd43",
+   "id": "75396664",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -709,14 +768,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f2dd0ab3",
+   "execution_count": 12,
+   "id": "063fdb78",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.301908Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.301781Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.315570Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.313852Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.520545Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.519976Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.548345Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.545495Z"
     }
    },
    "outputs": [
@@ -767,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0213db5d",
+   "id": "bf351f85",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -777,14 +836,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "9580d873",
+   "execution_count": 13,
+   "id": "12184e2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.318840Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.318554Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.325068Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.323970Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.553235Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.552727Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.566750Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.564938Z"
     }
    },
    "outputs": [
@@ -810,7 +869,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2bc2eb6",
+   "id": "6ca4f227",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -820,14 +879,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "ab8feacb",
+   "execution_count": 14,
+   "id": "4d16237b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.328144Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.327998Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.335647Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.334647Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.571834Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.571595Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.584482Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.583308Z"
     }
    },
    "outputs": [
@@ -860,7 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0dfcc3a1",
+   "id": "beda9cab",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -870,14 +929,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "79f4fa48",
+   "execution_count": 15,
+   "id": "9ebc2905",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.338129Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.337987Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.343259Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.341506Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.588642Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.588383Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.603291Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.601696Z"
     }
    },
    "outputs": [
@@ -913,7 +972,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23a9b35a",
+   "id": "0e3dca88",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -923,14 +982,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "d5c66ffe",
+   "execution_count": 16,
+   "id": "89f5c596",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.347081Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.346852Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.359904Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.358894Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.607687Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.607441Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.633366Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.628657Z"
     }
    },
    "outputs": [
@@ -977,7 +1036,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51820428",
+   "id": "9223512c",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -987,14 +1046,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "d84de2a6",
+   "execution_count": 17,
+   "id": "5b28c3d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.362376Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.362250Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.387280Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.386285Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.636936Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.636619Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.673391Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.672238Z"
     }
    },
    "outputs": [
@@ -1042,7 +1101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98e59ac7",
+   "id": "fa9cf610",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -1052,14 +1111,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "4d44826b",
+   "execution_count": 18,
+   "id": "32addccb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:10:14.390288Z",
-     "iopub.status.busy": "2026-06-23T05:10:14.390123Z",
-     "iopub.status.idle": "2026-06-23T05:10:14.397208Z",
-     "shell.execute_reply": "2026-06-23T05:10:14.396227Z"
+     "iopub.execute_input": "2026-06-23T05:28:05.682211Z",
+     "iopub.status.busy": "2026-06-23T05:28:05.681918Z",
+     "iopub.status.idle": "2026-06-23T05:28:05.701173Z",
+     "shell.execute_reply": "2026-06-23T05:28:05.698170Z"
     }
    },
    "outputs": [
@@ -1067,7 +1126,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "satisfied Early-FTQC physical-qubit budget margin: 4.384e+4\n",
+      "satisfied"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Early-FTQC physical-qubit budget margin: 4.384e+4\n",
       "violated One-hour runtime budget margin: -1.656e+4\n",
       "satisfied No worse than plain Trotter depth margin: 2.432e+11\n"
      ]
@@ -1110,7 +1176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "515c57ba",
+   "id": "a6f65369",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1129,7 +1195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "454ee38d",
+   "id": "b28f6baa",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -243,6 +243,9 @@ block_plan_values = block_plan.resource_values()
 for step in block_plan.to_dict()["steps"]:
     print(step["name"], step["repetitions"])
 
+for formula in block_plan.to_dict()["formulas"]:
+    print(formula["quantity"], "<-", ", ".join(formula["depends_on"]))
+
 assert block_plan.steps[0].name == "block_encoding_contract"
 assert block_plan.steps[1].name == "qubitized_walk_qpe"
 assert block_plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 5100
@@ -250,6 +253,22 @@ assert block_plan_values[FTQCResourceQuantity.LOGICAL_QUBITS] == 132
 assert block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
     block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5100
 )
+assert block_plan.reference_keys() == ("arXiv:1610.06546",)
+assert block_plan.to_dict()["formulas"][0]["quantity"] == "walk_cost_toffoli"
+
+# %% [markdown]
+# plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。
+
+# %%
+block_plan_dict = block_plan.to_dict()
+
+print(block_plan_dict["reference_keys"])
+print(block_plan_dict["steps"][0]["formulas"][0]["description"])
+
+assert block_plan_dict["reference_keys"] == ["arXiv:1610.06546"]
+assert block_plan_dict["steps"][0]["formulas"][0]["reference_keys"] == [
+    "arXiv:1610.06546"
+]
 
 # %% [markdown]
 # ## 最小例

--- a/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_block_encoding.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import sympy as sp
 
@@ -420,6 +420,14 @@ def plan_qubitized_qpe_from_block_encoding(
     qpe_iterations = sp.simplify(block_encoding._normalization / precision_expr)
     logical_qubits = sp.simplify(block_encoding.logical_qubits + qpe_qubits)
     walk_spacetime = sp.simplify(logical_qubits * block_encoding.walk_cost_toffoli)
+    formulas_by_quantity = {
+        cast(FTQCResourceQuantity, formula.quantity): formula
+        for formula in _block_encoding_qpe_formulas()
+    }
+    block_reference_keys = (
+        _QUBITIZATION_REFERENCE.key,
+        *(reference.key for reference in block_encoding.references),
+    )
 
     return FTQCResourcePlan(
         (
@@ -448,6 +456,11 @@ def plan_qubitized_qpe_from_block_encoding(
                     FTQCResourceQuantity.LOGICAL_QUBITS: logical_qubits,
                 },
                 label="Block-encoding contract",
+                formulas=(
+                    formulas_by_quantity[FTQCResourceQuantity.WALK_COST_TOFFOLI],
+                    formulas_by_quantity[FTQCResourceQuantity.QPE_ITERATIONS],
+                ),
+                reference_keys=block_reference_keys,
             ),
             FTQCResourcePlanStep(
                 "qubitized_walk_qpe",
@@ -464,6 +477,12 @@ def plan_qubitized_qpe_from_block_encoding(
                 },
                 repetitions=qpe_iterations,
                 label="Repeated qubitized walk",
+                formulas=(
+                    formulas_by_quantity[FTQCResourceQuantity.TOFFOLI_GATES],
+                    formulas_by_quantity[FTQCResourceQuantity.LOGICAL_DEPTH],
+                    formulas_by_quantity[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],
+                ),
+                reference_keys=(_QUBITIZATION_REFERENCE.key,),
             ),
         ),
         title=title or f"Qubitized QPE plan: {block_encoding.name}",

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import sympy as sp
 
@@ -709,10 +709,15 @@ class FTQCResourcePlanStep:
             override for this step. Defaults to canonical quantity rules.
         label (str): Optional reader-facing subroutine label. Defaults to
             ``name`` when serialized.
+        formulas (tuple[FTQCResourceFormula, ...]): Symbolic formulas that
+            justify this step's resources. Defaults to an empty tuple.
+        reference_keys (tuple[str, ...]): Research or design-reference keys
+            supporting this step. Defaults to an empty tuple.
 
     Raises:
         TypeError: If ``resources`` or ``repetitions`` cannot be converted to
-            SymPy expressions.
+            SymPy expressions, if ``formulas`` contains non-formula items, or
+            if ``reference_keys`` contains non-string items.
         ValueError: If a quantity or aggregation rule is unknown, or if
             ``repetitions`` is negative when decidable.
 
@@ -737,15 +742,25 @@ class FTQCResourcePlanStep:
         | None
     ) = None
     label: str = ""
+    formulas: tuple[FTQCResourceFormula, ...] = ()
+    reference_keys: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Normalize step fields after dataclass construction.
 
         Raises:
-            TypeError: If resource values cannot be sympified.
+            TypeError: If resource values cannot be sympified, formulas are
+                not ``FTQCResourceFormula`` instances, or reference keys are
+                not strings.
             ValueError: If a closed-set key is unknown or repetitions are
                 negative when decidable.
         """
+        if not all(
+            isinstance(formula, FTQCResourceFormula) for formula in self.formulas
+        ):
+            raise TypeError("formulas must contain only FTQCResourceFormula instances.")
+        if not all(isinstance(key, str) for key in self.reference_keys):
+            raise TypeError("reference_keys must contain only strings.")
         normalized_resources = {
             _normalize_resource_quantity(quantity): _sympify_resource_expr(
                 value,
@@ -764,6 +779,8 @@ class FTQCResourcePlanStep:
         object.__setattr__(self, "resources", normalized_resources)
         object.__setattr__(self, "repetitions", repetitions)
         object.__setattr__(self, "aggregation", normalized_aggregation)
+        object.__setattr__(self, "formulas", tuple(self.formulas))
+        object.__setattr__(self, "reference_keys", tuple(self.reference_keys))
 
     def aggregation_rule_for(
         self,
@@ -809,12 +826,12 @@ class FTQCResourcePlanStep:
                 values[quantity] = value
         return values
 
-    def to_dict(self) -> dict[str, str | list[dict[str, str]]]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the plan step.
 
         Returns:
-            dict[str, str | list[dict[str, str]]]: JSON-friendly subroutine
-                metadata and resource values.
+            dict[str, Any]: JSON-friendly subroutine metadata, resource
+                values, formulas, and references.
         """
         rows = []
         resources = cast(dict[FTQCResourceQuantity, sp.Expr], self.resources)
@@ -837,6 +854,8 @@ class FTQCResourcePlanStep:
             "label": self.label or self.name,
             "repetitions": str(self.repetitions),
             "resources": rows,
+            "formulas": [formula.to_dict() for formula in self.formulas],
+            "reference_keys": list(self.reference_keys),
         }
 
 
@@ -955,6 +974,69 @@ class FTQCResourcePlan:
                 )
         return values
 
+    def formulas(self) -> tuple[FTQCResourceFormula, ...]:
+        """Return step formulas with duplicate formulas removed.
+
+        Formulas are deduplicated by their serialized content while preserving
+        the first occurrence. This keeps report metadata compact when multiple
+        steps cite the same derivation.
+
+        Returns:
+            tuple[FTQCResourceFormula, ...]: Formulas referenced by plan steps.
+        """
+        formulas: list[FTQCResourceFormula] = []
+        seen: set[
+            tuple[str, str, tuple[FTQCResourceQuantity, ...], str, tuple[str, ...]]
+        ] = set()
+        for step in self.steps:
+            for formula in step.formulas:
+                quantity = cast(FTQCResourceQuantity, formula.quantity)
+                depends_on = cast(tuple[FTQCResourceQuantity, ...], formula.depends_on)
+                key = (
+                    quantity.value,
+                    str(formula.expression),
+                    depends_on,
+                    formula.description,
+                    formula.reference_keys,
+                )
+                if key in seen:
+                    continue
+                formulas.append(formula)
+                seen.add(key)
+        return tuple(formulas)
+
+    def reference_keys(self) -> tuple[str, ...]:
+        """Return reference keys used by plan steps and formulas.
+
+        Returns:
+            tuple[str, ...]: Deduplicated reference keys preserving first-seen
+                order.
+        """
+        references: list[str] = []
+        seen: set[str] = set()
+        for step in self.steps:
+            for key in (*step.reference_keys, *self._formula_reference_keys(step)):
+                if key in seen:
+                    continue
+                references.append(key)
+                seen.add(key)
+        return tuple(references)
+
+    def _formula_reference_keys(
+        self,
+        step: FTQCResourcePlanStep,
+    ) -> tuple[str, ...]:
+        """Return reference keys cited by one plan step's formulas.
+
+        Args:
+            step (FTQCResourcePlanStep): Step whose formulas should be
+                inspected.
+
+        Returns:
+            tuple[str, ...]: Reference keys cited by the step's formulas.
+        """
+        return tuple(key for formula in step.formulas for key in formula.reference_keys)
+
     def to_quantity_table(self) -> list[dict[str, str]]:
         """Return aggregate plan resources as table rows.
 
@@ -983,17 +1065,12 @@ class FTQCResourcePlan:
             )
         return rows
 
-    def to_dict(
-        self,
-    ) -> dict[
-        str, str | list[dict[str, str]] | list[dict[str, str | list[dict[str, str]]]]
-    ]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the resource plan.
 
         Returns:
-            dict[str, str | list[dict[str, str]] | list[dict[str, str |
-                list[dict[str, str]]]]]: JSON-friendly plan metadata, steps,
-                and aggregate resource rows.
+            dict[str, Any]: JSON-friendly plan metadata, steps, aggregate
+                resource rows, formulas, and references.
 
         Raises:
             ValueError: If a consistent quantity has conflicting values across
@@ -1003,6 +1080,8 @@ class FTQCResourcePlan:
             "title": self.title,
             "steps": [step.to_dict() for step in self.steps],
             "resources": self.to_quantity_table(),
+            "formulas": [formula.to_dict() for formula in self.formulas()],
+            "reference_keys": list(self.reference_keys()),
         }
 
 

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -265,6 +265,8 @@ def test_ftqc_resource_plan_composes_abstract_subroutines():
     )
     assert plan.to_quantity_table()[0]["quantity"] == "target_precision"
     assert plan.to_dict()["steps"][0]["label"] == "State preparation and filtering"
+    assert plan.formulas() == ()
+    assert plan.reference_keys() == ()
 
     budget = evaluate_ftqc_resource_constraints(
         plan,
@@ -344,6 +346,61 @@ def test_ftqc_resource_plan_rejects_invalid_composition_inputs():
 
     with pytest.raises(TypeError, match="FTQCResourcePlanStep"):
         FTQCResourcePlan((object(),))  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="formulas"):
+        FTQCResourcePlanStep(
+            "bad",
+            {"toffoli_gates": 1},
+            formulas=(object(),),  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(TypeError, match="reference_keys"):
+        FTQCResourcePlanStep(
+            "bad",
+            {"toffoli_gates": 1},
+            reference_keys=(object(),),  # type: ignore[arg-type]
+        )
+
+
+def test_ftqc_resource_plan_serializes_step_provenance():
+    """Plans preserve formulas and reference keys for review reports."""
+    formula = FTQCResourceFormula(
+        quantity="toffoli_gates",
+        expression=sp.Symbol("qpe_iterations") * sp.Symbol("walk_cost_toffoli"),
+        depends_on=("qpe_iterations", "walk_cost_toffoli"),
+        description="Multiply walk calls by per-walk Toffoli cost.",
+        reference_keys=("arXiv:1610.06546",),
+    )
+    repeated_formula = FTQCResourceFormula(
+        quantity="toffoli_gates",
+        expression=sp.Symbol("qpe_iterations") * sp.Symbol("walk_cost_toffoli"),
+        depends_on=("qpe_iterations", "walk_cost_toffoli"),
+        description="Multiply walk calls by per-walk Toffoli cost.",
+        reference_keys=("arXiv:1610.06546",),
+    )
+    prepare = FTQCResourcePlanStep(
+        "prepare",
+        {"toffoli_gates": 10},
+        formulas=(formula,),
+        reference_keys=("internal:loader",),
+    )
+    walk = FTQCResourcePlanStep(
+        "walk",
+        {"toffoli_gates": 20},
+        formulas=(repeated_formula,),
+        reference_keys=("arXiv:1610.06546",),
+    )
+    plan = FTQCResourcePlan((prepare, walk))
+
+    assert plan.formulas() == (formula,)
+    assert plan.reference_keys() == ("internal:loader", "arXiv:1610.06546")
+    serialized = plan.to_dict()
+    assert serialized["formulas"][0]["quantity"] == "toffoli_gates"
+    assert serialized["steps"][0]["formulas"][0]["depends_on"] == [
+        "qpe_iterations",
+        "walk_cost_toffoli",
+    ]
+    assert serialized["reference_keys"] == ["internal:loader", "arXiv:1610.06546"]
 
 
 def test_describe_ftqc_resource_quantity_normalizes_strings():
@@ -504,6 +561,17 @@ def test_block_encoding_qpe_plan_matches_logical_estimate_resources():
     )
     assert plan_values[FTQCResourceQuantity.WALK_COST_TOFFOLI] == 20
     assert plan.to_dict()["steps"][1]["label"] == "Repeated qubitized walk"
+    assert plan.reference_keys() == ("arXiv:1610.06546",)
+    assert [formula.quantity for formula in plan.formulas()] == [
+        FTQCResourceQuantity.WALK_COST_TOFFOLI,
+        FTQCResourceQuantity.QPE_ITERATIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+        FTQCResourceQuantity.LOGICAL_DEPTH,
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+    ]
+    assert plan.to_dict()["steps"][0]["formulas"][0]["quantity"] == (
+        "walk_cost_toffoli"
+    )
 
 
 def test_block_encoding_qpe_plan_rejects_invalid_precision_inputs():


### PR DESCRIPTION
## Summary
- attach formula metadata and reference keys to FTQC resource plan steps
- expose deduplicated plan-level formulas and reference keys in serialized plans
- thread block-encoding QPE derivation formulas into the generated resource plan
- update EN/JA FTQC resource design docs and executed notebooks

## Verification
- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design'`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run python docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run python docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `git diff --check`

## Local Review Note
- The local-review skill still lists the stale command `uv run zuban qamomile/`; it now fails with `unrecognized subcommand`. The current repo-standard command `uv run zuban check qamomile/` passed.
