### PR TITLE
Compose state-preparation FTQC plans

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a593d9ea",
+   "id": "ce3b9a32",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b4fc6968",
+   "id": "da0a1f95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:27:59.822317Z",
-     "iopub.status.busy": "2026-06-23T05:27:59.821273Z",
-     "iopub.status.idle": "2026-06-23T05:27:59.832130Z",
-     "shell.execute_reply": "2026-06-23T05:27:59.831136Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.283940Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.283847Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.286704Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.286180Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ed0d924c",
+   "id": "ee10b7f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:27:59.837796Z",
-     "iopub.status.busy": "2026-06-23T05:27:59.837574Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.105409Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.103471Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.288376Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.288294Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.590187Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.589531Z"
     }
    },
    "outputs": [],
@@ -64,6 +64,7 @@
     "    FTQCResourcePlanStep,\n",
     "    FTQCResourceProfile,\n",
     "    FTQCResourceQuantity,\n",
+    "    QPEStatePreparationBudget,\n",
     "    SurfaceCodeCostModel,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    build_ftqc_resource_comparison_report,\n",
@@ -84,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1603bf0",
+   "id": "e65e8a95",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -109,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56ae7688",
+   "id": "275d7caf",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -132,13 +133,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c72c6459",
+   "id": "e2be1728",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.113162Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.111726Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.123333Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.119094Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.592813Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.592546Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.605067Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.601123Z"
     }
    },
    "outputs": [
@@ -169,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4ae8fc6",
+   "id": "069e89ae",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -181,13 +182,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "42d357d6",
+   "id": "97924818",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.131992Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.131521Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.144139Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.140325Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.609481Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.609233Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.623964Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.622190Z"
     }
    },
    "outputs": [
@@ -281,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cede022",
+   "id": "cdd0028a",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -292,13 +293,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5d5e9e40",
+   "id": "49bf97de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.150195Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.149927Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.164951Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.156511Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.626552Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.626379Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.632539Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.630721Z"
     }
    },
    "outputs": [
@@ -328,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fcbbf34",
+   "id": "b0b52abc",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -343,13 +344,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "564b99b1",
+   "id": "de9a9da1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.172647Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.172182Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.216245Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.212783Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.634988Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.634828Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.646330Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.642190Z"
     }
    },
    "outputs": [
@@ -409,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c52433e",
+   "id": "0883f1d0",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -421,13 +422,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "44d84c74",
+   "id": "a7ec4627",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.221639Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.221426Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.238593Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.237549Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.650114Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.649891Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.655865Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.655095Z"
     }
    },
    "outputs": [],
