### PR TITLE
Demonstrate FTQC chemistry driver reports

### DIFF
--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -25,10 +25,10 @@
    "id": "f69d935d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:36.786239Z",
-     "iopub.status.busy": "2026-06-23T07:15:36.785962Z",
-     "iopub.status.idle": "2026-06-23T07:15:36.792097Z",
-     "shell.execute_reply": "2026-06-23T07:15:36.790705Z"
+     "iopub.execute_input": "2026-06-23T08:19:53.383162Z",
+     "iopub.status.busy": "2026-06-23T08:19:53.382936Z",
+     "iopub.status.idle": "2026-06-23T08:19:53.389021Z",
+     "shell.execute_reply": "2026-06-23T08:19:53.386424Z"
     }
    },
    "outputs": [],
@@ -43,10 +43,10 @@
    "id": "e7d533fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:36.795121Z",
-     "iopub.status.busy": "2026-06-23T07:15:36.794959Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.462857Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.461944Z"
+     "iopub.execute_input": "2026-06-23T08:19:53.392241Z",
+     "iopub.status.busy": "2026-06-23T08:19:53.391943Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.129948Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.129325Z"
     }
    },
    "outputs": [],
@@ -66,6 +66,7 @@
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
     "    build_ftqc_research_signal_report,\n",
+    "    build_ftqc_resource_driver_report,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
@@ -135,10 +136,10 @@
    "id": "64ed5d5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.470764Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.468962Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.486135Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.484960Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.131617Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.131451Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.135544Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.135056Z"
     }
    },
    "outputs": [],
@@ -192,10 +193,10 @@
    "id": "00ff2b55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.488949Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.488856Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.492681Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.491957Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.137003Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.136941Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.139756Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.139303Z"
     }
    },
    "outputs": [
@@ -281,10 +282,10 @@
    "id": "73bff7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.496163Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.495961Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.501027Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.499303Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.141135Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.141062Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.143412Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.142944Z"
     }
    },
    "outputs": [
@@ -333,10 +334,10 @@
    "id": "c1ef454f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.506170Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.506053Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.509679Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.508875Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.144510Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.144443Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.147009Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.146664Z"
     }
    },
    "outputs": [
@@ -391,10 +392,10 @@
    "id": "a523683f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.512898Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.512663Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.521852Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.520698Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.148083Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.148022Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.150938Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.150487Z"
     }
    },
    "outputs": [],
@@ -432,10 +433,10 @@
    "id": "6bf1b019",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.523869Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.523789Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.529258Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.526925Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.152032Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.151967Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.154451Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.154122Z"
     }
    },
    "outputs": [],
