### PR TITLE
Expose FTQC estimate driver values

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "82183a94",
+   "id": "0e03d511",
    "metadata": {},
    "source": [
     "---\n",
@@ -22,13 +22,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1cd9be66",
+   "id": "f69d935d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.479651Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.479373Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.483367Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.482465Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.786239Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.785962Z",
+     "iopub.status.idle": "2026-06-23T07:15:36.792097Z",
+     "shell.execute_reply": "2026-06-23T07:15:36.790705Z"
     }
    },
    "outputs": [],
@@ -40,13 +40,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f4df78e1",
+   "id": "e7d533fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.485060Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.484981Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.839025Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.838406Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.795121Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.794959Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.462857Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.461944Z"
     }
    },
    "outputs": [],
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c888f770",
+   "id": "2d150616",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "808b364e",
+   "id": "204a3120",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -132,13 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a2f8afb7",
+   "id": "64ed5d5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.841632Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.840874Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.846158Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.845699Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.470764Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.468962Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.486135Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.484960Z"
     }
    },
    "outputs": [],
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7c26636",
+   "id": "3cc8588a",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -189,13 +189,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "4d0a170e",
+   "id": "00ff2b55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.847409Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.847328Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.850350Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.849967Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.488949Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.488856Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.492681Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.491957Z"
     }
    },
    "outputs": [
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "012ea3aa",
+   "id": "8171982e",
    "metadata": {},
    "source": [
     "Qamomile also provides standard review profiles: small reusable bundles of\n",
@@ -278,13 +278,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4c156137",
+   "id": "73bff7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.851604Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.851533Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.854130Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.853545Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.496163Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.495961Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.501027Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.499303Z"
     }
    },
    "outputs": [
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89b859b0",
+   "id": "182039a6",
    "metadata": {},
    "source": [
     "The research-signal catalog maps recent papers to the quantities they ask a\n",
@@ -330,13 +330,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d7f2504e",
+   "id": "c1ef454f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.855183Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.855108Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.858544Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.857382Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.506170Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.506053Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.509679Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.508875Z"
     }
    },
    "outputs": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42b6d781",
+   "id": "cab42053",
    "metadata": {},
    "source": [
     "We start from a small Qamomile observable so the workflow has the same shape\n",
@@ -388,13 +388,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e7083791",
+   "id": "a523683f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.859709Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.859649Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.862475Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.862076Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.512898Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.512663Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.521852Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.520698Z"
     }
    },
    "outputs": [],
@@ -417,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1af6da8c",
+   "id": "4d2f0d4c",
    "metadata": {},
    "source": [
     "If your chemistry preprocessing already produces an OpenFermion\n",
@@ -429,13 +429,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "51367eb9",
+   "id": "6bf1b019",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.863586Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.863515Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.865724Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.865333Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.523869Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.523789Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.529258Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.526925Z"
     }
    },
    "outputs": [],
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7396360",
+   "id": "a77182c4",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -480,13 +480,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3b446f38",
+   "id": "e57fd487",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.866960Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.866902Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.895432Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.895096Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.533228Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.532856Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.577221Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.576187Z"
     }
    },
    "outputs": [
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9cda242",
+   "id": "46fc7cdb",
    "metadata": {},
    "source": [
     "## State-Preparation Success Budget\n",
@@ -628,13 +628,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "cff0192a",
+   "id": "7aee05d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.896652Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.896585Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.912094Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.911618Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.580020Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.579763Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.625951Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.625374Z"
     }
    },
    "outputs": [
@@ -699,7 +699,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25bce229",
+   "id": "bea63f20",
    "metadata": {},
    "source": [
     "The same chemistry model can also be converted into a block-encoding\n",
@@ -711,13 +711,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9d5bfa88",
+   "id": "6ab331bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.913378Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.913308Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.917316Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.916936Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.627285Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.627219Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.631306Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.630986Z"
     }
    },
    "outputs": [
@@ -751,7 +751,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "179c060b",
+   "id": "00e66371",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -766,13 +766,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "e7b762d9",
+   "id": "a60fdd1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.918400Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.918336Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.931320Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.930853Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.632848Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.632761Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.645827Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.645384Z"
     }
    },
    "outputs": [
@@ -790,7 +790,7 @@
       "Physical qubits ratio: 1.000 reduction: 0\n",
       "Runtime ratio: 0.07500 reduction: 0.9250\n",
       "Physical qubit-seconds ratio: 0.07500 reduction: 0.9250\n",
-      "['qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
      ]
     }
    ],
@@ -853,16 +853,18 @@
     "    uwc_trotter,\n",
     "    baseline_label=\"Plain Trotter QPE\",\n",
     "    candidate_label=\"UWC-style Trotter QPE\",\n",
+    "    require_all_quantities=True,\n",
     ")\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
     "\n",
+    "assert uwc_signal_report.summary.rows[0].quantity == FTQCResourceQuantity.LAMBDA_NORM\n",
     "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