@@ -452,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0ef2820",
+   "id": "f22eeb09",
    "metadata": {},
    "source": [
     "A block-encoding model can also produce a plan directly. The plan separates\n",
@@ -464,13 +465,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e7f96544",
+   "id": "c9566719",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.246423Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.246157Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.381682Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.377710Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.658078Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.657978Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.728175Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.727658Z"
     }
    },
    "outputs": [
@@ -478,14 +479,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "block_encoding_contract"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 1\n",
+      "block_encoding_contract 1\n",
       "qubitized_walk_qpe 133333333.333333\n",
       "walk_cost_toffoli <- prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
       "qpe_iterations <- lambda_norm, target_precision\n",
@@ -531,7 +525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "948cf2c4",
+   "id": "056d05cd",
    "metadata": {},
    "source": [
     "Plan provenance is intentionally separate from circuit lowering. A review can\n",
@@ -542,13 +536,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "84e16580",
+   "id": "e65b600a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.386336Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.385959Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.404801Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.402410Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.729695Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.729629Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.733964Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.733451Z"
     }
    },
    "outputs": [
@@ -575,7 +569,65 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa999c09",
+   "id": "9aa00654",
+   "metadata": {},
+   "source": [
+    "State-preparation success probability can be layered onto the same plan. This\n",
+    "keeps trial-state overlap or filtering assumptions visible without requiring\n",
+    "a concrete state-preparation circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "343dac57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:49:42.735092Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.735034Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.750487Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.750135Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "state_preparation_budget 1\n",
+      "repeated_qpe_attempt 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "preparation_budget = QPEStatePreparationBudget(\n",
+    "    success_probability=sp.Rational(1, 5),\n",
+    "    state_preparation_toffoli=100,\n",
+    "    state_preparation_t_gates=20,\n",
+    "    state_preparation_logical_depth=50,\n",
+    "    description=\"symmetry-filtered trial state\",\n",
+    ")\n",
+    "filtered_block_plan = preparation_budget.apply_to_plan(block_plan)\n",
+    "filtered_block_values = filtered_block_plan.resource_values()\n",
+    "\n",
+    "for step in filtered_block_plan.to_dict()[\"steps\"]:\n",
+    "    print(step[\"name\"], step[\"repetitions\"])\n",
+    "\n",
+    "assert filtered_block_values[FTQCResourceQuantity.QPE_REPETITIONS] == 5\n",
+    "assert filtered_block_values[FTQCResourceQuantity.QPE_ITERATIONS] == (\n",
+    "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5\n",
+    ")\n",
+    "assert filtered_block_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
+    "    (block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] + 100) * 5\n",
+    ")\n",
+    "assert filtered_block_values[FTQCResourceQuantity.LOGICAL_DEPTH] == (\n",
+    "    (block_plan_values[FTQCResourceQuantity.LOGICAL_DEPTH] + 50) * 5\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a627628",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -587,14 +639,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "83a8dfeb",
+   "execution_count": 11,
+   "id": "e3ce495d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.409798Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.409077Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.488972Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.488085Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.751799Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.751723Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.765911Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.765186Z"
     }
    },
    "outputs": [
@@ -730,7 +782,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d88b14a",
+   "id": "3762792b",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -740,14 +792,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "89fae04c",
+   "execution_count": 12,
+   "id": "35223425",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.497736Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.497423Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.517551Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.516533Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.767162Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.767077Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.771187Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.770806Z"
     }
    },
    "outputs": [
@@ -793,7 +845,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fa53b49",
+   "id": "a6743b75",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -804,14 +856,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "58369830",
+   "execution_count": 13,
+   "id": "40d3d81c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.525460Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.523863Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.549298Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.546672Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.772268Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.772210Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.777796Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.777225Z"
     }
    },
    "outputs": [
@@ -862,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cb76753",
+   "id": "0edb0c55",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -875,14 +927,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "68596631",
+   "execution_count": 14,
+   "id": "75e9c2be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.553266Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.553053Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.567797Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.566503Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.778990Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.778909Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.781344Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.780900Z"
     }
    },
    "outputs": [
@@ -908,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89609a87",
+   "id": "fb7d0c9c",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -921,14 +973,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "61fed7c1",
+   "execution_count": 15,
+   "id": "384d3068",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.572717Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.572476Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.585389Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.584262Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.782435Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.782363Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.785058Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.784697Z"
     }
    },
    "outputs": [
@@ -936,14 +988,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QPE iterations"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " = lambda_norm/target_precision\n",
+      "QPE iterations = lambda_norm/target_precision\n",
       "Toffoli gates = qpe_iterations*walk_cost_toffoli\n",
       "Runtime = Max(logical_cycle_time_seconds*logical_depth, toffoli_gates/toffoli_throughput_per_second)\n"
      ]
