### PR TITLE
Reject aliased quantum arguments in qkernel calls

### DIFF
--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -46,6 +46,7 @@ from qamomile.circuit.ir.types import BitType, FloatType, ObservableType, UIntTy
 from qamomile.circuit.ir.value import ArrayValue, DictValue, Value
 from qamomile.circuit.transpiler.errors import (
     FrontendTransformError,
+    QubitConsumedError,
     QubitRebindError,
 )
 
@@ -117,6 +118,118 @@ def _promote_literal_to_handle(value: Any, expected_type: Any) -> Any:
         if is_bool:
             return bit(value)
     return value
+
+
+def _quantum_handle_display_name(handle: Handle) -> str:
+    """Return a human-readable name for a quantum handle in error messages.
+
+    Args:
+        handle (Handle): Handle to name. Falls back from the handle's own
+            name to its backing value's name to a shortened handle id.
+
+    Returns:
+        str: Non-empty display name for the handle.
+    """
+    return handle.name or handle.value.name or f"qubit_{handle.id[:8]}"
+
+
+def _reject_aliased_quantum_args(kernel_name: str, arguments: dict[str, Any]) -> None:
+    """Reject two call arguments backed by the same quantum register.
+
+    ``QKernel.__call__`` defers ``VectorView`` consumption until after the
+    call is recorded, so binding the same view to two parameters would
+    bypass the per-handle ``consume()`` check that plain ``Qubit`` /
+    ``Vector`` arguments hit, silently aliasing both formal registers onto
+    the same physical qubits.  This guard runs before any handle is
+    consumed and compares the backing ``Value.uuid``, mirroring
+    ``composite_gate._reject_duplicate_targets``.
+
+    Keying on ``uuid`` (a single ``Value`` instance bound twice) rather
+    than ``logical_id`` (stable across SSA versions) is deliberate and
+    complete.  The affine invariant forbids two *live* handles of one
+    wire, so two arguments that share a ``logical_id`` but not a ``uuid``
+    always include a stale (already-consumed) version, which the
+    consumption loop below rejects anyway — a stale view via
+    :func:`_reject_consumed_view_arg`, a stale whole register via
+    ``Handle.consume()``.  (A broadcast gate on a full view keeps the same
+    backing ``Value``, so a view and its post-gate successor collide on
+    ``uuid`` here directly.)
+
+    Args:
+        kernel_name (str): Name of the called kernel, used in the error
+            message.
+        arguments (dict[str, Any]): Bound call arguments keyed by parameter
+            name.  Non-``Handle`` entries and classical handles are
+            ignored.
+
+    Returns:
+        None.
+
+    Raises:
+        QubitConsumedError: If two quantum arguments are backed by the same
+            ``Value`` instance (the same live handle passed twice).
+    """
+    seen: dict[str, str] = {}
+    for name, handle in arguments.items():
+        if not isinstance(handle, Handle) or not handle._should_enforce_linear():
+            continue
+        backing_uuid = handle.value.uuid
+        first_name = seen.get(backing_uuid)
+        if first_name is not None:
+            display_name = _quantum_handle_display_name(handle)
+            raise QubitConsumedError(
+                f"Arguments '{first_name}' and '{name}' of "
+                f"'QKernel[{kernel_name}]' are backed by the same qubit "
+                f"register ('{display_name}').\n\n"
+                f"Affine type rule: Each qubit handle can be passed to a "
+                f"kernel call at most once — binding one register to two "
+                f"parameters would alias both onto the same physical "
+                f"qubits.\n\n"
+                f"Fix: pass disjoint registers, e.g.:\n"
+                f"  x, y = {kernel_name}(q[0:2], q[2:4])  # disjoint slices",
+                handle_name=display_name,
+                operation_name=f"QKernel[{kernel_name}]",
+            )
+        seen[backing_uuid] = name
+
+
+def _reject_consumed_view_arg(kernel_name: str, handle: Handle) -> None:
+    """Reject an already-consumed ``VectorView`` passed as a call argument.
+
+    View consumption is deferred until after the call is recorded, and the
+    deferred loop only consumes views that are still live — so a view that
+    was already consumed before the call would slip through without the
+    ``QubitConsumedError`` that a plain handle gets from ``consume()``.
+    This guard restores that error at the call boundary.
+
+    Args:
+        kernel_name (str): Name of the called kernel, used in the error
+            message.
+        handle (Handle): View argument to check.
+
+    Returns:
+        None.
+
+    Raises:
+        QubitConsumedError: If ``handle`` was already consumed.
+    """
+    if not handle._consumed:
+        return
+    display_name = _quantum_handle_display_name(handle)
+    raise QubitConsumedError(
+        f"Qubit view '{display_name}' was already consumed by "
+        f"'{handle._consumed_by}' and cannot be used again in "
+        f"'QKernel[{kernel_name}]'.\n\n"
+        f"Affine type rule: Each qubit handle can only be used once. "
+        f"After a gate operation, reassign the result to use the new "
+        f"handle.\n\n"
+        f"Fix:\n"
+        f"  v = qm.h(v)  # Reassign to capture the new handle\n"
+        f"  {kernel_name}(v)  # Pass the reassigned handle",
+        handle_name=display_name,
+        operation_name=f"QKernel[{kernel_name}]",
+        first_use_location=handle._consumed_by,
+    )
 
 
 def _const_int(value: Value | None) -> int | None:
