### PR TITLE
Connect FTQC reductions to Trotter estimates

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3682cc18",
+   "id": "63a3329d",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6b78f2a5",
+   "id": "aa3ffb08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:02.111150Z",
-     "iopub.status.busy": "2026-06-23T03:35:02.110841Z",
-     "iopub.status.idle": "2026-06-23T03:35:02.117872Z",
-     "shell.execute_reply": "2026-06-23T03:35:02.116484Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.845680Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.845324Z",
+     "iopub.status.idle": "2026-06-23T06:27:41.851440Z",
+     "shell.execute_reply": "2026-06-23T06:27:41.850224Z"
     }
    },
    "outputs": [],
@@ -40,13 +40,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "66a40154",
+   "id": "d8e9def1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:02.121254Z",
-     "iopub.status.busy": "2026-06-23T03:35:02.121054Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.870767Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.870335Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.854888Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.854733Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.938697Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.938091Z"
     }
    },
    "outputs": [],
@@ -61,6 +61,7 @@
     "    FTQCAccuracyBudget,\n",
     "    FTQCResourceProfile,\n",
     "    FTQCResourceQuantity,\n",
+    "    HamiltonianResourceReduction,\n",
     "    QPEStatePreparationBudget,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
@@ -80,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79b23658",
+   "id": "b9423a1b",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -110,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3f85454",
+   "id": "0c53e713",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -130,13 +131,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "36890291",
+   "id": "21121338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.872274Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.872131Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.876031Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.875705Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.940829Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.940613Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.944938Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.944511Z"
     }
    },
    "outputs": [],
@@ -173,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c267714b",
+   "id": "db9d8f41",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -187,13 +188,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e2cead08",
+   "id": "ea0e14e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.877866Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.877752Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.880590Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.880198Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.946540Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.946474Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.949255Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.948840Z"
     }
    },
    "outputs": [
@@ -264,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfb944f7",
+   "id": "b5bf0379",
    "metadata": {},
    "source": [
     "Qamomile also provides standard review profiles: small reusable bundles of\n",
@@ -276,13 +277,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "1e036d9d",
+   "id": "815ffef2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.882017Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.881932Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.884156Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.883798Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.950309Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.950255Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.952494Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.952022Z"
     }
    },
    "outputs": [
@@ -316,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1f05ad6",
+   "id": "7820ff67",
    "metadata": {},
    "source": [
     "The research-signal catalog maps recent papers to the quantities they ask a\n",
@@ -327,13 +328,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ea6757a3",
+   "id": "06877768",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.885358Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.885285Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.887853Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.887124Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.953585Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.953530Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.955830Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.955497Z"
     }
    },
    "outputs": [
@@ -367,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f2b81a8",
+   "id": "04d2d539",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -380,13 +381,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "dfc17b0a",
+   "id": "cab56d87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.888873Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.888808Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.891476Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.891040Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.956808Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.956755Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.959582Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.959144Z"
     }
    },
    "outputs": [],
@@ -409,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de1f0298",
+   "id": "1dce6dad",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -421,13 +422,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "b67eb1fb",
+   "id": "1515866b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.892682Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.892607Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.894913Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.894590Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.960630Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.960568Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.963028Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.962640Z"
     }
    },
    "outputs": [],
@@ -450,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0054a08c",
+   "id": "8cd28a52",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -472,13 +473,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "fdd4612a",
+   "id": "87d72b2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.896114Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.896046Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.920075Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.919595Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.964299Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.964239Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.990215Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.989794Z"
     }
    },
    "outputs": [
@@ -605,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d429a2d",
+   "id": "b86c4078",
    "metadata": {},
    "source": [
     "## State-Preparation Success Budget\n",
@@ -620,13 +621,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "8c4a7fb5",
+   "id": "66331994",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.921302Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.921246Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.934708Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.934256Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.991414Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.991338Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.005621Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.005247Z"
     }
    },
    "outputs": [
@@ -691,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2309057",
+   "id": "e16bf52c",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -703,13 +704,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "21198316",
+   "id": "1f6f2d3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.935904Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.935824Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.939666Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.939282Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.006820Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.006742Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.010843Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.010381Z"
     }
    },
    "outputs": [
@@ -743,28 +744,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d8e1826",
+   "id": "5a327b7e",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
     "\n",
     "Early-FTQC proposals may favor shallower single-ancilla QPE and Pauli\n",
     "rotations over qubitized walks when qubits and depth are tightly constrained.\n",
-    "The unitary-weight concentration factor below represents a spectrally\n",
-    "invariant Hamiltonian transformation that reduces the cost-driving effective\n",
-    "weight."
+    "The resource reduction below represents a spectrally invariant Hamiltonian\n",
+    "transformation, such as unitary weight concentration, that reduces the\n",
+    "cost-driving effective weight while staying separate from circuit lowering."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f46fee18",
+   "id": "10118eca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.940686Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.940623Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.948436Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.948014Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.012205Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.012147Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.020778Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.020445Z"
     }
    },
    "outputs": [
@@ -786,6 +787,10 @@
     }
    ],
    "source": [
+    "uwc_reduction = HamiltonianResourceReduction(\n",
+    "    lambda_norm_factor=sp.Float(\"0.1\"),\n",
+    "    description=\"unitary weight concentration\",\n",
+    ")\n",
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
     "    precision=qpe_precision,\n",
@@ -799,9 +804,9 @@
     "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
-    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
     "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
     "    rotation_synthesis_t_gates=3,\n",
+    "    resource_reduction=uwc_reduction,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -829,12 +834,15 @@
     "\n",
     "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
     "assert trotter_savings[2].ratio == sp.Float(\"0.05\")\n",
-    "assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME"
+    "assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "assert \"lambda_norm=0.100000000000000\" in uwc_trotter.assumptions[\n",
+    "    \"resource_reduction_factors\"\n",
+    "]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0c264cfe",
+   "id": "a39116b6",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -849,13 +857,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "3a7ee08d",
+   "id": "fd30b971",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.949517Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.949444Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.953144Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.952628Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.022190Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.022114Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.025880Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.025576Z"
     }
    },
    "outputs": [
@@ -908,7 +916,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "711bae59",
+   "id": "a1330df3",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -41,6 +41,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCAccuracyBudget,
     FTQCResourceProfile,
     FTQCResourceQuantity,
+    HamiltonianResourceReduction,
     QPEStatePreparationBudget,
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
@@ -458,11 +459,15 @@ assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 #
 # Early-FTQC proposals may favor shallower single-ancilla QPE and Pauli
 # rotations over qubitized walks when qubits and depth are tightly constrained.
-# The unitary-weight concentration factor below represents a spectrally
-# invariant Hamiltonian transformation that reduces the cost-driving effective
-# weight.
+# The resource reduction below represents a spectrally invariant Hamiltonian
+# transformation, such as unitary weight concentration, that reduces the
+# cost-driving effective weight while staying separate from circuit lowering.
 
 # %%
+uwc_reduction = HamiltonianResourceReduction(
+    lambda_norm_factor=sp.Float("0.1"),
+    description="unitary weight concentration",
+)
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
     precision=qpe_precision,
@@ -476,9 +481,9 @@ uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
-    unitary_weight_factor=sp.Float("0.1"),
     randomized_compilation_factor=sp.Float("0.5"),
     rotation_synthesis_t_gates=3,
+    resource_reduction=uwc_reduction,
     cost_model=cost_model,
 )
 
