### PR TITLE
Track FTQC report symbols in manifests

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "9004aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.468260Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.468091Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.473407Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.472270Z"
+     "iopub.execute_input": "2026-06-23T10:21:06.956535Z",
+     "iopub.status.busy": "2026-06-23T10:21:06.956300Z",
+     "iopub.status.idle": "2026-06-23T10:21:06.962138Z",
+     "shell.execute_reply": "2026-06-23T10:21:06.961237Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "b1c698bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.475725Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.475551Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.817310Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.816884Z"
+     "iopub.execute_input": "2026-06-23T10:21:06.965359Z",
+     "iopub.status.busy": "2026-06-23T10:21:06.965179Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.323186Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.322639Z"
     }
    },
    "outputs": [],
@@ -148,10 +148,10 @@
    "id": "877d5ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.818679Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.818585Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.821812Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.821365Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.324532Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.324442Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.327321Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.326829Z"
     }
    },
    "outputs": [
@@ -205,10 +205,10 @@
    "id": "1e1d9d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.822991Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.822914Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.826096Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.825642Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.328421Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.328364Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.331905Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.331260Z"
     }
    },
    "outputs": [
@@ -316,10 +316,10 @@
    "id": "2fc667c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.827194Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.827139Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.829008Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.828714Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.333003Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.332926Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.335074Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.334712Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "1481b495",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.830132Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.830083Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.834179Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.833823Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.336319Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.336238Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.340400Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.340102Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "dedfdd29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.835281Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.835227Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.837877Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.837577Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.341506Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.341452Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.343919Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.343506Z"
     }
    },
    "outputs": [],
@@ -488,10 +488,10 @@
    "id": "12a7ac56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.839021Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.838961Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.863260Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.862783Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.344877Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.344824Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.370437Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.370036Z"
     }
    },
    "outputs": [
@@ -559,10 +559,10 @@
    "id": "5d5352a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.864854Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.864732Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.870323Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.868406Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.371540Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.371476Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.374982Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.374661Z"
     }
    },
    "outputs": [
@@ -603,10 +603,10 @@
    "id": "1e813ef9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.871807Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.871609Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.895445Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.894823Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.376102Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.376044Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.388847Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.388345Z"
     }
    },
    "outputs": [
@@ -665,10 +665,10 @@
    "id": "198b002f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.896672Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.896586Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.061513Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.061068Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.390024Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.389968Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.531713Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.531009Z"
     }
    },
    "outputs": [
@@ -676,7 +676,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'lambda_norm_factor': '1/5', 'pauli_term_factor': '1/2', 'walk_cost_factor': '3/4', 'sparsity_factor': '2/5', 'second_factor_rank_factor': '1', 'logical_qubit_factor': '1', 'truncation_error': None, 'source': '', 'description': 'unitary weight concentration', 'references': []}\n",
+      "{'lambda_norm_factor': '1/5', 'pauli_term_factor': '1/2', 'walk_cost_factor': '3/4', 'sparsity_factor': '2/5', 'second_factor_rank_factor': '1', 'logical_qubit_factor': '1', 'truncation_error': None, 'source': '', 'description': 'unitary weight concentration', 'references': []}"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "unitary weight concentration\n"
      ]
     }