@@ -483,10 +484,10 @@
    "id": "e57fd487",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.533228Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.532856Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.577221Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.576187Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.155644Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.155585Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.182535Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.182020Z"
     }
    },
    "outputs": [
@@ -631,10 +632,10 @@
    "id": "7aee05d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.580020Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.579763Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.625951Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.625374Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.183821Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.183755Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.197434Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.197039Z"
     }
    },
    "outputs": [
@@ -714,10 +715,10 @@
    "id": "6ab331bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.627285Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.627219Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.631306Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.630986Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.198655Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.198569Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.202187Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.201763Z"
     }
    },
    "outputs": [
@@ -769,10 +770,10 @@
    "id": "a60fdd1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.632848Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.632761Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.645827Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.645384Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.203309Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.203255Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.214606Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.214293Z"
     }
    },
    "outputs": [
@@ -864,6 +865,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "271f5aaa",
+   "metadata": {},
+   "source": [
+    "A research-signal report says which quantities changed. A driver report adds\n",
+    "a second review lens: start from a target output quantity, then follow the\n",
+    "symbolic formulas backward to the upstream quantities that explain it. Here\n",
+    "we target physical qubit-seconds, because early-FTQC studies often care about\n",
+    "the space-time footprint more than a single gate count."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e4350069",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T08:19:55.216093Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.216038Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.223554Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.223145Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "logical_qubits target= False ratio= 1.000\n",
+      "physical_qubits_per_logical target= False ratio= 1.000\n",
+      "factory_qubits target= False ratio= 1.000\n",
+      "physical_qubits target= False ratio= 1.000\n",
+      "lambda_norm target= False ratio= 0.1000\n",
+      "target_precision target= False ratio= 1.000\n",
+      "qpe_iterations target= False ratio= 0.1000\n",
+      "n_pauli_terms target= False ratio= 1.000\n",
+      "logical_depth target= False ratio= 0.05000\n",
+      "t_gates target= False ratio= 0.1500\n",
+      "logical_cycle_time_seconds target= False ratio= 1.000\n",
+      "toffoli_throughput_per_second target= False ratio= 1.000\n",
+      "runtime_seconds target= False ratio= 0.07500\n",
+      "physical_qubit_seconds target= True ratio= 0.07500\n"
+     ]
+    }
+   ],
+   "source": [
+    "uwc_driver_report = build_ftqc_resource_driver_report(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    targets=(FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,),\n",
+    "    baseline_label=\"Plain Trotter QPE\",\n",
+    "    candidate_label=\"UWC-style Trotter QPE\",\n",
+    ")\n",
+    "for row in uwc_driver_report.to_row_table():\n",
+    "    print(\n",
+    "        row[\"quantity\"],\n",
+    "        \"target=\",\n",
+    "        row[\"is_target\"],\n",
+    "        \"ratio=\",\n",
+    "        sp.N(sp.sympify(row[\"ratio\"]), 4),\n",
+    "    )\n",
+    "\n",
+    "uwc_driver_quantities = {row.quantity for row in uwc_driver_report.summary.rows}\n",
+    "assert FTQCResourceQuantity.LAMBDA_NORM in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.QPE_ITERATIONS in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.T_GATES in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.RUNTIME_SECONDS in uwc_driver_quantities\n",
+    "assert uwc_driver_report.to_row_table()[-1][\"is_target\"] is True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8ce17fe5",
    "metadata": {},
    "source": [
@@ -878,14 +950,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "f281db61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.647499Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.647419Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.651575Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.651118Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.224969Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.224903Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.228795Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.228444Z"
     }
    },
    "outputs": [
@@ -963,6 +1035,8 @@
     "  SELECT, reflection, and workspace costs can be reviewed separately.\n",
     "- Demonstrated how a unitary-weight concentration factor can be modeled as a\n",
     "  cost-driver reduction for early-FTQC single-ancilla Trotter QPE.\n",
+    "- Traced a physical qubit-seconds target back to the symbolic quantities\n",
+    "  that drive the early-FTQC estimate.\n",
     "- Connected recent FTQC chemistry research signals to the canonical\n",
     "  quantities that the tutorial compares.\n",
     "- Used a standard `FTQCResourceProfile` so space-time comparisons have the\n",

--- a/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/en/algorithm/ftqc_chemistry_resource_estimation.py
@@ -46,6 +46,7 @@ from qamomile.circuit.estimator.algorithmic import (
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
     build_ftqc_research_signal_report,
+    build_ftqc_resource_driver_report,
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_qubitized_qpe_from_block_encoding,
@@ -536,6 +537,37 @@ assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
 assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]
+# A research-signal report says which quantities changed. A driver report adds
+# a second review lens: start from a target output quantity, then follow the
+# symbolic formulas backward to the upstream quantities that explain it. Here
+# we target physical qubit-seconds, because early-FTQC studies often care about
+# the space-time footprint more than a single gate count.
+
+# %%
+uwc_driver_report = build_ftqc_resource_driver_report(
+    plain_trotter,
+    uwc_trotter,
+    targets=(FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,),
+    baseline_label="Plain Trotter QPE",
+    candidate_label="UWC-style Trotter QPE",
+)
+for row in uwc_driver_report.to_row_table():
+    print(
+        row["quantity"],
+        "target=",
+        row["is_target"],
+        "ratio=",
+        sp.N(sp.sympify(row["ratio"]), 4),
+    )
+
+uwc_driver_quantities = {row.quantity for row in uwc_driver_report.summary.rows}
+assert FTQCResourceQuantity.LAMBDA_NORM in uwc_driver_quantities
+assert FTQCResourceQuantity.QPE_ITERATIONS in uwc_driver_quantities
+assert FTQCResourceQuantity.T_GATES in uwc_driver_quantities
+assert FTQCResourceQuantity.RUNTIME_SECONDS in uwc_driver_quantities
+assert uwc_driver_report.to_row_table()[-1]["is_target"] is True
+
+# %% [markdown]
 # ## Result
 #
 # We can put the estimates into a compact table. The important point is that
@@ -602,6 +634,8 @@ assert uwc_trotter.resource_values()[
 #   SELECT, reflection, and workspace costs can be reviewed separately.
 # - Demonstrated how a unitary-weight concentration factor can be modeled as a
 #   cost-driver reduction for early-FTQC single-ancilla Trotter QPE.
+# - Traced a physical qubit-seconds target back to the symbolic quantities
+#   that drive the early-FTQC estimate.
 # - Connected recent FTQC chemistry research signals to the canonical
 #   quantities that the tutorial compares.
 # - Used a standard `FTQCResourceProfile` so space-time comparisons have the

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
@@ -20,10 +20,10 @@
    "id": "0d7ef56d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:36.786473Z",
-     "iopub.status.busy": "2026-06-23T07:15:36.786083Z",
-     "iopub.status.idle": "2026-06-23T07:15:36.792045Z",
-     "shell.execute_reply": "2026-06-23T07:15:36.790701Z"
+     "iopub.execute_input": "2026-06-23T08:19:53.382565Z",
+     "iopub.status.busy": "2026-06-23T08:19:53.382351Z",
+     "iopub.status.idle": "2026-06-23T08:19:53.389806Z",
+     "shell.execute_reply": "2026-06-23T08:19:53.386481Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "6e269613",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:36.794884Z",
-     "iopub.status.busy": "2026-06-23T07:15:36.794722Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.451435Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.447922Z"
+     "iopub.execute_input": "2026-06-23T08:19:53.392798Z",
+     "iopub.status.busy": "2026-06-23T08:19:53.392543Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.129965Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.129325Z"
     }
    },
    "outputs": [],