@@ -507,6 +512,9 @@ for row in trotter_savings:
 assert trotter_savings[0].ratio == sp.Float("0.1")
 assert trotter_savings[2].ratio == sp.Float("0.05")
 assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+assert "lambda_norm=0.100000000000000" in uwc_trotter.assumptions[
+    "resource_reduction_factors"
+]
 
 # %% [markdown]
 # ## Result

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6ab7c04c",
+   "id": "f58f3b38",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "921fae50",
+   "id": "db068678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:40.630200Z",
-     "iopub.status.busy": "2026-06-23T06:07:40.630004Z",
-     "iopub.status.idle": "2026-06-23T06:07:40.636350Z",
-     "shell.execute_reply": "2026-06-23T06:07:40.635549Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.845645Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.845357Z",
+     "iopub.status.idle": "2026-06-23T06:27:41.851497Z",
+     "shell.execute_reply": "2026-06-23T06:27:41.850324Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ff3767e7",
+   "id": "366e077b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:40.638367Z",
-     "iopub.status.busy": "2026-06-23T06:07:40.638248Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.020961Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.020175Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.854873Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.854703Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.292756Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.292135Z"
     }
    },
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b98b053e",
+   "id": "2bc591fb",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14b884f4",
+   "id": "5478fb0c",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -134,13 +134,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "ab10fcd0",
+   "id": "1949e99b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.022399Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.022286Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.024975Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.024439Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.294445Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.294268Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.297065Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.296565Z"
     }
    },
    "outputs": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf5a6aba",
+   "id": "658f7e4a",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -183,13 +183,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c020219d",
+   "id": "085a4ac3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.026253Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.026174Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.029565Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.029156Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.298497Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.298426Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.302642Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.301624Z"
     }
    },
    "outputs": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c62ecf4c",
+   "id": "9899a3d7",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -294,13 +294,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c0c5d71e",
+   "id": "0e579fc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.030652Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.030590Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.032937Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.032277Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.304292Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.304225Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.306766Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.306287Z"
     }
    },
    "outputs": [
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a57210f3",
+   "id": "a67b6b8b",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -345,13 +345,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "29cb3269",
+   "id": "2bb7d65b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.034221Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.034162Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.038567Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.038195Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.308371Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.308280Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.313967Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.313432Z"
     }
    },
    "outputs": [
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d836b74",
+   "id": "ab4354c5",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -423,13 +423,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b7a31239",
+   "id": "66b36535",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.039811Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.039746Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.042517Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.042076Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.315292Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.315217Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.319107Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.317789Z"
     }
    },
    "outputs": [],
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af3f9e27",
+   "id": "940677f3",
    "metadata": {},
    "source": [
     "A block-encoding model can also produce a plan directly. The plan separates\n",
@@ -466,13 +466,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f6894607",
+   "id": "75ec9da5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.043510Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.043453Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.070964Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.070474Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.321295Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.321147Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.352526Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.351446Z"
     }
    },
    "outputs": [
@@ -526,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a946ae32",
+   "id": "c18a4a7a",
    "metadata": {},
    "source": [
     "Plan provenance is intentionally separate from circuit lowering. A review can\n",
@@ -537,13 +537,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b861d65e",
+   "id": "21113b9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.072122Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.072056Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.075838Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.075339Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.354050Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.353967Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.358169Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.357478Z"
     }
    },
    "outputs": [
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c322c73c",
+   "id": "206f5643",
    "metadata": {},
    "source": [
     "State-preparation success probability can be layered onto the same plan. This\n",
@@ -581,13 +581,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a52f9a03",
+   "id": "1665cba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.077029Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.076960Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.090630Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.090159Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.359443Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.359384Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.375385Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.374747Z"
     }
    },
    "outputs": [
@@ -628,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6fb59ff",
+   "id": "d00df198",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -643,13 +643,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "256ed32b",
+   "id": "37b89bbf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.091858Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.091799Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.241099Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.240528Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.376758Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.376674Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.541044Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.540274Z"
     }
    },
    "outputs": [
@@ -657,14 +657,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'lambda_norm_factor': '1/5', 'pauli_term_factor': '1/2', 'walk_cost_factor': '3/4', 'sparsity_factor': '2/5', 'second_factor_rank_factor': '1', 'logical_qubit_factor': '1', 'truncation_error': None, 'source': '', 'description': 'unitary weight concentration', 'references': []}"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "{'lambda_norm_factor': '1/5', 'pauli_term_factor': '1/2', 'walk_cost_factor': '3/4', 'sparsity_factor': '2/5', 'second_factor_rank_factor': '1', 'logical_qubit_factor': '1', 'truncation_error': None, 'source': '', 'description': 'unitary weight concentration', 'references': []}\n",
       "unitary weight concentration\n"
      ]
     }