@@ -968,7 +1013,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f01e61cd",
+   "id": "a042a078",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -981,14 +1026,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "473962ad",
+   "execution_count": 16,
+   "id": "610d26cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.590077Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.589512Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.603191Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.601691Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.786148Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.786083Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.788195Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.787840Z"
     }
    },
    "outputs": [
@@ -1024,7 +1069,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3621dc6f",
+   "id": "97d15874",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -1035,14 +1080,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "6d76c02d",
+   "execution_count": 17,
+   "id": "ce601fff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.607277Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.607033Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.632888Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.623261Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.789256Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.789192Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.794301Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.793716Z"
     }
    },
    "outputs": [
@@ -1089,7 +1134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7719c4a4",
+   "id": "45f13065",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -1100,14 +1145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "81aae241",
+   "execution_count": 18,
+   "id": "06049833",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.636213Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.635705Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.673520Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.672235Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.795659Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.795576Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.803636Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.803082Z"
     }
    },
    "outputs": [
@@ -1155,7 +1200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "998ea498",
+   "id": "41f606d3",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1168,14 +1213,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "56ec1542",
+   "execution_count": 19,
+   "id": "3d5c4bf1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.682770Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.682457Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.700867Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.697387Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.804993Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.804918Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.808502Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.807952Z"
     }
    },
    "outputs": [
@@ -1226,7 +1271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "151c84ba",
+   "id": "cb643e97",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1251,7 +1296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b174c98f",
+   "id": "fb57d70c",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1270,6 +1315,8 @@
     "  circuit implementation exists.\n",
     "- `plan_qubitized_qpe_from_block_encoding` turns a block-encoding contract\n",
     "  into a PREPARE/SELECT/reflection/QPE resource plan.\n",
+    "- `QPEStatePreparationBudget.apply_to_plan` layers success probability and\n",
+    "  per-attempt preparation overhead onto an abstract QPE plan.\n",
     "- Qamomile keeps those quantities in algorithmic metadata so the circuit IR\n",
     "  remains backend-neutral.\n",
     "- Accuracy budgets split a total target precision into representation\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -44,6 +44,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCResourcePlanStep,
     FTQCResourceProfile,
     FTQCResourceQuantity,
+    QPEStatePreparationBudget,
     SurfaceCodeCostModel,
     SurfaceCodeDistanceBudget,
     build_ftqc_resource_comparison_report,
@@ -298,6 +299,36 @@ assert block_plan_dict["reference_keys"] == ["arXiv:1610.06546"]
 assert block_plan_dict["steps"][0]["formulas"][0]["reference_keys"] == [
     "arXiv:1610.06546"
 ]
+
+# %% [markdown]
+# State-preparation success probability can be layered onto the same plan. This
+# keeps trial-state overlap or filtering assumptions visible without requiring
+# a concrete state-preparation circuit.
+
+# %%
+preparation_budget = QPEStatePreparationBudget(
+    success_probability=sp.Rational(1, 5),
+    state_preparation_toffoli=100,
+    state_preparation_t_gates=20,
+    state_preparation_logical_depth=50,
+    description="symmetry-filtered trial state",
+)
+filtered_block_plan = preparation_budget.apply_to_plan(block_plan)
+filtered_block_values = filtered_block_plan.resource_values()
+
+for step in filtered_block_plan.to_dict()["steps"]:
+    print(step["name"], step["repetitions"])
+
+assert filtered_block_values[FTQCResourceQuantity.QPE_REPETITIONS] == 5
+assert filtered_block_values[FTQCResourceQuantity.QPE_ITERATIONS] == (
+    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5
+)
+assert filtered_block_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
+    (block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] + 100) * 5
+)
+assert filtered_block_values[FTQCResourceQuantity.LOGICAL_DEPTH] == (
+    (block_plan_values[FTQCResourceQuantity.LOGICAL_DEPTH] + 50) * 5
+)
 
 # %% [markdown]
 # ## Minimal Example
@@ -696,6 +727,8 @@ assert budget_report.to_dict()["counts"] == {
 #   circuit implementation exists.
 # - `plan_qubitized_qpe_from_block_encoding` turns a block-encoding contract
 #   into a PREPARE/SELECT/reflection/QPE resource plan.
+# - `QPEStatePreparationBudget.apply_to_plan` layers success probability and
+#   per-attempt preparation overhead onto an abstract QPE plan.
 # - Qamomile keeps those quantities in algorithmic metadata so the circuit IR
 #   remains backend-neutral.
 # - Accuracy budgets split a total target precision into representation

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c2a93a02",
+   "id": "b0ce2ec3",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "adcdb61f",
+   "id": "1aa8732f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:27:59.821355Z",
-     "iopub.status.busy": "2026-06-23T05:27:59.820730Z",
-     "iopub.status.idle": "2026-06-23T05:27:59.832726Z",
-     "shell.execute_reply": "2026-06-23T05:27:59.831351Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.284261Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.284176Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.286853Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.286182Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5c50aa99",
+   "id": "30747c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:27:59.838559Z",
-     "iopub.status.busy": "2026-06-23T05:27:59.838257Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.104901Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.103513Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.288328Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.288251Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.608676Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.606253Z"
     }
    },
    "outputs": [],
@@ -61,6 +61,7 @@
     "    FTQCResourcePlanStep,\n",
     "    FTQCResourceProfile,\n",
     "    FTQCResourceQuantity,\n",
+    "    QPEStatePreparationBudget,\n",
     "    SurfaceCodeCostModel,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    build_ftqc_resource_comparison_report,\n",
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bb14d3e",
+   "id": "703abee3",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -98,7 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fffcf4aa",
+   "id": "5cd57e97",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -118,13 +119,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6635f501",
+   "id": "0f8b6635",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.111660Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.111206Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.123357Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.119607Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.612592Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.612142Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.622558Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.617595Z"
     }
    },
    "outputs": [
@@ -155,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f25ea3ff",
+   "id": "da45e91d",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -166,13 +167,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6bea509b",
+   "id": "a008adba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.131788Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.131452Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.144897Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.140256Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.625608Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.625402Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.632472Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.630810Z"
     }
    },
    "outputs": [
@@ -266,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cccfb10",
+   "id": "c93edcc6",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -275,13 +276,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0a6172dd",
+   "id": "82ad933b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.150552Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.150277Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.167610Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.160821Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.634915Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.634749Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.640317Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.639336Z"
     }
    },
    "outputs": [
@@ -311,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6081d590",
+   "id": "01c3a4e8",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -322,13 +323,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3da6c0f8",
+   "id": "36b0f4a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.173491Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.173201Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.216182Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.212605Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.643202Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.642653Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.655213Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.654224Z"
     }
    },
    "outputs": [
@@ -388,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b7fb49b",
+   "id": "54cfd1bd",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -397,13 +398,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "70923a93",
+   "id": "85398fb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.221639Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.221411Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.238659Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.237521Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.657407Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.657326Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.660929Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.660230Z"
     }
    },
    "outputs": [],