@@ -61,6 +61,7 @@
     "    SurfaceCodeDistanceBudget,\n",
     "    block_encoding_from_chemistry_model,\n",
     "    build_ftqc_research_signal_report,\n",
+    "    build_ftqc_resource_driver_report,\n",
     "    compare_ftqc_resource_estimates,\n",
     "    estimate_qubitized_chemistry_qpe_from_model,\n",
     "    estimate_qubitized_qpe_from_block_encoding,\n",
@@ -109,10 +110,10 @@
    "id": "eb0d4d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.459334Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.456084Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.474296Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.471260Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.131671Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.131508Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.135501Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.135023Z"
     }
    },
    "outputs": [],
@@ -166,10 +167,10 @@
    "id": "afad3cd8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.479066Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.478455Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.488199Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.486788Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.136943Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.136875Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.139733Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.139260Z"
     }
    },
    "outputs": [
@@ -252,10 +253,10 @@
    "id": "31d5eca4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.490829Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.490539Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.495866Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.494802Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.141102Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.141033Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.143443Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.142941Z"
     }
    },
    "outputs": [
@@ -301,10 +302,10 @@
    "id": "62668eb6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.498604Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.498479Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.506095Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.504987Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.144544Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.144466Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.147095Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.146664Z"
     }
    },
    "outputs": [
@@ -355,10 +356,10 @@
    "id": "75a3d553",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.508762Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.508583Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.512639Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.511362Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.148088Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.148025Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.150888Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.150428Z"
     }
    },
    "outputs": [],
@@ -396,10 +397,10 @@
    "id": "1531a0cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.516761Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.516507Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.522416Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.521794Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.151898Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.151833Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.154531Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.154127Z"
     }
    },
    "outputs": [],