-    "assert \"lambda_norm\" not in uwc_signal_report.to_dict()[\"quantities\"]"
+    "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c848ad0f",
+   "id": "8ce17fe5",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -877,13 +879,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "5407b587",
+   "id": "f281db61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.932470Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.932371Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.936192Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.935772Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.647499Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.647419Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.651575Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.651118Z"
     }
    },
    "outputs": [
@@ -936,7 +938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c47696f3",
+   "id": "fdef6965",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -527,11 +527,13 @@ uwc_signal_report = build_ftqc_research_signal_report(
     uwc_trotter,
     baseline_label="Plain Trotter QPE",
     candidate_label="UWC-style Trotter QPE",
+    require_all_quantities=True,
 )
 print(uwc_signal_report.to_dict()["quantities"])
 
+assert uwc_signal_report.summary.rows[0].quantity == FTQCResourceQuantity.LAMBDA_NORM
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
-assert "lambda_norm" not in uwc_signal_report.to_dict()["quantities"]
+assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]
 # ## Result

--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "385e7d9a",
+   "id": "32ce697f",
    "metadata": {},
    "source": [
     "---\n",
@@ -20,13 +20,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8b9fa0a0",
+   "id": "ec062621",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.478770Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.473672Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.483121Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.482247Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.787333Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.786987Z",
+     "iopub.status.idle": "2026-06-23T07:15:36.792473Z",
+     "shell.execute_reply": "2026-06-23T07:15:36.791351Z"
     }
    },
    "outputs": [],
@@ -38,13 +38,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8a021dec",
+   "id": "7edfe581",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.484918Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.484840Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.949034Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.948654Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.795238Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.795087Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.249687Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.248463Z"
     }
    },
    "outputs": [],
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b910ab4",
+   "id": "2f6ef61c",
    "metadata": {},
    "source": [
     "## Design Boundary\n",
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc598117",
+   "id": "8bfd0137",
    "metadata": {},
    "source": [
     "## Research Signals\n",
@@ -136,13 +136,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7a339a2a",
+   "id": "5fd568c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.950786Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.950675Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.954616Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.953517Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.252294Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.252115Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.256046Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.255197Z"
     }
    },
    "outputs": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31ac0ee4",
