### PR TITLE
Recommend FTQC review profiles for research signals

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "63a3329d",
+   "id": "4649b5d3",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "aa3ffb08",
+   "id": "4ffdd877",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.845680Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.845324Z",
-     "iopub.status.idle": "2026-06-23T06:27:41.851440Z",
-     "shell.execute_reply": "2026-06-23T06:27:41.850224Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.030040Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.029852Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.033670Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.032880Z"
     }
    },
    "outputs": [],
@@ -40,13 +40,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d8e9def1",
+   "id": "cdd6c459",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.854888Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.854733Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.938697Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.938091Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.036773Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.036623Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.917041Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.916595Z"
     }
    },
    "outputs": [],
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9423a1b",
+   "id": "ce80a702",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c53e713",
+   "id": "499ef6d2",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -131,13 +131,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "21121338",
+   "id": "9ce974e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.940829Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.940613Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.944938Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.944511Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.919088Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.918807Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.922764Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.922302Z"
     }
    },
    "outputs": [],
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db9d8f41",
+   "id": "86781bab",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -188,13 +188,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ea0e14e1",
+   "id": "920de249",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.946540Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.946474Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.949255Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.948840Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.923855Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.923797Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.926510Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.926072Z"
     }
    },
    "outputs": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5bf0379",
+   "id": "b7a9eaf6",
    "metadata": {},
    "source": [
     "Qamomile also provides standard review profiles: small reusable bundles of\n",
@@ -277,13 +277,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "815ffef2",
+   "id": "06930fdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.950309Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.950255Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.952494Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.952022Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.927768Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.927712Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.929843Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.929303Z"
     }
    },
    "outputs": [
@@ -317,24 +317,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7820ff67",
+   "id": "1a3d83db",
    "metadata": {},
    "source": [
     "The research-signal catalog maps recent papers to the quantities they ask a\n",
-    "Qamomile model to expose. This keeps the tutorial grounded in a small,\n",
-    "inspectable contract instead of prose-only claims."
+    "Qamomile model to expose, plus the review profiles that should be inspected\n",
+    "first. This keeps the tutorial grounded in a small, inspectable contract\n",
+    "instead of prose-only claims."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "06877768",
+   "id": "d1318e4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.953585Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.953530Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.955830Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.955497Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.931022Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.930958Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.936402Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.935024Z"
     }
    },
    "outputs": [
@@ -344,8 +345,10 @@
      "text": [
       "Symmetry-compressed double factorization for fault-tolerant chemistry simulation\n",
       "['lambda_norm', 'qpe_iterations', 'walk_cost_toffoli', 'toffoli_gates', 'logical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['block_encoding', 'chemistry_qpe', 'spacetime']\n",
       "Chemically accurate QPE in the early fault-tolerant regime\n",
-      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['chemistry_qpe', 'spacetime', 'architecture']\n"
      ]
     }
    ],
@@ -358,17 +361,20 @@
     "\n",
     "print(scdf_signal.title)\n",
     "print([quantity.value for quantity in scdf_signal.quantities])\n",
+    "print([profile.value for profile in scdf_signal.profiles])\n",
     "print(early_ftqc_signal.title)\n",
     "print([quantity.value for quantity in early_ftqc_signal.quantities])\n",
+    "print([profile.value for profile in early_ftqc_signal.profiles])\n",
     "\n",
     "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities\n",
     "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities\n",
-    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities"
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities\n",
+    "assert FTQCResourceProfile.SPACETIME in early_ftqc_signal.profiles"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "04d2d539",
+   "id": "16342819",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -381,13 +387,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cab56d87",
+   "id": "4ebcfce9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.956808Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.956755Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.959582Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.959144Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.939017Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.938943Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.941897Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.941560Z"
     }
    },
    "outputs": [],
@@ -410,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1dce6dad",
+   "id": "2a8a60ea",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -422,13 +428,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1515866b",
+   "id": "8fa7710e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.960630Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.960568Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.963028Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.962640Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.943109Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.943049Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.945357Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.944871Z"
     }
    },
    "outputs": [],