@@ -443,10 +444,10 @@
    "id": "ee36cb58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.525002Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.524880Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.573705Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.572848Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.155696Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.155634Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.182313Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.181840Z"
     }
    },
    "outputs": [
@@ -587,10 +588,10 @@
    "id": "d60e15f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.576137Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.575938Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.626228Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.625714Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.183764Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.183696Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.197378Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.197039Z"
     }
    },
    "outputs": [
@@ -667,10 +668,10 @@
    "id": "7637e730",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.627342Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.627278Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.632041Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.631486Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.198637Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.198557Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.202194Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.201789Z"
     }
    },
    "outputs": [
@@ -718,10 +719,10 @@
    "id": "a1937e61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.633327Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.633243Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.646307Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.645888Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.203554Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.203492Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.214900Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.214478Z"
     }
    },
    "outputs": [
@@ -813,6 +814,73 @@
   },
   {
    "cell_type": "markdown",
+   "id": "faae9863",
+   "metadata": {},
+   "source": [
+    "research-signal reportでは、どのquantityが変わったかを確認できます。driver reportを使うと、target output quantityから始めてsymbolic formulaを上流へたどり、そのquantityを説明するdriverを確認できます。ここではphysical qubit-secondsをtargetにします。early-FTQC研究では、単一のgate countよりspace-time footprintが重要になることが多いためです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2f7c3d93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T08:19:55.216103Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.216049Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.223566Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.223145Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "logical_qubits target= False ratio= 1.000\n",
+      "physical_qubits_per_logical target= False ratio= 1.000\n",
+      "factory_qubits target= False ratio= 1.000\n",
+      "physical_qubits target= False ratio= 1.000\n",
+      "lambda_norm target= False ratio= 0.1000\n",
+      "target_precision target= False ratio= 1.000\n",
+      "qpe_iterations target= False ratio= 0.1000\n",
+      "n_pauli_terms target= False ratio= 1.000\n",
+      "logical_depth target= False ratio= 0.05000\n",
+      "t_gates target= False ratio= 0.1500\n",
+      "logical_cycle_time_seconds target= False ratio= 1.000\n",
+      "toffoli_throughput_per_second target= False ratio= 1.000\n",
+      "runtime_seconds target= False ratio= 0.07500\n",
+      "physical_qubit_seconds target= True ratio= 0.07500\n"
+     ]
+    }
+   ],
+   "source": [
+    "uwc_driver_report = build_ftqc_resource_driver_report(\n",
+    "    plain_trotter,\n",
+    "    uwc_trotter,\n",
+    "    targets=(FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,),\n",
+    "    baseline_label=\"Plain Trotter QPE\",\n",
+    "    candidate_label=\"UWC-style Trotter QPE\",\n",
+    ")\n",
+    "for row in uwc_driver_report.to_row_table():\n",
+    "    print(\n",
+    "        row[\"quantity\"],\n",
+    "        \"target=\",\n",
+    "        row[\"is_target\"],\n",
+    "        \"ratio=\",\n",
+    "        sp.N(sp.sympify(row[\"ratio\"]), 4),\n",
+    "    )\n",
+    "\n",
+    "uwc_driver_quantities = {row.quantity for row in uwc_driver_report.summary.rows}\n",
+    "assert FTQCResourceQuantity.LAMBDA_NORM in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.QPE_ITERATIONS in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.T_GATES in uwc_driver_quantities\n",
+    "assert FTQCResourceQuantity.RUNTIME_SECONDS in uwc_driver_quantities\n",
+    "assert uwc_driver_report.to_row_table()[-1][\"is_target\"] is True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2ab74ff1",
    "metadata": {},
    "source": [
@@ -823,14 +891,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "16e68f70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T07:15:39.647959Z",
-     "iopub.status.busy": "2026-06-23T07:15:39.647867Z",
-     "iopub.status.idle": "2026-06-23T07:15:39.651833Z",
-     "shell.execute_reply": "2026-06-23T07:15:39.651441Z"
+     "iopub.execute_input": "2026-06-23T08:19:55.224899Z",
+     "iopub.status.busy": "2026-06-23T08:19:55.224831Z",
+     "iopub.status.idle": "2026-06-23T08:19:55.228546Z",
+     "shell.execute_reply": "2026-06-23T08:19:55.228215Z"
     }
    },
    "outputs": [
@@ -898,6 +966,7 @@
     "- code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。\n",
     "- chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。\n",
     "- unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。\n",
+    "- physical qubit-secondsというtargetを、early-FTQC estimateを支配するsymbolic quantityへたどりました。\n",
     "- 近年のFTQC化学計算のresearch signalを、このチュートリアルで比較するcanonical quantitiesへ結びつけました。\n",
     "- 標準の`FTQCResourceProfile`を使い、space-time比較で同じquantity setを使うようにしました。"
    ]