@@ -740,10 +747,10 @@
    "id": "dc5a94a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.062944Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.062877Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.076021Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.075427Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.532811Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.532735Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.544382Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.544001Z"
     }
    },
    "outputs": [
@@ -890,10 +897,10 @@
    "id": "f594c0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.077239Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.077178Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.081081Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.080688Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.545493Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.545432Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.549234Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.548889Z"
     }
    },
    "outputs": [
@@ -954,10 +961,10 @@
    "id": "7f47799c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.082301Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.082246Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.087706Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.087191Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.550415Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.550352Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.555427Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.555040Z"
     }
    },
    "outputs": [
@@ -1025,10 +1032,10 @@
    "id": "c48101f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.088882Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.088812Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.091290Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.090744Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.556507Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.556441Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.558837Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.558453Z"
     }
    },
    "outputs": [
@@ -1071,10 +1078,10 @@
    "id": "a6a40b86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.092427Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.092359Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.094923Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.094593Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.559920Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.559847Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.562541Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.562152Z"
     }
    },
    "outputs": [
@@ -1124,10 +1131,10 @@
    "id": "4ea1d09a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.096266Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.096200Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.098241Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.097824Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.563640Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.563564Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.565947Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.565385Z"
     }
    },
    "outputs": [
@@ -1178,10 +1185,10 @@
    "id": "65456e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.099317Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.099250Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.103601Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.102884Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.567048Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.566977Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.570823Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.570477Z"
     }
    },
    "outputs": [
@@ -1245,10 +1252,10 @@
    "id": "fa19c3e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.104762Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.104706Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.165674Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.165281Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.571866Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.571803Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.627034Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.626604Z"
     }
    },
    "outputs": [
@@ -1335,10 +1342,10 @@
    "id": "144d31d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.166826Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.166752Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.181192Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.180767Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.628042Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.627976Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.642277Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.641803Z"
     }
    },
    "outputs": [
@@ -1392,10 +1399,10 @@
    "id": "b8d9f0a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.182446Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.182352Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.187346Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.187002Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.643401Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.643328Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.649460Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.649110Z"
     }
    },
    "outputs": [
@@ -1406,6 +1413,7 @@
       "scenario 2\n",
       "{'snapshots': 3, 'rows': 16}\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
+      "['factory_qubits', 'logical_cycle_time', 'physical_qubits_per_logical', 'toffoli_throughput']\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1422,6 +1430,7 @@
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
+    "print(review_bundle.to_manifest()[\"symbol_names\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1438,6 +1447,8 @@
     "}\n",
     "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
     "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
+    "assert \"logical_cycle_time\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
+    "assert \"toffoli_throughput\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert review_bundle.counts_by_kind() == {\n",
     "    \"comparison\": 1,\n",
     "    \"scenario\": 1,\n",
@@ -1466,10 +1477,10 @@
    "id": "c60e04c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.188467Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.188410Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.195545Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.195255Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.650599Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.650536Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.658076Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.657676Z"
     }
    },
    "outputs": [
@@ -1540,10 +1551,10 @@
    "id": "b7b0c958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.196904Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.196853Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.199595Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.199270Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.659182Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.659120Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.661937Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.661575Z"
     }
    },
    "outputs": [
@@ -1603,10 +1614,10 @@
    "id": "6d54ea9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.200638Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.200577Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.205863Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.205307Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.663107Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.663047Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.668086Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.667644Z"
     }
    },
    "outputs": [
@@ -1653,10 +1664,10 @@
    "id": "bc5bd6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.207124Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.207060Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.214406Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.213595Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.669160Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.669087Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.675685Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.675237Z"
     }
    },
    "outputs": [
@@ -1723,10 +1734,10 @@
    "id": "7e74c2d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.215853Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.215787Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.219616Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.218913Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.676713Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.676650Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.680034Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.679589Z"
     }
    },
    "outputs": [
@@ -1784,10 +1795,10 @@
    "id": "6ec3a10f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.220845Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.220786Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.226412Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.226001Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.681059Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.680996Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.686497Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.686121Z"
     }
    },
    "outputs": [
@@ -1864,10 +1875,10 @@
    "id": "6f60d357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.227568Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.227490Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.230481Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.230103Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.687622Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.687556Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.690616Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.690222Z"
     }
    },
    "outputs": [

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -782,6 +782,7 @@ review_bundle = build_ftqc_resource_report_bundle(
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.to_manifest()["counts_by_kind"])
+print(review_bundle.to_manifest()["symbol_names"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -798,6 +799,8 @@ assert review_bundle.to_dict()["counts"] == {
 }
 assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
 assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
+assert "logical_cycle_time" in review_bundle.to_manifest()["symbol_names"]
+assert "toffoli_throughput" in review_bundle.to_manifest()["symbol_names"]
 assert review_bundle.counts_by_kind() == {
     "comparison": 1,
     "scenario": 1,

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "0568ebd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.463144Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.462964Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.467660Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.466684Z"
+     "iopub.execute_input": "2026-06-23T10:21:06.956249Z",
+     "iopub.status.busy": "2026-06-23T10:21:06.955995Z",
+     "iopub.status.idle": "2026-06-23T10:21:06.962443Z",
+     "shell.execute_reply": "2026-06-23T10:21:06.961351Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "64c31fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.471234Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.470970Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.817442Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.816859Z"
+     "iopub.execute_input": "2026-06-23T10:21:06.965325Z",
+     "iopub.status.busy": "2026-06-23T10:21:06.965132Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.323075Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.322656Z"
     }
    },
    "outputs": [],
@@ -133,10 +133,10 @@
    "id": "245db61b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.818892Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.818799Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.822172Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.821548Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.324617Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.324523Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.327304Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.326829Z"
     }
    },
    "outputs": [
@@ -189,10 +189,10 @@
    "id": "1c51b24c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.823309Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.823243Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.826421Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.826011Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.328401Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.328345Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.331853Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.331225Z"
     }
    },
    "outputs": [
@@ -298,10 +298,10 @@
    "id": "89549b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.827497Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.827443Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.829341Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.829045Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.332932Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.332855Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.334917Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.334583Z"
     }
    },
    "outputs": [
@@ -343,10 +343,10 @@
    "id": "c15595d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.830367Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.830303Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.834288Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.833887Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.336199Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.336128Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.340416Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.340045Z"
     }
    },
    "outputs": [
@@ -418,10 +418,10 @@
    "id": "fdbe0ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.835310Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.835253Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.837924Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.837578Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.341334Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.341282Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.343568Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.343280Z"
     }
    },
    "outputs": [],
