### PR TITLE
Flatten FTQC report bundle rows

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "9004aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.333481Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.333263Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.338675Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.337886Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.256427Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.255928Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.261948Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.261156Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "b1c698bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.341292Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.341025Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.683323Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.682800Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.265501Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.265282Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.643405Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.642779Z"
     }
    },
    "outputs": [],
@@ -147,10 +147,10 @@
    "id": "877d5ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.685062Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.684957Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.687362Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.686994Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.645147Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.645047Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.647663Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.647161Z"
     }
    },
    "outputs": [
@@ -203,10 +203,10 @@
    "id": "1e1d9d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.688661Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.688597Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.691748Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.691348Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.648855Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.648795Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.652128Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.651625Z"
     }
    },
    "outputs": [
@@ -314,10 +314,10 @@
    "id": "2fc667c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.692744Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.692694Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.694670Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.694266Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.653304Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.653236Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.655321Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.654897Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "1481b495",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.695869Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.695804Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.700048Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.699651Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.656574Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.656508Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.660711Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.660329Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "dedfdd29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.701335Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.701259Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.703704Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.703372Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.661765Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.661712Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.664061Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.663748Z"
     }
    },
    "outputs": [],
@@ -486,10 +486,10 @@
    "id": "12a7ac56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.704917Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.704838Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.728685Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.728309Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.665097Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.665039Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.689243Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.688753Z"
     }
    },
    "outputs": [
@@ -557,10 +557,10 @@
    "id": "5d5352a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.729739Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.729686Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.733076Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.732700Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.690415Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.690359Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.693934Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.693570Z"
     }
    },
    "outputs": [
@@ -601,10 +601,10 @@
    "id": "1e813ef9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.734195Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.734129Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.746435Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.746102Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.695004Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.694943Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.707813Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.707351Z"
     }
    },
    "outputs": [
@@ -663,10 +663,10 @@
    "id": "198b002f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.747615Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.747555Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.879681Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.879222Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.708887Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.708827Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.843703Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.843261Z"
     }
    },
    "outputs": [
@@ -740,10 +740,10 @@
    "id": "dc5a94a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.880988Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.880923Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.892968Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.892609Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.844989Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.844920Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.857264Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.856886Z"
     }
    },
    "outputs": [
@@ -893,10 +893,10 @@
    "id": "f594c0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.894261Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.894191Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.898054Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.897709Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.858526Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.858469Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.862156Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.861889Z"
     }
    },
    "outputs": [
@@ -957,10 +957,10 @@
    "id": "7f47799c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.899274Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.899210Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.904324Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.903926Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.863499Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.863441Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.868596Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.868231Z"
     }
    },
    "outputs": [
@@ -1028,10 +1028,10 @@
    "id": "c48101f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.905403Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.905326Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.907465Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.907188Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.869815Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.869741Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.872069Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.871655Z"
     }
    },
    "outputs": [
@@ -1074,10 +1074,10 @@
    "id": "a6a40b86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.908668Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.908602Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.911269Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.910836Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.873185Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.873120Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.875709Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.875337Z"
     }
    },
    "outputs": [
@@ -1127,10 +1127,10 @@
    "id": "4ea1d09a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.912252Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.912183Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.914384Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.914100Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.876954Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.876880Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.879025Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.878621Z"
     }
    },
    "outputs": [
@@ -1181,10 +1181,10 @@
    "id": "65456e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.915739Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.915655Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.919389Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.919083Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.880078Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.880002Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.883951Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.883544Z"
     }
    },
    "outputs": [
@@ -1248,10 +1248,10 @@
    "id": "fa19c3e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.920603Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.920541Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.973588Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.973202Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.885036Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.884986Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.939674Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.939256Z"
     }
    },
    "outputs": [
@@ -1338,10 +1338,10 @@
    "id": "b8d9f0a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.974731Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.974671Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.977790Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.977413Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.941042Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.940970Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.944373Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.943863Z"
     }
    },
    "outputs": [
@@ -1351,7 +1351,9 @@
      "text": [
       "scenario 2\n",
       "{'snapshots': 2, 'rows': 10}\n",
-      "{'comparison': 1, 'scenario': 1}\n"
+      "{'comparison': 1, 'scenario': 1}\n",
+      "comparison QPE iterations\n",
+      "comparison Toffoli gates\n"
      ]
     }
    ],
