### PR TITLE
Track FTQC report references in manifests

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "9004aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.246385Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.246150Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.252378Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.251519Z"
+     "iopub.execute_input": "2026-06-23T09:51:40.868710Z",
+     "iopub.status.busy": "2026-06-23T09:51:40.868480Z",
+     "iopub.status.idle": "2026-06-23T09:51:40.874295Z",
+     "shell.execute_reply": "2026-06-23T09:51:40.873240Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "b1c698bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.255000Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.254702Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.593380Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.592914Z"
+     "iopub.execute_input": "2026-06-23T09:51:40.876523Z",
+     "iopub.status.busy": "2026-06-23T09:51:40.876355Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.205390Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.205026Z"
     }
    },
    "outputs": [],
@@ -147,10 +147,10 @@
    "id": "877d5ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.594921Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.594835Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.597580Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.597140Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.207008Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.206923Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.209708Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.209244Z"
     }
    },
    "outputs": [
@@ -203,10 +203,10 @@
    "id": "1e1d9d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.598650Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.598592Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.601954Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.601519Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.210795Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.210726Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.214061Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.213724Z"
     }
    },
    "outputs": [
@@ -314,10 +314,10 @@
    "id": "2fc667c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.602969Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.602906Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.605167Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.604794Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.215233Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.215180Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.217350Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.216997Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "1481b495",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.606381Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.606320Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.610357Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.609996Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.218534Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.218471Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.222528Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.222206Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "dedfdd29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.611448Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.611397Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.613826Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.613503Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.223715Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.223654Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.226144Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.225822Z"
     }
    },
    "outputs": [],