+   "id": "e2ae2874",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -192,13 +192,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e620c7b5",
+   "id": "e2ec9628",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.956553Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.956484Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.962253Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.961624Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.258394Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.258196Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.262529Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.262000Z"
     }
    },
    "outputs": [
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40c98f10",
+   "id": "1460e1ad",
    "metadata": {},
    "source": [
     "Standard review profiles provide reusable quantity bundles for recurring\n",
@@ -303,13 +303,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e016ef13",
+   "id": "b7ad1210",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.963720Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.963653Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.966272Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.965514Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.263822Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.263765Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.267604Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.266788Z"
     }
    },
    "outputs": [
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2a2c0eb",
+   "id": "480850f6",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -354,13 +354,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6a8b04b6",
+   "id": "d9c54092",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.967370Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.967310Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.973004Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.972219Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.268863Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.268786Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.275133Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.274475Z"
     }
    },
    "outputs": [
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ba376df",
+   "id": "84ad0790",
    "metadata": {},
    "source": [
     "The same plan object exposes `resource_values()`, so comparison and budget\n",
@@ -432,13 +432,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "05537fdb",
+   "id": "7f36e630",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.975114Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.975002Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.978661Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.977801Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.276845Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.276767Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.279327Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.279011Z"
     }
    },
    "outputs": [],
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "965f7d26",
+   "id": "af66e30f",
    "metadata": {},
    "source": [
     "A block-encoding model can also produce a plan directly. The plan separates\n",
@@ -475,13 +475,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "632b88fb",
+   "id": "98566b61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.979828Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.979764Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.014276Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.013795Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.281958Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.281876Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.314765Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.313663Z"
     }
    },
    "outputs": [
@@ -535,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a258e152",
+   "id": "23657760",
    "metadata": {},
    "source": [
     "Plan provenance is intentionally separate from circuit lowering. A review can\n",
@@ -546,13 +546,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1b0fffd3",
+   "id": "40843b75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.015675Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.015585Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.020870Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.019778Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.316175Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.316107Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.320386Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.319602Z"
     }
    },
    "outputs": [
@@ -579,7 +579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99af1ae7",
+   "id": "0671dda4",
    "metadata": {},
    "source": [
     "State-preparation success probability can be layered onto the same plan. This\n",
@@ -590,13 +590,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "c4059050",
+   "id": "85c4adcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.022407Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.022262Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.038437Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.037419Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.321573Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.321510Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.337479Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.336602Z"
     }
    },
    "outputs": [
@@ -637,7 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71fecdd5",
+   "id": "a9e0cf37",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -652,13 +652,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1053fca3",
+   "id": "160b48e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.041033Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.040835Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.306825Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.306348Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.339042Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.338932Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.603475Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.601184Z"
     }
    },
    "outputs": [
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2841144",
+   "id": "77b9d69e",
    "metadata": {},
    "source": [
     "## Minimal Example\n",
@@ -729,13 +729,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "1fd9b14a",
+   "id": "0661bcac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.311005Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.310863Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.329407Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.328951Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.622273Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.621909Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.706294Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.700904Z"
     }
    },
    "outputs": [
@@ -871,7 +871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e336b74c",
+   "id": "35486196",
    "metadata": {},
    "source": [
     "For design reviews, the summary helper groups the same rows by whether the\n",
@@ -882,13 +882,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d0abaec9",
+   "id": "4dc19fd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.330822Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.330754Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.336966Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.336275Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.712965Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.712737Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.727945Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.726863Z"
     }
    },
    "outputs": [
@@ -934,7 +934,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f8d5331",
+   "id": "d358a349",
    "metadata": {},
    "source": [
     "When you need a self-contained artifact for a design review, build a report.\n",
@@ -946,13 +946,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "9ef575a1",
+   "id": "785ded4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.339212Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.338978Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.346814Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.346344Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.735446Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.735165Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.750723Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.749937Z"
     }
    },
    "outputs": [
@@ -1003,7 +1003,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a473a429",
+   "id": "817e867b",
    "metadata": {},
    "source": [
     "## Reference Provenance\n",
@@ -1017,13 +1017,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9ae2fa63",
+   "id": "117a59cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.347891Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.347818Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.351010Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.350323Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.753871Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.753669Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.762227Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.760459Z"
     }
    },
    "outputs": [
@@ -1049,7 +1049,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a4a0046",
+   "id": "b9912338",
    "metadata": {},
    "source": [
     "## Formula Provenance\n",
@@ -1063,13 +1063,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "2d3050e8",
+   "id": "9f715396",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.352803Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.352649Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.356477Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.356081Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.765072Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.764857Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.773748Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.772260Z"
     }
    },
    "outputs": [
@@ -1102,7 +1102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ff37f82",
+   "id": "3f2bd9ef",
    "metadata": {},
    "source": [
     "## Common Logical Resource Shape\n",
@@ -1116,13 +1116,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "30b09259",
+   "id": "b5870d6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.359520Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.359403Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.362560Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.361776Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.779597Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.779346Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.784195Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.783120Z"
     }
    },
    "outputs": [
@@ -1158,7 +1158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c48d250",
+   "id": "c92731a5",
    "metadata": {},
    "source": [
     "## Architecture Sensitivity\n",
@@ -1170,13 +1170,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "aabed1a3",
+   "id": "ddb7642e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.364777Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.364645Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.369759Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.369331Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.786226Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.786148Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.796581Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.795110Z"
     }
    },
    "outputs": [
@@ -1223,7 +1223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dcd1bab",
+   "id": "7a5efa4f",
    "metadata": {},
    "source": [
     "## Early-FTQC Pattern\n",
@@ -1237,13 +1237,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "c4e7c19a",
+   "id": "e3852730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.371031Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.370944Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.381977Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.381630Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.798775Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.798690Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.816783Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.813837Z"
     }
    },
    "outputs": [
@@ -1299,25 +1299,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96d42323",
+   "id": "9ec05026",
    "metadata": {},
    "source": [
     "A research-signal report scopes the comparison to the quantities motivated by\n",
-    "a specific paper. Concrete estimates may not expose every problem-level\n",
-    "driver from the signal, so the default report uses the signal quantities\n",
-    "available on both estimates."
+    "a specific paper. The Hamiltonian-driven Trotter estimator exposes its\n",
+    "problem-level drivers, so this report can require the full signal contract."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d773ae4d",
+   "id": "7288f096",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.384047Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.383968Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.389822Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.389432Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.819596Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.819033Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.829913Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.828995Z"
     }
    },
    "outputs": [
@@ -1326,7 +1325,7 @@
      "output_type": "stream",
      "text": [
       "arXiv:2603.22778 resource signal review\n",
-      "['qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
      ]
     }
    ],
@@ -1337,20 +1336,21 @@
     "    uwc_trotter,\n",
     "    baseline_label=\"Plain Trotter\",\n",
     "    candidate_label=\"UWC Trotter\",\n",
+    "    require_all_quantities=True,\n",
     ")\n",
     "print(uwc_signal_report.to_dict()[\"title\"])\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
     "\n",
     "assert uwc_signal_report.summary.rows[0].quantity == (\n",
-    "    FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "    FTQCResourceQuantity.LAMBDA_NORM\n",
     ")\n",
-    "assert \"lambda_norm\" not in uwc_signal_report.to_dict()[\"quantities\"]\n",
+    "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
     "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "43456a33",