@@ -1365,6 +1367,8 @@
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.counts_by_kind())\n",
+    "for row in review_bundle.to_row_table()[:2]:\n",
+    "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
     "\n",
     "assert scenario_snapshot.to_dict()[\"kind\"] == \"scenario\"\n",
     "assert scenario_snapshot.row_count == len(scenario_report.rows)\n",
@@ -1372,7 +1376,9 @@
     "    \"snapshots\": 2,\n",
     "    \"rows\": len(comparison_report.summary.rows) + len(scenario_report.rows),\n",
     "}\n",
-    "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}"
+    "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}\n",
+    "assert review_bundle.to_row_table()[0][\"report_kind\"] == \"comparison\"\n",
+    "assert review_bundle.to_row_table()[-1][\"report_kind\"] == \"scenario\""
    ]
   },
   {
@@ -1394,10 +1400,10 @@
    "id": "c60e04c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.978899Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.978847Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.986350Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.985993Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.945460Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.945407Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.952879Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.952264Z"
     }
    },
    "outputs": [
@@ -1468,10 +1474,10 @@
    "id": "b7b0c958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.987577Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.987513Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.990496Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.990129Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.953999Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.953934Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.956653Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.956389Z"
     }
    },
    "outputs": [
@@ -1531,10 +1537,10 @@
    "id": "6d54ea9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.991753Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.991690Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.996269Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.995894Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.958000Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.957942Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.962689Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.962259Z"
     }
    },
    "outputs": [
@@ -1583,10 +1589,10 @@
    "id": "bc5bd6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.997435Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.997371Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.004403Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.003991Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.963735Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.963666Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.970880Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.970441Z"
     }
    },
    "outputs": [
@@ -1660,10 +1666,10 @@
    "id": "6ec3a10f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:24.005657Z",
-     "iopub.status.busy": "2026-06-23T09:11:24.005594Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.011126Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.010695Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.972023Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.971961Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.977265Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.976948Z"
     }
    },
    "outputs": [
@@ -1740,10 +1746,10 @@
    "id": "6f60d357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:24.012202Z",
-     "iopub.status.busy": "2026-06-23T09:11:24.012123Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.015073Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.014685Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.978427Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.978349Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.981334Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.980895Z"
     }
    },
    "outputs": [
@@ -1864,7 +1870,8 @@
     "  several named architecture scenarios and reports unresolved symbols.\n",
     "- `build_ftqc_resource_report_snapshot` and\n",
     "  `build_ftqc_resource_report_bundle` wrap heterogeneous reports in a stable\n",
-    "  review manifest without changing their specialized payloads.\n",
+    "  review manifest and flat row table without changing their specialized\n",
+    "  payloads.\n",
     "- `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable\n",
     "  savings tables without hard-coding a particular chemistry factorization.\n",
     "- `summarize_ftqc_resource_comparison` groups those rows into smaller,\n",

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -760,6 +760,8 @@ review_bundle = build_ftqc_resource_report_bundle(
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.counts_by_kind())
+for row in review_bundle.to_row_table()[:2]:
+    print(row["report_kind"], row.get("label", row.get("quantity")))
 
 assert scenario_snapshot.to_dict()["kind"] == "scenario"
 assert scenario_snapshot.row_count == len(scenario_report.rows)
@@ -768,6 +770,8 @@ assert review_bundle.to_dict()["counts"] == {
     "rows": len(comparison_report.summary.rows) + len(scenario_report.rows),
 }
 assert review_bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
+assert review_bundle.to_row_table()[0]["report_kind"] == "comparison"
+assert review_bundle.to_row_table()[-1]["report_kind"] == "scenario"
 
 # %% [markdown]
 # ## Early-FTQC Pattern
@@ -1064,7 +1068,8 @@ assert budget_report.to_dict()["counts"] == {
 #   several named architecture scenarios and reports unresolved symbols.
 # - `build_ftqc_resource_report_snapshot` and
 #   `build_ftqc_resource_report_bundle` wrap heterogeneous reports in a stable
-#   review manifest without changing their specialized payloads.
+#   review manifest and flat row table without changing their specialized
+#   payloads.
 # - `compare_ftqc_resource_estimates` turns symbolic estimates into reviewable
 #   savings tables without hard-coding a particular chemistry factorization.
 # - `summarize_ftqc_resource_comparison` groups those rows into smaller,

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "0568ebd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.333325Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.333085Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.338643Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.337749Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.256545Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.256149Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.261996Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.261138Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "64c31fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.340988Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.340696Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.683367Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.682799Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.265555Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.265294Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.643334Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.642806Z"
     }
    },
    "outputs": [],