@@ -486,10 +486,10 @@
    "id": "12a7ac56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.614835Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.614779Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.638310Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.637910Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.227170Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.227116Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.250745Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.250369Z"
     }
    },
    "outputs": [
@@ -557,10 +557,10 @@
    "id": "5d5352a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.639465Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.639404Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.642906Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.642564Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.251885Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.251819Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.255705Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.255416Z"
     }
    },
    "outputs": [
@@ -601,10 +601,10 @@
    "id": "1e813ef9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.644090Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.644030Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.656533Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.656144Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.257006Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.256946Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.269442Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.269091Z"
     }
    },
    "outputs": [
@@ -663,10 +663,10 @@
    "id": "198b002f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.657673Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.657601Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.790936Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.790402Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.270683Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.270625Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.401320Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.400926Z"
     }
    },
    "outputs": [
@@ -740,10 +740,10 @@
    "id": "dc5a94a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.792122Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.792059Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.804829Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.804478Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.402668Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.402598Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.414407Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.414063Z"
     }
    },
    "outputs": [
@@ -893,10 +893,10 @@
    "id": "f594c0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.806170Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.806118Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.809845Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.809485Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.415642Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.415575Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.419270Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.418938Z"
     }
    },
    "outputs": [
@@ -957,10 +957,10 @@
    "id": "7f47799c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.811123Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.811063Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.816214Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.815801Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.420477Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.420416Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.425479Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.425039Z"
     }
    },
    "outputs": [
@@ -1028,10 +1028,10 @@
    "id": "c48101f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.817404Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.817318Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.819682Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.819305Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.426554Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.426490Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.428664Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.428316Z"
     }
    },
    "outputs": [
@@ -1074,10 +1074,10 @@
    "id": "a6a40b86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.820737Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.820662Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.823448Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.823037Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.429785Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.429721Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.432199Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.431888Z"
     }
    },
    "outputs": [
@@ -1127,10 +1127,10 @@
    "id": "4ea1d09a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.824569Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.824496Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.826507Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.826204Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.433414Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.433337Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.435377Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.435047Z"
     }
    },
    "outputs": [
@@ -1181,10 +1181,10 @@
    "id": "65456e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.827643Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.827562Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.831536Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.831093Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.436499Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.436433Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.440120Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.439794Z"
     }
    },
    "outputs": [
@@ -1248,10 +1248,10 @@
    "id": "fa19c3e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.832676Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.832618Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.886530Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.886100Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.441263Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.441201Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.495321Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.494793Z"
     }
    },
    "outputs": [
@@ -1338,10 +1338,10 @@
    "id": "b8d9f0a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.887770Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.887695Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.891414Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.890971Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.496541Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.496462Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.500511Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.500080Z"
     }
    },
    "outputs": [
@@ -1404,10 +1404,10 @@
    "id": "c60e04c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.892412Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.892349Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.899605Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.899226Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.501519Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.501455Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.508745Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.508357Z"
     }
    },
    "outputs": [
@@ -1478,10 +1478,10 @@
    "id": "b7b0c958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.900704Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.900643Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.903565Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.903162Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.509822Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.509760Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.512674Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.512215Z"
     }
    },
    "outputs": [
@@ -1541,10 +1541,10 @@
    "id": "6d54ea9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.904728Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.904673Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.909436Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.909023Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.513677Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.513616Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.518651Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.518134Z"
     }
    },
    "outputs": [
@@ -1593,10 +1593,10 @@
    "id": "bc5bd6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.910461Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.910382Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.917341Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.916888Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.519772Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.519701Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.526621Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.526223Z"
     }
    },
    "outputs": [
@@ -1649,6 +1649,60 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b61750e",
+   "metadata": {},
+   "source": [
+    "Report bundles also preserve structured research provenance in their compact\n",
+    "manifest. That lets review tooling trace an artifact back to the paper-level\n",
+    "signals it was built to check without loading every nested payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "7e74c2d0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T09:51:41.527874Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.527815Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.531317Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.530804Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n"
+     ]
+    }
+   ],
+   "source": [
+    "research_review_bundle = build_ftqc_resource_report_bundle(\n",
+    "    \"UWC research review bundle\",\n",
+    "    (signal_catalog_report, uwc_signal_report, uwc_driver_report),\n",
+    ")\n",
+    "research_manifest = research_review_bundle.to_manifest()\n",
+    "print(research_manifest[\"reference_keys\"])\n",
+    "\n",
+    "assert research_manifest[\"reference_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]\n",
+    "assert research_manifest[\"counts_by_kind\"] == {\n",
+    "    \"research_signal_coverage\": 1,\n",
+    "    \"comparison\": 1,\n",
+    "    \"driver\": 1,\n",
+    "}\n",
+    "assert research_manifest[\"snapshots\"][0][\"reference_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4e02dd2d",
    "metadata": {},
    "source": [
@@ -1666,14 +1720,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "6ec3a10f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.918354Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.918293Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.923771Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.923398Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.532494Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.532436Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.537719Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.537369Z"
     }
    },
    "outputs": [
@@ -1746,14 +1800,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "6f60d357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.924877Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.924799Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.927813Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.927438Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.538789Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.538716Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.541673Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.541213Z"
     }
    },
    "outputs": [

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -912,6 +912,33 @@ assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in driver_quantities
 assert uwc_driver_report.to_row_table()[-1]["is_target"] is True
 
 # %% [markdown]
+# Report bundles also preserve structured research provenance in their compact
+# manifest. That lets review tooling trace an artifact back to the paper-level
+# signals it was built to check without loading every nested payload.
+
+# %%
+research_review_bundle = build_ftqc_resource_report_bundle(
+    "UWC research review bundle",
+    (signal_catalog_report, uwc_signal_report, uwc_driver_report),
+)
+research_manifest = research_review_bundle.to_manifest()
+print(research_manifest["reference_keys"])
+
+assert research_manifest["reference_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+assert research_manifest["counts_by_kind"] == {
+    "research_signal_coverage": 1,
+    "comparison": 1,
+    "driver": 1,
+}
+assert research_manifest["snapshots"][0]["reference_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+
+# %% [markdown]
 # ## Pareto Frontier Review
 #
 # Pairwise comparisons are useful, but FTQC design reviews usually compare

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "0568ebd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.246451Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.246220Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.252212Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.251512Z"
+     "iopub.execute_input": "2026-06-23T09:51:40.871347Z",
+     "iopub.status.busy": "2026-06-23T09:51:40.871116Z",
+     "iopub.status.idle": "2026-06-23T09:51:40.875888Z",
+     "shell.execute_reply": "2026-06-23T09:51:40.875027Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "64c31fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.255097Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.254838Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.593278Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.592914Z"
+     "iopub.execute_input": "2026-06-23T09:51:40.877923Z",
+     "iopub.status.busy": "2026-06-23T09:51:40.877777Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.205414Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.205032Z"
     }
    },
    "outputs": [],