@@ -451,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cd28a52",
+   "id": "78f0d08b",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -473,13 +479,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "87d72b2b",
+   "id": "541b4a22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.964299Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.964239Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.990215Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.989794Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.946332Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.946280Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.983695Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.983231Z"
     }
    },
    "outputs": [
@@ -606,7 +612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b86c4078",
+   "id": "0dbabd72",
    "metadata": {},
    "source": [
     "## State-Preparation Success Budget\n",
@@ -621,13 +627,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "66331994",
+   "id": "167b2065",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.991414Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.991338Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.005621Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.005247Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.985241Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.985163Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.003142Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.002589Z"
     }
    },
    "outputs": [
@@ -692,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e16bf52c",
+   "id": "f985b745",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -704,13 +710,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1f6f2d3d",
+   "id": "5f53229b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.006820Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.006742Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.010843Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.010381Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.004483Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.004422Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.009437Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.008591Z"
     }
    },
    "outputs": [
@@ -744,7 +750,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a327b7e",
+   "id": "17858299",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -759,13 +765,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "10118eca",
+   "id": "18b97fd3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.012205Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.012147Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.020778Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.020445Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.011403Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.011322Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.021320Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.020571Z"
     }
    },
    "outputs": [
@@ -842,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a39116b6",
+   "id": "045d08d0",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -857,13 +863,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "fd30b971",
+   "id": "a6e0b048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.022190Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.022114Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.025880Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.025576Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.022638Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.022576Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.027967Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.027258Z"
     }
    },
    "outputs": [
@@ -916,7 +922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1330df3",
+   "id": "3e3b6a83",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -205,8 +205,9 @@ assert space_time_quantities == (
 
 # %% [markdown]
 # The research-signal catalog maps recent papers to the quantities they ask a
-# Qamomile model to expose. This keeps the tutorial grounded in a small,
-# inspectable contract instead of prose-only claims.
+# Qamomile model to expose, plus the review profiles that should be inspected
+# first. This keeps the tutorial grounded in a small, inspectable contract
+# instead of prose-only claims.
 
 # %%
 signal_by_key = {
@@ -217,12 +218,15 @@ early_ftqc_signal = signal_by_key["arXiv:2603.22778"]
 
 print(scdf_signal.title)
 print([quantity.value for quantity in scdf_signal.quantities])
+print([profile.value for profile in scdf_signal.profiles])
 print(early_ftqc_signal.title)
 print([quantity.value for quantity in early_ftqc_signal.quantities])
+print([profile.value for profile in early_ftqc_signal.profiles])
 
 assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities
 assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities
 assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities
+assert FTQCResourceProfile.SPACETIME in early_ftqc_signal.profiles
 
 # %% [markdown]
 # We start from a small Qamomile observable so the workflow has the same shape

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f58f3b38",
+   "id": "9c7c3d5c",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "db068678",
+   "id": "70049956",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.845645Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.845357Z",
-     "iopub.status.idle": "2026-06-23T06:27:41.851497Z",
-     "shell.execute_reply": "2026-06-23T06:27:41.850324Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.023076Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.022905Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.028241Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.026972Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "366e077b",
+   "id": "252e0f51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.854873Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.854703Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.292756Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.292135Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.031017Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.030856Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.426417Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.425675Z"
     }
    },
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bc591fb",
+   "id": "d4ffc058",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -111,14 +111,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5478fb0c",
+   "id": "f273e85d",
    "metadata": {},
    "source": [
     "## Research Signals\n",
     "\n",
     "The current quantity catalog follows the cost drivers used in recent FTQC\n",
     "chemistry work. Qamomile exposes that mapping as structured research signals\n",
-    "so reports can show why a quantity is being measured:\n",
+    "so reports can show why a quantity is being measured and which review profile\n",
+    "should be used first:\n",
     "\n",
     "| Research direction | Cost signal for Qamomile |\n",
     "| --- | --- |\n",
@@ -134,13 +135,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "1949e99b",
+   "id": "b1bcaf04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.294445Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.294268Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.297065Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.296565Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.428287Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.428171Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.431381Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.430569Z"
     }
    },
    "outputs": [
@@ -148,30 +149,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "arXiv:1610.06546 -> lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
-      "arXiv:2403.03502 -> lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
-      "arXiv:2412.01338 -> lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
-      "arXiv:2601.08533 -> state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
-      "arXiv:2603.22778 -> lambda_norm, qpe_iterations, t_gates, logical_depth\n"
+      "arXiv:1610.06546 -> block_encoding, chemistry_qpe | lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "arXiv:2403.03502 -> block_encoding, chemistry_qpe, spacetime | lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
+      "arXiv:2412.01338 -> chemistry_qpe | lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
+      "arXiv:2601.08533 -> chemistry_qpe, spacetime | state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
+      "arXiv:2603.22778 -> chemistry_qpe, spacetime, architecture | lambda_norm, qpe_iterations, t_gates, logical_depth\n"
      ]
     }
    ],
    "source": [
     "research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]\n",
     "for signal in research_signals:\n",
-    "    print(signal[\"reference_key\"], \"->\", \", \".join(signal[\"quantities\"][:4]))\n",
+    "    print(\n",
+    "        signal[\"reference_key\"],\n",
+    "        \"->\",\n",
+    "        \", \".join(signal[\"profiles\"]),\n",
+    "        \"|\",\n",
+    "        \", \".join(signal[\"quantities\"][:4]),\n",
+    "    )\n",
     "\n",
     "signal_by_key = {signal[\"reference_key\"]: signal for signal in research_signals}\n",
     "assert \"lambda_norm\" in signal_by_key[\"arXiv:2403.03502\"][\"quantities\"]\n",
     "assert \"state_preparation_success_probability\" in signal_by_key[\"arXiv:2601.08533\"][\n",
     "    \"quantities\"\n",
     "]\n",
-    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]"
+    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]\n",
+    "assert \"spacetime\" in signal_by_key[\"arXiv:2603.22778\"][\"profiles\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "658f7e4a",
+   "id": "7512a3c7",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -183,13 +191,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "085a4ac3",
+   "id": "897661d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.298497Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.298426Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.302642Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.301624Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.433441Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.433384Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.437493Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.436765Z"
     }
    },
    "outputs": [
@@ -283,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9899a3d7",
+   "id": "1e536e45",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -294,13 +302,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0e579fc7",
+   "id": "70872b4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.304292Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.304225Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.306766Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.306287Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.438765Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.438688Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.441339Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.440617Z"
     }
    },
    "outputs": [
@@ -330,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a67b6b8b",
+   "id": "68b7ad4c",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -345,13 +353,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2bb7d65b",
+   "id": "e3de5717",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.308371Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.308280Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.313967Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.313432Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.442644Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.442559Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.447581Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.447152Z"
     }
    },
    "outputs": [
@@ -411,7 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab4354c5",
+   "id": "d754dff2",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -423,13 +431,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "66b36535",
+   "id": "609850cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.315292Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.315217Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.319107Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.317789Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.448756Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.448698Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.451322Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.450933Z"
     }
    },
    "outputs": [],