@@ -714,7 +707,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e32576de",
+   "id": "28a5e731",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -727,13 +720,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "fa32fd77",
+   "id": "9c2488e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.242494Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.242428Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.256285Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.255854Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.542731Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.542668Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.557642Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.556766Z"
     }
    },
    "outputs": [
@@ -869,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbd3538a",
+   "id": "1de622e4",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -880,13 +873,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "92343ecc",
+   "id": "eac9bed7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.257487Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.257409Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.262745Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.262133Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.559403Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.559316Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.564177Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.563564Z"
     }
    },
    "outputs": [
@@ -932,7 +925,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e6a6620",
+   "id": "9fe14823",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -944,13 +937,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "1918e538",
+   "id": "faf762dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.264674Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.264592Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.271309Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.270823Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.565837Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.565759Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.571397Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.570898Z"
     }
    },
    "outputs": [
@@ -1001,7 +994,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "360d62ae",
+   "id": "505f3ba9",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -1015,13 +1008,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "6c419d87",
+   "id": "ac5d6a26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.272430Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.272352Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.274804Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.274364Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.572462Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.572395Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.574926Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.574447Z"
     }
    },
    "outputs": [
@@ -1047,7 +1040,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1c670cd",
+   "id": "aabb927d",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -1061,13 +1054,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "4242897a",
+   "id": "24de74cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.275993Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.275924Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.279086Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.278496Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.576175Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.576102Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.579998Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.579188Z"
     }
    },
    "outputs": [
@@ -1100,7 +1093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45e7cb6d",
+   "id": "8c5b1ce1",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -1114,13 +1107,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "4954b105",
+   "id": "25f156a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.280426Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.280330Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.282593Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.282111Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.581395Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.581326Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.584021Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.583703Z"
     }
    },
    "outputs": [
@@ -1156,7 +1149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4a088f8",
+   "id": "289da61a",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -1168,13 +1161,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "6f1314c5",
+   "id": "1cbc711e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.283774Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.283707Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.287928Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.287582Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.585357Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.585207Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.590696Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.590296Z"
     }
    },
    "outputs": [
@@ -1221,25 +1214,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d27dfec0",
+   "id": "9233d1c3",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
     "\n",
     "Early-FTQC estimates may not be Toffoli-native. The same comparison API works\n",
-    "for Trotter-style models that primarily report T gates and logical depth."
+    "for Trotter-style models that primarily report T gates and logical depth.\n",
+    "The same `HamiltonianResourceReduction` object used for representation\n",
+    "review can be passed into the Hamiltonian-driven Trotter estimator."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "b9331e75",
+   "id": "73337e59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.289114Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.289056Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.297835Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.297074Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.592308Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.592235Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.600932Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.600617Z"
     }
    },
    "outputs": [
@@ -1254,6 +1249,10 @@
     }
    ],
    "source": [
+    "early_ftqc_reduction = HamiltonianResourceReduction(\n",
+    "    lambda_norm_factor=sp.Float(\"0.1\"),\n",
+    "    description=\"unitary weight concentration\",\n",
+    ")\n",
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
     "    precision=sp.Float(\"0.0016\"),\n",
@@ -1266,9 +1265,9 @@
     "    precision=sp.Float(\"0.0016\"),\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
-    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
     "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
     "    rotation_synthesis_t_gates=3,\n",
+    "    resource_reduction=early_ftqc_reduction,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -1282,12 +1281,16 @@
     "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
     "\n",
     "assert trotter_comparison[0].ratio == sp.Float(\"0.1\")\n",
-    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")"
+    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")\n",
+    "assert (\n",
+    "    uwc_trotter.assumptions[\"resource_reduction_description\"]\n",
+    "    == \"unitary weight concentration\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3cb0af40",
+   "id": "fccc10e4",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1301,13 +1304,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "189647c1",
+   "id": "d496a8de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.299886Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.299750Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.303271Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.302778Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.603163Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.603013Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.606293Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.605904Z"
     }
    },
    "outputs": [
@@ -1358,7 +1361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f7b4f9c",
+   "id": "b5872361",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1383,7 +1386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc9d3c4e",
+   "id": "f00349ea",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -668,8 +668,14 @@ assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float
 #
 # Early-FTQC estimates may not be Toffoli-native. The same comparison API works
 # for Trotter-style models that primarily report T gates and logical depth.
+# The same `HamiltonianResourceReduction` object used for representation
+# review can be passed into the Hamiltonian-driven Trotter estimator.
 
 # %%
+early_ftqc_reduction = HamiltonianResourceReduction(
+    lambda_norm_factor=sp.Float("0.1"),
+    description="unitary weight concentration",
+)
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
     precision=sp.Float("0.0016"),
@@ -682,9 +688,9 @@ uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     precision=sp.Float("0.0016"),
     trotter_steps_per_sample=8,
     samples=128,
-    unitary_weight_factor=sp.Float("0.1"),
     randomized_compilation_factor=sp.Float("0.5"),
     rotation_synthesis_t_gates=3,
+    resource_reduction=early_ftqc_reduction,
     cost_model=cost_model,
 )
 
@@ -699,6 +705,10 @@ for row in trotter_comparison:
 
 assert trotter_comparison[0].ratio == sp.Float("0.1")
 assert trotter_comparison[1].ratio == sp.Float("0.05")
