### PR TITLE
Track FTQC research signals in manifests

### DIFF
--- a/docs/en/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/en/usage/ftqc_resource_estimation_design.ipynb
@@ -23,10 +23,10 @@
    "id": "9004aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:06.956535Z",
-     "iopub.status.busy": "2026-06-23T10:21:06.956300Z",
-     "iopub.status.idle": "2026-06-23T10:21:06.962138Z",
-     "shell.execute_reply": "2026-06-23T10:21:06.961237Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.048104Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.048035Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.051304Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.050653Z"
     }
    },
    "outputs": [],
@@ -41,10 +41,10 @@
    "id": "b1c698bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:06.965359Z",
-     "iopub.status.busy": "2026-06-23T10:21:06.965179Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.323186Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.322639Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.052652Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.052583Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.334829Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.334471Z"
     }
    },
    "outputs": [],
@@ -148,10 +148,10 @@
    "id": "877d5ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.324532Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.324442Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.327321Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.326829Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.336487Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.336385Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.339311Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.338793Z"
     }
    },
    "outputs": [
@@ -205,10 +205,10 @@
    "id": "1e1d9d54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.328421Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.328364Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.331905Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.331260Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.340374Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.340320Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.343802Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.343274Z"
     }
    },
    "outputs": [
@@ -316,10 +316,10 @@
    "id": "2fc667c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.333003Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.332926Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.335074Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.334712Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.344729Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.344677Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.347094Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.346521Z"
     }
    },
    "outputs": [
@@ -365,10 +365,10 @@
    "id": "1481b495",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.336319Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.336238Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.340400Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.340102Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.348260Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.348206Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.352218Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.351874Z"
     }
    },
    "outputs": [
@@ -443,10 +443,10 @@
    "id": "dedfdd29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.341506Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.341452Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.343919Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.343506Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.353199Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.353105Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.356032Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.355637Z"
     }
    },
    "outputs": [],
@@ -488,10 +488,10 @@
    "id": "12a7ac56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.344877Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.344824Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.370437Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.370036Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.357234Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.357174Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.380770Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.380266Z"
     }
    },
    "outputs": [
@@ -559,10 +559,10 @@
    "id": "5d5352a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.371540Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.371476Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.374982Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.374661Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.382263Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.382200Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.385893Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.385445Z"
     }
    },
    "outputs": [
@@ -603,10 +603,10 @@
    "id": "1e813ef9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.376102Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.376044Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.388847Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.388345Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.387020Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.386969Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.400234Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.399819Z"
     }
    },
    "outputs": [
@@ -665,10 +665,10 @@
    "id": "198b002f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.390024Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.389968Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.531713Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.531009Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.401353Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.401301Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.554119Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.553721Z"
     }
    },
    "outputs": [
@@ -747,10 +747,10 @@
    "id": "dc5a94a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.532811Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.532735Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.544382Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.544001Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.555428Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.555364Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.567374Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.567054Z"
     }
    },
    "outputs": [
@@ -897,10 +897,10 @@
    "id": "f594c0fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.545493Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.545432Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.549234Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.548889Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.568476Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.568415Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.572306Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.571947Z"
     }
    },
    "outputs": [
@@ -961,10 +961,10 @@
    "id": "7f47799c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.550415Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.550352Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.555427Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.555040Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.573336Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.573282Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.578313Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.577999Z"
     }
    },
    "outputs": [
@@ -1032,10 +1032,10 @@
    "id": "c48101f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.556507Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.556441Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.558837Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.558453Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.579391Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.579333Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.581914Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.581581Z"
     }
    },
    "outputs": [
@@ -1078,10 +1078,10 @@
    "id": "a6a40b86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.559920Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.559847Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.562541Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.562152Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.583023Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.582960Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.585673Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.585375Z"
     }
    },
    "outputs": [
@@ -1131,10 +1131,10 @@
    "id": "4ea1d09a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.563640Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.563564Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.565947Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.565385Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.587036Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.586965Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.589519Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.588903Z"
     }
    },
    "outputs": [
@@ -1185,10 +1185,10 @@
    "id": "65456e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.567048Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.566977Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.570823Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.570477Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.590724Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.590655Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.594597Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.594264Z"
     }
    },
    "outputs": [
@@ -1252,10 +1252,10 @@
    "id": "fa19c3e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.571866Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.571803Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.627034Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.626604Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.595629Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.595573Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.653084Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.652673Z"
     }
    },
    "outputs": [
@@ -1342,10 +1342,10 @@
    "id": "144d31d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.628042Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.627976Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.642277Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.641803Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.654227Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.654143Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.669174Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.668787Z"
     }
    },
    "outputs": [
@@ -1399,10 +1399,10 @@
    "id": "b8d9f0a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.643401Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.643328Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.649460Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.649110Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.670302Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.670227Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.677549Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.677228Z"
     }
    },
    "outputs": [
@@ -1414,6 +1414,7 @@
       "{'snapshots': 3, 'rows': 16}\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "['factory_qubits', 'logical_cycle_time', 'physical_qubits_per_logical', 'toffoli_throughput']\n",
+      "[]\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1431,6 +1432,7 @@
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
     "print(review_bundle.to_manifest()[\"symbol_names\"])\n",
+    "print(review_bundle.to_manifest()[\"research_signal_keys\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1447,6 +1449,7 @@
     "}\n",
     "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
     "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
+    "assert review_bundle.to_manifest()[\"research_signal_keys\"] == []\n",
     "assert \"logical_cycle_time\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert \"toffoli_throughput\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert review_bundle.counts_by_kind() == {\n",
@@ -1477,10 +1480,10 @@
    "id": "c60e04c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.650599Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.650536Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.658076Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.657676Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.678560Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.678511Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.686183Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.685870Z"
     }
    },
    "outputs": [
@@ -1551,10 +1554,10 @@
    "id": "b7b0c958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.659182Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.659120Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.661937Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.661575Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.687266Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.687217Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.690153Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.689673Z"
     }
    },
    "outputs": [
@@ -1614,10 +1617,10 @@
    "id": "6d54ea9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.663107Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.663047Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.668086Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.667644Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.691204Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.691152Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.696872Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.696455Z"
     }
    },
    "outputs": [
@@ -1626,7 +1629,8 @@
      "output_type": "stream",
      "text": [
       "arXiv:2603.22778 resource signal review\n",
-      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['arXiv:2603.22778']\n"
      ]
     }
    ],