@@ -454,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "940677f3",
+   "id": "a7399874",
    "metadata": {},
    "source": [
     "A block-encoding model can also produce a plan directly. The plan separates\n",
@@ -466,13 +474,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "75ec9da5",
+   "id": "0e6bad2d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.321295Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.321147Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.352526Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.351446Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.453120Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.452998Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.480752Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.480194Z"
     }
    },
    "outputs": [
@@ -526,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c18a4a7a",
+   "id": "5a719719",
    "metadata": {},
    "source": [
     "Plan provenance is intentionally separate from circuit lowering. A review can\n",
@@ -537,13 +545,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "21113b9e",
+   "id": "62b4998c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.354050Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.353967Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.358169Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.357478Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.482201Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.482123Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.486723Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.485888Z"
     }
    },
    "outputs": [
@@ -570,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "206f5643",
+   "id": "7b429b30",
    "metadata": {},
    "source": [
     "State-preparation success probability can be layered onto the same plan. This\n",
@@ -581,13 +589,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "1665cba0",
+   "id": "6e4a5b31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.359443Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.359384Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.375385Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.374747Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.488136Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.488072Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.503265Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.502379Z"
     }
    },
    "outputs": [
@@ -628,7 +636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d00df198",
+   "id": "4f9d1a5a",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -643,13 +651,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "37b89bbf",
+   "id": "89a46779",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.376758Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.376674Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.541044Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.540274Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.505190Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.505089Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.662457Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.661815Z"
     }
    },
    "outputs": [
@@ -707,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28a5e731",
+   "id": "8df79ba7",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -720,13 +728,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "9c2488e7",
+   "id": "aef8e101",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.542731Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.542668Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.557642Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.556766Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.663830Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.663763Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.677417Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.676925Z"
     }
    },
    "outputs": [
@@ -862,7 +870,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1de622e4",
+   "id": "00a65e7f",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -873,13 +881,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "eac9bed7",
+   "id": "2f1a9911",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.559403Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.559316Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.564177Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.563564Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.678677Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.678614Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.682991Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.682570Z"
     }
    },
    "outputs": [
@@ -925,7 +933,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fe14823",
+   "id": "44c2d2e6",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -937,13 +945,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "faf762dc",
+   "id": "9a163ab3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.565837Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.565759Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.571397Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.570898Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.684234Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.684160Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.690441Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.689899Z"
     }
    },
    "outputs": [
@@ -994,7 +1002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "505f3ba9",
+   "id": "73ab0ee8",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -1008,13 +1016,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "ac5d6a26",
+   "id": "e99c8fe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.572462Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.572395Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.574926Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.574447Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.691749Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.691678Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.694195Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.693740Z"
     }
    },
    "outputs": [
@@ -1040,7 +1048,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aabb927d",
+   "id": "78cdbccf",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -1054,13 +1062,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "24de74cd",
+   "id": "6d9c605d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.576175Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.576102Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.579998Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.579188Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.695447Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.695368Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.698300Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.697818Z"
     }
    },
    "outputs": [
@@ -1093,7 +1101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c5b1ce1",
+   "id": "44b4ec91",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -1107,13 +1115,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "25f156a4",
+   "id": "c37fddd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.581395Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.581326Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.584021Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.583703Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.699636Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.699567Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.701673Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.701262Z"
     }
    },
    "outputs": [
@@ -1149,7 +1157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "289da61a",
+   "id": "4e4e9145",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -1161,13 +1169,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "1cbc711e",
+   "id": "ac196b71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.585357Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.585207Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.590696Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.590296Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.703409Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.703333Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.707800Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.707261Z"
     }
    },
    "outputs": [
@@ -1214,7 +1222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9233d1c3",
+   "id": "1ea6f8a9",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -1228,13 +1236,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "73337e59",
+   "id": "3cb2ae93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.592308Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.592235Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.600932Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.600617Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.709133Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.709076Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.716913Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.716474Z"
     }
    },
    "outputs": [
@@ -1290,7 +1298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fccc10e4",
+   "id": "e8c47ded",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1304,13 +1312,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d496a8de",
+   "id": "63ab9432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.603163Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.603013Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.606293Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.605904Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.718069Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.718011Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.721500Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.721128Z"
     }
    },
    "outputs": [
@@ -1361,7 +1369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5872361",
+   "id": "b228ed7e",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1386,7 +1394,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f00349ea",
+   "id": "e8201ec2",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -88,7 +88,8 @@ from qamomile.circuit.estimator.algorithmic import (
 #
 # The current quantity catalog follows the cost drivers used in recent FTQC
 # chemistry work. Qamomile exposes that mapping as structured research signals
-# so reports can show why a quantity is being measured:
+# so reports can show why a quantity is being measured and which review profile
+# should be used first:
 #
 # | Research direction | Cost signal for Qamomile |
 # | --- | --- |
@@ -103,7 +104,13 @@ from qamomile.circuit.estimator.algorithmic import (
 # %%
 research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]
 for signal in research_signals:
-    print(signal["reference_key"], "->", ", ".join(signal["quantities"][:4]))
+    print(
+        signal["reference_key"],
+        "->",
+        ", ".join(signal["profiles"]),
+        "|",
+        ", ".join(signal["quantities"][:4]),
+    )
 
 signal_by_key = {signal["reference_key"]: signal for signal in research_signals}
 assert "lambda_norm" in signal_by_key["arXiv:2403.03502"]["quantities"]
@@ -111,6 +118,7 @@ assert "state_preparation_success_probability" in signal_by_key["arXiv:2601.0853
     "quantities"
 ]
 assert "t_gates" in signal_by_key["arXiv:2603.22778"]["quantities"]
+assert "spacetime" in signal_by_key["arXiv:2603.22778"]["profiles"]
 
 # %% [markdown]
 # ## Quantity Catalog

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b7244784",
+   "id": "db1fba6c",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f6c7ef6c",
+   "id": "8f1b579d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.847722Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.847431Z",
-     "iopub.status.idle": "2026-06-23T06:27:41.853562Z",
-     "shell.execute_reply": "2026-06-23T06:27:41.852126Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.030108Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.029927Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.033581Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.032671Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f6b5e100",
+   "id": "6521a32e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.856339Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.856170Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.941851Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.941414Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.036829Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.036634Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.917426Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.917000Z"
     }
    },
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cdc0a33",
+   "id": "196e07e6",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eff0733a",
+   "id": "8e4be31b",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -105,13 +105,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c4f39b66",
+   "id": "c03205ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.943385Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.943237Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.947738Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.947440Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.919369Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.919118Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.923089Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.922703Z"
     }
    },
    "outputs": [],
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f326721",
+   "id": "2023ef3c",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -162,13 +162,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2ca9596e",
+   "id": "1e62d451",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.949185Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.949119Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.951918Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.951421Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.924184Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.924120Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.926843Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.926332Z"
     }
    },
    "outputs": [
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5921c252",
+   "id": "50ab3f90",
    "metadata": {},
    "source": [
     "Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付け、comparison helperへ直接渡せます。"
@@ -248,13 +248,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "813ba64d",
+   "id": "defd6ef8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.953284Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.953226Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.955206Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.954927Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.927946Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.927891Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.930127Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.929616Z"
     }
    },
    "outputs": [
@@ -288,22 +288,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a28700a",
+   "id": "53d7844c",
    "metadata": {},
    "source": [
-    "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
+    "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量、さらに最初に確認すべきreview profileを対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e5083355",
+   "id": "f27585d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.956377Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.956308Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.958589Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.958204Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.931236Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.931179Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.936460Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.935442Z"
     }
    },
    "outputs": [
@@ -313,8 +313,10 @@
      "text": [
       "Symmetry-compressed double factorization for fault-tolerant chemistry simulation\n",
       "['lambda_norm', 'qpe_iterations', 'walk_cost_toffoli', 'toffoli_gates', 'logical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['block_encoding', 'chemistry_qpe', 'spacetime']\n",
       "Chemically accurate QPE in the early fault-tolerant regime\n",
-      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['chemistry_qpe', 'spacetime', 'architecture']\n"
      ]
     }
    ],