+assert (
+    uwc_trotter.assumptions["resource_reduction_description"]
+    == "unitary weight concentration"
+)
 
 # %% [markdown]
 # ## Budget Constraints

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "641f7549",
+   "id": "b7244784",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9bb76ba7",
+   "id": "f6c7ef6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:02.110837Z",
-     "iopub.status.busy": "2026-06-23T03:35:02.110538Z",
-     "iopub.status.idle": "2026-06-23T03:35:02.118982Z",
-     "shell.execute_reply": "2026-06-23T03:35:02.117295Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.847722Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.847431Z",
+     "iopub.status.idle": "2026-06-23T06:27:41.853562Z",
+     "shell.execute_reply": "2026-06-23T06:27:41.852126Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "70c437ba",
+   "id": "f6b5e100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:02.121923Z",
-     "iopub.status.busy": "2026-06-23T03:35:02.121736Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.870819Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.870320Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.856339Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.856170Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.941851Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.941414Z"
     }
    },
    "outputs": [],
@@ -56,6 +56,7 @@
     "    FTQCAccuracyBudget,\n",
     "    FTQCResourceProfile,\n",
     "    FTQCResourceQuantity,\n",
+    "    HamiltonianResourceReduction,\n",
     "    QPEStatePreparationBudget,\n",
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9adae759",
+   "id": "2cdc0a33",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -87,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c452f17e",
+   "id": "eff0733a",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -104,13 +105,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b088f52d",
+   "id": "c4f39b66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.872298Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.872142Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.876152Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.875704Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.943385Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.943237Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.947738Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.947440Z"
     }
    },
    "outputs": [],
@@ -147,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7655dd44",
+   "id": "9f326721",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -161,13 +162,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2fdf90a5",
+   "id": "2ca9596e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.877612Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.877532Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.880691Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.880019Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.949185Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.949119Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.951918Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.951421Z"
     }
    },
    "outputs": [
@@ -238,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84f96347",
+   "id": "5921c252",
    "metadata": {},
    "source": [
     "Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付け、comparison helperへ直接渡せます。"
@@ -247,13 +248,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "037400ee",
+   "id": "813ba64d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.881915Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.881814Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.884109Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.883703Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.953284Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.953226Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.955206Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.954927Z"
     }
    },
    "outputs": [
@@ -287,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50b6a072",
+   "id": "9a28700a",
    "metadata": {},
    "source": [
     "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
@@ -296,13 +297,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4e5ca20d",
+   "id": "e5083355",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.885217Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.885132Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.887602Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.887085Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.956377Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.956308Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.958589Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.958204Z"
     }
    },
    "outputs": [
@@ -336,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1923345f",
+   "id": "f92dd51e",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -345,13 +346,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "deb2d563",
+   "id": "f27fe84d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.888747Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.888677Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.891497Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.891035Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.959793Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.959723Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.962718Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.962400Z"
     }
    },
    "outputs": [],
@@ -374,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0eb88b28",
+   "id": "1a089b9c",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -386,13 +387,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "7228b542",
+   "id": "cca4ae63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.892622Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.892553Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.894554Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.894199Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.963925Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.963857Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.966354Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.965960Z"
     }
    },
    "outputs": [],