@@ -1641,10 +1645,65 @@
     ")\n",
     "print(uwc_signal_report.to_dict()[\"title\"])\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
+    "print(uwc_signal_report.to_dict()[\"research_signal_keys\"])\n",
     "\n",
     "assert uwc_signal_report.summary.rows[0].quantity == (FTQCResourceQuantity.LAMBDA_NORM)\n",
     "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
-    "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]"
+    "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
+    "assert uwc_signal_report.to_dict()[\"research_signal_keys\"] == [\"arXiv:2603.22778\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c28ed096",
+   "metadata": {},
+   "source": [
+    "Signal reports and coverage audits can also be bundled into a compact review\n",
+    "manifest. The manifest keeps the research-signal keys separate from generic\n",
+    "reference provenance, so review tooling can show which paper-level contracts\n",
+    "this artifact audits without loading the full report payloads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "2543eb83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T10:36:46.698243Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.698191Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.701086Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.700735Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n",
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n",
+      "['arXiv:2603.22778']\n"
+     ]
+    }
+   ],
+   "source": [
+    "signal_review_bundle = build_ftqc_resource_report_bundle(\n",
+    "    \"UWC research signal bundle\",\n",
+    "    (signal_catalog_report, uwc_signal_report),\n",
+    ")\n",
+    "signal_manifest = signal_review_bundle.to_manifest()\n",
+    "print(signal_manifest[\"research_signal_keys\"])\n",
+    "print(signal_manifest[\"snapshots\"][0][\"research_signal_keys\"])\n",
+    "print(signal_manifest[\"snapshots\"][1][\"research_signal_keys\"])\n",
+    "\n",
+    "assert signal_manifest[\"research_signal_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]\n",
+    "assert signal_manifest[\"snapshots\"][0][\"kind\"] == \"research_signal_coverage\"\n",
+    "assert signal_manifest[\"snapshots\"][1][\"kind\"] == \"comparison\"\n",
+    "assert signal_manifest[\"snapshots\"][1][\"research_signal_keys\"] == [\"arXiv:2603.22778\"]"
    ]
   },
   {
@@ -1660,14 +1719,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "bc5bd6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.669160Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.669087Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.675685Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.675237Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.702116Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.702066Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.708661Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.708343Z"
     }
    },
    "outputs": [
@@ -1730,14 +1789,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "7e74c2d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.676713Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.676650Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.680034Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.679589Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.709772Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.709718Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.713284Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.712899Z"
     }
    },
    "outputs": [
@@ -1791,14 +1850,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "6ec3a10f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.681059Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.680996Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.686497Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.686121Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.714328Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.714276Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.719595Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.719323Z"
     }
    },
    "outputs": [
@@ -1871,14 +1930,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "6f60d357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.687622Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.687556Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.690616Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.690222Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.720631Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.720562Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.723589Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.723196Z"
     }
    },
    "outputs": [

--- a/docs/en/usage/ftqc_resource_estimation_design.py
+++ b/docs/en/usage/ftqc_resource_estimation_design.py
@@ -783,6 +783,7 @@ print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.to_manifest()["counts_by_kind"])
 print(review_bundle.to_manifest()["symbol_names"])