@@ -132,10 +132,10 @@
    "id": "245db61b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.594919Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.594826Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.597615Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.597101Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.206993Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.206906Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.209709Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.209242Z"
     }
    },
    "outputs": [
@@ -187,10 +187,10 @@
    "id": "1c51b24c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.598625Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.598567Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.601960Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.601525Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.210774Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.210703Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.213903Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.213643Z"
     }
    },
    "outputs": [
@@ -296,10 +296,10 @@
    "id": "89549b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.602970Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.602908Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.605390Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.604727Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.215075Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.215023Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.217301Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.216846Z"
     }
    },
    "outputs": [
@@ -343,10 +343,10 @@
    "id": "c15595d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.606449Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.606386Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.610567Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.610057Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.218407Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.218345Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.222510Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.222176Z"
     }
    },
    "outputs": [
@@ -418,10 +418,10 @@
    "id": "fdbe0ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.611587Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.611534Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.613957Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.613502Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.223567Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.223506Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.226195Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.225767Z"
     }
    },
    "outputs": [],
@@ -458,10 +458,10 @@
    "id": "e12aded6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.614851Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.614793Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.638266Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.637803Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.227189Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.227131Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.251145Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.250715Z"
     }
    },
    "outputs": [
@@ -527,10 +527,10 @@
    "id": "afc69281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.639368Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.639312Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.642777Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.642444Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.252258Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.252196Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.255961Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.255551Z"
     }
    },
    "outputs": [
@@ -569,10 +569,10 @@
    "id": "13279f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.644125Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.644059Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.656431Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.656040Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.257083Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.257020Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.269531Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.269096Z"
     }
    },
    "outputs": [
@@ -627,10 +627,10 @@
    "id": "768805d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.657572Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.657518Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.790767Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.790283Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.270664Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.270608Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.401511Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.400979Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "id": "3797a63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.792108Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.792046Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.804820Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.804344Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.402685Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.402613Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.414581Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.414236Z"
     }
    },
    "outputs": [
@@ -853,10 +853,10 @@
    "id": "adacec7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.806130Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.806074Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.809886Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.809574Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.415810Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.415748Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.419451Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.419154Z"
     }
    },
    "outputs": [
@@ -914,10 +914,10 @@
    "id": "e5eb2526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.811238Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.811177Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.816351Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.815955Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.420782Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.420721Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.425812Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.425342Z"
     }
    },
    "outputs": [
@@ -982,10 +982,10 @@
    "id": "76757432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.817529Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.817451Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.819752Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.819450Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.426853Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.426782Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.429151Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.428780Z"
     }
    },
    "outputs": [
@@ -1025,10 +1025,10 @@
    "id": "bb1caac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.821012Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.820941Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.823665Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.823271Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.430192Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.430121Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.432650Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.432313Z"
     }
    },
    "outputs": [
@@ -1075,10 +1075,10 @@
    "id": "50616921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.824778Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.824705Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.826742Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.826417Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.433869Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.433795Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.435842Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.435425Z"
     }
    },
    "outputs": [
@@ -1128,10 +1128,10 @@
    "id": "b7f70d90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.827903Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.827830Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.831651Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.831243Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.436852Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.436789Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.440579Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.440258Z"
     }
    },
    "outputs": [
@@ -1192,10 +1192,10 @@
    "id": "590d1767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.832737Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.832676Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.886637Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.886214Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.441792Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.441731Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.495415Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.494789Z"
     }
    },
    "outputs": [
@@ -1203,14 +1203,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "baseline hardware"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " resolved= True runtime= 3.080e+5\n",
+      "baseline hardware resolved= True runtime= 3.080e+5\n",
       "faster factories resolved= True runtime= 1.540e+5\n"
      ]
     }