+   "id": "781f7e12",
    "metadata": {},
    "source": [
     "## Budget Constraints\n",
@@ -1364,13 +1364,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "fdbb2eed",
+   "id": "4603ccc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.393052Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.392875Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.397368Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.396953Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.832759Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.832628Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.837441Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.836775Z"
     }
    },
    "outputs": [
@@ -1421,7 +1421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d7b0489",
+   "id": "d5483f32",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1446,7 +1446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b57fe6",
+   "id": "63ae5864",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -721,9 +721,8 @@ assert (
 
 # %% [markdown]
 # A research-signal report scopes the comparison to the quantities motivated by
-# a specific paper. Concrete estimates may not expose every problem-level
-# driver from the signal, so the default report uses the signal quantities
-# available on both estimates.
+# a specific paper. The Hamiltonian-driven Trotter estimator exposes its
+# problem-level drivers, so this report can require the full signal contract.
 
 # %%
 uwc_signal_report = build_ftqc_research_signal_report(
@@ -732,14 +731,15 @@ uwc_signal_report = build_ftqc_research_signal_report(
     uwc_trotter,
     baseline_label="Plain Trotter",
     candidate_label="UWC Trotter",
+    require_all_quantities=True,
 )
 print(uwc_signal_report.to_dict()["title"])
 print(uwc_signal_report.to_dict()["quantities"])
 
 assert uwc_signal_report.summary.rows[0].quantity == (
-    FTQCResourceQuantity.QPE_ITERATIONS
+    FTQCResourceQuantity.LAMBDA_NORM
 )
-assert "lambda_norm" not in uwc_signal_report.to_dict()["quantities"]
+assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f150384e",
+   "id": "5b3e93bb",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "31382a31",
+   "id": "0d7ef56d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.481549Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.481446Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.484222Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.483606Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.786473Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.786083Z",
+     "iopub.status.idle": "2026-06-23T07:15:36.792045Z",
+     "shell.execute_reply": "2026-06-23T07:15:36.790701Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "0910936b",
+   "id": "6e269613",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.486373Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.486189Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.838946Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.838320Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.794884Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.794722Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.451435Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.447922Z"
     }
    },
    "outputs": [],
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17ab76b2",
+   "id": "56c973ba",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "735ffe1f",
+   "id": "280a3f3b",
    "metadata": {},
    "source": [
     "## Problem Settings\n",
@@ -106,13 +106,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7796c268",
+   "id": "eb0d4d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.841669Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.840935Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.846138Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.845674Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.459334Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.456084Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.474296Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.471260Z"
     }
    },
    "outputs": [],
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e936755",
+   "id": "28a2b708",
    "metadata": {},
    "source": [
     "## Resource Quantities\n",
@@ -163,13 +163,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7a684be5",
+   "id": "afad3cd8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.847381Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.847302Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.850217Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.849786Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.479066Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.478455Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.488199Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.486788Z"
     }
    },
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c73a9142",
+   "id": "ad58a9a9",
    "metadata": {},
    "source": [
     "Qamomileは標準review profileも提供します。これはよく使うaudit上の問いに対応する、小さなquantity bundleです。profileは新しいresourceを計算するものではなく、比較すべき列に名前を付け、comparison helperへ直接渡せます。"
@@ -249,13 +249,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "11dbeeed",
+   "id": "31d5eca4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.851574Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.851460Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.854008Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.853498Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.490829Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.490539Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.495866Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.494802Z"
     }
    },
    "outputs": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4813188",
+   "id": "a91cd6df",
    "metadata": {},
    "source": [
     "research-signal catalogは、近年の論文と、Qamomile modelが公開すべき量、さらに最初に確認すべきreview profileを対応づけます。これにより、このチュートリアルは文章だけの主張ではなく、小さく確認可能なcontractに基づきます。"
@@ -298,13 +298,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "36f1d3a6",
+   "id": "62668eb6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.855168Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.855098Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.858449Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.857304Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.498604Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.498479Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.506095Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.504987Z"
     }
    },
    "outputs": [
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00052e0e",
+   "id": "0856639a",
    "metadata": {},
    "source": [
     "小さなQamomile observableから始めます。実際の化学計算pipelineと同じ形にするためです。Hamiltonianを作る、または読み込み、LCU量を要約して、そのsummaryをFTQC Estimatorへ渡します。下のrescalingは、toy Hamiltonianを大きなactive-space modelの代わりとして使うためのものです。この係数が特定の分子を表すという主張ではありません。"
@@ -352,13 +352,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2496d0f9",
+   "id": "75a3d553",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.859665Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.859604Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.862518Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.862091Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.508762Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.508583Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.512639Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.511362Z"
     }
    },
    "outputs": [],
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f83cdfa",
+   "id": "a4f7be93",
    "metadata": {},
    "source": [
     "chemistry preprocessingがすでにOpenFermionの`QubitOperator`を生成する場合も、\n",
@@ -393,13 +393,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "a5e1a9b0",
+   "id": "1531a0cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.863626Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.863549Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.865763Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.865338Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.516761Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.516507Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.522416Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.521794Z"
     }
    },
    "outputs": [],
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08927ec3",
+   "id": "d32b6f59",
    "metadata": {},
    "source": [
     "## Qubitized QPE Comparison\n",
@@ -440,13 +440,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "147449e4",
+   "id": "ee36cb58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.866825Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.866765Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.894798Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.894369Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.525002Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.524880Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.573705Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.572848Z"
     }
    },
    "outputs": [
@@ -573,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d3ac07f",
+   "id": "1d9718b2",
    "metadata": {},
    "source": [
     "## State-preparation success budget\n",
@@ -584,13 +584,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3962d172",
+   "id": "d60e15f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.895998Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.895934Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.911283Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.910786Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.576137Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.575938Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.626228Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.625714Z"
     }
    },
    "outputs": [
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cfd7952",
+   "id": "c0069a72",
    "metadata": {},
    "source": [
     "同じchemistry modelはblock-encoding contractにも変換できます。将来のloader実装では、chemistry summaryやcompiler IRを変えずに、PREPARE、SELECT、reflection、workspaceのcostを分けてreviewできます。"
@@ -664,13 +664,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "bce85920",
+   "id": "7637e730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.912544Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.912473Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.916507Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.916164Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.627342Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.627278Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.632041Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.631486Z"
     }
    },
    "outputs": [
@@ -704,7 +704,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1265f3b",
+   "id": "28bc487f",
    "metadata": {},
    "source": [
     "## Early-FTQC Trotter QPE\n",
@@ -715,13 +715,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c07a894e",
+   "id": "a1937e61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.917768Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.917703Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.930447Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.929981Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.633327Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.633243Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.646307Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.645888Z"
     }
    },
    "outputs": [
@@ -739,7 +739,7 @@
       "Physical qubits ratio: 1.000 reduction: 0\n",
       "Runtime ratio: 0.07500 reduction: 0.9250\n",
       "Physical qubit-seconds ratio: 0.07500 reduction: 0.9250\n",
-      "['qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
      ]
     }
    ],