+print(review_bundle.to_manifest()["research_signal_keys"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -799,6 +800,7 @@ assert review_bundle.to_dict()["counts"] == {
 }
 assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
 assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
+assert review_bundle.to_manifest()["research_signal_keys"] == []
 assert "logical_cycle_time" in review_bundle.to_manifest()["symbol_names"]
 assert "toffoli_throughput" in review_bundle.to_manifest()["symbol_names"]
 assert review_bundle.counts_by_kind() == {
@@ -906,10 +908,36 @@ uwc_signal_report = build_ftqc_research_signal_report(
 )
 print(uwc_signal_report.to_dict()["title"])
 print(uwc_signal_report.to_dict()["quantities"])
+print(uwc_signal_report.to_dict()["research_signal_keys"])
 
 assert uwc_signal_report.summary.rows[0].quantity == (FTQCResourceQuantity.LAMBDA_NORM)
 assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
+assert uwc_signal_report.to_dict()["research_signal_keys"] == ["arXiv:2603.22778"]
+
+# %% [markdown]
+# Signal reports and coverage audits can also be bundled into a compact review
+# manifest. The manifest keeps the research-signal keys separate from generic
+# reference provenance, so review tooling can show which paper-level contracts
+# this artifact audits without loading the full report payloads.
+
+# %%
+signal_review_bundle = build_ftqc_resource_report_bundle(
+    "UWC research signal bundle",
+    (signal_catalog_report, uwc_signal_report),
+)
+signal_manifest = signal_review_bundle.to_manifest()
+print(signal_manifest["research_signal_keys"])
+print(signal_manifest["snapshots"][0]["research_signal_keys"])
+print(signal_manifest["snapshots"][1]["research_signal_keys"])
+
+assert signal_manifest["research_signal_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+assert signal_manifest["snapshots"][0]["kind"] == "research_signal_coverage"
+assert signal_manifest["snapshots"][1]["kind"] == "comparison"
+assert signal_manifest["snapshots"][1]["research_signal_keys"] == ["arXiv:2603.22778"]
 
 # %% [markdown]
 # A driver report starts from a target output quantity and follows the formula

--- a/docs/ja/usage/ftqc_resource_estimation_design.ipynb
+++ b/docs/ja/usage/ftqc_resource_estimation_design.ipynb
@@ -20,10 +20,10 @@
    "id": "0568ebd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:06.956249Z",
-     "iopub.status.busy": "2026-06-23T10:21:06.955995Z",
-     "iopub.status.idle": "2026-06-23T10:21:06.962443Z",
-     "shell.execute_reply": "2026-06-23T10:21:06.961351Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.047893Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.047823Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.051057Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.050527Z"
     }
    },
    "outputs": [],
@@ -38,10 +38,10 @@
    "id": "64c31fb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:06.965325Z",
-     "iopub.status.busy": "2026-06-23T10:21:06.965132Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.323075Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.322656Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.052539Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.052457Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.334407Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.333963Z"
     }
    },
    "outputs": [],
@@ -133,10 +133,10 @@
    "id": "245db61b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.324617Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.324523Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.327304Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.326829Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.335919Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.335818Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.338712Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.338334Z"
     }
    },
    "outputs": [
@@ -189,10 +189,10 @@
    "id": "1c51b24c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.328401Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.328345Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.331853Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.331225Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.340188Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.340122Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.343348Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.342826Z"
     }
    },
    "outputs": [
@@ -298,10 +298,10 @@
    "id": "89549b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.332932Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.332855Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.334917Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.334583Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.344508Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.344453Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.346694Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.346047Z"
     }
    },
    "outputs": [
@@ -343,10 +343,10 @@
    "id": "c15595d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.336199Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.336128Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.340416Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.340045Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.347864Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.347808Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.351722Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.351390Z"
     }
    },
    "outputs": [
@@ -418,10 +418,10 @@
    "id": "fdbe0ba0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.341334Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.341282Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.343568Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.343280Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.352855Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.352800Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.355688Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.355290Z"
     }
    },
    "outputs": [],