@@ -327,17 +329,20 @@
     "\n",
     "print(scdf_signal.title)\n",
     "print([quantity.value for quantity in scdf_signal.quantities])\n",
+    "print([profile.value for profile in scdf_signal.profiles])\n",
     "print(early_ftqc_signal.title)\n",
     "print([quantity.value for quantity in early_ftqc_signal.quantities])\n",
+    "print([profile.value for profile in early_ftqc_signal.profiles])\n",
     "\n",
     "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities\n",
     "assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities\n",
-    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities"
+    "assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities\n",
+    "assert FTQCResourceProfile.SPACETIME in early_ftqc_signal.profiles"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f92dd51e",
+   "id": "69c58386",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -346,13 +351,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f27fe84d",
+   "id": "39c25b17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.959793Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.959723Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.962718Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.962400Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.938742Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.938674Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.942415Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.941950Z"
     }
    },
    "outputs": [],
@@ -375,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a089b9c",
+   "id": "28e72667",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -387,13 +392,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "cca4ae63",
+   "id": "056d131b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.963925Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.963857Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.966354Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.965960Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.943381Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.943320Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.945380Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.945090Z"
     }
    },
    "outputs": [],
@@ -416,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "066b8ccb",
+   "id": "0b8f839a",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -434,13 +439,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "29a7dbd4",
+   "id": "4fe83082",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.967338Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.967270Z",
-     "iopub.status.idle": "2026-06-23T06:27:43.993159Z",
-     "shell.execute_reply": "2026-06-23T06:27:43.992644Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.946499Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.946447Z",
+     "iopub.status.idle": "2026-06-23T06:44:31.984337Z",
+     "shell.execute_reply": "2026-06-23T06:44:31.983824Z"
     }
    },
    "outputs": [
@@ -567,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7d3cd80",
+   "id": "b05a0b90",
    "metadata": {},
    "source": [
     "## State-preparation success budget\n",
@@ -578,13 +583,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "4b87975e",
+   "id": "b352f9e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:43.994278Z",
-     "iopub.status.busy": "2026-06-23T06:27:43.994213Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.008063Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.007668Z"
+     "iopub.execute_input": "2026-06-23T06:44:31.986069Z",
+     "iopub.status.busy": "2026-06-23T06:44:31.985952Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.002638Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.002167Z"
     }
    },
    "outputs": [
@@ -649,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c7c8e90",
+   "id": "150d86b1",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -658,13 +663,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "fa15808d",
+   "id": "802a830d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.009209Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.009146Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.013313Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.012993Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.004269Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.004189Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.008709Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.007957Z"
     }
    },
    "outputs": [
@@ -698,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8510209d",
+   "id": "20a98d54",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -709,13 +714,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "14d36a5a",
+   "id": "297b0012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.014510Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.014448Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.023293Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.022949Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.011077Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.011015Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.020762Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.020209Z"
     }
    },
    "outputs": [
@@ -792,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "940af423",
+   "id": "661649df",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -803,13 +808,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "3df97b6d",
+   "id": "b48d56ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:44.024361Z",
-     "iopub.status.busy": "2026-06-23T06:27:44.024287Z",
-     "iopub.status.idle": "2026-06-23T06:27:44.028205Z",
-     "shell.execute_reply": "2026-06-23T06:27:44.027720Z"
+     "iopub.execute_input": "2026-06-23T06:44:32.022319Z",
+     "iopub.status.busy": "2026-06-23T06:44:32.022255Z",
+     "iopub.status.idle": "2026-06-23T06:44:32.027564Z",
+     "shell.execute_reply": "2026-06-23T06:44:32.026967Z"
     }
    },
    "outputs": [
@@ -862,7 +867,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c885442",
+   "id": "10b1017b",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -175,7 +175,7 @@ assert space_time_quantities == (
 )
 
 # %% [markdown]
-# research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量を対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。
+# research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量、さらに最初に確認すべきreview profileを対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。
 
 # %%
 signal_by_key = {
@@ -186,12 +186,15 @@ early_ftqc_signal = signal_by_key["arXiv:2603.22778"]
 
 print(scdf_signal.title)
 print([quantity.value for quantity in scdf_signal.quantities])
+print([profile.value for profile in scdf_signal.profiles])
 print(early_ftqc_signal.title)
 print([quantity.value for quantity in early_ftqc_signal.quantities])
+print([profile.value for profile in early_ftqc_signal.profiles])
 
 assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf_signal.quantities
 assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc_signal.quantities
 assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in early_ftqc_signal.quantities
+assert FTQCResourceProfile.SPACETIME in early_ftqc_signal.profiles
 
 # %% [markdown]
 # 小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0673ca83",
+   "id": "ee05ebf2",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "908f95d4",
+   "id": "21b55317",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.845697Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.845294Z",
-     "iopub.status.idle": "2026-06-23T06:27:41.851668Z",
-     "shell.execute_reply": "2026-06-23T06:27:41.850420Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.029797Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.029634Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.033564Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.032699Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "68d10afa",
+   "id": "b302630e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:41.855048Z",
-     "iopub.status.busy": "2026-06-23T06:27:41.854862Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.292454Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.292058Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.036723Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.036531Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.426287Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.425675Z"
     }
    },
    "outputs": [],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "438bbb1f",