@@ -415,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c48a049",
+   "id": "066b8ccb",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -433,13 +434,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "0f4771af",
+   "id": "29a7dbd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.895889Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.895814Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.920309Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.919717Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.967338Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.967270Z",
+     "iopub.status.idle": "2026-06-23T06:27:43.993159Z",
+     "shell.execute_reply": "2026-06-23T06:27:43.992644Z"
     }
    },
    "outputs": [
@@ -566,7 +567,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1abfa48c",
+   "id": "a7d3cd80",
    "metadata": {},
    "source": [
     "## State-preparation success budget\n",
@@ -577,13 +578,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "63716203",
+   "id": "4b87975e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.921539Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.921476Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.934833Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.934335Z"
+     "iopub.execute_input": "2026-06-23T06:27:43.994278Z",
+     "iopub.status.busy": "2026-06-23T06:27:43.994213Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.008063Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.007668Z"
     }
    },
    "outputs": [
@@ -648,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90dedcd2",
+   "id": "3c7c8e90",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -657,13 +658,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "12193753",
+   "id": "fa15808d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.935947Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.935871Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.939675Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.939193Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.009209Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.009146Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.013313Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.012993Z"
     }
    },
    "outputs": [
@@ -697,24 +698,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b275604a",
+   "id": "8510209d",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
     "\n",
-    "Early-FTQCの提案では、量子ビット数とdepthが強く制限される場合、qubitized walksよりも浅いsingle-ancilla QPEとPauli rotationsが好まれることがあります。下のunitary-weight concentration factorは、コストを支配するeffective weightを下げるspectrally invariantなHamiltonian transformationを表します。"
+    "Early-FTQCの提案では、量子ビット数とdepthが強く制限される場合、qubitized walksよりも浅いsingle-ancilla QPEとPauli rotationsが好まれることがあります。下のresource reductionは、unitary weight concentrationのようなspectrally invariantなHamiltonian transformationを表します。コストを支配するeffective weightを下げつつ、circuit loweringとは分けて保持します。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "4dffd214",
+   "id": "14d36a5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.940682Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.940620Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.948133Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.947736Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.014510Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.014448Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.023293Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.022949Z"
     }
    },
    "outputs": [
@@ -736,6 +737,10 @@
     }
    ],
    "source": [
+    "uwc_reduction = HamiltonianResourceReduction(\n",
+    "    lambda_norm_factor=sp.Float(\"0.1\"),\n",
+    "    description=\"unitary weight concentration\",\n",
+    ")\n",
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
     "    precision=qpe_precision,\n",
@@ -749,9 +754,9 @@
     "    precision=qpe_precision,\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
-    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
     "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
     "    rotation_synthesis_t_gates=3,\n",
+    "    resource_reduction=uwc_reduction,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -779,12 +784,15 @@
     "\n",
     "assert trotter_savings[0].ratio == sp.Float(\"0.1\")\n",
     "assert trotter_savings[2].ratio == sp.Float(\"0.05\")\n",
-    "assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME"
+    "assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME\n",
+    "assert \"lambda_norm=0.100000000000000\" in uwc_trotter.assumptions[\n",
+    "    \"resource_reduction_factors\"\n",
+    "]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f314b11b",
+   "id": "940af423",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -795,13 +803,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "4f3ff645",
+   "id": "3df97b6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T03:35:03.949348Z",
-     "iopub.status.busy": "2026-06-23T03:35:03.949273Z",
-     "iopub.status.idle": "2026-06-23T03:35:03.952903Z",
-     "shell.execute_reply": "2026-06-23T03:35:03.952491Z"
+     "iopub.execute_input": "2026-06-23T06:27:44.024361Z",
+     "iopub.status.busy": "2026-06-23T06:27:44.024287Z",
+     "iopub.status.idle": "2026-06-23T06:27:44.028205Z",
+     "shell.execute_reply": "2026-06-23T06:27:44.027720Z"
     }
    },
    "outputs": [
@@ -854,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e5f599c",
+   "id": "0c885442",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -36,6 +36,7 @@ from qamomile.circuit.estimator.algorithmic import (
     FTQCAccuracyBudget,
     FTQCResourceProfile,
     FTQCResourceQuantity,
+    HamiltonianResourceReduction,
     QPEStatePreparationBudget,
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
@@ -410,9 +411,13 @@ assert scdf_block_estimate.logical_qubits == scdf_block.logical_qubits + 12
 # %% [markdown]
 # ## Early-FTQC Trotter QPE
 #
-# Early-FTQCの提案では、量子ビット数とdepthが強く制限される場合、qubitized walksよりも浅いsingle-ancilla QPEとPauli rotationsが好まれることがあります。下のunitary-weight concentration factorは、コストを支配するeffective weightを下げるspectrally invariantなHamiltonian transformationを表します。
+# Early-FTQCの提案では、量子ビット数とdepthが強く制限される場合、qubitized walksよりも浅いsingle-ancilla QPEとPauli rotationsが好まれることがあります。下のresource reductionは、unitary weight concentrationのようなspectrally invariantなHamiltonian transformationを表します。コストを支配するeffective weightを下げつつ、circuit loweringとは分けて保持します。
 
 # %%
+uwc_reduction = HamiltonianResourceReduction(
+    lambda_norm_factor=sp.Float("0.1"),
+    description="unitary weight concentration",
+)
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
     precision=qpe_precision,
@@ -426,9 +431,9 @@ uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     precision=qpe_precision,
     trotter_steps_per_sample=8,
     samples=128,
-    unitary_weight_factor=sp.Float("0.1"),
     randomized_compilation_factor=sp.Float("0.5"),
     rotation_synthesis_t_gates=3,
+    resource_reduction=uwc_reduction,
     cost_model=cost_model,
 )
 
@@ -457,6 +462,9 @@ for row in trotter_savings:
 assert trotter_savings[0].ratio == sp.Float("0.1")
 assert trotter_savings[2].ratio == sp.Float("0.05")
 assert trotter_savings[3].quantity == FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME
+assert "lambda_norm=0.100000000000000" in uwc_trotter.assumptions[
+    "resource_reduction_factors"
+]
 
 # %% [markdown]
 # ## Result

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "462fa58b",
+   "id": "0673ca83",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6ffa51c7",
+   "id": "908f95d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:40.630289Z",
-     "iopub.status.busy": "2026-06-23T06:07:40.630127Z",
-     "iopub.status.idle": "2026-06-23T06:07:40.636382Z",
-     "shell.execute_reply": "2026-06-23T06:07:40.635599Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.845697Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.845294Z",
+     "iopub.status.idle": "2026-06-23T06:27:41.851668Z",
+     "shell.execute_reply": "2026-06-23T06:27:41.850420Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "867361a2",
+   "id": "68d10afa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:40.638724Z",
-     "iopub.status.busy": "2026-06-23T06:07:40.638597Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.020886Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.020174Z"
+     "iopub.execute_input": "2026-06-23T06:27:41.855048Z",
+     "iopub.status.busy": "2026-06-23T06:27:41.854862Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.292454Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.292058Z"
     }
    },
    "outputs": [],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f65aa53",
+   "id": "438bbb1f",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ba67e04",
+   "id": "82f00207",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -120,13 +120,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7f636ef3",
+   "id": "d2e61d1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.022417Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.022309Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.025068Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.024476Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.294563Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.294287Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.297407Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.296806Z"
     }
    },
    "outputs": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe9b36ef",
+   "id": "7380f964",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -168,13 +168,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "eb40a2aa",
+   "id": "1ee6a72c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.026375Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.026301Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.029705Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.029338Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.298670Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.298611Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.302677Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.301965Z"
     }
    },
    "outputs": [
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb04c95a",
+   "id": "ca109c97",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -277,13 +277,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "28b03a14",
+   "id": "31fb37e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.030789Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.030730Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.033038Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.032485Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.304463Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.304316Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.306839Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.306394Z"
     }
    },
    "outputs": [
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2acc4830",
+   "id": "9c0c11b9",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -324,13 +324,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "139b33f5",
+   "id": "530a5438",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.034270Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.034214Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.038561Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.038199Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.308466Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.308387Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.313681Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.313130Z"
     }
    },
    "outputs": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9389fc55",