@@ -428,7 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4dbf5bf",
+   "id": "fd974729",
    "metadata": {},
    "source": [
     "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
@@ -437,13 +438,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "17e50a7b",
+   "id": "4130be27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.246331Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.245920Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.382073Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.378012Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.664314Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.664070Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.731607Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.731214Z"
     }
    },
    "outputs": [
@@ -451,14 +452,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "block_encoding_contract"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 1\n",
+      "block_encoding_contract 1\n",
       "qubitized_walk_qpe 133333333.333333\n",
       "walk_cost_toffoli <- prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
       "qpe_iterations <- lambda_norm, target_precision\n",
@@ -504,7 +498,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a83b011b",
+   "id": "53863601",
    "metadata": {},
    "source": [
     "plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。"
@@ -513,13 +507,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f0767a4d",
+   "id": "8ddeec3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.386310Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.386049Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.404979Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.403030Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.732952Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.732884Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.736956Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.736333Z"
     }
    },
    "outputs": [
@@ -546,7 +540,63 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2986b2f",
+   "id": "46fb0660",
+   "metadata": {},
+   "source": [
+    "state-preparation success probabilityは、同じplanへ重ねられます。これにより、具体的なstate-preparation回路がなくても、trial-state overlapやfiltering仮定を見える形で保持できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "91b05af7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T05:49:42.738326Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.738253Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.754393Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.754009Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "state_preparation_budget 1\n",
+      "repeated_qpe_attempt 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "preparation_budget = QPEStatePreparationBudget(\n",
+    "    success_probability=sp.Rational(1, 5),\n",
+    "    state_preparation_toffoli=100,\n",
+    "    state_preparation_t_gates=20,\n",
+    "    state_preparation_logical_depth=50,\n",
+    "    description=\"symmetry-filtered trial state\",\n",
+    ")\n",
+    "filtered_block_plan = preparation_budget.apply_to_plan(block_plan)\n",
+    "filtered_block_values = filtered_block_plan.resource_values()\n",
+    "\n",
+    "for step in filtered_block_plan.to_dict()[\"steps\"]:\n",
+    "    print(step[\"name\"], step[\"repetitions\"])\n",
+    "\n",
+    "assert filtered_block_values[FTQCResourceQuantity.QPE_REPETITIONS] == 5\n",
+    "assert filtered_block_values[FTQCResourceQuantity.QPE_ITERATIONS] == (\n",
+    "    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5\n",
+    ")\n",
+    "assert filtered_block_values[FTQCResourceQuantity.TOFFOLI_GATES] == (\n",
+    "    (block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] + 100) * 5\n",
+    ")\n",
+    "assert filtered_block_values[FTQCResourceQuantity.LOGICAL_DEPTH] == (\n",
+    "    (block_plan_values[FTQCResourceQuantity.LOGICAL_DEPTH] + 50) * 5\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa19fefd",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -556,14 +606,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "72e5c926",
+   "execution_count": 11,
+   "id": "69a18b7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.409915Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.409067Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.487667Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.485935Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.755438Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.755376Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.769018Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.768634Z"
     }
    },
    "outputs": [
@@ -699,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cfb3cd4",
+   "id": "37eef33c",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -707,14 +757,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "abbd047a",
+   "execution_count": 12,
+   "id": "53b09448",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.493753Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.492840Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.515709Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.513824Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.770205Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.770138Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.774040Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.773704Z"
     }
    },
    "outputs": [
@@ -760,7 +810,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75396664",
+   "id": "69a94d5a",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -768,14 +818,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "063fdb78",
+   "execution_count": 13,
+   "id": "8dbbcb38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.520545Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.519976Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.548345Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.545495Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.775098Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.775045Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.780822Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.780443Z"
     }
    },
    "outputs": [
@@ -826,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf351f85",
+   "id": "a2cf03dc",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -836,14 +886,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "12184e2f",
+   "execution_count": 14,
+   "id": "c70a9864",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.553235Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.552727Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.566750Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.564938Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.782151Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.782075Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.784515Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.784009Z"
     }
    },
    "outputs": [
@@ -869,7 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ca4f227",
+   "id": "bf842ef2",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -879,14 +929,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "4d16237b",
+   "execution_count": 15,
+   "id": "5a7a3f9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.571834Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.571595Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.584482Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.583308Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.785578Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.785507Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.788340Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.787993Z"
     }
    },
    "outputs": [
@@ -919,7 +969,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "beda9cab",
+   "id": "9dab3979",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -929,14 +979,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "9ebc2905",
+   "execution_count": 16,
+   "id": "da09cfcf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.588642Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.588383Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.603291Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.601696Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.789458Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.789390Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.791774Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.791224Z"
     }
    },
    "outputs": [
@@ -972,7 +1022,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e3dca88",
+   "id": "2bdfcfae",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -982,14 +1032,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "89f5c596",
+   "execution_count": 17,
+   "id": "b80ea0f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.607687Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.607441Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.633366Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.628657Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.793638Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.793554Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.797928Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.797626Z"
     }
    },
    "outputs": [
@@ -1036,7 +1086,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9223512c",
+   "id": "5104b2b1",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -1046,14 +1096,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "5b28c3d5",
+   "execution_count": 18,
+   "id": "80893000",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.636936Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.636619Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.673391Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.672238Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.798981Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.798926Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.806867Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.806196Z"
     }
    },
    "outputs": [
@@ -1101,7 +1151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa9cf610",
+   "id": "752b15b7",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -1111,14 +1161,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "32addccb",
+   "execution_count": 19,
+   "id": "0a071166",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T05:28:05.682211Z",
-     "iopub.status.busy": "2026-06-23T05:28:05.681918Z",
-     "iopub.status.idle": "2026-06-23T05:28:05.701173Z",
-     "shell.execute_reply": "2026-06-23T05:28:05.698170Z"
+     "iopub.execute_input": "2026-06-23T05:49:42.808639Z",
+     "iopub.status.busy": "2026-06-23T05:49:42.808556Z",
+     "iopub.status.idle": "2026-06-23T05:49:42.812692Z",
+     "shell.execute_reply": "2026-06-23T05:49:42.811954Z"
     }
    },
    "outputs": [
@@ -1126,14 +1176,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "satisfied"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " Early-FTQC physical-qubit budget margin: 4.384e+4\n",
+      "satisfied Early-FTQC physical-qubit budget margin: 4.384e+4\n",
       "violated One-hour runtime budget margin: -1.656e+4\n",
       "satisfied No worse than plain Trotter depth margin: 2.432e+11\n"
      ]