+   "id": "6df07285",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -100,12 +100,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82f00207",
+   "id": "0b7a3492",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
     "\n",
-    "現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」を示せます。\n",
+    "現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」と、最初に使うべきreview profileを示せます。\n",
     "\n",
     "| Research direction | Cost signal for Qamomile |\n",
     "| --- | --- |\n",
@@ -120,13 +120,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d2e61d1c",
+   "id": "376b7207",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.294563Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.294287Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.297407Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.296806Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.428129Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.428016Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.431362Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.430578Z"
     }
    },
    "outputs": [
@@ -134,30 +134,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "arXiv:1610.06546 -> lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
-      "arXiv:2403.03502 -> lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
-      "arXiv:2412.01338 -> lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
-      "arXiv:2601.08533 -> state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
-      "arXiv:2603.22778 -> lambda_norm, qpe_iterations, t_gates, logical_depth\n"
+      "arXiv:1610.06546 -> block_encoding, chemistry_qpe | lambda_norm, prepare_cost_toffoli, select_cost_toffoli, reflection_cost_toffoli\n",
+      "arXiv:2403.03502 -> block_encoding, chemistry_qpe, spacetime | lambda_norm, qpe_iterations, walk_cost_toffoli, toffoli_gates\n",
+      "arXiv:2412.01338 -> chemistry_qpe | lambda_norm, truncation_error, qpe_iterations, toffoli_gates\n",
+      "arXiv:2601.08533 -> chemistry_qpe, spacetime | state_preparation_success_probability, qpe_repetitions, state_preparation_t_gates, state_preparation_logical_depth\n",
+      "arXiv:2603.22778 -> chemistry_qpe, spacetime, architecture | lambda_norm, qpe_iterations, t_gates, logical_depth\n"
      ]
     }
    ],
    "source": [
     "research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]\n",
     "for signal in research_signals:\n",
-    "    print(signal[\"reference_key\"], \"->\", \", \".join(signal[\"quantities\"][:4]))\n",
+    "    print(\n",
+    "        signal[\"reference_key\"],\n",
+    "        \"->\",\n",
+    "        \", \".join(signal[\"profiles\"]),\n",
+    "        \"|\",\n",
+    "        \", \".join(signal[\"quantities\"][:4]),\n",
+    "    )\n",
     "\n",
     "signal_by_key = {signal[\"reference_key\"]: signal for signal in research_signals}\n",
     "assert \"lambda_norm\" in signal_by_key[\"arXiv:2403.03502\"][\"quantities\"]\n",
     "assert \"state_preparation_success_probability\" in signal_by_key[\"arXiv:2601.08533\"][\n",
     "    \"quantities\"\n",
     "]\n",
-    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]"
+    "assert \"t_gates\" in signal_by_key[\"arXiv:2603.22778\"][\"quantities\"]\n",
+    "assert \"spacetime\" in signal_by_key[\"arXiv:2603.22778\"][\"profiles\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7380f964",
+   "id": "828d14c5",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -168,13 +175,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1ee6a72c",
+   "id": "e10365dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.298670Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.298611Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.302677Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.301965Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.433432Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.433373Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.437434Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.436710Z"
     }
    },
    "outputs": [
@@ -268,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca109c97",
+   "id": "0a432c14",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -277,13 +284,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "31fb37e7",
+   "id": "aa8bed0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.304463Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.304316Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.306839Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.306394Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.438680Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.438603Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.441305Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.440677Z"
     }
    },
    "outputs": [
@@ -313,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c0c11b9",
+   "id": "ca6fc9f5",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -324,13 +331,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "530a5438",
+   "id": "f41df20e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.308466Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.308387Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.313681Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.313130Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.442616Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.442544Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.447558Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.447134Z"
     }
    },
    "outputs": [
@@ -390,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc839176",
+   "id": "c3598a3e",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -399,13 +406,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "6c1d3441",
+   "id": "5e9888e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.315020Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.314955Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.318761Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.317204Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.448711Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.448656Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.451329Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.450909Z"
     }
    },
    "outputs": [],