@@ -460,10 +460,10 @@
    "id": "e12aded6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.344590Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.344534Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.370281Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.369871Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.356834Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.356771Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.380961Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.380314Z"
     }
    },
    "outputs": [
@@ -529,10 +529,10 @@
    "id": "afc69281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.371399Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.371339Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.375010Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.374608Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.382294Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.382220Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.386063Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.385581Z"
     }
    },
    "outputs": [
@@ -571,10 +571,10 @@
    "id": "13279f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.376104Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.376043Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.388817Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.388349Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.387150Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.387099Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.400743Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.400304Z"
     }
    },
    "outputs": [
@@ -629,10 +629,10 @@
    "id": "768805d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.389978Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.389916Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.530476Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.530082Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.401806Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.401752Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.555813Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.555435Z"
     }
    },
    "outputs": [
@@ -702,10 +702,10 @@
    "id": "3797a63d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.531897Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.531829Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.543875Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.543500Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.556921Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.556865Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.569424Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.569096Z"
     }
    },
    "outputs": [
@@ -850,10 +850,10 @@
    "id": "adacec7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.545183Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.545127Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.548937Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.548465Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.570538Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.570480Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.574453Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.574114Z"
     }
    },
    "outputs": [
@@ -911,10 +911,10 @@
    "id": "e5eb2526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.550187Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.550128Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.555182Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.554799Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.575459Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.575406Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.580665Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.580255Z"
     }
    },
    "outputs": [
@@ -979,10 +979,10 @@
    "id": "76757432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.556270Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.556196Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.558558Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.558132Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.582055Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.581975Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.584462Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.583911Z"
     }
    },
    "outputs": [
@@ -1022,10 +1022,10 @@
    "id": "bb1caac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.559641Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.559566Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.562067Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.561709Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.585613Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.585522Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.588701Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.588034Z"
     }
    },
    "outputs": [
@@ -1072,10 +1072,10 @@
    "id": "50616921",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.563244Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.563163Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.565475Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.564831Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.590075Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.590020Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.592117Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.591752Z"
     }
    },
    "outputs": [
@@ -1125,10 +1125,10 @@
    "id": "b7f70d90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.566674Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.566592Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.570491Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.570096Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.593044Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.592999Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.597456Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.597167Z"
     }
    },
    "outputs": [
@@ -1189,10 +1189,10 @@
    "id": "590d1767",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.571636Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.571571Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.626173Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.625725Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.598518Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.598466Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.656078Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.655668Z"
     }
    },
    "outputs": [
@@ -1276,10 +1276,10 @@
    "id": "12d77492",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.627411Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.627332Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.641870Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.641492Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.657116Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.657059Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.672503Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.672115Z"
     }
    },
    "outputs": [
@@ -1330,10 +1330,10 @@
    "id": "d7f49b01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.643140Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.643069Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.649077Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.648748Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.673553Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.673482Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.681050Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.680616Z"
     }
    },
    "outputs": [
@@ -1345,6 +1345,7 @@
       "{'snapshots': 3, 'rows': 16}\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "['factory_qubits', 'logical_cycle_time', 'physical_qubits_per_logical', 'toffoli_throughput']\n",
+      "[]\n",
       "{'comparison': 1, 'scenario': 1, 'symbolic_dependencies': 1}\n",
       "comparison QPE iterations\n",
       "comparison Toffoli gates\n"
@@ -1362,6 +1363,7 @@
     "print(review_bundle.to_dict()[\"counts\"])\n",
     "print(review_bundle.to_manifest()[\"counts_by_kind\"])\n",
     "print(review_bundle.to_manifest()[\"symbol_names\"])\n",
+    "print(review_bundle.to_manifest()[\"research_signal_keys\"])\n",
     "print(review_bundle.counts_by_kind())\n",
     "for row in review_bundle.to_row_table()[:2]:\n",
     "    print(row[\"report_kind\"], row.get(\"label\", row.get(\"quantity\")))\n",
@@ -1378,6 +1380,7 @@
     "}\n",
     "assert review_bundle.to_manifest()[\"counts\"] == review_bundle.to_dict()[\"counts\"]\n",
     "assert review_bundle.to_manifest()[\"snapshots\"][0][\"kind\"] == \"comparison\"\n",
+    "assert review_bundle.to_manifest()[\"research_signal_keys\"] == []\n",
     "assert \"logical_cycle_time\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert \"toffoli_throughput\" in review_bundle.to_manifest()[\"symbol_names\"]\n",
     "assert review_bundle.counts_by_kind() == {\n",
@@ -1405,10 +1408,10 @@
    "id": "8a5c890c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.650197Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.650128Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.657524Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.657250Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.682089Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.682035Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.689627Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.689169Z"
     }
    },
    "outputs": [
@@ -1476,10 +1479,10 @@
    "id": "15bd42c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.658821Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.658759Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.661787Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.661310Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.690749Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.690695Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.693600Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.693282Z"
     }
    },
    "outputs": [
@@ -1537,10 +1540,10 @@
    "id": "18161f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.662908Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.662845Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.667759Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.667393Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.694703Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.694648Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.700494Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.700016Z"
     }
    },
    "outputs": [
@@ -1549,7 +1552,8 @@
      "output_type": "stream",
      "text": [
       "arXiv:2603.22778 resource signal review\n",
-      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n"
+      "['lambda_norm', 'qpe_iterations', 't_gates', 'logical_depth', 'logical_spacetime_volume', 'physical_qubits', 'runtime_seconds', 'physical_qubit_seconds']\n",
+      "['arXiv:2603.22778']\n"
      ]
     }
    ],
@@ -1564,10 +1568,62 @@
     ")\n",
     "print(uwc_signal_report.to_dict()[\"title\"])\n",
     "print(uwc_signal_report.to_dict()[\"quantities\"])\n",
+    "print(uwc_signal_report.to_dict()[\"research_signal_keys\"])\n",
     "\n",
     "assert uwc_signal_report.summary.rows[0].quantity == (FTQCResourceQuantity.LAMBDA_NORM)\n",
     "assert \"lambda_norm\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