@@ -1176,7 +1219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6f65369",
+   "id": "3b016473",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1195,7 +1238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b28f6baa",
+   "id": "2adcd621",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -1207,6 +1250,7 @@
     "- `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。\n",
     "- `FTQCResourcePlan`を使うと、具体的な回路実装ができる前に抽象的なFTQC subroutineを合成できます。\n",
     "- `plan_qubitized_qpe_from_block_encoding`は、block-encoding contractをPREPARE/SELECT/reflection/QPE resource planへ変換します。\n",
+    "- `QPEStatePreparationBudget.apply_to_plan`は、success probabilityとattemptごとのpreparation overheadを抽象的なQPE planへ重ねます。\n",
     "- Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。\n",
     "- accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。\n",
     "- Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -41,6 +41,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCResourcePlanStep,
     FTQCResourceProfile,
     FTQCResourceQuantity,
+    QPEStatePreparationBudget,
     SurfaceCodeCostModel,
     SurfaceCodeDistanceBudget,
     build_ftqc_resource_comparison_report,
@@ -269,6 +270,34 @@ assert block_plan_dict["reference_keys"] == ["arXiv:1610.06546"]
 assert block_plan_dict["steps"][0]["formulas"][0]["reference_keys"] == [
     "arXiv:1610.06546"
 ]