@@ -802,16 +802,18 @@
     "    uwc_trotter,\n",
     "    baseline_label=\"Plain Trotter QPE\",\n",
     "    candidate_label=\"UWC-style Trotter QPE\",\n",
+    "    require_all_quantities=True,\n",
     ")\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
     "\n",
+    "assert uwc_signal_report.summary.rows[0].quantity == FTQCResourceQuantity.LAMBDA_NORM\n",
     "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
-    "assert \"lambda_norm\" not in uwc_signal_report.to_dict()[\"quantities\"]"
+    "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "234c7360",
+   "id": "2ab74ff1",
    "metadata": {},
    "source": [
     "## Result\n",
@@ -822,13 +824,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "011531e1",
+   "id": "16e68f70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:29.931689Z",
-     "iopub.status.busy": "2026-06-23T06:59:29.931616Z",
-     "iopub.status.idle": "2026-06-23T06:59:29.935572Z",
-     "shell.execute_reply": "2026-06-23T06:59:29.935111Z"
+     "iopub.execute_input": "2026-06-23T07:15:39.647959Z",
+     "iopub.status.busy": "2026-06-23T07:15:39.647867Z",
+     "iopub.status.idle": "2026-06-23T07:15:39.651833Z",
+     "shell.execute_reply": "2026-06-23T07:15:39.651441Z"
     }
    },
    "outputs": [
@@ -881,7 +883,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8a8b433",
+   "id": "7174336c",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -476,11 +476,13 @@ uwc_signal_report = build_ftqc_research_signal_report(
     uwc_trotter,
     baseline_label="Plain Trotter QPE",
     candidate_label="UWC-style Trotter QPE",
+    require_all_quantities=True,
 )
 print(uwc_signal_report.to_dict()["quantities"])
 
+assert uwc_signal_report.summary.rows[0].quantity == FTQCResourceQuantity.LAMBDA_NORM
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
-assert "lambda_norm" not in uwc_signal_report.to_dict()["quantities"]
+assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]
 # ## Result

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "749602ee",
+   "id": "273640ea",
    "metadata": {},
    "source": [
     "---\n",
@@ -17,13 +17,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fd56ff9f",
+   "id": "fa9e2a83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.478689Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.475383Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.483181Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.482341Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.786781Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.786516Z",
+     "iopub.status.idle": "2026-06-23T07:15:36.792005Z",
+     "shell.execute_reply": "2026-06-23T07:15:36.790569Z"
     }
    },
    "outputs": [],
@@ -35,13 +35,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "aefcc367",
+   "id": "66ade65b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.485027Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.484946Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.949105Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.948594Z"
+     "iopub.execute_input": "2026-06-23T07:15:36.794974Z",
+     "iopub.status.busy": "2026-06-23T07:15:36.794751Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.248741Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.248170Z"
     }
    },
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8146931",
+   "id": "d4b9d38a",
    "metadata": {},
    "source": [
     "## 設計上の境界\n",
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74ab020c",
+   "id": "7685321b",
    "metadata": {},
    "source": [
     "## 研究上のシグナル\n",
@@ -121,13 +121,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "083e6baa",
+   "id": "a0273656",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.950736Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.950632Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.954783Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.953903Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.252227Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.251997Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.256493Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.255738Z"
     }
    },
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "287634ee",
+   "id": "31c41d85",
    "metadata": {},
    "source": [
     "## Quantity Catalog\n",
@@ -176,13 +176,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b71f74ab",
+   "id": "1a559896",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.956537Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.956472Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.961968Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.961374Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.258705Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.258551Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.262837Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.262134Z"
     }
    },
    "outputs": [
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af45446f",
+   "id": "b8975405",
    "metadata": {},
    "source": [
     "標準review profileは、「space-time footprintは何か」のように繰り返し使う問いに対するquantity bundleです。reportごとにad hocな列listを手で写す必要を減らし、comparison helperへ直接渡せます。"
@@ -285,13 +285,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7492d99a",
+   "id": "4a7e78a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.963655Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.963575Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.966044Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.965406Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.263950Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.263873Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.267353Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.266741Z"
     }
    },
    "outputs": [
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e3c0f67",
+   "id": "57729837",
    "metadata": {},
    "source": [
     "## Compositional Algorithm Plans\n",
@@ -332,13 +332,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "586ffacf",
+   "id": "e90fe18f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.967388Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.967309Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.972701Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.972141Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.268894Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.268822Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.275491Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.274637Z"
     }
    },
    "outputs": [
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ad53394",
+   "id": "5ae8f38e",
    "metadata": {},
    "source": [
     "同じplan objectは`resource_values()`を公開するため、comparison helperやbudget helperは化学計算estimateと同じように扱えます。resourceをstep間のピークとして合成したい場合は、そのquantityに対してplan-level ruleをoverrideします。各step自身のrepetition scalingは先に適用されます。"
@@ -407,13 +407,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b7a08db2",
+   "id": "ad01afef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.974962Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.974677Z",
-     "iopub.status.idle": "2026-06-23T06:59:27.978274Z",
-     "shell.execute_reply": "2026-06-23T06:59:27.977756Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.276849Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.276781Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.279428Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.279092Z"
     }
    },
    "outputs": [],