@@ -460,10 +460,10 @@
    "id": "e12aded6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.838954Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.838898Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.863390Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.862944Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.344590Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.344534Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.370281Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.369871Z"
     }
    },
    "outputs": [
@@ -529,10 +529,10 @@
    "id": "afc69281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.864945Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.864867Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.869268Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.868418Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.371399Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.371339Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.375010Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.374608Z"
     }
    },
    "outputs": [
@@ -571,10 +571,10 @@
    "id": "13279f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.871929Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.871595Z",
-     "iopub.status.idle": "2026-06-23T10:07:59.895437Z",
-     "shell.execute_reply": "2026-06-23T10:07:59.894903Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.376104Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.376043Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.388817Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.388349Z"
     }
    },
    "outputs": [
@@ -629,10 +629,10 @@
    "id": "768805d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:07:59.896905Z",
-     "iopub.status.busy": "2026-06-23T10:07:59.896816Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.061672Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.061095Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.389978Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.389916Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.530476Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.530082Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "id": "3797a63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.062944Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.062877Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.076086Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.075722Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.531897Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.531829Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.543875Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.543500Z"
     }
    },
    "outputs": [
@@ -850,10 +850,10 @@
    "id": "adacec7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.077459Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.077396Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.081519Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.081031Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.545183Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.545127Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.548937Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.548465Z"
     }
    },
    "outputs": [
@@ -911,10 +911,10 @@
    "id": "e5eb2526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.082576Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.082523Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.088072Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.087646Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.550187Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.550128Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.555182Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.554799Z"
     }
    },
    "outputs": [
@@ -979,10 +979,10 @@
    "id": "76757432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.089305Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.089245Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.091739Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.091251Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.556270Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.556196Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.558558Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.558132Z"
     }
    },
    "outputs": [
@@ -1022,10 +1022,10 @@
    "id": "bb1caac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.092752Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.092690Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.095397Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.094975Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.559641Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.559566Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.562067Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.561709Z"
     }
    },
    "outputs": [
@@ -1072,10 +1072,10 @@
    "id": "50616921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.096473Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.096408Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.098487Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.098147Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.563244Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.563163Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.565475Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.564831Z"
     }
    },
    "outputs": [
@@ -1125,10 +1125,10 @@
    "id": "b7f70d90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.099627Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.099566Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.104160Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.103720Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.566674Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.566592Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.570491Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.570096Z"
     }
    },
    "outputs": [
@@ -1189,10 +1189,10 @@
    "id": "590d1767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.105230Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.105175Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.165325Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.164872Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.571636Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.571571Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.626173Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.625725Z"
     }
    },
    "outputs": [
@@ -1276,10 +1276,10 @@
    "id": "12d77492",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.166568Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.166496Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.181509Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.181013Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.627411Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.627332Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.641870Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.641492Z"
     }
    },
    "outputs": [
@@ -1330,10 +1330,10 @@
    "id": "d7f49b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.182668Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.182599Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.187614Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.187193Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.643140Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.643069Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.649077Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.648748Z"
     }
    },
    "outputs": [
@@ -1344,6 +1344,7 @@
       "scenario 2\n",
       "{'snapshots': 3, 'rows': 16}\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
+      "['factory_qubits', 'logical_cycle_time', 'physical_qubits_per_logical', 'toffoli_throughput']\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1360,6 +1361,7 @@
     "print(scenario_snapshot.to_dict()[\"kind\"], scenario_snapshot.row_count)\n",
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
+    "print(review_bundle.to_manifest()[\"symbol_names\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1376,6 +1378,8 @@
     "}\n",
     "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
     "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
+    "assert \"logical_cycle_time\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
+    "assert \"toffoli_throughput\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert review_bundle.counts_by_kind() == {\n",
     "    \"comparison\": 1,\n",
     "    \"scenario\": 1,\n",
@@ -1401,10 +1405,10 @@
    "id": "8a5c890c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.188755Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.188692Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.196007Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.195690Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.650197Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.650128Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.657524Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.657250Z"
     }
    },
    "outputs": [
@@ -1472,10 +1476,10 @@
    "id": "15bd42c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.197204Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.197145Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.200058Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.199705Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.658821Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.658759Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.661787Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.661310Z"
     }
    },
    "outputs": [
@@ -1533,10 +1537,10 @@
    "id": "18161f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.201129Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.201067Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.206450Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.205991Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.662908Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.662845Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.667759Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.667393Z"
     }
    },
    "outputs": [
@@ -1580,10 +1584,10 @@
    "id": "613ad1ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.207572Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.207508Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.214795Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.214084Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.668952Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.668874Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.675536Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.675124Z"
     }
    },
    "outputs": [
@@ -1648,10 +1652,10 @@
    "id": "30bb703c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.216166Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.216100Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.219804Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.219113Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.676660Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.676600Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.680022Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.679559Z"
     }
    },
    "outputs": [
@@ -1704,10 +1708,10 @@
    "id": "95e4f4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.221010Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.220946Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.226580Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.226209Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.681041Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.680981Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.686760Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.686341Z"
     }
    },
    "outputs": [
@@ -1781,10 +1785,10 @@
    "id": "38caf5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:08:00.227855Z",
-     "iopub.status.busy": "2026-06-23T10:08:00.227779Z",
-     "iopub.status.idle": "2026-06-23T10:08:00.230634Z",
-     "shell.execute_reply": "2026-06-23T10:08:00.230318Z"
+     "iopub.execute_input": "2026-06-23T10:21:07.687918Z",
+     "iopub.status.busy": "2026-06-23T10:21:07.687844Z",
+     "iopub.status.idle": "2026-06-23T10:21:07.690867Z",
+     "shell.execute_reply": "2026-06-23T10:21:07.690382Z"
     }
    },
    "outputs": [

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -720,6 +720,7 @@ review_bundle = build_ftqc_resource_report_bundle(
 print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.to_manifest()["counts_by_kind"])
+print(review_bundle.to_manifest()["symbol_names"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -736,6 +737,8 @@ assert review_bundle.to_dict()["counts"] == {
 }
 assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
 assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
+assert "logical_cycle_time" in review_bundle.to_manifest()["symbol_names"]
+assert "toffoli_throughput" in review_bundle.to_manifest()["symbol_names"]
 assert review_bundle.counts_by_kind() == {
     "comparison": 1,
     "scenario": 1,

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -2529,7 +2529,8 @@ class FTQCResourceReportSnapshot:
 
         Returns:
             dict[str, Any]: JSON-friendly snapshot envelope containing kind,
-                title, row count, grouped counts, reference keys, and payload.
+                title, row count, grouped counts, reference keys, symbol names,
+                and payload.
         """
         kind = cast(FTQCResourceReportKind, self.kind)
         return {
@@ -2538,6 +2539,7 @@ class FTQCResourceReportSnapshot:
             "row_count": self.row_count,
             "counts": dict(self.counts or {}),
             "reference_keys": list(_extract_report_reference_keys(self.payload)),
+            "symbol_names": list(_extract_report_symbol_names(self.payload)),
             "payload": dict(self.payload),
         }
 
@@ -2654,6 +2656,15 @@ class FTQCResourceReportBundle:
                     )
                 )
             ),
+            "symbol_names": list(
+                _dedupe_strings(
+                    tuple(
+                        symbol
+                        for snapshot in self.snapshots
+                        for symbol in _extract_report_symbol_names(snapshot.payload)
+                    )
+                )
+            ),
             "snapshots": [
                 {
                     "index": index,
@@ -2663,6 +2674,9 @@ class FTQCResourceReportBundle:
                     "counts": dict(snapshot.counts or {}),
                     "reference_keys": list(
                         _extract_report_reference_keys(snapshot.payload)
+                    ),
+                    "symbol_names": list(
+                        _extract_report_symbol_names(snapshot.payload)
                     ),
                 }
                 for index, snapshot in enumerate(self.snapshots)
@@ -4625,6 +4639,52 @@ def _extract_report_reference_keys(payload: dict[str, Any]) -> tuple[str, ...]:
     keys: list[str] = []
     _collect_report_reference_keys(payload, keys)
     return _dedupe_strings(tuple(keys))
+
+
+def _extract_report_symbol_names(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Extract structured symbolic dependency names from a report payload.
+
+    Args:
+        payload (dict[str, Any]): Serialized report payload.
+
+    Returns:
+        tuple[str, ...]: Deduplicated symbol names discovered in structured
+            ``symbols``, ``symbol_names``, or ``unresolved_symbols`` fields.
+
+    Raises:
+        ValueError: If a structured symbol-name field is list-shaped but does
+            not contain only strings.
+    """
+    names: list[str] = []
+    _collect_report_symbol_names(payload, names)
+    return _dedupe_strings(tuple(names))
+
+
+def _collect_report_symbol_names(value: Any, names: list[str]) -> None:
+    """Collect structured symbol names recursively.
+
+    Args:
+        value (Any): JSON-like value to inspect.
+        names (list[str]): Mutable output list that receives symbol names.
+
+    Raises:
+        ValueError: If a structured symbol-name field is a malformed list.
+    """
+    if isinstance(value, dict):
+        for field, field_value in value.items():
+            if field in {"symbols", "symbol_names", "unresolved_symbols"}:
+                if isinstance(field_value, list):
+                    if not all(isinstance(name, str) for name in field_value):
+                        raise ValueError(
+                            f"report payload {field} must be a list of strings."
+                        )
+                    names.extend(field_value)
+                continue
+            _collect_report_symbol_names(field_value, names)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_report_symbol_names(item, names)
 
 
 def _collect_report_reference_keys(value: Any, keys: list[str]) -> None:

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1538,6 +1538,7 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
                 "symbolic": 0,
             },
             "reference_keys": [],
+            "symbol_names": [],
         },
         {
             "index": 1,
@@ -1546,9 +1547,11 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
             "row_count": 2,
             "counts": {"resolved": 2, "unresolved": 0},
             "reference_keys": [],
+            "symbol_names": [],
         },
     ]
     assert bundle_manifest["reference_keys"] == []
+    assert bundle_manifest["symbol_names"] == []
     assert "payload" not in bundle_manifest["snapshots"][0]
     assert bundle_dict["counts"] == {"snapshots": 2, "rows": 3}
     assert bundle_dict["rows"] == bundle_rows
@@ -1671,6 +1674,75 @@ def test_ftqc_report_bundle_manifest_collects_reference_keys():
         0,
     )
     with pytest.raises(ValueError, match="reference_keys"):