+
+# %% [markdown]
+# state-preparation success probabilityは、同じplanへ重ねられます。これにより、具体的なstate-preparation回路がなくても、trial-state overlapやfiltering仮定を見える形で保持できます。
+
+# %%
+preparation_budget = QPEStatePreparationBudget(
+    success_probability=sp.Rational(1, 5),
+    state_preparation_toffoli=100,
+    state_preparation_t_gates=20,
+    state_preparation_logical_depth=50,
+    description="symmetry-filtered trial state",
+)
+filtered_block_plan = preparation_budget.apply_to_plan(block_plan)
+filtered_block_values = filtered_block_plan.resource_values()
+
+for step in filtered_block_plan.to_dict()["steps"]:
+    print(step["name"], step["repetitions"])
+
+assert filtered_block_values[FTQCResourceQuantity.QPE_REPETITIONS] == 5
+assert filtered_block_values[FTQCResourceQuantity.QPE_ITERATIONS] == (
+    block_plan_values[FTQCResourceQuantity.QPE_ITERATIONS] * 5
+)
+assert filtered_block_values[FTQCResourceQuantity.TOFFOLI_GATES] == (
+    (block_plan_values[FTQCResourceQuantity.TOFFOLI_GATES] + 100) * 5
+)
+assert filtered_block_values[FTQCResourceQuantity.LOGICAL_DEPTH] == (
+    (block_plan_values[FTQCResourceQuantity.LOGICAL_DEPTH] + 50) * 5
+)
 
 # %% [markdown]
 # ## 最小例
@@ -633,6 +662,7 @@ assert budget_report.to_dict()["counts"] == {
 # - `FTQCResourceProfile`を使うと、space-time profileのような再利用可能なquantity bundleをcomparison helperへ直接渡せます。
 # - `FTQCResourcePlan`を使うと、具体的な回路実装ができる前に抽象的なFTQC subroutineを合成できます。
 # - `plan_qubitized_qpe_from_block_encoding`は、block-encoding contractをPREPARE/SELECT/reflection/QPE resource planへ変換します。
+# - `QPEStatePreparationBudget.apply_to_plan`は、success probabilityとattemptごとのpreparation overheadを抽象的なQPE planへ重ねます。
 # - Qamomileはこれらの量をアルゴリズム上のメタデータとして保持するため、circuit IRはbackend-neutralに保たれます。
 # - accuracy budgetを使うと、estimateを比較する前にtotal target precisionをrepresentation truncation errorとQPE precisionへ分けられます。
 # - Formula provenanceにより、重要なresource quantityの背後にあるsymbolic derivationを公開できます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -12,6 +12,8 @@ import sympy as sp
 
 from qamomile.circuit.estimator.algorithmic.ftqc_resources import (
     FTQCResourceFormula,
+    FTQCResourcePlan,
+    FTQCResourcePlanStep,
     FTQCResourceQuantity,
     describe_ftqc_resource_quantity,
 )
@@ -1366,6 +1368,98 @@ class QPEStatePreparationBudget:
             architecture_values=estimate.architecture_values,
         )
 