@@ -438,7 +438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de2fb107",
+   "id": "1bcd0c95",
    "metadata": {},
    "source": [
     "block-encoding modelから直接planを作ることもできます。このplanは再利用するblock-encoding contractと、繰り返されるqubitized-walk stepを分けます。そのため、loader circuitが存在しない段階でも、PREPARE、SELECT、reflection、walk cost、QPE反復回数をreviewできます。"
@@ -447,13 +447,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3efae1ed",
+   "id": "8c3e7f03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:27.979702Z",
-     "iopub.status.busy": "2026-06-23T06:59:27.979638Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.014120Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.013715Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.281985Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.281905Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.314911Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.313945Z"
     }
    },
    "outputs": [
@@ -507,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e34fbef1",
+   "id": "ccfefa3d",
    "metadata": {},
    "source": [
     "plan provenanceは、circuit loweringとは意図的に分けています。reviewでは、PREPARE/SELECT実装を具体的なQamomile量子カーネルにするか決める前に、導出式とcitation keyを確認できます。"
@@ -516,13 +516,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "0b2fadcb",
+   "id": "77cdea9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.015902Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.015830Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.020753Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.019881Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.316339Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.316262Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.320379Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.319929Z"
     }
    },
    "outputs": [
@@ -549,7 +549,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c92bd054",
+   "id": "83d5e085",
    "metadata": {},
    "source": [
     "state-preparation success probabilityは、同じplanへ重ねられます。これにより、具体的なstate-preparation回路がなくても、trial-state overlapやfiltering仮定を見える形で保持できます。"
@@ -558,13 +558,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d89ad12e",
+   "id": "dd7df452",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.022450Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.022293Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.038056Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.037251Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.321695Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.321636Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.337283Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.336532Z"
     }
    },
    "outputs": [
@@ -605,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46f2da06",
+   "id": "9461f0c2",
    "metadata": {},
    "source": [
     "## Hamiltonian Resource Reductions\n",
@@ -616,13 +616,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "2926047f",
+   "id": "dbd7bc96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.040715Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.040538Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.302022Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.301202Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.339106Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.339001Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.603671Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.602814Z"
     }
    },
    "outputs": [
@@ -680,7 +680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab0eff6f",
+   "id": "20cdcea5",
    "metadata": {},
    "source": [
     "## 最小例\n",
@@ -691,13 +691,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "eb3e2fb6",
+   "id": "307b9f54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.305138Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.304960Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.327443Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.326285Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.625176Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.624781Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.710414Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.707608Z"
     }
    },
    "outputs": [
@@ -833,7 +833,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29ccc201",
+   "id": "bd20af26",
    "metadata": {},
    "source": [
     "設計レビューでは、summary helperを使うと、同じ行をcandidateが小さい、大きい、変わらない、または現在の仮定ではsymbolicなまま、というグループに分けて読めます。`smaller`の先頭には、数値化できる範囲で削減率が大きい行が来ます。"
@@ -842,13 +842,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "9a1061a0",
+   "id": "70df43a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.329222Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.329149Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.334779Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.334271Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.716068Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.714475Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.732187Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.729566Z"
     }
    },
    "outputs": [
@@ -894,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29375959",
+   "id": "98f96e6e",
    "metadata": {},
    "source": [
     "設計レビュー用の自己完結したartifactが必要な場合は、reportを作ります。label、選択したprofile、行の順序、grouped summary countをまとめて保持できます。reportからは優先順位つきfindingも作れます。最初に大きな削減、次に大きなresource tradeoffが並びます。"
@@ -903,13 +903,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cf1809bb",
+   "id": "7a0b92d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.336980Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.336698Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.345569Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.345145Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.738270Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.738054Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.752013Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.751392Z"
     }
    },
    "outputs": [
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d69adea",
+   "id": "9fe4b3c4",
    "metadata": {},
    "source": [
     "## Reference provenance\n",
@@ -971,13 +971,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d4c480ee",
+   "id": "3b08278c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.347146Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.347083Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.349893Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.349408Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.755433Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.755221Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.763018Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.762226Z"
     }
    },
    "outputs": [
@@ -1003,7 +1003,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb030244",
+   "id": "0a42f1b4",
    "metadata": {},
    "source": [
     "## Formula provenance\n",
@@ -1014,13 +1014,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ba8586a6",
+   "id": "7f301404",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.351554Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.351477Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.354942Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.354250Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.767036Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.766826Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.775120Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.773862Z"
     }
    },
    "outputs": [
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11362abb",
+   "id": "77d19b43",
    "metadata": {},
    "source": [
     "## 共通の論理リソース形状\n",
@@ -1064,13 +1064,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "11ea778d",
+   "id": "79ce7893",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.356468Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.356405Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.360175Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.359540Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.780251Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.780027Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.784578Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.783615Z"
     }
    },
    "outputs": [
@@ -1106,7 +1106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1f5dc27",
+   "id": "3c7d9264",
    "metadata": {},
    "source": [
     "## Architecture感度\n",
@@ -1117,13 +1117,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d76ba22b",
+   "id": "fb9a57a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.362047Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.361951Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.367328Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.366913Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.786670Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.786594Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.796254Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.794671Z"
     }
    },
    "outputs": [
@@ -1170,7 +1170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100de6a3",
+   "id": "9c52aa86",
    "metadata": {},
    "source": [
     "## Early-FTQCのパターン\n",
@@ -1181,13 +1181,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "25e494dd",
+   "id": "91e71e22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.368447Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.368361Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.380008Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.379482Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.798697Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.798613Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.818953Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.817954Z"
     }
    },
    "outputs": [
@@ -1243,22 +1243,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f944ce9e",
+   "id": "0432c1fa",
    "metadata": {},
    "source": [
-    "research-signal reportは、特定の論文が動機づけるquantityに比較対象を絞ります。具体的なestimateはsignal内のproblem-level driverをすべて公開するとは限らないため、defaultのreportは両方のestimateで利用できるsignal quantityを使います。"
+    "research-signal reportは、特定の論文が動機づけるquantityに比較対象を絞ります。Hamiltonianから作るTrotter estimatorはproblem-level driverも公開するため、ここではsignal contract全体を要求できます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "50610760",
+   "id": "900459a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.381298Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.381219Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.387748Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.387008Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.822873Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.822666Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.832973Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.832348Z"
     }
    },
    "outputs": [
@@ -1267,7 +1267,7 @@
      "output_type": "stream",
      "text": [
       "arXiv:2603.22778 resource signal review\n",
-      "['qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
      ]
     }
    ],
