### PR TITLE
Add FTQC report bundle manifests

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "9004aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.256427Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.255928Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.261948Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.261156Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.246385Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.246150Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.252378Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.251519Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "b1c698bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.265501Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.265282Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.643405Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.642779Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.255000Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.254702Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.593380Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.592914Z"
     }
    },
    "outputs": [],
@@ -147,10 +147,10 @@
    "id": "877d5ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.645147Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.645047Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.647663Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.647161Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.594921Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.594835Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.597580Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.597140Z"
     }
    },
    "outputs": [
@@ -203,10 +203,10 @@
    "id": "1e1d9d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.648855Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.648795Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.652128Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.651625Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.598650Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.598592Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.601954Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.601519Z"
     }
    },
    "outputs": [
@@ -314,10 +314,10 @@
    "id": "2fc667c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.653304Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.653236Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.655321Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.654897Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.602969Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.602906Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.605167Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.604794Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "1481b495",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.656574Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.656508Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.660711Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.660329Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.606381Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.606320Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.610357Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.609996Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "dedfdd29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.661765Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.661712Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.664061Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.663748Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.611448Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.611397Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.613826Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.613503Z"
     }
    },
    "outputs": [],
@@ -486,10 +486,10 @@
    "id": "12a7ac56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.665097Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.665039Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.689243Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.688753Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.614835Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.614779Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.638310Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.637910Z"
     }
    },
    "outputs": [
@@ -557,10 +557,10 @@
    "id": "5d5352a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.690415Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.690359Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.693934Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.693570Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.639465Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.639404Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.642906Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.642564Z"
     }
    },
    "outputs": [
@@ -601,10 +601,10 @@
    "id": "1e813ef9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.695004Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.694943Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.707813Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.707351Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.644090Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.644030Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.656533Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.656144Z"
     }
    },
    "outputs": [
@@ -663,10 +663,10 @@
    "id": "198b002f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.708887Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.708827Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.843703Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.843261Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.657673Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.657601Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.790936Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.790402Z"
     }
    },
    "outputs": [
@@ -740,10 +740,10 @@
    "id": "dc5a94a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.844989Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.844920Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.857264Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.856886Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.792122Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.792059Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.804829Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.804478Z"
     }
    },
    "outputs": [
@@ -893,10 +893,10 @@
    "id": "f594c0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.858526Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.858469Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.862156Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.861889Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.806170Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.806118Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.809845Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.809485Z"
     }
    },
    "outputs": [
@@ -957,10 +957,10 @@
    "id": "7f47799c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.863499Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.863441Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.868596Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.868231Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.811123Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.811063Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.816214Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.815801Z"
     }
    },
    "outputs": [
@@ -1028,10 +1028,10 @@
    "id": "c48101f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.869815Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.869741Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.872069Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.871655Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.817404Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.817318Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.819682Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.819305Z"
     }
    },
    "outputs": [
@@ -1074,10 +1074,10 @@
    "id": "a6a40b86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.873185Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.873120Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.875709Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.875337Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.820737Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.820662Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.823448Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.823037Z"
     }
    },
    "outputs": [
@@ -1127,10 +1127,10 @@
    "id": "4ea1d09a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.876954Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.876880Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.879025Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.878621Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.824569Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.824496Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.826507Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.826204Z"
     }
    },
    "outputs": [
@@ -1181,10 +1181,10 @@
    "id": "65456e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.880078Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.880002Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.883951Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.883544Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.827643Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.827562Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.831536Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.831093Z"
     }
    },
    "outputs": [
@@ -1248,10 +1248,10 @@
    "id": "fa19c3e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.885036Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.884986Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.939674Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.939256Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.832676Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.832618Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.886530Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.886100Z"
     }
    },
    "outputs": [
@@ -1328,8 +1328,8 @@
     "\n",
     "Reports keep their specialized tables, but review tooling often needs one\n",
     "stable envelope with a report kind, row count, grouped counts, and payload.\n",
-    "Snapshot and bundle helpers provide that manifest without changing the\n",
-    "report-specific dictionaries."
+    "Snapshot and bundle helpers provide that envelope and a compact manifest\n",
+    "without changing the report-specific dictionaries."
    ]
   },
   {
@@ -1338,10 +1338,10 @@
    "id": "b8d9f0a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.941042Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.940970Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.944373Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.943863Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.887770Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.887695Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.891414Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.890971Z"
     }
    },
    "outputs": [
@@ -1351,6 +1351,7 @@
      "text": [
       "scenario 2\n",
       "{'snapshots': 2, 'rows': 10}\n",
+      "{'comparison': 1, 'scenario': 1}\n",
       "{'comparison': 1, 'scenario': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1366,6 +1367,7 @@
     "\n",
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
+    "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1376,6 +1378,8 @@
     "    \"snapshots\": 2,\n",
     "    \"rows\": len(comparison_report.summary.rows) + len(scenario_report.rows),\n",
     "}\n",
+    "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
+    "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
     "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}\n",
     "assert review_bundle.to_row_table()[0][\"report_kind\"] == \"comparison\"\n",
     "assert review_bundle.to_row_table()[-1][\"report_kind\"] == \"scenario\""
@@ -1400,10 +1404,10 @@
    "id": "c60e04c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.945460Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.945407Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.952879Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.952264Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.892412Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.892349Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.899605Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.899226Z"
     }
    },
    "outputs": [
@@ -1474,10 +1478,10 @@
    "id": "b7b0c958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.953999Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.953934Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.956653Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.956389Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.900704Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.900643Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.903565Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.903162Z"
     }
    },
    "outputs": [
@@ -1537,10 +1541,10 @@
    "id": "6d54ea9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.958000Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.957942Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.962689Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.962259Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.904728Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.904673Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.909436Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.909023Z"
     }
    },
    "outputs": [
@@ -1589,10 +1593,10 @@
    "id": "bc5bd6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.963735Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.963666Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.970880Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.970441Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.910461Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.910382Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.917341Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.916888Z"
     }
    },
    "outputs": [
@@ -1666,10 +1670,10 @@
    "id": "6ec3a10f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.972023Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.971961Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.977265Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.976948Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.918354Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.918293Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.923771Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.923398Z"
     }
    },
    "outputs": [
@@ -1746,10 +1750,10 @@
    "id": "6f60d357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.978427Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.978349Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.981334Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.980895Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.924877Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.924799Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.927813Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.927438Z"
     }
    },
    "outputs": [

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -747,8 +747,8 @@ assert scenario_report.to_dict()["counts"] == {"resolved": 2, "unresolved": 0}
 #
 # Reports keep their specialized tables, but review tooling often needs one
 # stable envelope with a report kind, row count, grouped counts, and payload.
-# Snapshot and bundle helpers provide that manifest without changing the
-# report-specific dictionaries.
+# Snapshot and bundle helpers provide that envelope and a compact manifest
+# without changing the report-specific dictionaries.
 
 # %%
 scenario_snapshot = build_ftqc_resource_report_snapshot(scenario_report)
@@ -759,6 +759,7 @@ review_bundle = build_ftqc_resource_report_bundle(
 
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
+print(review_bundle.to_manifest()["counts_by_kind"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -769,6 +770,8 @@ assert review_bundle.to_dict()["counts"] == {
     "snapshots": 2,
     "rows": len(comparison_report.summary.rows) + len(scenario_report.rows),
 }
+assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
+assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
 assert review_bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
 assert review_bundle.to_row_table()[0]["report_kind"] == "comparison"
 assert review_bundle.to_row_table()[-1]["report_kind"] == "scenario"

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "0568ebd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.256545Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.256149Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.261996Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.261138Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.246451Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.246220Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.252212Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.251512Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "64c31fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.265555Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.265294Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.643334Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.642806Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.255097Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.254838Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.593278Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.592914Z"
     }
    },
    "outputs": [],
@@ -132,10 +132,10 @@
    "id": "245db61b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.645092Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.644988Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.647654Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.647087Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.594919Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.594826Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.597615Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.597101Z"
     }
    },
    "outputs": [
@@ -187,10 +187,10 @@
    "id": "1c51b24c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.648885Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.648815Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.652221Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.651832Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.598625Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.598567Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.601960Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.601525Z"
     }
    },
    "outputs": [
@@ -296,10 +296,10 @@
    "id": "89549b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.653494Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.653433Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.655484Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.655089Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.602970Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.602908Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.605390Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.604727Z"
     }
    },
    "outputs": [
@@ -343,10 +343,10 @@
    "id": "c15595d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.656620Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.656561Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.660789Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.660347Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.606449Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.606386Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.610567Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.610057Z"
     }
    },
    "outputs": [
@@ -418,10 +418,10 @@
    "id": "fdbe0ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.661759Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.661705Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.664112Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.663748Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.611587Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.611534Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.613957Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.613502Z"
     }
    },
    "outputs": [],