+   "id": "cc839176",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -399,13 +399,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e5e10802",
+   "id": "6c1d3441",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.039619Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.039560Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.042202Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.041845Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.315020Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.314955Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.318761Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.317204Z"
     }
    },
    "outputs": [],
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20a17861",
+   "id": "7e0f7663",
    "metadata": {},
    "source": [
     "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
@@ -439,13 +439,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "93286c18",
+   "id": "534cee5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.043204Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.043143Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.070803Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.070301Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.320885Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.320816Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.352589Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.351515Z"
     }
    },
    "outputs": [
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3a9e6da",
+   "id": "6443fc49",
    "metadata": {},
    "source": [
     "plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。"
@@ -508,13 +508,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7f16d9d9",
+   "id": "da76b146",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.071949Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.071878Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.075642Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.075194Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.354064Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.353982Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.358364Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.357519Z"
     }
    },
    "outputs": [
@@ -541,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57bc4d3e",
+   "id": "f8b8e12b",
    "metadata": {},
    "source": [
     "state-preparation success probabilityは、同じplanへ重ねられます。これにより、具体的なstate-preparation回路がなくても、trial-state overlapやfiltering仮定を見える形で保持できます。"
@@ -550,13 +550,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "8a1f76b9",
+   "id": "6f581e9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.076885Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.076810Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.090271Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.089848Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.359649Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.359590Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.375448Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.374931Z"
     }
    },
    "outputs": [
@@ -597,7 +597,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a1e2c1a",
+   "id": "b66d0f80",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -608,13 +608,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6cd89c55",
+   "id": "624120ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.091688Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.091627Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.241067Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.240530Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.376630Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.376556Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.540592Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.539994Z"
     }
    },
    "outputs": [
@@ -672,7 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27775964",
+   "id": "f9101788",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -683,13 +683,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "56509653",
+   "id": "585fcd11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.242482Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.242415Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.255932Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.255505Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.542427Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.542355Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.557554Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.556891Z"
     }
    },
    "outputs": [
@@ -825,7 +825,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61f29581",
+   "id": "88d3df5c",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -834,13 +834,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "253c9450",
+   "id": "71d34327",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.257212Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.257138Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.262487Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.261202Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.559365Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.559286Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.564617Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.563791Z"
     }
    },
    "outputs": [
@@ -886,7 +886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32e889bf",
+   "id": "ef6345e2",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -895,13 +895,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c7ff7b0c",
+   "id": "d50faf05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.264384Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.264296Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.270908Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.270525Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.566038Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.565965Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.571376Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.570909Z"
     }
    },
    "outputs": [
@@ -952,7 +952,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f87b7e2",
+   "id": "95a965c1",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -963,13 +963,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "80b08c2b",
+   "id": "bd3ca680",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.272199Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.272122Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.274652Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.274176Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.572384Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.572330Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.574949Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.574421Z"
     }
    },
    "outputs": [
@@ -995,7 +995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c41236ea",
+   "id": "e5b16933",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -1006,13 +1006,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "91c0a3ba",
+   "id": "844dcb2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.275847Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.275779Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.279110Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.278299Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.576026Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.575972Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.579847Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.579107Z"
     }
    },
    "outputs": [
@@ -1045,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "333d16bc",
+   "id": "7c40f52c",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -1056,13 +1056,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "4038ff7e",
+   "id": "1d73bb91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.280324Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.280256Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.282784Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.282148Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.581175Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.581114Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.583540Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.583202Z"
     }
    },
    "outputs": [
@@ -1098,7 +1098,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9e6afb3",
+   "id": "ce339762",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -1109,13 +1109,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "5b2d6715",
+   "id": "6f925021",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.283846Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.283786Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.287994Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.287616Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.584795Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.584740Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.589873Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.589419Z"
     }
    },
    "outputs": [
@@ -1162,24 +1162,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b30a92e",
+   "id": "3c3181ea",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
     "\n",
-    "Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。"
+    "Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。representation reviewで使うものと同じ`HamiltonianResourceReduction` objectを、Hamiltonianから作るTrotter estimatorへ渡せます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "21020f89",
+   "id": "6c06129b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.289071Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.289009Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.297555Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.297010Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.591187Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.591113Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.600134Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.599776Z"
     }
    },
    "outputs": [
@@ -1194,6 +1194,10 @@
     }
    ],
    "source": [
+    "early_ftqc_reduction = HamiltonianResourceReduction(\n",
+    "    lambda_norm_factor=sp.Float(\"0.1\"),\n",
+    "    description=\"unitary weight concentration\",\n",
+    ")\n",
     "plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(\n",
     "    scaled_summary,\n",
     "    precision=sp.Float(\"0.0016\"),\n",
@@ -1206,9 +1210,9 @@
     "    precision=sp.Float(\"0.0016\"),\n",
     "    trotter_steps_per_sample=8,\n",
     "    samples=128,\n",
-    "    unitary_weight_factor=sp.Float(\"0.1\"),\n",
     "    randomized_compilation_factor=sp.Float(\"0.5\"),\n",
     "    rotation_synthesis_t_gates=3,\n",
+    "    resource_reduction=early_ftqc_reduction,\n",
     "    cost_model=cost_model,\n",
     ")\n",
     "\n",
@@ -1222,12 +1226,16 @@
     "    print(row.label, \"ratio:\", sp.N(row.ratio, 4), \"reduction:\", sp.N(row.reduction, 4))\n",
     "\n",
     "assert trotter_comparison[0].ratio == sp.Float(\"0.1\")\n",
-    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")"
+    "assert trotter_comparison[1].ratio == sp.Float(\"0.05\")\n",
+    "assert (\n",
+    "    uwc_trotter.assumptions[\"resource_reduction_description\"]\n",
+    "    == \"unitary weight concentration\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a153b161",
+   "id": "4b2c49f1",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -1238,13 +1246,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "5d562b56",
+   "id": "4f3014b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:07:41.299457Z",
-     "iopub.status.busy": "2026-06-23T06:07:41.299361Z",
-     "iopub.status.idle": "2026-06-23T06:07:41.303198Z",
-     "shell.execute_reply": "2026-06-23T06:07:41.302647Z"
+     "iopub.execute_input": "2026-06-23T06:27:42.601469Z",
+     "iopub.status.busy": "2026-06-23T06:27:42.601409Z",
+     "iopub.status.idle": "2026-06-23T06:27:42.605687Z",
+     "shell.execute_reply": "2026-06-23T06:27:42.605172Z"
     }
    },
    "outputs": [
@@ -1295,7 +1303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "023f1e0c",
+   "id": "6b4a4578",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1314,7 +1322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fabc7665",
+   "id": "298eec48",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -614,9 +614,13 @@ assert sp.Abs(architecture_comparison[1].ratio - sp.Rational(10, 21)) < sp.Float
 # %% [markdown]
 # ## Early-FTQCのパターン
 #
-# Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。
+# Early-FTQC推定はToffoli-nativeとは限りません。同じ比較APIを、主にT gatesとlogical depthを報告するTrotter型modelにも使えます。representation reviewで使うものと同じ`HamiltonianResourceReduction` objectを、Hamiltonianから作るTrotter estimatorへ渡せます。
 
 # %%
+early_ftqc_reduction = HamiltonianResourceReduction(
+    lambda_norm_factor=sp.Float("0.1"),
+    description="unitary weight concentration",
+)
 plain_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     scaled_summary,
     precision=sp.Float("0.0016"),
@@ -629,9 +633,9 @@ uwc_trotter = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     precision=sp.Float("0.0016"),
     trotter_steps_per_sample=8,
     samples=128,
-    unitary_weight_factor=sp.Float("0.1"),
     randomized_compilation_factor=sp.Float("0.5"),
     rotation_synthesis_t_gates=3,
+    resource_reduction=early_ftqc_reduction,
     cost_model=cost_model,
 )
 