@@ -1286,10 +1279,10 @@
    "id": "d7f49b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.887773Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.887694Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.891286Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.890820Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.496500Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.496423Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.500250Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.499881Z"
     }
    },
    "outputs": [
@@ -1349,10 +1342,10 @@
    "id": "8a5c890c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.892370Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.892309Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.899489Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.899105Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.501283Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.501225Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.508687Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.508353Z"
     }
    },
    "outputs": [
@@ -1420,10 +1413,10 @@
    "id": "15bd42c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.900745Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.900678Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.903683Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.903240Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.509811Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.509751Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.512593Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.512273Z"
     }
    },
    "outputs": [
@@ -1481,10 +1474,10 @@
    "id": "18161f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.904683Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.904624Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.909219Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.908867Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.513736Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.513676Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.518544Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.518053Z"
     }
    },
    "outputs": [
@@ -1530,10 +1523,10 @@
    "id": "613ad1ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.910360Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.910284Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.917292Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.916886Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.519692Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.519617Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.526723Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.526348Z"
     }
    },
    "outputs": [
@@ -1586,6 +1579,58 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e3be14ed",
+   "metadata": {},
+   "source": [
+    "Report bundleは、軽量なmanifestの中に構造化されたresearch provenanceも残します。これにより、review toolingはすべてのnested payloadを読み込まなくても、そのartifactがどのpaper-level signalを確認するために作られたかを追跡できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "30bb703c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T09:51:41.527851Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.527797Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.531200Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.530810Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n"
+     ]
+    }
+   ],
+   "source": [
+    "research_review_bundle = build_ftqc_resource_report_bundle(\n",
+    "    \"UWC research review bundle\",\n",
+    "    (signal_catalog_report, uwc_signal_report, uwc_driver_report),\n",
+    ")\n",
+    "research_manifest = research_review_bundle.to_manifest()\n",
+    "print(research_manifest[\"reference_keys\"])\n",
+    "\n",
+    "assert research_manifest[\"reference_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]\n",
+    "assert research_manifest[\"counts_by_kind\"] == {\n",
+    "    \"research_signal_coverage\": 1,\n",
+    "    \"comparison\": 1,\n",
+    "    \"driver\": 1,\n",
+    "}\n",
+    "assert research_manifest[\"snapshots\"][0][\"reference_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "21de6663",
    "metadata": {},
    "source": [
@@ -1598,14 +1643,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "95e4f4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.918348Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.918290Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.923935Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.923501Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.532338Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.532275Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.537435Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.537134Z"
     }
    },
    "outputs": [
@@ -1675,14 +1720,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "38caf5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T09:37:25.924990Z",
-     "iopub.status.busy": "2026-06-23T09:37:25.924913Z",
-     "iopub.status.idle": "2026-06-23T09:37:25.927945Z",
-     "shell.execute_reply": "2026-06-23T09:37:25.927481Z"
+     "iopub.execute_input": "2026-06-23T09:51:41.538604Z",
+     "iopub.status.busy": "2026-06-23T09:51:41.538536Z",
+     "iopub.status.idle": "2026-06-23T09:51:41.541420Z",
+     "shell.execute_reply": "2026-06-23T09:51:41.541007Z"
     }
    },
    "outputs": [

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -842,6 +842,31 @@ assert FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS in driver_quantities
 assert uwc_driver_report.to_row_table()[-1]["is_target"] is True
 
 # %% [markdown]
+# Report bundleは、軽量なmanifestの中に構造化されたresearch provenanceも残します。これにより、review toolingはすべてのnested payloadを読み込まなくても、そのartifactがどのpaper-level signalを確認するために作られたかを追跡できます。
+
+# %%
+research_review_bundle = build_ftqc_resource_report_bundle(
+    "UWC research review bundle",
+    (signal_catalog_report, uwc_signal_report, uwc_driver_report),
+)
+research_manifest = research_review_bundle.to_manifest()
+print(research_manifest["reference_keys"])
+
+assert research_manifest["reference_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+assert research_manifest["counts_by_kind"] == {
+    "research_signal_coverage": 1,
+    "comparison": 1,
+    "driver": 1,
+}
+assert research_manifest["snapshots"][0]["reference_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+
+# %% [markdown]
 # ## Pareto Frontierレビュー
 #
 # ペアごとの比較は有用ですが、FTQC設計レビューでは複数の候補を競合する目的で比べることがよくあります。Pareto reportでは、別の候補が選択したすべてのresource quantityで同じか小さく、少なくとも1つで厳密に小さい場合にだけ、その候補をdominatedとして扱います。symbolicなtradeoffはfrontierに残るため、reviewerが確認できます。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -2307,7 +2307,7 @@ class FTQCResourceReportSnapshot:
 
         Returns:
             dict[str, Any]: JSON-friendly snapshot envelope containing kind,
-                title, row count, grouped counts, and payload.
+                title, row count, grouped counts, reference keys, and payload.
         """
         kind = cast(FTQCResourceReportKind, self.kind)
         return {
@@ -2315,6 +2315,7 @@ class FTQCResourceReportSnapshot:
             "title": self.title,
             "row_count": self.row_count,
             "counts": dict(self.counts or {}),
+            "reference_keys": list(_extract_report_reference_keys(self.payload)),
             "payload": dict(self.payload),
         }
 
@@ -2422,6 +2423,15 @@ class FTQCResourceReportBundle:
                 "rows": sum(snapshot.row_count for snapshot in self.snapshots),
             },
             "counts_by_kind": self.counts_by_kind(),
+            "reference_keys": list(
+                _dedupe_strings(
+                    tuple(
+                        key
+                        for snapshot in self.snapshots
+                        for key in _extract_report_reference_keys(snapshot.payload)
+                    )
+                )
+            ),
             "snapshots": [
                 {
                     "index": index,
@@ -2429,6 +2439,9 @@ class FTQCResourceReportBundle:
                     "title": snapshot.title,
                     "row_count": snapshot.row_count,
                     "counts": dict(snapshot.counts or {}),
+                    "reference_keys": list(
+                        _extract_report_reference_keys(snapshot.payload)
+                    ),
                 }
                 for index, snapshot in enumerate(self.snapshots)
             ],
@@ -4318,6 +4331,101 @@ def _extract_report_counts(payload: dict[str, Any]) -> dict[str, int]:
             raise ValueError("report payload counts must map strings to integers.")
         counts[key] = value
     return counts
+
+
+def _extract_report_reference_keys(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Extract structured reference keys from a report payload.
+
+    Args:
+        payload (dict[str, Any]): Serialized report payload.
+
+    Returns:
+        tuple[str, ...]: Deduplicated reference keys discovered in
+            ``reference_key``, ``reference_keys``, or ``references`` fields.
+
+    Raises:
+        ValueError: If a reference field exists but is not string-shaped.
+    """
+    keys: list[str] = []
+    _collect_report_reference_keys(payload, keys)
+    return _dedupe_strings(tuple(keys))
+
+
+def _collect_report_reference_keys(value: Any, keys: list[str]) -> None:
+    """Collect structured reference keys recursively.
+
+    Args:
+        value (Any): JSON-like value to inspect.
+        keys (list[str]): Mutable output list that receives discovered keys.
+
+    Raises:
+        ValueError: If a structured reference field has an unsupported shape.
+    """
+    if isinstance(value, dict):
+        for field, field_value in value.items():
+            if field == "reference_key":
+                if not isinstance(field_value, str):
+                    raise ValueError("report payload reference_key must be a string.")
+                keys.append(field_value)
+                continue
+            if field == "reference_keys":
+                if not isinstance(field_value, list) or not all(
+                    isinstance(key, str) for key in field_value
+                ):
+                    raise ValueError(
+                        "report payload reference_keys must be a list of strings."
+                    )
+                keys.extend(field_value)
+                continue
+            if field == "references":
+                _collect_reference_entries(field_value, keys)
+                continue
+            _collect_report_reference_keys(field_value, keys)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_report_reference_keys(item, keys)
+
+
+def _collect_reference_entries(value: Any, keys: list[str]) -> None:
+    """Collect keys from a serialized references field.
+
+    Args:
+        value (Any): Value from a ``references`` payload field.
+        keys (list[str]): Mutable output list that receives discovered keys.
+
+    Raises:
+        ValueError: If ``value`` is not a list of dictionaries with string
+            ``key`` fields.
+    """
+    if not isinstance(value, list):
+        raise ValueError("report payload references must be a list.")
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("report payload references must contain dictionaries.")
+        key = item.get("key")
+        if not isinstance(key, str):
+            raise ValueError("report payload reference entries must contain key.")
+        keys.append(key)
+
+
+def _dedupe_strings(values: tuple[str, ...]) -> tuple[str, ...]:
+    """Deduplicate strings while preserving first occurrence order.
+
+    Args:
+        values (tuple[str, ...]): String values to deduplicate.
+
+    Returns:
+        tuple[str, ...]: Deduplicated values in first-seen order.
+    """
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        deduped.append(value)
+        seen.add(value)
+    return tuple(deduped)
 
 
 def _normalize_substitution_symbol(symbol: str | sp.Symbol) -> sp.Symbol:

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1454,6 +1454,7 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
                 "unchanged": 0,
                 "symbolic": 0,
             },
+            "reference_keys": [],
         },
         {
             "index": 1,
@@ -1461,8 +1462,10 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
             "title": "FTQC resource scenario report",
             "row_count": 2,
             "counts": {"resolved": 2, "unresolved": 0},
+            "reference_keys": [],
         },
     ]