@@ -458,10 +458,10 @@
    "id": "e12aded6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.665119Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.665062Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.688924Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.688527Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.614851Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.614793Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.638266Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.637803Z"
     }
    },
    "outputs": [
@@ -527,10 +527,10 @@
    "id": "afc69281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.689980Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.689925Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.693381Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.693001Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.639368Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.639312Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.642777Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.642444Z"
     }
    },
    "outputs": [
@@ -569,10 +569,10 @@
    "id": "13279f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.694561Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.694500Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.707318Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.706993Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.644125Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.644059Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.656431Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.656040Z"
     }
    },
    "outputs": [
@@ -627,10 +627,10 @@
    "id": "768805d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.708622Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.708570Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.844353Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.843888Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.657572Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.657518Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.790767Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.790283Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "id": "3797a63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.845638Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.845570Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.857751Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.857248Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.792108Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.792046Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.804820Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.804344Z"
     }
    },
    "outputs": [
@@ -853,10 +853,10 @@
    "id": "adacec7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.858850Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.858785Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.862550Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.862243Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.806130Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.806074Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.809886Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.809574Z"
     }
    },
    "outputs": [
@@ -914,10 +914,10 @@
    "id": "e5eb2526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.863748Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.863688Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.868772Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.868370Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.811238Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.811177Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.816351Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.815955Z"
     }
    },
    "outputs": [
@@ -982,10 +982,10 @@
    "id": "76757432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.870021Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.869946Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.872482Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.871975Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.817529Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.817451Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.819752Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.819450Z"
     }
    },
    "outputs": [
@@ -1025,10 +1025,10 @@
    "id": "bb1caac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.873506Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.873442Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.876127Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.875651Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.821012Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.820941Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.823665Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.823271Z"
     }
    },
    "outputs": [
@@ -1075,10 +1075,10 @@
    "id": "50616921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.877172Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.877100Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.879235Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.878709Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.824778Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.824705Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.826742Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.826417Z"
     }
    },
    "outputs": [
@@ -1128,10 +1128,10 @@
    "id": "b7f70d90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.880328Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.880256Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.884199Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.883797Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.827903Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.827830Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.831651Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.831243Z"
     }
    },
    "outputs": [
@@ -1192,10 +1192,10 @@
    "id": "590d1767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.885345Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.885285Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.940108Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.939589Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.832737Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.832676Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.886637Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.886214Z"
     }
    },
    "outputs": [
@@ -1203,7 +1203,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "baseline hardware resolved= True runtime= 3.080e+5\n",
+      "baseline hardware"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " resolved= True runtime= 3.080e+5\n",
       "faster factories resolved= True runtime= 1.540e+5\n"
      ]
     }