@@ -1278,20 +1278,21 @@
     "    uwc_trotter,\n",
     "    baseline_label=\"Plain Trotter\",\n",
     "    candidate_label=\"UWC Trotter\",\n",
+    "    require_all_quantities=True,\n",
     ")\n",
     "print(uwc_signal_report.to_dict()[\"title\"])\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
     "\n",
     "assert uwc_signal_report.summary.rows[0].quantity == (\n",
-    "    FTQCResourceQuantity.QPE_ITERATIONS\n",
+    "    FTQCResourceQuantity.LAMBDA_NORM\n",
     ")\n",
-    "assert \"lambda_norm\" not in uwc_signal_report.to_dict()[\"quantities\"]\n",
+    "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
     "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a2851928",
+   "id": "94fe97d6",
    "metadata": {},
    "source": [
     "## Budget constraints\n",
@@ -1302,13 +1303,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "fcecd736",
+   "id": "25bc75c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T06:59:28.388797Z",
-     "iopub.status.busy": "2026-06-23T06:59:28.388732Z",
-     "iopub.status.idle": "2026-06-23T06:59:28.394051Z",
-     "shell.execute_reply": "2026-06-23T06:59:28.393644Z"
+     "iopub.execute_input": "2026-06-23T07:15:37.835449Z",
+     "iopub.status.busy": "2026-06-23T07:15:37.835221Z",
+     "iopub.status.idle": "2026-06-23T07:15:37.840723Z",
+     "shell.execute_reply": "2026-06-23T07:15:37.839936Z"
     }
    },
    "outputs": [
@@ -1359,7 +1360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9726de7c",
+   "id": "1948712e",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -1378,7 +1379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1331aa5",
+   "id": "b2b375b3",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -664,7 +664,7 @@ assert (
 )
 
 # %% [markdown]
-# research-signal reportは、特定の論文が動機づけるquantityに比較対象を絞ります。具体的なestimateはsignal内のproblem-level driverをすべて公開するとは限らないため、defaultのreportは両方のestimateで利用できるsignal quantityを使います。
+# research-signal reportは、特定の論文が動機づけるquantityに比較対象を絞ります。Hamiltonianから作るTrotter estimatorはproblem-level driverも公開するため、ここではsignal contract全体を要求できます。
 
 # %%
 uwc_signal_report = build_ftqc_research_signal_report(
@@ -673,14 +673,15 @@ uwc_signal_report = build_ftqc_research_signal_report(
     uwc_trotter,
     baseline_label="Plain Trotter",
     candidate_label="UWC Trotter",
+    require_all_quantities=True,
 )
 print(uwc_signal_report.to_dict()["title"])
 print(uwc_signal_report.to_dict()["quantities"])
 
 assert uwc_signal_report.summary.rows[0].quantity == (
-    FTQCResourceQuantity.QPE_ITERATIONS
+    FTQCResourceQuantity.LAMBDA_NORM
 )
-assert "lambda_norm" not in uwc_signal_report.to_dict()["quantities"]
+assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]

--- a/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_chemistry.py
@@ -2541,6 +2541,15 @@ def estimate_qubitized_chemistry_qpe(
             "bake in one chemistry factorization implementation."
         ),
     }