@@ -430,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e0f7663",
+   "id": "946217ac",
    "metadata": {},
    "source": [
     "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
@@ -439,13 +446,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "534cee5b",
+   "id": "d95647aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.320885Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.320816Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.352589Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.351515Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.452880Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.452800Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.481139Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.480412Z"
     }
    },
    "outputs": [
@@ -499,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6443fc49",
+   "id": "1d2c6614",
    "metadata": {},
    "source": [
     "plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。"
@@ -508,13 +515,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "da76b146",
+   "id": "0d8a4afc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.354064Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.353982Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.358364Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.357519Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.482450Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.482372Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.486940Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.486065Z"
     }
    },
    "outputs": [
@@ -541,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8b8e12b",
+   "id": "4af18465",
    "metadata": {},
    "source": [
     "state-preparation success probabilityは、同じplanへ重ねられます。これにより、具体的なstate-preparation回路がなくても、trial-state overlapやfiltering仮定を見える形で保持できます。"
@@ -550,13 +557,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "6f581e9d",
+   "id": "ac3e934d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.359649Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.359590Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.375448Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.374931Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.488377Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.488312Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.503708Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.502719Z"
     }
    },
    "outputs": [
@@ -597,7 +604,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b66d0f80",
+   "id": "d9c46db9",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -608,13 +615,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "624120ef",
+   "id": "f78188d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.376630Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.376556Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.540592Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.539994Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.505279Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.505189Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.662187Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.661635Z"
     }
    },
    "outputs": [
@@ -672,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9101788",
+   "id": "e156d3b3",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -683,13 +690,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "585fcd11",
+   "id": "5a8c5e30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.542427Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.542355Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.557554Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.556891Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.663692Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.663621Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.677742Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.677252Z"
     }
    },
    "outputs": [
@@ -825,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88d3df5c",
+   "id": "baf98d85",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -834,13 +841,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "71d34327",
+   "id": "548eb747",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.559365Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.559286Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.564617Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.563791Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.679021Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.678943Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.683341Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.682772Z"
     }
    },
    "outputs": [
@@ -886,7 +893,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef6345e2",
+   "id": "f73d4d02",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -895,13 +902,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d50faf05",
+   "id": "faa21164",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.566038Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.565965Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.571376Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.570909Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.684415Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.684359Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.690390Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.689980Z"
     }
    },
    "outputs": [
@@ -952,7 +959,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95a965c1",
+   "id": "be2ad7cb",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -963,13 +970,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "bd3ca680",
+   "id": "3942ed0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.572384Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.572330Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.574949Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.574421Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.691702Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.691640Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.694324Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.693740Z"
     }
    },
    "outputs": [
@@ -995,7 +1002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5b16933",
+   "id": "de5c7441",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -1006,13 +1013,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "844dcb2c",
+   "id": "9503e3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.576026Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.575972Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.579847Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.579107Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.695632Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.695562Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.698695Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.698193Z"
     }
    },
    "outputs": [
@@ -1045,7 +1052,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c40f52c",
+   "id": "be6be850",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -1056,13 +1063,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "1d73bb91",
+   "id": "3bc30a1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.581175Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.581114Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.583540Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.583202Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.699818Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.699764Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.702380Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.701664Z"
     }
    },
    "outputs": [
@@ -1098,7 +1105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce339762",
+   "id": "9ab6ebdb",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -1109,13 +1116,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "6f925021",
+   "id": "1e81f28a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.584795Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.584740Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.589873Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.589419Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.703602Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.703542Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.707913Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.707468Z"
     }
    },
    "outputs": [
@@ -1162,7 +1169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c3181ea",
+   "id": "a586a89c",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -1173,13 +1180,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "6c06129b",
+   "id": "96118f18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.591187Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.591113Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.600134Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.599776Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.709282Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.709199Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.717029Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.716545Z"
     }
    },
    "outputs": [
@@ -1235,7 +1242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b2c49f1",
+   "id": "22f711ce",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -1246,13 +1253,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "4f3014b3",
+   "id": "2b307ad2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:27:42.601469Z",
-     "iopub.status.busy": "2026-06-23T06:27:42.601409Z",
-     "iopub.status.idle": "2026-06-23T06:27:42.605687Z",
-     "shell.execute_reply": "2026-06-23T06:27:42.605172Z"
+     "iopub.execute_input": "2026-06-23T06:44:30.718106Z",
+     "iopub.status.busy": "2026-06-23T06:44:30.718049Z",
+     "iopub.status.idle": "2026-06-23T06:44:30.721787Z",
+     "shell.execute_reply": "2026-06-23T06:44:30.721397Z"
     }
    },
    "outputs": [
@@ -1303,7 +1310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b4a4578",
+   "id": "cfd8c795",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1322,7 +1329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "298eec48",
+   "id": "11aa90bf",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -75,7 +75,7 @@ from qamomile.circuit.estimator.algorithmic import (
 # %% [markdown]
 # ## 研究上のシグナル
 #
-# 現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」を示せます。
+# 現在のquantity catalogは、近年のFTQC化学計算研究で使われているcost driverに合わせています。Qamomileはこの対応をstructured research signalとして公開しているため、reportで「なぜそのquantityを測るのか」と、最初に使うべきreview profileを示せます。
 #
 # | Research direction | Cost signal for Qamomile |
 # | --- | --- |
@@ -89,7 +89,13 @@ from qamomile.circuit.estimator.algorithmic import (
 # %%
 research_signals = [signal.to_dict() for signal in iter_ftqc_research_signals()]
 for signal in research_signals:
-    print(signal["reference_key"], "->", ", ".join(signal["quantities"][:4]))
+    print(
+        signal["reference_key"],
+        "->",
+        ", ".join(signal["profiles"]),
+        "|",
+        ", ".join(signal["quantities"][:4]),
+    )
 
 signal_by_key = {signal["reference_key"]: signal for signal in research_signals}
 assert "lambda_norm" in signal_by_key["arXiv:2403.03502"]["quantities"]
@@ -97,6 +103,7 @@ assert "state_preparation_success_probability" in signal_by_key["arXiv:2601.0853
     "quantities"
 ]
 assert "t_gates" in signal_by_key["arXiv:2603.22778"]["quantities"]
+assert "spacetime" in signal_by_key["arXiv:2603.22778"]["profiles"]
 
 # %% [markdown]
 # ## Quantity Catalog

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -355,6 +355,8 @@ class FTQCResearchSignal:
             quantities that should be inspected when modeling this direction.
         design_note (str): Guidance for how Qamomile should represent the
             signal without prematurely lowering it into backend circuits.
+        profiles (tuple[FTQCResourceProfile, ...]): Standard review profiles
+            that cover this research signal. Defaults to an empty tuple.
 
     Example:
         >>> signal = iter_ftqc_research_signals()[0]
@@ -368,6 +370,7 @@ class FTQCResearchSignal:
     cost_driver: str
     quantities: tuple[FTQCResourceQuantity, ...]
     design_note: str
+    profiles: tuple[FTQCResourceProfile, ...] = ()
 
     def to_dict(self) -> dict[str, str | list[str]]:
         """Serialize the research signal.
@@ -382,6 +385,7 @@ class FTQCResearchSignal:
             "cost_driver": self.cost_driver,
             "quantities": [quantity.value for quantity in self.quantities],
             "design_note": self.design_note,
+            "profiles": [profile.value for profile in self.profiles],
         }
 
 
@@ -1788,7 +1792,11 @@ FTQC_RESOURCE_PROFILE_SPECS: tuple[FTQCResourceProfileSpec, ...] = (
             FTQCResourceQuantity.LAMBDA_NORM,
             FTQCResourceQuantity.TARGET_PRECISION,
             FTQCResourceQuantity.TRUNCATION_ERROR,
+            FTQCResourceQuantity.STATE_PREPARATION_SUCCESS_PROBABILITY,
             FTQCResourceQuantity.QPE_REPETITIONS,
+            FTQCResourceQuantity.STATE_PREPARATION_TOFFOLI,
+            FTQCResourceQuantity.STATE_PREPARATION_T_GATES,
+            FTQCResourceQuantity.STATE_PREPARATION_LOGICAL_DEPTH,
             FTQCResourceQuantity.QPE_ITERATIONS,
             FTQCResourceQuantity.TOFFOLI_GATES,
             FTQCResourceQuantity.T_GATES,
@@ -1901,6 +1909,10 @@ FTQC_RESEARCH_SIGNALS = (
             "Represent the block encoding as algorithmic metadata until a "
             "loader implementation is ready to emit concrete circuits."
         ),
+        profiles=(
+            FTQCResourceProfile.BLOCK_ENCODING,
+            FTQCResourceProfile.CHEMISTRY_QPE,
+        ),
     ),
     FTQCResearchSignal(
         reference_key="arXiv:2403.03502",
@@ -1926,6 +1938,11 @@ FTQC_RESEARCH_SIGNALS = (
             "Keep factorization ranks, normalization, and walk cost on the "
             "chemistry model rather than baking them into IR gates."
         ),
+        profiles=(
+            FTQCResourceProfile.BLOCK_ENCODING,
+            FTQCResourceProfile.CHEMISTRY_QPE,
+            FTQCResourceProfile.SPACETIME,
+        ),
     ),
     FTQCResearchSignal(
         reference_key="arXiv:2412.01338",
@@ -1948,6 +1965,7 @@ FTQC_RESEARCH_SIGNALS = (
             "Model symmetry-shift effects as representation metadata with an "
             "explicit accuracy budget."
         ),
+        profiles=(FTQCResourceProfile.CHEMISTRY_QPE,),
     ),
     FTQCResearchSignal(
         reference_key="arXiv:2601.08533",
@@ -1968,6 +1986,10 @@ FTQC_RESEARCH_SIGNALS = (
         design_note=(
             "Represent overlap and filtering success as an algorithmic budget "
             "that scales expected QPE work."
+        ),
+        profiles=(
+            FTQCResourceProfile.CHEMISTRY_QPE,
+            FTQCResourceProfile.SPACETIME,
         ),
     ),
     FTQCResearchSignal(
@@ -1992,6 +2014,11 @@ FTQC_RESEARCH_SIGNALS = (
         design_note=(
             "Track T gates, logical depth, and architecture knobs alongside "
             "Toffoli-native qubitization estimates."
+        ),
+        profiles=(
+            FTQCResourceProfile.CHEMISTRY_QPE,
+            FTQCResourceProfile.SPACETIME,
+            FTQCResourceProfile.ARCHITECTURE,
         ),
     ),
 )

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -102,11 +102,23 @@ def test_ftqc_research_signals_map_sources_to_quantity_catalog():
     assert "arXiv:2601.08533" in signal_by_key
     assert "arXiv:2603.22778" in signal_by_key
     assert all(signal.url.startswith("https://arxiv.org/abs/") for signal in signals)
+    profile_catalog = {
+        profile.profile: set(profile.quantities)
+        for profile in iter_ftqc_resource_profile_specs()
+    }
 
     scdf = signal_by_key["arXiv:2403.03502"]
     assert FTQCResourceQuantity.LAMBDA_NORM in scdf.quantities
     assert FTQCResourceQuantity.TOFFOLI_GATES in scdf.quantities
     assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in scdf.quantities
+    assert scdf.profiles == (
+        FTQCResourceProfile.BLOCK_ENCODING,
+        FTQCResourceProfile.CHEMISTRY_QPE,
+        FTQCResourceProfile.SPACETIME,
+    )
+    assert set(scdf.quantities).issubset(
+        set().union(*(profile_catalog[profile] for profile in scdf.profiles))
+    )
 
     state_preparation = signal_by_key["arXiv:2601.08533"]
     assert (
@@ -117,8 +129,25 @@ def test_ftqc_research_signals_map_sources_to_quantity_catalog():
     assert state_preparation.to_dict()["quantities"][0] == (
         "state_preparation_success_probability"
     )
+    assert state_preparation.to_dict()["profiles"] == [
+        "chemistry_qpe",
+        "spacetime",
+    ]
+    assert set(state_preparation.quantities).issubset(
+        set().union(
+            *(profile_catalog[profile] for profile in state_preparation.profiles)
+        )
+    )
     early_ftqc = signal_by_key["arXiv:2603.22778"]
     assert FTQCResourceQuantity.LOGICAL_SPACETIME_VOLUME in early_ftqc.quantities
+    assert early_ftqc.profiles == (
+        FTQCResourceProfile.CHEMISTRY_QPE,
+        FTQCResourceProfile.SPACETIME,
+        FTQCResourceProfile.ARCHITECTURE,
+    )
+    assert set(early_ftqc.quantities).issubset(
+        set().union(*(profile_catalog[profile] for profile in early_ftqc.profiles))
+    )
 
 
 def test_ftqc_resource_profiles_group_review_quantities():


### PR DESCRIPTION
## Summary
- add recommended FTQC review profiles to each research signal
- extend the chemistry QPE profile to cover state-preparation success and overhead quantities
- update EN/JA FTQC docs and executed notebooks so research signals show both profiles and quantities

## Tests
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_block_encoding.py -q
- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design or ftqc_chemistry_resource_estimation'
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check
- executed the four updated EN/JA FTQC notebooks with jupyter nbconvert

## Local review note
- The documented local-review command uv run zuban qamomile/ still fails with the current zuban CLI: error: unrecognized subcommand 'qamomile/'. The repository command uv run zuban check qamomile/ passed.