@@ -646,6 +650,10 @@ for row in trotter_comparison:
 
 assert trotter_comparison[0].ratio == sp.Float("0.1")
 assert trotter_comparison[1].ratio == sp.Float("0.05")
+assert (
+    uwc_trotter.assumptions["resource_reduction_description"]
+    == "unitary weight concentration"
+)
 
 # %% [markdown]
 # ## Budget constraints

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -2766,6 +2766,7 @@ def estimate_single_ancilla_trotter_qpe_from_hamiltonian(
     rotation_synthesis_t_gates: sp.Expr | int = 1,
     logical_qubits: sp.Expr | int | None = None,
     cost_model: _FTQCCostModelLike | None = None,
+    resource_reduction: HamiltonianResourceReduction | None = None,
     references: tuple[FTQCReference, ...] = (),
 ) -> FTQCResourceEstimate:
     """Estimate single-ancilla Trotter QPE from a Hamiltonian summary.
@@ -2787,16 +2788,41 @@ def estimate_single_ancilla_trotter_qpe_from_hamiltonian(
         cost_model (FTQCCostModel | SurfaceCodeCostModel | None):
             Architecture model used to lift logical estimates to physical
             qubits and runtime.
+        resource_reduction (HamiltonianResourceReduction | None): Optional
+            representation-level reduction to apply to the Hamiltonian summary
+            before building the Trotter estimate. Defaults to None.
         references (tuple[FTQCReference, ...]): Additional research sources
             to attach to the estimate.
 
     Returns:
         FTQCResourceEstimate: Symbolic FTQC resource estimate.
+
+    Raises:
+        TypeError: If ``hamiltonian`` is not a ``PauliHamiltonianResource`` or
+            ``resource_reduction`` is not a ``HamiltonianResourceReduction``.
     """