+    algorithm_values = {
+        FTQCResourceQuantity.N_SPIN_ORBITALS: n_expr,
+        FTQCResourceQuantity.LAMBDA_NORM: lambda_expr,
+        FTQCResourceQuantity.WALK_COST_TOFFOLI: walk_expr,
+    }
+    if method_enum == ChemistryQPEMethod.SPARSE and sparsity is not None:
+        sparsity_expr = _as_expr(sparsity, "sparsity")
+        _validate_positive(sparsity_expr, "sparsity")
+        algorithm_values[FTQCResourceQuantity.N_PAULI_TERMS] = sparsity_expr
     return _build_estimate(
         algorithm=f"qubitized_qpe:{method_enum.value}",
         logical_qubits=logical_expr,
@@ -2558,6 +2567,7 @@ def estimate_qubitized_chemistry_qpe(
             references,
         ),
         formulas=_qubitized_qpe_formulas(),
+        algorithm_values=algorithm_values,
         architecture_values=architecture_values,
     )
 
@@ -2737,6 +2747,11 @@ def estimate_single_ancilla_trotter_qpe(
         "qpe_style": "Single-ancilla Hadamard-test QPE with product-formula evolution.",
         "randomization": "randomized_compilation_factor rescales Pauli-rotation work.",
     }
+    algorithm_values = {
+        FTQCResourceQuantity.N_SPIN_ORBITALS: n_expr,
+        FTQCResourceQuantity.N_PAULI_TERMS: terms_expr,
+        FTQCResourceQuantity.LAMBDA_NORM: lambda_expr,
+    }
     return _build_estimate(
         algorithm="single_ancilla_trotter_qpe:unitary_weight_concentration",
         logical_qubits=logical_expr,
@@ -2751,6 +2766,7 @@ def estimate_single_ancilla_trotter_qpe(
         assumptions=assumptions,
         references=_combine_references((_UWC_REFERENCE,), references),
         formulas=_single_ancilla_trotter_formulas(),
+        algorithm_values=algorithm_values,
         architecture_values=architecture_values,
     )
 

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1026,19 +1026,19 @@ def test_build_ftqc_research_signal_report_selects_available_quantities():
     )
     assert report.title == "arXiv:2603.22778 resource signal review"
     assert report.profile is None
-    assert row_quantities[0] == FTQCResourceQuantity.QPE_ITERATIONS
-    assert FTQCResourceQuantity.LAMBDA_NORM not in row_quantities
+    assert row_quantities[0] == FTQCResourceQuantity.LAMBDA_NORM
+    assert row_quantities[1] == FTQCResourceQuantity.QPE_ITERATIONS
     assert FTQCResourceQuantity.T_GATES in row_quantities
     assert row_table[0]["baseline_label"] == "Plain Trotter"
     assert row_table[0]["candidate_label"] == "UWC Trotter"
 
-    with pytest.raises(ValueError, match="lambda_norm"):
-        build_ftqc_research_signal_report(
-            "arXiv:2603.22778",
-            baseline,
-            candidate,
-            require_all_quantities=True,
-        )
+    strict_report = build_ftqc_research_signal_report(
+        "arXiv:2603.22778",
+        baseline,
+        candidate,
+        require_all_quantities=True,
+    )
+    assert strict_report.summary.rows[0].quantity == FTQCResourceQuantity.LAMBDA_NORM
 
     with pytest.raises(ValueError, match="Unknown FTQC research signal"):
         describe_ftqc_research_signal("arXiv:0000.00000")


### PR DESCRIPTION
## Summary
- Record Hamiltonian problem drivers on chemistry FTQC estimates, including spin-orbital count, lambda norm, Pauli-term count, and walk Toffoli cost where available.
- Let the UWC research-signal report require the full arXiv:2603.22778 quantity contract instead of silently omitting lambda_norm.
- Regenerate and execute the English and Japanese FTQC resource-estimation notebooks.

## Tests
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_ftqc_chemistry.py -q
- uv run python docs/en/usage/ftqc_resource_estimation_design.py
- uv run python docs/ja/usage/ftqc_resource_estimation_design.py
- uv run python docs/en/algorithm/ftqc_chemistry_resource_estimation.py
- uv run python docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py tests/circuit/estimator/test_ftqc_chemistry.py tests/circuit/estimator/test_ftqc_block_encoding.py -q
- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design or ftqc_chemistry_resource_estimation'
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check

## Local review note
- The local-review skill still lists the stale command `uv run zuban qamomile/`, which fails with `error: unrecognized subcommand 'qamomile/'`. The repository-standard command from AGENTS.md, `uv run zuban check qamomile/`, passes.