-    "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]"
+    "assert \"t_gates\" in uwc_signal_report.to_dict()[\"quantities\"]\n",
+    "assert uwc_signal_report.to_dict()[\"research_signal_keys\"] == [\"arXiv:2603.22778\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82ee30b1",
+   "metadata": {},
+   "source": [
+    "signal reportとcoverage auditは、軽量なreview manifestとしてbundleにまとめることもできます。manifestではresearch-signal keyを一般的なreference provenanceとは分けて保持するため、review toolingはreport payload全体を読み込まなくても、このartifactがどの論文レベルのcontractをauditしているかを表示できます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "0f07bba2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T10:36:46.701614Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.701564Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.704409Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.704065Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n",
+      "['arXiv:2603.22778', 'arXiv:2601.08533']\n",
+      "['arXiv:2603.22778']\n"
+     ]
+    }
+   ],
+   "source": [
+    "signal_review_bundle = build_ftqc_resource_report_bundle(\n",
+    "    \"UWC research signal bundle\",\n",
+    "    (signal_catalog_report, uwc_signal_report),\n",
+    ")\n",
+    "signal_manifest = signal_review_bundle.to_manifest()\n",
+    "print(signal_manifest[\"research_signal_keys\"])\n",
+    "print(signal_manifest[\"snapshots\"][0][\"research_signal_keys\"])\n",
+    "print(signal_manifest[\"snapshots\"][1][\"research_signal_keys\"])\n",
+    "\n",
+    "assert signal_manifest[\"research_signal_keys\"] == [\n",
+    "    \"arXiv:2603.22778\",\n",
+    "    \"arXiv:2601.08533\",\n",
+    "]\n",
+    "assert signal_manifest[\"snapshots\"][0][\"kind\"] == \"research_signal_coverage\"\n",
+    "assert signal_manifest[\"snapshots\"][1][\"kind\"] == \"comparison\"\n",
+    "assert signal_manifest[\"snapshots\"][1][\"research_signal_keys\"] == [\"arXiv:2603.22778\"]"
    ]
   },
   {
@@ -1580,14 +1636,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "613ad1ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.668952Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.668874Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.675536Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.675124Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.705357Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.705310Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.712144Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.711699Z"
     }
    },
    "outputs": [
@@ -1648,14 +1704,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "30bb703c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.676660Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.676600Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.680022Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.679559Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.713690Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.713640Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.717035Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.716727Z"
     }
    },
    "outputs": [
@@ -1704,14 +1760,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "95e4f4ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.681041Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.680981Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.686760Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.686341Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.718096Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.718049Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.723957Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.723368Z"
     }
    },
    "outputs": [
@@ -1781,14 +1837,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "38caf5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-23T10:21:07.687918Z",
-     "iopub.status.busy": "2026-06-23T10:21:07.687844Z",
-     "iopub.status.idle": "2026-06-23T10:21:07.690867Z",
-     "shell.execute_reply": "2026-06-23T10:21:07.690382Z"
+     "iopub.execute_input": "2026-06-23T10:36:46.725055Z",
+     "iopub.status.busy": "2026-06-23T10:36:46.724986Z",
+     "iopub.status.idle": "2026-06-23T10:36:46.728228Z",
+     "shell.execute_reply": "2026-06-23T10:36:46.727847Z"
     }
    },
    "outputs": [

--- a/docs/ja/usage/ftqc_resource_estimation_design.py
+++ b/docs/ja/usage/ftqc_resource_estimation_design.py
@@ -721,6 +721,7 @@ print(scenario_snapshot.to_dict()["kind"], scenario_snapshot.row_count)
 print(review_bundle.to_dict()["counts"])
 print(review_bundle.to_manifest()["counts_by_kind"])
 print(review_bundle.to_manifest()["symbol_names"])
+print(review_bundle.to_manifest()["research_signal_keys"])
 print(review_bundle.counts_by_kind())
 for row in review_bundle.to_row_table()[:2]:
     print(row["report_kind"], row.get("label", row.get("quantity")))
@@ -737,6 +738,7 @@ assert review_bundle.to_dict()["counts"] == {
 }
 assert review_bundle.to_manifest()["counts"] == review_bundle.to_dict()["counts"]
 assert review_bundle.to_manifest()["snapshots"][0]["kind"] == "comparison"
+assert review_bundle.to_manifest()["research_signal_keys"] == []
 assert "logical_cycle_time" in review_bundle.to_manifest()["symbol_names"]
 assert "toffoli_throughput" in review_bundle.to_manifest()["symbol_names"]
 assert review_bundle.counts_by_kind() == {
@@ -836,10 +838,33 @@ uwc_signal_report = build_ftqc_research_signal_report(
 )
 print(uwc_signal_report.to_dict()["title"])
 print(uwc_signal_report.to_dict()["quantities"])
+print(uwc_signal_report.to_dict()["research_signal_keys"])
 
 assert uwc_signal_report.summary.rows[0].quantity == (FTQCResourceQuantity.LAMBDA_NORM)
 assert "lambda_norm" in uwc_signal_report.to_dict()["quantities"]
 assert "t_gates" in uwc_signal_report.to_dict()["quantities"]
+assert uwc_signal_report.to_dict()["research_signal_keys"] == ["arXiv:2603.22778"]
+
+# %% [markdown]
+# signal reportとcoverage auditは、軽量なreview manifestとしてbundleにまとめることもできます。manifestではresearch-signal keyを一般的なreference provenanceとは分けて保持するため、review toolingはreport payload全体を読み込まなくても、このartifactがどの論文レベルのcontractをauditしているかを表示できます。
+
+# %%
+signal_review_bundle = build_ftqc_resource_report_bundle(
+    "UWC research signal bundle",
+    (signal_catalog_report, uwc_signal_report),
+)
+signal_manifest = signal_review_bundle.to_manifest()
+print(signal_manifest["research_signal_keys"])
+print(signal_manifest["snapshots"][0]["research_signal_keys"])
+print(signal_manifest["snapshots"][1]["research_signal_keys"])
+
+assert signal_manifest["research_signal_keys"] == [
+    "arXiv:2603.22778",
+    "arXiv:2601.08533",
+]
+assert signal_manifest["snapshots"][0]["kind"] == "research_signal_coverage"
+assert signal_manifest["snapshots"][1]["kind"] == "comparison"
+assert signal_manifest["snapshots"][1]["research_signal_keys"] == ["arXiv:2603.22778"]
 
 # %% [markdown]
 # driver reportは、target output quantityから始めて、estimateが公開しているformula metadataの依存関係をたどります。physical qubit-secondsのような最終metricが改善したとき、その上流にあるどのsymbolic driverが変わったのかをreviewしやすくなります。

--- a/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
+++ b/qamomile/circuit/estimator/algorithmic/ftqc_resources.py
@@ -496,6 +496,7 @@ class FTQCResearchSignalCoverage:
         """
         return {
             "reference_key": self.reference_key,
+            "research_signal_key": self.reference_key,
             "title": self.title,
             "available": [quantity.value for quantity in self.available],
             "missing": [quantity.value for quantity in self.missing],
@@ -586,6 +587,7 @@ class FTQCResearchSignalCoverageReport:
                 {
                     "estimate_label": self.estimate_label,
                     "reference_key": coverage.reference_key,
+                    "research_signal_key": coverage.reference_key,
                     "title": coverage.title,
                     "coverage_fraction": str(coverage.coverage_fraction),
                     "is_complete": coverage.is_complete,
@@ -1562,6 +1564,9 @@ class FTQCResourceComparisonReport:
         profile (FTQCResourceProfile | None): Standard review profile used to
             select comparison quantities, or None when no profile was used.
         summary (FTQCResourceComparisonSummary): Grouped comparison rows.
+        research_signal_keys (tuple[str, ...]): Optional research-signal keys
+            that this comparison was built to audit. Defaults to an empty
+            tuple for generic comparison reports.
 
     Example:
         >>> row = FTQCResourceComparisonRow(
@@ -1590,6 +1595,21 @@ class FTQCResourceComparisonReport:
     candidate_label: str
     profile: FTQCResourceProfile | None
     summary: FTQCResourceComparisonSummary
+    research_signal_keys: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Validate comparison-report metadata after construction.
+
+        Raises:
+            TypeError: If ``research_signal_keys`` contains non-string items.
+        """
+        if not all(isinstance(key, str) for key in self.research_signal_keys):
+            raise TypeError("research_signal_keys must contain only strings.")
+        object.__setattr__(
+            self,
+            "research_signal_keys",
+            _dedupe_strings(tuple(self.research_signal_keys)),
+        )
 
     def to_dict(
         self,
@@ -1610,6 +1630,7 @@ class FTQCResourceComparisonReport:
             "baseline_label": self.baseline_label,
             "candidate_label": self.candidate_label,
             "profile": None if self.profile is None else self.profile.value,
+            "research_signal_keys": list(self.research_signal_keys),
             "quantities": [row.quantity.value for row in self.summary.rows],
             "rows": summary["rows"],
             "smaller": summary["smaller"],
@@ -1634,6 +1655,34 @@ class FTQCResourceComparisonReport:
             serialized["candidate_label"] = self.candidate_label
             rows.append(serialized)
         return rows
+
+    def with_research_signal(self, reference_key: str) -> FTQCResourceComparisonReport:
+        """Return a copy tagged with a research-signal key.
+
+        Args:
+            reference_key (str): Research-signal key to attach to the report.
+
+        Returns:
+            FTQCResourceComparisonReport: Copy preserving comparison rows and
+                labels while appending ``reference_key`` to
+                ``research_signal_keys``.
+
+        Raises:
+            TypeError: If ``reference_key`` is not a string.
+            ValueError: If ``reference_key`` is empty.
+        """
+        if not isinstance(reference_key, str):
+            raise TypeError("reference_key must be a string.")
+        if not reference_key:
+            raise ValueError("reference_key must not be empty.")
+        return FTQCResourceComparisonReport(
+            title=self.title,
+            baseline_label=self.baseline_label,
+            candidate_label=self.candidate_label,
+            profile=self.profile,
+            summary=self.summary,
+            research_signal_keys=(*self.research_signal_keys, reference_key),
+        )
 
     def to_review_findings(
         self,
@@ -2529,8 +2578,8 @@ class FTQCResourceReportSnapshot:
 
         Returns:
             dict[str, Any]: JSON-friendly snapshot envelope containing kind,
-                title, row count, grouped counts, reference keys, symbol names,
-                and payload.
+                title, row count, grouped counts, reference keys,
+                research-signal keys, symbol names, and payload.
         """
         kind = cast(FTQCResourceReportKind, self.kind)
         return {
@@ -2539,6 +2588,9 @@ class FTQCResourceReportSnapshot:
             "row_count": self.row_count,
             "counts": dict(self.counts or {}),
             "reference_keys": list(_extract_report_reference_keys(self.payload)),
+            "research_signal_keys": list(
+                _extract_report_research_signal_keys(self.payload)
+            ),
             "symbol_names": list(_extract_report_symbol_names(self.payload)),
             "payload": dict(self.payload),
         }
@@ -2656,6 +2708,17 @@ class FTQCResourceReportBundle:
                     )
                 )
             ),
+            "research_signal_keys": list(
+                _dedupe_strings(
+                    tuple(
+                        key
+                        for snapshot in self.snapshots
+                        for key in _extract_report_research_signal_keys(
+                            snapshot.payload
+                        )
+                    )
+                )
+            ),
             "symbol_names": list(
                 _dedupe_strings(
                     tuple(
@@ -2674,6 +2737,9 @@ class FTQCResourceReportBundle:
                     "counts": dict(snapshot.counts or {}),
                     "reference_keys": list(
                         _extract_report_reference_keys(snapshot.payload)
+                    ),
+                    "research_signal_keys": list(
+                        _extract_report_research_signal_keys(snapshot.payload)
                     ),
                     "symbol_names": list(
                         _extract_report_symbol_names(snapshot.payload)
@@ -3715,7 +3781,7 @@ def build_ftqc_research_signal_report(
         baseline_label=baseline_label,
         candidate_label=candidate_label,
         quantities=quantities,
-    )
+    ).with_research_signal(signal.reference_key)
 
 
 def build_ftqc_resource_driver_report(
@@ -4641,6 +4707,24 @@ def _extract_report_reference_keys(payload: dict[str, Any]) -> tuple[str, ...]:
     return _dedupe_strings(tuple(keys))
 
 
+def _extract_report_research_signal_keys(payload: dict[str, Any]) -> tuple[str, ...]:
+    """Extract structured research-signal keys from a report payload.
+
+    Args:
+        payload (dict[str, Any]): Serialized report payload.
+
+    Returns:
+        tuple[str, ...]: Deduplicated research-signal keys discovered in
+            ``research_signal_key`` or ``research_signal_keys`` fields.
+
+    Raises:
+        ValueError: If a research-signal field exists but is not string-shaped.
+    """
+    keys: list[str] = []
+    _collect_report_research_signal_keys(payload, keys)
+    return _dedupe_strings(tuple(keys))
+
+
 def _extract_report_symbol_names(payload: dict[str, Any]) -> tuple[str, ...]:
     """Extract structured symbolic dependency names from a report payload.
 
@@ -4685,6 +4769,42 @@ def _collect_report_symbol_names(value: Any, names: list[str]) -> None:
     if isinstance(value, list):
         for item in value:
             _collect_report_symbol_names(item, names)
+
+
+def _collect_report_research_signal_keys(value: Any, keys: list[str]) -> None:
+    """Collect structured research-signal keys recursively.
+
+    Args:
+        value (Any): JSON-like value to inspect.
+        keys (list[str]): Mutable output list that receives discovered keys.
+
+    Raises:
+        ValueError: If a structured research-signal field has an unsupported
+            shape.
+    """
+    if isinstance(value, dict):
+        for field, field_value in value.items():
+            if field == "research_signal_key":
+                if not isinstance(field_value, str):
+                    raise ValueError(
+                        "report payload research_signal_key must be a string."
+                    )
+                keys.append(field_value)
+                continue
+            if field == "research_signal_keys":
+                if not isinstance(field_value, list) or not all(
+                    isinstance(key, str) for key in field_value
+                ):
+                    raise ValueError(
+                        "report payload research_signal_keys must be a list of strings."
+                    )
+                keys.extend(field_value)
+                continue
+            _collect_report_research_signal_keys(field_value, keys)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_report_research_signal_keys(item, keys)
 
 
 def _collect_report_reference_keys(value: Any, keys: list[str]) -> None:

--- a/tests/circuit/estimator/test_ftqc_resources.py
+++ b/tests/circuit/estimator/test_ftqc_resources.py
@@ -1047,6 +1047,8 @@ def test_build_ftqc_research_signal_report_selects_available_quantities():
     )
     assert report.title == "arXiv:2603.22778 resource signal review"
     assert report.profile is None
+    assert report.research_signal_keys == ("arXiv:2603.22778",)
+    assert report.to_dict()["research_signal_keys"] == ["arXiv:2603.22778"]
     assert row_quantities[0] == FTQCResourceQuantity.LAMBDA_NORM
     assert row_quantities[1] == FTQCResourceQuantity.QPE_ITERATIONS
     assert FTQCResourceQuantity.T_GATES in row_quantities
@@ -1538,6 +1540,7 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
                 "symbolic": 0,
             },
             "reference_keys": [],
+            "research_signal_keys": [],
             "symbol_names": [],
         },
         {
@@ -1547,10 +1550,12 @@ def test_build_ftqc_resource_report_bundle_snapshots_reports():
             "row_count": 2,
             "counts": {"resolved": 2, "unresolved": 0},
             "reference_keys": [],
+            "research_signal_keys": [],
             "symbol_names": [],
         },
     ]
     assert bundle_manifest["reference_keys"] == []