--- a/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
+++ b/docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
@@ -41,6 +41,7 @@ from qamomile.circuit.estimator.algorithmic import (
     SurfaceCodeDistanceBudget,
     block_encoding_from_chemistry_model,
     build_ftqc_research_signal_report,
+    build_ftqc_resource_driver_report,
     compare_ftqc_resource_estimates,
     estimate_qubitized_chemistry_qpe_from_model,
     estimate_qubitized_qpe_from_block_encoding,
@@ -485,6 +486,33 @@ assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
 assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 
 # %% [markdown]
+# research-signal reportでは、どのquantityが変わったかを確認できます。driver reportを使うと、target output quantityから始めてsymbolic formulaを上流へたどり、そのquantityを説明するdriverを確認できます。ここではphysical qubit-secondsをtargetにします。early-FTQC研究では、単一のgate countよりspace-time footprintが重要になることが多いためです。
+
+# %%
+uwc_driver_report = build_ftqc_resource_driver_report(
+    plain_trotter,
+    uwc_trotter,
+    targets=(FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,),
+    baseline_label="Plain Trotter QPE",
+    candidate_label="UWC-style Trotter QPE",
+)
+for row in uwc_driver_report.to_row_table():
+    print(
+        row["quantity"],
+        "target=",
+        row["is_target"],
+        "ratio=",
+        sp.N(sp.sympify(row["ratio"]), 4),
+    )
+
+uwc_driver_quantities = {row.quantity for row in uwc_driver_report.summary.rows}
+assert FTQCResourceQuantity.LAMBDA_NORM in uwc_driver_quantities
+assert FTQCResourceQuantity.QPE_ITERATIONS in uwc_driver_quantities
+assert FTQCResourceQuantity.T_GATES in uwc_driver_quantities
+assert FTQCResourceQuantity.RUNTIME_SECONDS in uwc_driver_quantities
+assert uwc_driver_report.to_row_table()[-1]["is_target"] is True
+
+# %% [markdown]
 # ## Result
 #
 # 推定結果を小さな表にまとめます。重要なのは、各列が別々の設計上の意味を持つことです。Hamiltonian representationの変更は`qpe_iterations`とper-step costに効くべきで、hardware modelの変更は`physical_qubits`、runtime、physical qubit-secondsに効くべきです。
@@ -537,5 +565,6 @@ assert uwc_trotter.resource_values()[
 # - code distanceなどのarchitecture quantityを各resource estimateに残し、後続のreportでauditできるようにしました。
 # - chemistry QPE modelをblock-encoding contractへ変換し、PREPARE、SELECT、reflection、workspace costを分けてreviewできる形にしました。
 # - unitary-weight concentration factorを、early-FTQC single-ancilla Trotter QPEのcost-driver reductionとしてモデル化する方法を示しました。
+# - physical qubit-secondsというtargetを、early-FTQC estimateを支配するsymbolic quantityへたどりました。
 # - 近年のFTQC化学計算のresearch signalを、このチュートリアルで比較するcanonical quantitiesへ結びつけました。
 # - 標準の`FTQCResourceProfile`を使い、space-time比較で同じquantity setを使うようにしました。


### PR DESCRIPTION
## Summary
- add the FTQC resource driver report to the chemistry resource-estimation tutorial
- show how a physical qubit-seconds target traces back to lambda norm, QPE iterations, T gates, runtime, and architecture drivers in the UWC-style Trotter example
- keep EN/JA notebook sources and executed notebooks in sync

## Verification
- uv run python docs/en/algorithm/ftqc_chemistry_resource_estimation.py
- uv run python docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
- uv run jupytext --to notebook --update docs/en/algorithm/ftqc_chemistry_resource_estimation.py
- uv run jupytext --to notebook --update docs/ja/algorithm/ftqc_chemistry_resource_estimation.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/algorithm/ftqc_chemistry_resource_estimation.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/algorithm/ftqc_chemistry_resource_estimation.ipynb
- uv run pytest -m docs tests/docs -q -k ftqc_chemistry_resource_estimation
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- git diff --check

## Local review note
- The local-review skill still asks for the stale command uv run zuban qamomile/; it fails with error: unrecognized subcommand qamomile/. The repository-standard uv run zuban check qamomile/ passes.