-    return estimate_single_ancilla_trotter_qpe(
-        n_spin_orbitals=hamiltonian.n_spin_orbitals,
-        n_pauli_terms=hamiltonian.n_pauli_terms,
-        lambda_norm=hamiltonian.lambda_norm,
+    if not isinstance(hamiltonian, PauliHamiltonianResource):
+        raise TypeError("hamiltonian must be a PauliHamiltonianResource instance.")
+    if resource_reduction is not None and not isinstance(
+        resource_reduction,
+        HamiltonianResourceReduction,
+    ):
+        raise TypeError(
+            "resource_reduction must be a HamiltonianResourceReduction instance."
+        )
+
+    effective_hamiltonian = (
+        hamiltonian
+        if resource_reduction is None
+        else resource_reduction.apply_to_hamiltonian(hamiltonian)
+    )
+    reduction_references = (
+        () if resource_reduction is None else resource_reduction.references
+    )
+    estimate = estimate_single_ancilla_trotter_qpe(
+        n_spin_orbitals=effective_hamiltonian.n_spin_orbitals,
+        n_pauli_terms=effective_hamiltonian.n_pauli_terms,
+        lambda_norm=effective_hamiltonian.lambda_norm,
         precision=precision,
         trotter_steps_per_sample=trotter_steps_per_sample,
         samples=samples,
@@ -2805,7 +2831,34 @@ def estimate_single_ancilla_trotter_qpe_from_hamiltonian(
         rotation_synthesis_t_gates=rotation_synthesis_t_gates,
         logical_qubits=logical_qubits,
         cost_model=cost_model,
-        references=references,
+        references=_combine_references(reduction_references, references),
+    )
+    assumptions = dict(estimate.assumptions)
+    assumptions["hamiltonian_source"] = effective_hamiltonian.source
+    if resource_reduction is not None:
+        if resource_reduction.description:
+            assumptions["resource_reduction_description"] = (
+                resource_reduction.description
+            )
+        assumptions["resource_reduction_factors"] = _format_resource_factors(
+            resource_reduction.resource_factors()
+        )
+    return _build_estimate(
+        algorithm=estimate.algorithm,
+        logical_qubits=estimate.logical_qubits,
+        physical_qubits=estimate.physical_qubits,
+        toffoli_gates=estimate.toffoli_gates,
+        t_gates=estimate.t_gates,
+        clifford_gates=estimate.clifford_gates,
+        qpe_iterations=estimate.qpe_iterations,
+        target_precision=estimate.target_precision,
+        logical_depth=estimate.logical_depth,
+        runtime_seconds=estimate.runtime_seconds,
+        assumptions=assumptions,
+        references=estimate.references,
+        formulas=estimate.formulas,
+        algorithm_values=estimate.algorithm_values,
+        architecture_values=estimate.architecture_values,
     )
 
 
@@ -3448,6 +3501,24 @@ def _combine_descriptions(base: str, extra: str) -> str:
     """
     parts = [part for part in (base, extra) if part]
     return "; ".join(parts)
+
+
+def _format_resource_factors(
+    factors: dict[FTQCResourceQuantity, sp.Expr],
+) -> str:
+    """Format resource-reduction factors for estimate assumptions.
+
+    Args:
+        factors (dict[FTQCResourceQuantity, sp.Expr]): Multiplicative factors
+            keyed by canonical FTQC resource quantity.
+
+    Returns:
+        str: Stable comma-separated ``quantity=factor`` string.
+    """
+    return ", ".join(
+        f"{quantity.value}={factors[quantity]}"
+        for quantity in sorted(factors, key=lambda item: item.value)
+    )
 
 
 def _normalize_method(method: str | ChemistryQPEMethod) -> ChemistryQPEMethod:

--- a/tests/circuit/estimator/test_ftqc_chemistry.py
+++ b/tests/circuit/estimator/test_ftqc_chemistry.py
@@ -441,6 +441,23 @@ def test_hamiltonian_resource_reduction_rejects_invalid_inputs():
     with pytest.raises(TypeError, match="ChemistryQPEModel"):
         reduction.apply_to_model(object())
 
+    with pytest.raises(TypeError, match="PauliHamiltonianResource"):
+        estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+            object(),
+            precision=1,
+            trotter_steps_per_sample=1,
+            samples=1,
+        )
+
+    with pytest.raises(TypeError, match="HamiltonianResourceReduction"):
+        estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+            summarize_pauli_hamiltonian(qm_o.Z(0)),
+            precision=1,
+            trotter_steps_per_sample=1,
+            samples=1,
+            resource_reduction=object(),
+        )
+
 
 def test_cost_model_lifts_logical_estimates_to_physical_runtime():
     """Concrete architecture knobs produce concrete physical-qubit/runtime values."""
@@ -864,6 +881,58 @@ def test_single_ancilla_trotter_qpe_from_hamiltonian_summary():
     assert estimate.target_precision == 1
     assert sp.simplify(estimate.logical_depth - 36) == 0
     assert sp.simplify(estimate.t_gates - 180) == 0
+
+
+def test_single_ancilla_trotter_qpe_accepts_hamiltonian_reduction():
+    """Hamiltonian reductions feed early-FTQC Trotter QPE estimates."""
+    summary = summarize_pauli_hamiltonian(
+        qm_o.Z(0) + 2 * qm_o.Z(1) + 3 * qm_o.Z(2) + 4 * qm_o.Z(3),
+        source="plain_trotter_lcu",
+    )
+    reference = FTQCReference(
+        key="arXiv:2603.22778",
+        title="Early FTQC chemistry resource model",
+        url="https://arxiv.org/abs/2603.22778",
+    )
+    reduction = HamiltonianResourceReduction(
+        lambda_norm_factor=sp.Rational(1, 10),
+        pauli_term_factor=sp.Rational(1, 2),
+        description="unitary weight concentration",
+        references=(reference,),
+    )
+
+    baseline = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+        summary,
+        precision=1,
+        trotter_steps_per_sample=2,
+        samples=5,
+        rotation_synthesis_t_gates=3,
+    )
+    reduced = estimate_single_ancilla_trotter_qpe_from_hamiltonian(
+        summary,
+        precision=1,
+        trotter_steps_per_sample=2,
+        samples=5,
+        randomized_compilation_factor=sp.Rational(1, 2),
+        rotation_synthesis_t_gates=3,
+        resource_reduction=reduction,
+    )
+
+    assert sp.Abs(reduced.qpe_iterations - baseline.qpe_iterations / 10) < sp.Float(
+        "1e-12"
+    )
+    assert sp.Abs(reduced.logical_depth - baseline.logical_depth / 40) < sp.Float(
+        "1e-12"
+    )
+    assert sp.Abs(reduced.t_gates - baseline.t_gates / 40) < sp.Float("1e-12")
+    assert reduced.assumptions["hamiltonian_source"] == "plain_trotter_lcu:reduced"
+    assert (
+        reduced.assumptions["resource_reduction_description"]
+        == "unitary weight concentration"
+    )
+    assert "lambda_norm=1/10" in reduced.assumptions["resource_reduction_factors"]
+    assert "n_pauli_terms=1/2" in reduced.assumptions["resource_reduction_factors"]
+    assert [item.key for item in reduced.references].count("arXiv:2603.22778") == 1
 
 
 def test_chemistry_qpe_model_rejects_negative_truncation_error():


### PR DESCRIPTION
## Summary
- allow HamiltonianResourceReduction to feed Hamiltonian-driven single-ancilla Trotter QPE estimates
- preserve reduced Hamiltonian provenance, reduction factors, and references in the returned estimate
- update EN/JA FTQC resource-estimation docs and executed notebooks to demonstrate the shared reduction object in early-FTQC Trotter comparisons

## Tests
- uv run pytest tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_ftqc_block_encoding.py -q
- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design or ftqc_chemistry_resource_estimation'
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check
- executed the four updated EN/JA FTQC notebooks with jupyter nbconvert

## Local review note
- The documented local-review command uv run zuban qamomile/ still fails with the current zuban CLI: error: unrecognized subcommand 'qamomile/'. The repository command uv run zuban check qamomile/ passed.