@@ -132,10 +132,10 @@
    "id": "245db61b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.685148Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.685041Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.687658Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.687189Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.645092Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.644988Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.647654Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.647087Z"
     }
    },
    "outputs": [
@@ -187,10 +187,10 @@
    "id": "1c51b24c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.688749Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.688682Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.692016Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.691523Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.648885Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.648815Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.652221Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.651832Z"
     }
    },
    "outputs": [
@@ -296,10 +296,10 @@
    "id": "89549b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.692953Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.692899Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.694944Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.694487Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.653494Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.653433Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.655484Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.655089Z"
     }
    },
    "outputs": [
@@ -343,10 +343,10 @@
    "id": "c15595d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.695868Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.695806Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.699896Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.699552Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.656620Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.656561Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.660789Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.660347Z"
     }
    },
    "outputs": [
@@ -418,10 +418,10 @@
    "id": "fdbe0ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.701081Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.701017Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.703695Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.703243Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.661759Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.661705Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.664112Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.663748Z"
     }
    },
    "outputs": [],
@@ -458,10 +458,10 @@
    "id": "e12aded6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.704868Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.704801Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.728927Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.728459Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.665119Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.665062Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.688924Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.688527Z"
     }
    },
    "outputs": [
@@ -527,10 +527,10 @@
    "id": "afc69281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.730031Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.729975Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.733488Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.733113Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.689980Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.689925Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.693381Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.693001Z"
     }
    },
    "outputs": [
@@ -569,10 +569,10 @@
    "id": "13279f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.734607Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.734546Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.747003Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.746653Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.694561Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.694500Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.707318Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.706993Z"
     }
    },
    "outputs": [
@@ -627,10 +627,10 @@
    "id": "768805d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.748242Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.748180Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.880124Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.879755Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.708622Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.708570Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.844353Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.843888Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "id": "3797a63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.881333Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.881267Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.893226Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.892824Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.845638Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.845570Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.857751Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.857248Z"
     }
    },
    "outputs": [
@@ -853,10 +853,10 @@
    "id": "adacec7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.894339Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.894282Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.898259Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.897861Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.858850Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.858785Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.862550Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.862243Z"
     }
    },
    "outputs": [
@@ -914,10 +914,10 @@
    "id": "e5eb2526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.899334Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.899270Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.904319Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.903976Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.863748Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.863688Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.868772Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.868370Z"
     }
    },
    "outputs": [
@@ -982,10 +982,10 @@
    "id": "76757432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.905632Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.905557Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.907795Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.907422Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.870021Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.869946Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.872482Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.871975Z"
     }
    },
    "outputs": [
@@ -1025,10 +1025,10 @@
    "id": "bb1caac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.908932Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.908855Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.911460Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.911118Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.873506Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.873442Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.876127Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.875651Z"
     }
    },
    "outputs": [
@@ -1075,10 +1075,10 @@
    "id": "50616921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.912621Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.912548Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.914687Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.914386Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.877172Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.877100Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.879235Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.878709Z"
     }
    },
    "outputs": [
@@ -1128,10 +1128,10 @@
    "id": "b7f70d90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.915880Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.915806Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.919640Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.919249Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.880328Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.880256Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.884199Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.883797Z"
     }
    },
    "outputs": [
@@ -1192,10 +1192,10 @@
    "id": "590d1767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.920605Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.920542Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.974628Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.974198Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.885345Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.885285Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.940108Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.939589Z"
     }
    },
    "outputs": [
@@ -1279,10 +1279,10 @@
    "id": "d7f49b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.975633Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.975555Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.978418Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.978105Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.941366Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.941286Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.944666Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.944219Z"
     }
    },
    "outputs": [
@@ -1292,7 +1292,9 @@
      "text": [
       "scenario 2\n",
       "{'snapshots': 2, 'rows': 10}\n",
-      "{'comparison': 1, 'scenario': 1}\n"
+      "{'comparison': 1, 'scenario': 1}\n",
+      "comparison QPE iterations\n",
+      "comparison Toffoli gates\n"
      ]
     }
    ],