+    assert bundle_manifest["research_signal_keys"] == []
     assert bundle_manifest["symbol_names"] == []
     assert "payload" not in bundle_manifest["snapshots"][0]
     assert bundle_dict["counts"] == {"snapshots": 2, "rows": 3}
@@ -1674,6 +1679,70 @@ def test_ftqc_report_bundle_manifest_collects_reference_keys():
         0,
     )
     with pytest.raises(ValueError, match="reference_keys"):
+        malformed.to_dict()
+
+
+def test_ftqc_report_bundle_manifest_collects_research_signal_keys():
+    """Report bundle manifests expose explicit research-signal coverage."""
+    row = FTQCResourceComparisonRow(
+        quantity=FTQCResourceQuantity.RUNTIME_SECONDS,
+        baseline=10,
+        candidate=4,
+        ratio=sp.Rational(2, 5),
+        reduction=sp.Rational(3, 5),
+        label="Runtime",
+        unit="seconds",
+        category=FTQCResourceCategory.PHYSICAL,
+    )
+    signal_report = FTQCResourceComparisonReport(
+        title="UWC signal review",
+        baseline_label="plain",
+        candidate_label="uwc",
+        profile=None,
+        summary=FTQCResourceComparisonSummary.from_rows((row,)),
+        research_signal_keys=("arXiv:2603.22778",),
+    )
+    coverage = FTQCResearchSignalCoverage(
+        reference_key="arXiv:2601.08533",
+        title="State-preparation filtering",
+        available=(FTQCResourceQuantity.QPE_REPETITIONS,),
+        missing=(),
+        total=1,
+    )
+    coverage_report = FTQCResearchSignalCoverageReport(
+        title="Coverage",
+        estimate_label="filtered",
+        coverages=(coverage,),
+    )
+    bundle = build_ftqc_resource_report_bundle(
+        "Research signal bundle",
+        (signal_report, coverage_report),
+    )
+    signal_snapshot = build_ftqc_resource_report_snapshot(signal_report)
+    manifest = bundle.to_manifest()
+
+    assert signal_snapshot.to_dict()["research_signal_keys"] == ["arXiv:2603.22778"]
+    assert coverage_report.to_dict()["rows"][0]["research_signal_key"] == (
+        "arXiv:2601.08533"
+    )
+    assert manifest["research_signal_keys"] == [
+        "arXiv:2603.22778",
+        "arXiv:2601.08533",
+    ]
+    assert manifest["snapshots"][0]["research_signal_keys"] == ["arXiv:2603.22778"]
+    assert manifest["snapshots"][1]["research_signal_keys"] == ["arXiv:2601.08533"]
+
+    malformed = FTQCResourceReportSnapshot(
+        "comparison",
+        "Malformed signal keys",
+        {
+            "title": "Malformed signal keys",
+            "rows": [],
+            "research_signal_keys": [object()],
+        },
+        0,
+    )
+    with pytest.raises(ValueError, match="research_signal_keys"):
         malformed.to_dict()
 
 