+    assert bundle_manifest["reference_keys"] == []
     assert "payload" not in bundle_manifest["snapshots"][0]
     assert bundle_dict["counts"] == {"snapshots": 2, "rows": 3}
     assert bundle_dict["rows"] == bundle_rows
@@ -1521,6 +1524,71 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
     )
     with pytest.raises(ValueError, match="rows must contain dictionaries"):
         malformed.to_row_table()
+
+
+def test_ftqc_report_bundle_manifest_collects_reference_keys():
+    """Report bundle manifests expose structured research provenance."""
+    referenced = FTQCResourceReportSnapshot(
+        "comparison",
+        "Referenced comparison",
+        {
+            "title": "Referenced comparison",
+            "rows": [{"quantity": "runtime_seconds"}],
+            "reference_keys": ["arXiv:2403.03502"],
+            "formulas": [
+                {
+                    "quantity": "runtime_seconds",
+                    "reference_keys": [
+                        "arXiv:1610.06546",
+                        "arXiv:2403.03502",
+                    ],
+                }
+            ],
+            "references": [{"key": "internal:loader"}],
+        },
+        1,
+    )
+    coverage = FTQCResourceReportSnapshot(
+        "research_signal_coverage",
+        "Coverage",
+        {
+            "title": "Coverage",
+            "rows": [{"reference_key": "arXiv:2603.22778"}],
+        },
+        1,
+    )
+    bundle = FTQCResourceReportBundle(
+        "Referenced bundle",
+        (referenced, coverage),
+    )
+    manifest = bundle.to_manifest()
+
+    assert referenced.to_dict()["reference_keys"] == [
+        "arXiv:2403.03502",
+        "arXiv:1610.06546",
+        "internal:loader",
+    ]
+    assert manifest["reference_keys"] == [
+        "arXiv:2403.03502",
+        "arXiv:1610.06546",
+        "internal:loader",
+        "arXiv:2603.22778",
+    ]
+    assert manifest["snapshots"][0]["reference_keys"] == [
+        "arXiv:2403.03502",
+        "arXiv:1610.06546",
+        "internal:loader",
+    ]
+    assert manifest["snapshots"][1]["reference_keys"] == ["arXiv:2603.22778"]
+
+    malformed = FTQCResourceReportSnapshot(
+        "comparison",
+        "Malformed references",
+        {"title": "Malformed references", "rows": [], "reference_keys": [object()]},
+        0,
+    )
+    with pytest.raises(ValueError, match="reference_keys"):
+        malformed.to_dict()
 
 
 def test_audit_ftqc_research_signal_coverage_marks_missing_quantities():


### PR DESCRIPTION
## Summary
- Add structured reference-key extraction for FTQC report snapshots and bundle manifests.
- Surface deduplicated reference_keys at the bundle level and per snapshot without scanning arbitrary prose.
- Demonstrate research-provenance manifests in the FTQC resource-estimation design docs in English and Japanese.

## Research context checked
- arXiv:2403.03502 identifies Hamiltonian normalization and Toffoli-dominated qubitized QPE cost as core SCDF review signals.
- arXiv:2601.08533 motivates tracking state-preparation success probability and QPE repetition overhead.

## Validation
- uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q
- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design'
- uv run python docs/en/usage/ftqc_resource_estimation_design.py
- uv run python docs/ja/usage/ftqc_resource_estimation_design.py
- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb
- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/

## Local review note
- The local-review skill still lists the stale command 'uv run zuban qamomile/', which fails with 'unrecognized subcommand'. The current repository command 'uv run zuban check qamomile/' passes.