@@ -1270,7 +1277,7 @@
    "source": [
     "### Review snapshot\n",
     "\n",
-    "reportは専用のtableを保ちますが、review toolingではreport kind、row count、grouped count、payloadを持つ安定したenvelopeが必要になることがあります。snapshot helperとbundle helperを使うと、reportごとの辞書を変えずに、そのmanifestを作れます。"
+    "reportは専用のtableを保ちますが、review toolingではreport kind、row count、grouped count、payloadを持つ安定したenvelopeが必要になることがあります。snapshot helperとbundle helperを使うと、reportごとの辞書を変えずに、そのenvelopeと軽量なmanifestを作れます。"
    ]
   },
   {
@@ -1279,10 +1286,10 @@
    "id": "d7f49b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.941366Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.941286Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.944666Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.944219Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.887773Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.887694Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.891286Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.890820Z"
     }
    },
    "outputs": [
@@ -1292,6 +1299,7 @@
      "text": [
       "scenario 2\n",
       "{'snapshots': 2, 'rows': 10}\n",
+      "{'comparison': 1, 'scenario': 1}\n",
       "{'comparison': 1, 'scenario': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1307,6 +1315,7 @@
     "\n",
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
+    "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1317,6 +1326,8 @@
     "    \"snapshots\": 2,\n",
     "    \"rows\": len(comparison_report.summary.rows) + len(scenario_report.rows),\n",
     "}\n",
+    "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
+    "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
     "assert review_bundle.counts_by_kind() == {\"comparison\": 1, \"scenario\": 1}\n",
     "assert review_bundle.to_row_table()[0][\"report_kind\"] == \"comparison\"\n",
     "assert review_bundle.to_row_table()[-1][\"report_kind\"] == \"scenario\""
@@ -1338,10 +1349,10 @@
    "id": "8a5c890c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.945699Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.945642Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.953060Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.952566Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.892370Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.892309Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.899489Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.899105Z"
     }
    },
    "outputs": [
@@ -1409,10 +1420,10 @@
    "id": "15bd42c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.954167Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.954106Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.957003Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.956645Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.900745Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.900678Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.903683Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.903240Z"
     }
    },
    "outputs": [
@@ -1470,10 +1481,10 @@
    "id": "18161f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.957996Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.957931Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.962734Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.962255Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.904683Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.904624Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.909219Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.908867Z"
     }
    },
    "outputs": [
@@ -1519,10 +1530,10 @@
    "id": "613ad1ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.963747Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.963682Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.970855Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.970384Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.910360Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.910284Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.917292Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.916886Z"
     }
    },
    "outputs": [
@@ -1591,10 +1602,10 @@
    "id": "95e4f4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.971990Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.971928Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.977696Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.977205Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.918348Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.918290Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.923935Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.923501Z"
     }
    },
    "outputs": [
@@ -1668,10 +1679,10 @@
    "id": "38caf5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:24:10.978774Z",
-     "iopub.status.busy": "2026-06-23T09:24:10.978703Z",
-     "iopub.status.idle": "2026-06-23T09:24:10.981713Z",
-     "shell.execute_reply": "2026-06-23T09:24:10.981294Z"
+     "iopub.execute_input": "2026-06-23T09:37:25.924990Z",
+     "iopub.status.busy": "2026-06-23T09:37:25.924913Z",
+     "iopub.status.idle": "2026-06-23T09:37:25.927945Z",
+     "shell.execute_reply": "2026-06-23T09:37:25.927481Z"
     }
    },
    "outputs": [

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -689,7 +689,7 @@ assert scenario_report.to_dict()["counts"] == {"resolved": 2, "unresolved": 0}
 # %% [markdown]
 # ### Review snapshot
 #
-# reportは専用のtableを保ちますが、review toolingではreport kind、row count、grouped count、payloadを持つ安定したenvelopeが必要になることがあります。snapshot helperとbundle helperを使うと、reportごとの辞書を変えずに、そのmanifestを作れます。
+# reportは専用のtableを保ちますが、review toolingではreport kind、row count、grouped count、payloadを持つ安定したenvelopeが必要になることがあります。snapshot helperとbundle helperを使うと、reportごとの辞書を変えずに、そのenvelopeと軽量なmanifestを作れます。
 
 # %%
 scenario_snapshot = build_ftqc_resource_report_snapshot(scenario_report)
@@ -700,6 +700,7 @@ review_bundle = build_ftqc_resource_report_bundle(
 
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
+print(review_bundle.to_manifest()["counts_by_kind"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -710,6 +711,8 @@ assert review_bundle.to_dict()["counts"] == {
     "snapshots": 2,
     "rows": len(comparison_report.summary.rows) + len(scenario_report.rows),
 }
+assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
+assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
 assert review_bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
 assert review_bundle.to_row_table()[0]["report_kind"] == "comparison"
 assert review_bundle.to_row_table()[-1]["report_kind"] == "scenario"

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -2344,6 +2344,8 @@ class FTQCResourceReportBundle:
         1
         >>> bundle.to_row_table()[0]["report_kind"]
         'comparison'
+        >>> bundle.to_manifest()["counts_by_kind"]
+        {'comparison': 1}
     """
 
     title: str
@@ -2405,6 +2407,33 @@ class FTQCResourceReportBundle:
                 )
         return rows
 
+    def to_manifest(self) -> dict[str, Any]:
+        """Return stable bundle metadata for review tooling.
+
+        Returns:
+            dict[str, Any]: JSON-friendly bundle manifest containing title,
+                aggregate counts, counts grouped by report kind, and compact
+                snapshot metadata without the full report payloads.
+        """
+        return {
+            "title": self.title,
+            "counts": {
+                "snapshots": len(self.snapshots),
+                "rows": sum(snapshot.row_count for snapshot in self.snapshots),
+            },
+            "counts_by_kind": self.counts_by_kind(),
+            "snapshots": [
+                {
+                    "index": index,
+                    "kind": cast(FTQCResourceReportKind, snapshot.kind).value,
+                    "title": snapshot.title,
+                    "row_count": snapshot.row_count,
+                    "counts": dict(snapshot.counts or {}),
+                }
+                for index, snapshot in enumerate(self.snapshots)
+            ],
+        }
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the report bundle.
 
@@ -2413,15 +2442,14 @@ class FTQCResourceReportBundle:
                 flattened rows, total counts, and counts grouped by report
                 kind.
         """
+        manifest = self.to_manifest()
         return {
             "title": self.title,
             "snapshots": [snapshot.to_dict() for snapshot in self.snapshots],
             "rows": self.to_row_table(),
-            "counts": {
-                "snapshots": len(self.snapshots),
-                "rows": sum(snapshot.row_count for snapshot in self.snapshots),
-            },
-            "counts_by_kind": self.counts_by_kind(),
+            "manifest": manifest,
+            "counts": manifest["counts"],
+            "counts_by_kind": manifest["counts_by_kind"],
         }
 
 

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1430,6 +1430,7 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
     )
     bundle_dict = bundle.to_dict()
     bundle_rows = bundle.to_row_table()
+    bundle_manifest = bundle.to_manifest()
 
     assert isinstance(snapshot, FTQCResourceReportSnapshot)
     assert snapshot.kind is FTQCResourceReportKind.COMPARISON
@@ -1438,6 +1439,31 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
     assert snapshot.to_dict()["payload"]["title"] == "Runtime comparison"
     assert isinstance(bundle, FTQCResourceReportBundle)
     assert bundle.counts_by_kind() == {"comparison": 1, "scenario": 1}
+    assert bundle_manifest == bundle_dict["manifest"]
+    assert bundle_manifest["counts"] == {"snapshots": 2, "rows": 3}
+    assert bundle_manifest["counts_by_kind"] == {"comparison": 1, "scenario": 1}
+    assert bundle_manifest["snapshots"] == [
+        {
+            "index": 0,
+            "kind": "comparison",
+            "title": "Runtime comparison",
+            "row_count": 1,
+            "counts": {
+                "smaller": 1,
+                "larger": 0,
+                "unchanged": 0,
+                "symbolic": 0,
+            },
+        },
+        {
+            "index": 1,
+            "kind": "scenario",
+            "title": "FTQC resource scenario report",
+            "row_count": 2,
+            "counts": {"resolved": 2, "unresolved": 0},
+        },
+    ]
+    assert "payload" not in bundle_manifest["snapshots"][0]
     assert bundle_dict["counts"] == {"snapshots": 2, "rows": 3}
     assert bundle_dict["rows"] == bundle_rows
     assert bundle_dict["snapshots"][1]["kind"] == "scenario"


### PR DESCRIPTION
## Summary
- Add FTQCResourceReportBundle.to_manifest() for compact bundle metadata without embedding full report payloads.
- Include the manifest in bundle serialization while preserving existing counts and flat row table fields.
- Update the FTQC resource-estimation design docs in English and Japanese with executed notebook outputs.

## Validation
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q
- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design'
- uv run python docs/en/usage/ftqc_resource_estimation_design.py
- uv run python docs/ja/usage/ftqc_resource_estimation_design.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/

## Local review note
- The local-review skill still lists the stale command 'uv run zuban qamomile/', which fails with 'unrecognized subcommand'. The current repository command 'uv run zuban check qamomile/' passes.