### PR DESCRIPTION
Summary\n- Add explicit research_signal_keys metadata to FTQC comparison reports and research-signal coverage outputs.\n- Surface research_signal_keys in FTQC report snapshots and bundle manifests alongside reference_keys and symbol_names.\n- Extend the FTQC resource-estimation design tutorial in English and Japanese with an executable research-signal bundle demo.\n\nValidation\n- uv run pytest tests/circuit/estimator/test_ftqc_resources.py -q\n- uv run python docs/en/usage/ftqc_resource_estimation_design.py\n- uv run python docs/ja/usage/ftqc_resource_estimation_design.py\n- uv run jupyter nbconvert --to notebook --execute --inplace docs/en/usage/ftqc_resource_estimation_design.ipynb\n- uv run jupyter nbconvert --to notebook --execute --inplace docs/ja/usage/ftqc_resource_estimation_design.ipynb\n- uv run pytest -m docs tests/docs -q -k 'ftqc_resource_estimation_design'\n- uv run ruff check qamomile/ tests/\n- uv run ruff format --check qamomile/ tests/\n- uv run zuban check qamomile/\n- git diff --check\n\nLocal review note\n- The local-review skill still asks for uv run zuban qamomile/, which now fails with: error: unrecognized subcommand 'qamomile/'. The repository-standard uv run zuban check qamomile/ command passes.