@@ -1306,6 +1308,8 @@
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.counts_by_kind())\n",
+    "for row in review_bundle.to_row_table()[:2]:\n",
+    "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
     "\n",
     "assert scenario_snapshot.to_dict()[\"kind\"] == \"scenario\"\n",
     "assert scenario_snapshot.row_count == len(scenario_report.rows)\n",
@@ -1313,7 +1317,9 @@
     "    \"snapshots\": 2,\n",
     "    \"rows\": len(comparison_report.summary.rows) + len(scenario_report.rows),\n",
     "}\n",
-    "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}"
+    "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}\n",
+    "assert review_bundle.to_row_table()[0][\"report_kind\"] == \"comparison\"\n",
+    "assert review_bundle.to_row_table()[-1][\"report_kind\"] == \"scenario\""
    ]
   },
   {
@@ -1332,10 +1338,10 @@
    "id": "8a5c890c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.979476Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.979398Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.986647Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.986342Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.945699Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.945642Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.953060Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.952566Z"
     }
    },
    "outputs": [
@@ -1403,10 +1409,10 @@
    "id": "15bd42c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.987752Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.987692Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.990627Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.990230Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.954167Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.954106Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.957003Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.956645Z"
     }
    },
    "outputs": [
@@ -1464,10 +1470,10 @@
    "id": "18161f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.991692Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.991630Z",
-     "iopub.status.idle": "2026-06-23T09:11:23.996468Z",
-     "shell.execute_reply": "2026-06-23T09:11:23.995997Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.957996Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.957931Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.962734Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.962255Z"
     }
    },
    "outputs": [
@@ -1513,10 +1519,10 @@
    "id": "613ad1ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:23.997436Z",
-     "iopub.status.busy": "2026-06-23T09:11:23.997361Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.004395Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.003932Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.963747Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.963682Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.970855Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.970384Z"
     }
    },
    "outputs": [
@@ -1585,10 +1591,10 @@
    "id": "95e4f4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:24.005527Z",
-     "iopub.status.busy": "2026-06-23T09:11:24.005456Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.010751Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.010341Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.971990Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.971928Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.977696Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.977205Z"
     }
    },
    "outputs": [
@@ -1662,10 +1668,10 @@
    "id": "38caf5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:11:24.011941Z",
-     "iopub.status.busy": "2026-06-23T09:11:24.011860Z",
-     "iopub.status.idle": "2026-06-23T09:11:24.014723Z",
-     "shell.execute_reply": "2026-06-23T09:11:24.014389Z"
+     "iopub.execute_input": "2026-06-23T09:24:10.978774Z",
+     "iopub.status.busy": "2026-06-23T09:24:10.978703Z",
+     "iopub.status.idle": "2026-06-23T09:24:10.981713Z",
+     "shell.execute_reply": "2026-06-23T09:24:10.981294Z"
     }
    },
    "outputs": [
@@ -1759,7 +1765,7 @@
     "- reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。\n",
     "- 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。\n",
     "- `build_ftqc_resource_scenario_report`を使うと、1つのsymbolic estimateを複数の名前付きarchitecture scenarioで評価し、未解決のsymbolも確認できます。\n",
-    "- `build_ftqc_resource_report_snapshot`と`build_ftqc_resource_report_bundle`を使うと、reportごとの専用payloadを変えずに、異なるreportを安定したreview manifestへまとめられます。\n",
+    "- `build_ftqc_resource_report_snapshot`と`build_ftqc_resource_report_bundle`を使うと、reportごとの専用payloadを変えずに、異なるreportを安定したreview manifestとflat row tableへまとめられます。\n",
     "- `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。\n",
     "- `summarize_ftqc_resource_comparison`を使うと、その行を小さい、大きい、変わらない、symbolicな変化へ分けて設計レビューできます。\n",
     "- `build_ftqc_resource_comparison_report`を使うと、label、profile、行、優先順位つきfinding、grouped countをreview artifactとしてまとめられます。\n",

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -701,6 +701,8 @@ review_bundle = build_ftqc_resource_report_bundle(
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.counts_by_kind())
+for row in review_bundle.to_row_table()[:2]:
+    print(row["report_kind"], row.get("label", row.get("quantity")))
 
 assert scenario_snapshot.to_dict()["kind"] == "scenario"
 assert scenario_snapshot.row_count == len(scenario_report.rows)
@@ -709,6 +711,8 @@ assert review_bundle.to_dict()["counts"] == {
     "rows": len(comparison_report.summary.rows) + len(scenario_report.rows),
 }
 assert review_bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
+assert review_bundle.to_row_table()[0]["report_kind"] == "comparison"
+assert review_bundle.to_row_table()[-1]["report_kind"] == "scenario"
 
 # %% [markdown]
 # ## Early-FTQCのパターン
@@ -959,7 +963,7 @@ assert budget_report.to_dict()["counts"] == {
 # - reportでcircuit-level estimateと同じ形が必要な場合は、FTQC estimateを共通のlogical `ResourceEstimate` objectとして見られます。
 # - 既存のlogical estimateは、algorithm estimateを作り直さずに新しいarchitecture仮定でreliftできます。
 # - `build_ftqc_resource_scenario_report`を使うと、1つのsymbolic estimateを複数の名前付きarchitecture scenarioで評価し、未解決のsymbolも確認できます。
-# - `build_ftqc_resource_report_snapshot`と`build_ftqc_resource_report_bundle`を使うと、reportごとの専用payloadを変えずに、異なるreportを安定したreview manifestへまとめられます。
+# - `build_ftqc_resource_report_snapshot`と`build_ftqc_resource_report_bundle`を使うと、reportごとの専用payloadを変えずに、異なるreportを安定したreview manifestとflat row tableへまとめられます。
 # - `compare_ftqc_resource_estimates`を使うと、特定のchemistry factorizationをhard-codeせず、symbolicな推定をreviewしやすいsavings tableへ変換できます。
 # - `summarize_ftqc_resource_comparison`を使うと、その行を小さい、大きい、変わらない、symbolicな変化へ分けて設計レビューできます。
 # - `build_ftqc_resource_comparison_report`を使うと、label、profile、行、優先順位つきfinding、grouped countをreview artifactとしてまとめられます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -2342,6 +2342,8 @@ class FTQCResourceReportBundle:
         >>> bundle = FTQCResourceReportBundle("Review", (snapshot,))
         >>> bundle.to_dict()["counts"]["rows"]
         1
+        >>> bundle.to_row_table()[0]["report_kind"]
+        'comparison'
     """
 
     title: str
@@ -2379,16 +2381,42 @@ class FTQCResourceReportBundle:
             counts[kind.value] = counts.get(kind.value, 0) + 1
         return counts
 
+    def to_row_table(self) -> list[dict[str, Any]]:
+        """Return all snapshot rows as one review table.
+
+        Returns:
+            list[dict[str, Any]]: Flattened rows. Each row preserves the
+                original report row fields and adds ``snapshot_index``,
+                ``report_kind``, ``report_title``, and ``row_index`` columns.
+        """
+        rows: list[dict[str, Any]] = []
+        for snapshot_index, snapshot in enumerate(self.snapshots):
+            kind = cast(FTQCResourceReportKind, snapshot.kind)
+            payload_rows = _extract_report_rows(snapshot.payload)
+            for row_index, payload_row in enumerate(payload_rows):
+                rows.append(
+                    {
+                        **payload_row,
+                        "snapshot_index": snapshot_index,
+                        "report_kind": kind.value,
+                        "report_title": snapshot.title,
+                        "row_index": row_index,
+                    }
+                )
+        return rows
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the report bundle.
 
         Returns:
             dict[str, Any]: JSON-friendly bundle containing snapshot payloads,
-                total counts, and counts grouped by report kind.
+                flattened rows, total counts, and counts grouped by report
+                kind.
         """
         return {
             "title": self.title,
             "snapshots": [snapshot.to_dict() for snapshot in self.snapshots],
+            "rows": self.to_row_table(),
             "counts": {
                 "snapshots": len(self.snapshots),
                 "rows": sum(snapshot.row_count for snapshot in self.snapshots),
@@ -4210,6 +4238,33 @@ def _extract_report_row_count(payload: dict[str, Any]) -> int:
     if isinstance(results, list):
         return len(results)
     return 0
+
+
+def _extract_report_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract primary rows from a report payload.
+
+    Args:
+        payload (dict[str, Any]): Serialized report payload.
+
+    Returns:
+        list[dict[str, Any]]: Shallow copies of row dictionaries from
+            ``payload["rows"]`` or, for budget reports, ``payload["results"]``.
+
+    Raises:
+        ValueError: If a row-like payload field exists but does not contain
+            dictionaries.
+    """
+    raw_rows = payload.get("rows")
+    if raw_rows is None:
+        raw_rows = payload.get("results", [])
+    if not isinstance(raw_rows, list):
+        raise ValueError("report payload rows must be a list.")
+    rows = []
+    for row in raw_rows:
+        if not isinstance(row, dict):
+            raise ValueError("report payload rows must contain dictionaries.")
+        rows.append(dict(row))
+    return rows
 
 
 def _extract_report_counts(payload: dict[str, Any]) -> dict[str, int]:

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1429,6 +1429,7 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
         (comparison, scenario),
     )
     bundle_dict = bundle.to_dict()
+    bundle_rows = bundle.to_row_table()
 
     assert isinstance(snapshot, FTQCResourceReportSnapshot)
     assert snapshot.kind is FTQCResourceReportKind.COMPARISON
@@ -1438,8 +1439,29 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
     assert isinstance(bundle, FTQCResourceReportBundle)
     assert bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
     assert bundle_dict["counts"] == {"snapshots": 2, "rows": 3}
+    assert bundle_dict["rows"] == bundle_rows
     assert bundle_dict["snapshots"][1]["kind"] == "scenario"
     assert bundle_dict["snapshots"][1]["counts"] == {"resolved": 2, "unresolved": 0}
+    assert bundle_rows[0]["snapshot_index"] == 0
+    assert bundle_rows[0]["report_kind"] == "comparison"
+    assert bundle_rows[0]["report_title"] == "Runtime comparison"
+    assert bundle_rows[0]["quantity"] == "runtime_seconds"
+    assert bundle_rows[1]["snapshot_index"] == 1
+    assert bundle_rows[1]["report_kind"] == "scenario"
+    assert bundle_rows[1]["label"] == "slow"
+    assert bundle_rows[2]["row_index"] == 1
+    colliding = FTQCResourceReportBundle(
+        "colliding",
+        (
+            FTQCResourceReportSnapshot(
+                "comparison",
+                "Colliding",
+                {"title": "Colliding", "rows": [{"report_kind": "payload"}]},
+                1,
+            ),
+        ),
+    )
+    assert colliding.to_row_table()[0]["report_kind"] == "comparison"
 
     overridden = build_ftqc_resource_report_snapshot(
         comparison,
@@ -1460,6 +1482,19 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
             0,
             {"resolved": -1},
         )
+    malformed = FTQCResourceReportBundle(
+        "malformed",
+        (
+            FTQCResourceReportSnapshot(
+                "comparison",
+                "Malformed",
+                {"title": "Malformed", "rows": ["bad"]},
+                1,
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="rows must contain dictionaries"):
+        malformed.to_row_table()
 
 
 def test_audit_ftqc_research_signal_coverage_marks_missing_quantities():


### PR DESCRIPTION
## Summary
- Add `FTQCResourceReportBundle.to_row_table()` to flatten heterogeneous report snapshots into one review table.
- Preserve original report row fields while adding stable snapshot metadata columns.
- Extend English and Japanese FTQC resource-estimation docs with flat bundle-row usage and executed notebook output.

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run python docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run python docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupytext --to notebook --update docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run jupytext --to notebook --update docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run pytest -m docs tests/docs -q -k "ftqc_resource_estimation_design"`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `git diff --check`

## Local review note
The local-review skill still lists `uv run zuban qamomile/`, which currently fails with `error: unrecognized subcommand 'qamomile/'`. The repository-standard command from AGENTS.md, `uv run zuban check qamomile/`, passes.