+        malformed.to_dict()
+
+
+def test_ftqc_report_bundle_manifest_collects_symbol_names():
+    """Report bundle manifests expose unresolved symbolic dependency names."""
+    x = sp.Symbol("x")
+    y = sp.Symbol("y")
+    z = sp.Symbol("z")
+    symbol_report = FTQCResourceSymbolDependencyReport(
+        "Symbol dependencies",
+        (
+            FTQCResourceSymbolDependencyRow(
+                FTQCResourceQuantity.RUNTIME_SECONDS,
+                x + y,
+                "Runtime",
+                "seconds",
+                FTQCResourceCategory.PHYSICAL,
+            ),
+            FTQCResourceSymbolDependencyRow(
+                FTQCResourceQuantity.PHYSICAL_QUBIT_SECONDS,
+                x * z,
+                "Physical qubit-seconds",
+                "physical qubit-seconds",
+                FTQCResourceCategory.PHYSICAL,
+            ),
+        ),
+    )
+    scenario_report = FTQCResourceScenarioReport(
+        title="Partial scenarios",
+        quantities=(FTQCResourceQuantity.RUNTIME_SECONDS,),
+        scenarios=(FTQCResourceScenario("partial", {}),),
+        rows=(
+            FTQCResourceScenarioRow(
+                "partial",
+                {FTQCResourceQuantity.RUNTIME_SECONDS: y + z},
+                unresolved_symbols=("y", "z"),
+            ),
+        ),
+    )
+    bundle = build_ftqc_resource_report_bundle(
+        "Symbol review bundle",
+        (symbol_report, scenario_report),
+    )
+    symbol_snapshot = build_ftqc_resource_report_snapshot(symbol_report)
+    manifest = bundle.to_manifest()
+
+    assert symbol_snapshot.to_dict()["symbol_names"] == ["x", "y", "z"]
+    assert manifest["symbol_names"] == ["x", "y", "z"]
+    assert manifest["snapshots"][0]["symbol_names"] == ["x", "y", "z"]
+    assert manifest["snapshots"][1]["symbol_names"] == ["y", "z"]
+
+    display_string_payload = FTQCResourceReportSnapshot(
+        "symbolic_dependencies",
+        "Display symbols",
+        {
+            "title": "Display symbols",
+            "rows": [{"symbols": "x, y"}],
+        },
+        1,
+    )
+    assert display_string_payload.to_dict()["symbol_names"] == []
+
+    malformed = FTQCResourceReportSnapshot(
+        "symbolic_dependencies",
+        "Malformed symbols",
+        {"title": "Malformed symbols", "symbols": [object()]},
+        0,
+    )
+    with pytest.raises(ValueError, match="symbols"):
         malformed.to_dict()
 
 


### PR DESCRIPTION
## Summary
- Add `symbol_names` to FTQC report snapshots and bundle manifests.
- Extract structured symbol metadata from `symbols`, `symbol_names`, and `unresolved_symbols` fields while ignoring display-only comma-separated strings.
- Update the EN/JA FTQC resource-estimation usage page and executed notebooks to show symbol names in review bundle manifests.

## Validation
- `uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q`
- `uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design'`
- `uv run python docs/en/usage/ftqc_resource_estimation_design.py`
- `uv run python docs/ja/usage/ftqc_resource_estimation_design.py`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb`
- `uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- `git diff --check`

Note: the local-review skill still documents `uv run zuban qamomile/`, which is stale in this repository and exits with `error: unrecognized subcommand 'qamomile/'`; the current repository command `uv run zuban check qamomile/` passes.