@@ -602,6 +715,13 @@ class QKernel(Generic[P, R]):
             self.input_types, bound_args.arguments, context=f"{self.name}()"
         )
 
+        # Two parameters bound to the same quantum register would make the
+        # deferred view consumption below silently alias both formal
+        # registers onto the same physical qubits (the identical views
+        # collapse to a single ``input_view_metas`` entry); reject before
+        # any handle is consumed.
+        _reject_aliased_quantum_args(self.name, bound_args.arguments)
+
         # Prepare inputs for the IR call (unwrap Handles to Values)
         inputs_map: dict[str, Value] = {}
         # Track borrow provenance for input-derived quantum scalar handles.
@@ -686,6 +806,7 @@ class QKernel(Generic[P, R]):
             # handle.  Everything else takes the regular ``consume``
             # path to enforce affine type.
             if isinstance(handle, VectorView) and handle._should_enforce_linear():
+                _reject_consumed_view_arg(self.name, handle)
                 inputs_map[name] = handle.value
                 continue
             if handle._should_enforce_linear():

--- a/qamomile/circuit/transpiler/passes/inline.py
+++ b/qamomile/circuit/transpiler/passes/inline.py
@@ -20,7 +20,7 @@ from qamomile.circuit.ir.operation.gate import ControlledUOperation
 from qamomile.circuit.ir.operation.inverse_block import InverseBlockOperation
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.value import ArrayValue, Value, ValueBase
-from qamomile.circuit.transpiler.errors import InliningError
+from qamomile.circuit.transpiler.errors import InliningError, QubitConsumedError
 from qamomile.circuit.transpiler.passes import Pass
 from qamomile.circuit.transpiler.passes.value_mapping import (
     UUIDRemapper,
@@ -335,6 +335,29 @@ class InlinePass(Pass[Block, Block]):
 
         Creates a fresh value_map for the called block's scope,
         mapping block inputs to call arguments.
+
+        Args:
+            call_op (CallBlockOperation): The call to dissolve into the
+                caller's operation stream.
+            value_map (dict[str, Value]): Caller-scope value substitutions
+                accumulated so far; updated in place with the mappings for
+                this call's results.
+            visiting_blocks (set[int]): ids of blocks currently being
+                expanded, used to leave self-recursive calls intact.
+
+        Returns:
+            list[Operation]: The callee's operations, cloned and rewritten
+                into the caller's value scope.
+
+        Raises:
+            InliningError: If ``call_op.block`` is unset.
+            QubitConsumedError: If two of the call's quantum operands
+                resolve to the same value — inlining would silently alias
+                two formal registers onto the same qubits, and this pass
+                dissolves the call before ``affine_validate`` could see the
+                duplicate.  Frontend-traced kernels reject this earlier in
+                ``QKernel.__call__``; this guard covers hand-built or
+                deserialized IR.
         """
         if call_op.block is None:
             raise InliningError("CallBlockOperation.block must be set")
@@ -361,9 +384,37 @@ class InlinePass(Pass[Block, Block]):
         # ``quad_``, and ``emit_for_items`` could not find the dict in
         # bindings. Always trust the substituted result.
         arg_substitutor = ValueSubstitutor(local_map, transitive=True)
-        for block_input, call_arg in zip(block.input_values, call_args):
+        # Same-uuid duplicates among the resolved quantum operands mean the
+        # call binds one register to two parameters.  Distinct SSA versions
+        # of one wire are legitimate IR values, so this deliberately keys on
+        # ``uuid`` (not ``logical_id``); wire-level linearity is enforced by
+        # the frontend.
+        seen_quantum_args: dict[str, str] = {}
+        for arg_index, (block_input, call_arg) in enumerate(
+            zip(block.input_values, call_args)
+        ):
             substituted_arg = arg_substitutor.substitute_value(call_arg)
             resolved_arg = cast(Value, substituted_arg)
+            if isinstance(resolved_arg, Value) and resolved_arg.type.is_quantum():
+                label = (
+                    block.label_args[arg_index]
+                    if arg_index < len(block.label_args)
+                    else f"argument {arg_index}"
+                )
+                first_label = seen_quantum_args.get(resolved_arg.uuid)
+                if first_label is not None:
+                    raise QubitConsumedError(
+                        f"Call into block '{block.name}' binds the same "
+                        f"quantum value ('{resolved_arg.name}') to parameters "
+                        f"'{first_label}' and '{label}'.\n\n"
+                        f"Affine type rule: Each qubit register can be passed "
+                        f"to a kernel call at most once — binding one register "
+                        f"to two parameters would alias both onto the same "
+                        f"physical qubits.",
+                        handle_name=resolved_arg.name,
+                        operation_name=f"inline[{block.name}]",
+                    )
+                seen_quantum_args[resolved_arg.uuid] = label
             local_map[block_input.uuid] = resolved_arg
 
             # If both are ArrayValues, also map shape dimensions

--- a/tests/circuit/test_affine_types.py
+++ b/tests/circuit/test_affine_types.py
@@ -3236,3 +3236,185 @@ class TestQuantumRebindErrorMessageDispatch:
             "q = some_classical_func(q, ...)"
         ) in msg
         assert "Or bind the new value to a different name" in msg
+
+
+class TestDuplicateQuantumCallArgs:
+    """Binding the same qubit register to two sub-kernel parameters must raise.
+
+    Regression tests for the deferred-view-consumption hole: identical
+    ``VectorView`` arguments used to collapse to a single
+    ``input_view_metas`` entry in ``QKernel.__call__``, silently aliasing
+    both formal registers onto the same physical qubits (or crashing with
+    a raw backend error once the callee entangled them).
+    """
+
+    @staticmethod
+    def _pair_kernel():
+        """Build a fresh two-register sub-kernel (H on ``a``, X on ``b``)."""
+
+        @qkernel
+        def pair(
+            a: qm.Vector[qm.Qubit], b: qm.Vector[qm.Qubit]
+        ) -> tuple[qm.Vector[qm.Qubit], qm.Vector[qm.Qubit]]:
+            a = qm.h(a)
+            b = qm.x(b)
+            return a, b
+
+        return pair
+
+    def test_same_view_twice_raises(self):
+        """The same VectorView bound to two parameters raises instead of
+        silently aliasing both formal registers onto the same qubits."""
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            v = q[0:2]
+            x, _y = pair(v, v)  # same view twice
+            q[0:2] = x
+            return qm.measure(q)
+
+        with pytest.raises(
+            QubitConsumedError, match="backed by the same qubit register"
+        ) as exc_info:
+            circuit.build()
+        assert "'a' and 'b'" in str(exc_info.value)
+
+    def test_same_view_twice_entangling_callee_raises(self):
+        """An entangling callee with an aliased view pair raises a Qamomile
+        affine error at trace time, not a raw backend error deep in emit."""
+
+        @qkernel
+        def entangle(
+            a: qm.Vector[qm.Qubit], b: qm.Vector[qm.Qubit]
+        ) -> tuple[qm.Vector[qm.Qubit], qm.Vector[qm.Qubit]]:
+            a0 = a[0]
+            b0 = b[0]
+            a0, b0 = qm.cx(a0, b0)
+            a[0] = a0
+            b[0] = b0
+            return a, b
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            v = q[0:2]
+            x, _y = entangle(v, v)  # same view twice
+            q[0:2] = x
+            return qm.measure(q)
+
+        with pytest.raises(
+            QubitConsumedError, match="backed by the same qubit register"
+        ):
+            circuit.build()
+
+    def test_stale_and_live_view_versions_raise(self):
+        """A stale SSA version and its live successor passed together raise.
+
+        A broadcast gate on a full view keeps the same backing ``Value``
+        (uuid preserved), so ``v`` and ``v2`` collide on the same-uuid
+        alias guard; either way the program is rejected (previously it
+        emitted the caller's gate twice on the same wires)."""
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            v = q[0:2]
+            v2 = qm.h(v)
+            x, _y = pair(v, v2)  # stale + live version of one register
+            q[0:2] = x
+            return qm.measure(q)
+
+        with pytest.raises(
+            QubitConsumedError, match="backed by the same qubit register"
+        ):
+            circuit.build()
+
+    def test_consumed_view_arg_raises(self):
+        """An already-consumed view passed as a call argument raises the
+        standard consumed error instead of slipping past deferred
+        consumption."""
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            v = q[0:2]
+            _v2 = qm.h(v)  # consumes v
+            x, y = pair(v, q[2:4])
+            q[0:2] = x
+            q[2:4] = y
+            return qm.measure(q)
+
+        with pytest.raises(QubitConsumedError, match="already consumed by 'H'"):
+            circuit.build()
+
+    def test_same_vector_twice_raises(self):
+        """A whole Vector bound to two parameters is rejected with the
+        argument-aliasing wording."""
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            x, _y = pair(q, q)  # same Vector twice
+            return qm.measure(x)
+
+        with pytest.raises(
+            QubitConsumedError, match="backed by the same qubit register"
+        ):
+            circuit.build()
+
+    def test_disjoint_views_accepted(self):
+        """Disjoint views of one array remain a valid argument pair."""
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            x, y = pair(q[0:2], q[2:4])
+            q[0:2] = x
+            q[2:4] = y
+            return qm.measure(q)
+
+        block = circuit.build()
+        assert block is not None
+
+    def test_inline_rejects_duplicate_quantum_call_operands(self):
+        """InlinePass rejects a hand-built CallBlockOperation that binds one
+        quantum value to two parameters (defense in depth for IR that did
+        not come from ``QKernel.__call__``)."""
+        from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
+        from qamomile.circuit.ir.value import Value
+        from qamomile.circuit.transpiler.passes.inline import InlinePass
+
+        pair = self._pair_kernel()
+
+        @qkernel
+        def circuit() -> qm.Vector[qm.Bit]:
+            q = qubit_array(4, "q")
+            x, y = pair(q[0:2], q[2:4])
+            q[0:2] = x
+            q[2:4] = y
+            return qm.measure(q)
+
+        block = circuit.block
+        call_ops = [op for op in block.operations if isinstance(op, CallBlockOperation)]
+        assert len(call_ops) == 1
+        call_op = call_ops[0]
+
+        # Positive control: the untampered block inlines cleanly.
+        InlinePass().run(block)
+
+        quantum_indices = [
+            i
+            for i, operand in enumerate(call_op.operands)
+            if isinstance(operand, Value) and operand.type.is_quantum()
+        ]
+        assert len(quantum_indices) == 2
+        call_op.operands[quantum_indices[1]] = call_op.operands[quantum_indices[0]]
+
+        with pytest.raises(QubitConsumedError, match="binds the same quantum value"):
+            InlinePass().run(block)


### PR DESCRIPTION
## Summary

Passing the same `VectorView` twice to a plain qkernel sub-kernel silently aliased both parameter registers onto the same physical qubits, with no diagnostic. Minimal repro:

```python
import qamomile.circuit as qmc
from qamomile.qiskit.transpiler import QiskitTranspiler

@qmc.qkernel
def pair(a: qmc.Vector[qmc.Qubit], b: qmc.Vector[qmc.Qubit]) -> tuple[qmc.Vector[qmc.Qubit], qmc.Vector[qmc.Qubit]]:
    a = qmc.h(a)
    b = qmc.x(b)
    return a, b

@qmc.qkernel
def circuit() -> qmc.Vector[qmc.Bit]:
    q = qmc.qubit_array(4, "q")
    v = q[0:2]
    x, y = pair(v, v)  # same view twice — silently aliased
    q[0:2] = x
    return qmc.measure(q)

QiskitTranspiler().to_circuit(circuit, bindings={})
# before: emits h[0], h[1], x[0], x[1] — both formals aliased onto qubits 0,1, no error
```

With an entangling callee (`cx(a[0], b[0])`) it instead crashed deep in emit with a raw qiskit `CircuitError: 'duplicate qubit arguments'` and no Qamomile diagnostic.

## Root cause

`QKernel.__call__` defers `VectorView` consumption until after the call is recorded and keys `input_view_metas` by `(root, start, step, length)`, so two identical views collapse to a single entry and never trip the per-handle `consume()` check that plain `Qubit` / `Vector` arguments hit. The IR-level `AffineValidationPass` cannot catch it either, because `InlinePass` dissolves the `CallBlockOperation` (whose operands are the same value twice) before `affine_validate` runs in the pipeline.

## Fix

- **`QKernel.__call__`** rejects two quantum arguments backed by the same `Value` (compared by `uuid`, mirroring `composite_gate._reject_duplicate_targets`) before any handle is consumed, raising `QubitConsumedError` with affine-rule wording. A broadcast gate on a full view keeps the same backing `Value`, so a stale view version passed alongside its live successor collides here too (this previously emitted the caller's gates twice on the same wires).
- An already-consumed `VectorView` argument now raises the standard consumed error at the call boundary instead of slipping past the deferred-consumption loop.
- **`InlinePass`** rejects duplicate quantum operands on a `CallBlockOperation` as defense in depth for hand-built or deserialized IR (which never went through `QKernel.__call__`), keyed on `uuid` and raising before the call is dissolved.

## Tests

New `TestDuplicateQuantumCallArgs` in `tests/circuit/test_affine_types.py` covers the silent-alias and entangling-crash variants, stale-version aliasing, consumed-view arguments, the whole-`Vector` duplicate, and the tampered-IR inline path, and asserts disjoint views of one array still compile.

## Verification

- `uv run pytest` (default suite): 8561 passed, 409 skipped, 1 xfailed (the pre-existing `test_noncommuting_trotter_converges_with_steps` local segfault deselected, unrelated).
- `uv run ruff check qamomile/ tests/`, `uv run ruff format --check`, `uv run zuban check qamomile/`: all clean.
- `/local-review`: no remaining findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