+    def apply_to_plan(
+        self,
+        plan: FTQCResourcePlan,
+        *,
+        title: str | None = None,
+        state_preparation_step_name: str = "state_preparation_budget",
+        repeated_attempt_step_name: str = "repeated_qpe_attempt",
+    ) -> FTQCResourcePlan:
+        """Apply the success budget to an abstract FTQC resource plan.
+
+        The returned plan keeps the state-preparation budget as its own
+        reviewable step, then repeats the base plan's aggregate QPE attempt by
+        ``1 / success_probability``. Gate counts and logical depth include the
+        per-attempt preparation overhead before repetition scaling.
+
+        Args:
+            plan (FTQCResourcePlan): Base resource plan for one QPE attempt.
+            title (str | None): Optional title for the returned plan. Defaults
+                to ``"<plan.title> with state-preparation budget"``.
+            state_preparation_step_name (str): Stable name for the metadata
+                step that records success probability and preparation
+                overheads. Defaults to ``"state_preparation_budget"``.
+            repeated_attempt_step_name (str): Stable name for the repeated
+                base-attempt step. Defaults to ``"repeated_qpe_attempt"``.
+
+        Returns:
+            FTQCResourcePlan: Plan including state-preparation success
+                probability, per-attempt overheads, and expected repeated QPE
+                attempts.
+
+        Raises:
+            TypeError: If ``plan`` is not an ``FTQCResourcePlan``.
+            ValueError: If ``plan`` has inconsistent resource values.
+
+        Example:
+            >>> step = FTQCResourcePlanStep("qpe", {"toffoli_gates": 10})
+            >>> plan = FTQCResourcePlan((step,))
+            >>> budget = QPEStatePreparationBudget(sp.Rational(1, 2), 3)
+            >>> budget.apply_to_plan(plan).resource_values()[
+            ...     FTQCResourceQuantity.TOFFOLI_GATES
+            ... ]
+            26
+        """
+        if not isinstance(plan, FTQCResourcePlan):
+            raise TypeError("plan must be an FTQCResourcePlan instance.")
+
+        base_values = dict(plan.resource_values())
+        repeated_values = self._resource_values_for_repeated_attempt(base_values)
+        formulas_by_quantity = {
+            cast(FTQCResourceQuantity, formula.quantity): formula
+            for formula in _qpe_state_preparation_formulas()
+        }
+        reference_keys = tuple(reference.key for reference in self.references)
+        budget_formulas = (
+            formulas_by_quantity[FTQCResourceQuantity.QPE_REPETITIONS],
+            formulas_by_quantity[FTQCResourceQuantity.TOFFOLI_GATES],
+            formulas_by_quantity[FTQCResourceQuantity.T_GATES],
+            formulas_by_quantity[FTQCResourceQuantity.LOGICAL_DEPTH],
+            formulas_by_quantity[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME],
+        )
+        budget_values: dict[
+            str | FTQCResourceQuantity,
+            sp.Expr | int | float,
+        ] = {quantity: value for quantity, value in self.resource_values().items()}
+        repeated_step_values: dict[
+            str | FTQCResourceQuantity,
+            sp.Expr | int | float,
+        ] = {quantity: value for quantity, value in repeated_values.items()}
+
+        return FTQCResourcePlan(
+            (
+                FTQCResourcePlanStep(
+                    state_preparation_step_name,
+                    budget_values,
+                    label=(self.description or "State-preparation success budget"),
+                    formulas=(
+                        formulas_by_quantity[FTQCResourceQuantity.QPE_REPETITIONS],
+                    ),
+                    reference_keys=reference_keys,
+                ),
+                FTQCResourcePlanStep(
+                    repeated_attempt_step_name,
+                    repeated_step_values,
+                    repetitions=self.qpe_repetitions,
+                    label="Repeated QPE attempt",
+                    formulas=(*plan.formulas(), *budget_formulas),
+                    reference_keys=(*plan.reference_keys(), *reference_keys),
+                ),
+            ),
+            title=title or f"{plan.title} with state-preparation budget",
+        )
+
     def to_dict(self) -> dict[str, str]:
         """Serialize the state-preparation budget.
 
@@ -1405,6 +1499,46 @@ class QPEStatePreparationBudget:
                 self._state_preparation_logical_depth
             ),
         }
+
+    def _resource_values_for_repeated_attempt(
+        self,
+        base_values: dict[FTQCResourceQuantity, sp.Expr],
+    ) -> dict[FTQCResourceQuantity, sp.Expr]:
+        """Return base plan values plus preparation overhead for one attempt.
+
+        Args:
+            base_values (dict[FTQCResourceQuantity, sp.Expr]): Aggregate
+                resource values from the base one-attempt plan.
+
+        Returns:
+            dict[FTQCResourceQuantity, sp.Expr]: Resource values for one QPE
+                attempt after adding state-preparation overhead to additive
+                gate-count and logical-depth quantities.
+        """
+        repeated_values = dict(base_values)
+        if FTQCResourceQuantity.QPE_REPETITIONS in repeated_values:
+            del repeated_values[FTQCResourceQuantity.QPE_REPETITIONS]
+
+        repeated_values[FTQCResourceQuantity.TOFFOLI_GATES] = sp.simplify(
+            repeated_values.get(FTQCResourceQuantity.TOFFOLI_GATES, sp.Integer(0))
+            + self._state_preparation_toffoli
+        )
+        repeated_values[FTQCResourceQuantity.T_GATES] = sp.simplify(
+            repeated_values.get(FTQCResourceQuantity.T_GATES, sp.Integer(0))
+            + self._state_preparation_t_gates
+        )
+        repeated_values[FTQCResourceQuantity.LOGICAL_DEPTH] = sp.simplify(
+            repeated_values.get(FTQCResourceQuantity.LOGICAL_DEPTH, sp.Integer(0))
+            + self._state_preparation_logical_depth
+        )
+        if FTQCResourceQuantity.LOGICAL_QUBITS in repeated_values:
+            repeated_values[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME] = (
+                sp.simplify(
+                    repeated_values[FTQCResourceQuantity.LOGICAL_QUBITS]
+                    * repeated_values[FTQCResourceQuantity.LOGICAL_DEPTH]
+                )
+            )
+        return repeated_values
 
     @property
     def _success_probability(self) -> sp.Expr:

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -12,6 +12,8 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCAccuracyBudget,
     FTQCCostModel,
     FTQCReference,
+    FTQCResourcePlan,
+    FTQCResourcePlanStep,
     FTQCResourceQuantity,
     QPEStatePreparationBudget,
     SurfaceCodeCostModel,
@@ -265,6 +267,64 @@ def test_state_preparation_budget_scales_expected_qpe_work():
     )
 
 
+def test_state_preparation_budget_scales_resource_plan_attempts():
+    """State-preparation success budgets compose with abstract QPE plans."""
+    base_plan = FTQCResourcePlan(
+        (
+            FTQCResourcePlanStep(
+                "qpe_attempt",
+                {
+                    FTQCResourceQuantity.QPE_ITERATIONS: 5,
+                    FTQCResourceQuantity.TOFFOLI_GATES: 10,
+                    FTQCResourceQuantity.T_GATES: 2,
+                    FTQCResourceQuantity.LOGICAL_DEPTH: 11,
+                    FTQCResourceQuantity.LOGICAL_QUBITS: 4,
+                },
+            ),
+        ),
+        title="Toy QPE plan",
+    )
+    reference = FTQCReference(
+        key="internal:trial-state",
+        title="Trial-state preparation model",
+        url="https://example.invalid/trial-state",
+    )
+    budget = QPEStatePreparationBudget(
+        success_probability=sp.Rational(1, 4),
+        state_preparation_toffoli=3,
+        state_preparation_t_gates=5,
+        state_preparation_logical_depth=7,
+        description="symmetry-filtered trial state",
+        references=(reference,),
+    )
+
+    repeated_plan = budget.apply_to_plan(base_plan)
+    values = repeated_plan.resource_values()
+
+    assert repeated_plan.title == "Toy QPE plan with state-preparation budget"
+    assert repeated_plan.steps[0].name == "state_preparation_budget"
+    assert repeated_plan.steps[1].name == "repeated_qpe_attempt"
+    assert values[FTQCResourceQuantity.QPE_REPETITIONS] == 4
+    assert values[FTQCResourceQuantity.QPE_ITERATIONS] == 20
+    assert values[FTQCResourceQuantity.TOFFOLI_GATES] == 52
+    assert values[FTQCResourceQuantity.T_GATES] == 28
+    assert values[FTQCResourceQuantity.LOGICAL_DEPTH] == 72
+    assert values[FTQCResourceQuantity.LOGICAL_QUBITS] == 4
+    assert values[FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME] == 288
+    assert values[FTQCResourceQuantity.STATE_PREPARATION_TOFFOLI] == 3
+    assert repeated_plan.reference_keys() == ("internal:trial-state",)
+    assert repeated_plan.to_dict()["steps"][0]["label"] == (
+        "symmetry-filtered trial state"
+    )
+    assert {formula.quantity for formula in repeated_plan.formulas()} >= {
+        FTQCResourceQuantity.QPE_REPETITIONS,
+        FTQCResourceQuantity.TOFFOLI_GATES,
+        FTQCResourceQuantity.T_GATES,
+        FTQCResourceQuantity.LOGICAL_DEPTH,
+        FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME,
+    }
+
+
 def test_state_preparation_budget_rejects_invalid_probabilities():
     """State-preparation success budgets reject invalid probability inputs."""
     with pytest.raises(ValueError, match="success_probability"):
@@ -278,6 +338,9 @@ def test_state_preparation_budget_rejects_invalid_probabilities():
 
     with pytest.raises(TypeError, match="FTQCResourceEstimate"):
         QPEStatePreparationBudget(success_probability=1).apply(object())
+
+    with pytest.raises(TypeError, match="FTQCResourcePlan"):
+        QPEStatePreparationBudget(success_probability=1).apply_to_plan(object())
 
 
 def test_cost_model_lifts_logical_estimates_to_physical_runtime():


### PR DESCRIPTION
## Summary
- add `QPEStatePreparationBudget.apply_to_plan` for composing success probability and per-attempt preparation overhead with abstract FTQC plans
- preserve state-preparation formulas and reference keys in the resulting plan provenance
- cover plan-level repetition scaling in FTQC chemistry tests
- update EN/JA FTQC resource design docs and executed notebooks

## Verification
- `uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run pytest -m docs tests/docs/test_tutorials.py -q -k 'ftqc_resource_estimation_design'`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `uv run python docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run python docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupytext --to ipynb --test docs/en/usage/ftqc_resource_estimation_design.py docs/ja/usage/ftqc_resource_estimation_design.py`
- `git diff --check`

## Local Review Note
- The local-review skill still lists the stale command `uv run zuban qamomile/`; it now fails with `unrecognized subcommand`. The current repo-standard command `uv run zuban check qamomile/` passed.
