### PR TITLE
Make classical array element assignment a real IR store

### DIFF
--- a/qamomile/circuit/frontend/handle/array.py
+++ b/qamomile/circuit/frontend/handle/array.py
@@ -9,6 +9,7 @@ from typing import Generic, Iterator, TypeVar, overload
 from qamomile._utils import is_plain_int
 from qamomile.circuit.frontend.tracer import get_current_tracer
 from qamomile.circuit.ir.operation.arithmetic_operations import BinOpKind
+from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
 from qamomile.circuit.ir.operation.operation import CInitOperation, QInitOperation
 from qamomile.circuit.ir.operation.slice_array import (
     ReleaseSliceViewOperation,
@@ -644,9 +645,9 @@ class ArrayBase(Handle, Generic[T]):
         return self.element_type(value=element_value, parent=self, indices=indices)
 
     def _return_element(self, indices: tuple[UInt, ...], value: T) -> None:
-        """Validate, consume, and release a borrowed element.
+        """Write an element back into the array at the given indices.
 
-        Order: validate -> consume -> borrow release (fixed sequence).
+        Order: validate -> store/consume -> borrow release (fixed sequence).
 
         Three paths for quantum arrays:
 
@@ -657,14 +658,31 @@ class ArrayBase(Handle, Generic[T]):
         3. **Unborrowed index**: consumes the handle without identity check.
            Allows writing a fresh qubit to an index that was never borrowed.
 
+        For **classical arrays** (``Bit`` / ``UInt`` / ``Float`` elements)
+        the assignment is a genuine value store, not a borrow return:
+        classical values are freely copyable, so
+        :meth:`_store_classical_element` emits a
+        ``StoreArrayElementOperation`` producing a fresh SSA version of the
+        array whose contents equal the old array with the addressed element
+        replaced.  The right-hand side handle stays usable afterwards.
+
         Args:
-            indices: The indices where the element is being returned.
-            value: The handle being written back.
+            indices (tuple[UInt, ...]): The indices where the element is
+                being written.
+            value (T): The handle being written.  For classical arrays a
+                plain Python literal compatible with the element type is
+                also accepted (coerced to a constant handle).
 
         Raises:
             NotImplementedError: If any index is a negative compile-time
-                constant — Python-style negative indexing is not
-                supported (see ``_reject_negative_const_indices``).
+                constant (see ``_reject_negative_const_indices``), or —
+                for classical arrays — if the write targets a slice view
+                or a multi-dimensional array (not supported yet).
+            IndexError: For classical arrays, if a constant index is out
+                of range for a constant-length array.
+            TypeError: For classical arrays, if the right-hand side is not
+                a handle of the element type or a compatible Python
+                literal.
             QubitConsumedError: If the array was already consumed.
             AffineTypeError: If the index was borrowed **and** the value
                 was not borrowed from this array (``value.parent is not self``).
@@ -724,6 +742,13 @@ class ArrayBase(Handle, Generic[T]):
             else target_key
         )
 
+        if not self.value.type.is_quantum():
+            # Classical element assignment is a real value store: emit the
+            # IR operation and advance ``self.value`` to the new SSA
+            # version.  This must happen before the borrow-release tail so
+            # a raised store error leaves no half-updated handle state.
+            self._store_classical_element(indices, value)
+
         if self.value.type.is_quantum():
             if release_key in self._borrowed_indices:
                 # Borrow-return path: element was borrowed, validate identity
@@ -769,8 +794,159 @@ class ArrayBase(Handle, Generic[T]):
             if not _is_destroyed_slot_owner(current):
                 del self._borrowed_indices[release_key]
         else:
-            # Classical types are freely copyable — no linear enforcement needed
+            # No borrow recorded for this slot.  For quantum arrays the
+            # write was already validated above; for classical arrays the
+            # store has been emitted and borrows carry no obligations.
             pass
+
+    def _store_classical_element(self, indices: tuple[UInt, ...], value: T) -> None:
+        """Emit the IR store for a classical array element assignment.
+
+        Builds a ``StoreArrayElementOperation`` consuming the current
+        ``ArrayValue`` version, the (coerced) right-hand side scalar, and
+        the index, and producing a fresh SSA version of the array.  The
+        handle's ``value`` is rebound to the new version so subsequent
+        reads and the kernel's return trace the post-store contents.
+
+        The result value deliberately drops ``scalar`` (parameter-binding)
+        and ``array_runtime`` (``const_array`` / element-identity) metadata
+        inherited from the source version: both describe the *pre-store*
+        contents, and keeping them would let downstream compile-time
+        resolution silently read stale data.  ``ConstantFoldingPass``
+        re-attaches an updated ``const_array`` when the store folds.
+
+        Args:
+            indices (tuple[UInt, ...]): The element indices being written.
+                Negative constant indices were already rejected by the
+                caller (``_return_element``).
+            value (T): The right-hand side.  Either a handle of the
+                element type or a Python literal coercible to it.
+
+        Raises:
+            NotImplementedError: If this array is a slice view, or the
+                write is multi-dimensional (``Matrix`` / ``Tensor``) —
+                classical element stores support 1-D root arrays only for
+                now.
+            IndexError: If a constant index is out of range for a
+                constant-length array.
+            TypeError: If ``value`` cannot be coerced to the element type
+                (see :meth:`_coerce_classical_element_value`).
+        """
+        index_str = self._format_index(indices)
+        display = self.value.name or "array"
+
+        if self.value.is_slice():
+            raise NotImplementedError(
+                f"Classical array element assignment through a slice view "
+                f"('{display}[{index_str}] = ...') is not supported yet.  "
+                f"Assign through the root array instead."
+            )
+        if len(indices) != 1:
+            raise NotImplementedError(
+                f"Classical element assignment to '{display}[{index_str}]' "
+                f"is only supported for 1-D arrays (Vector) for now; "
+                f"got {len(indices)} indices."
+            )
+
+        # Reject a constant index that overflows a constant dimension,
+        # mirroring the read-side check in ``_get_element``.  Without this
+        # the store would be built into the IR and only fail at runtime
+        # with a far less local error.
+        if self._shape:
+            idx_const = _as_int_const(indices[0])
+            dim_const = _as_int_const(self._shape[0])
+            if (
+                idx_const is not None
+                and dim_const is not None
+                and idx_const >= dim_const
+            ):
+                raise IndexError(
+                    f"Index {idx_const} is out of range for "
+                    f"'{display}' of length {dim_const}."
+                )
+
+        stored = self._coerce_classical_element_value(value, index_str)
+
+        result_value = self.value.next_version()
+        result_value = dataclasses.replace(
+            result_value,
+            metadata=dataclasses.replace(
+                result_value.metadata, scalar=None, array_runtime=None
+            ),
+        )
+
+        store_op = StoreArrayElementOperation(
+            operands=[
+                self.value,
+                stored.value,
+                *(idx.value for idx in indices),
+            ],
+            results=[result_value],
+        )
+        get_current_tracer().add_operation(store_op)
+        self.value = result_value
+
+    def _coerce_classical_element_value(self, value: object, index_str: str) -> Handle:
+        """Coerce the right-hand side of a classical element write to a handle.
+
+        Accepts either a handle whose type matches this array's element
+        type, or a Python literal that can be losslessly promoted to it:
+        ``bool`` / ``0`` / ``1`` for ``Bit``, a plain non-negative ``int``
+        for ``UInt``, and ``int`` / ``float`` for ``Float``.  ``bool`` is
+        never accepted where an integer is expected (mirroring the index
+        handling in ``_make_uint_index``).
+
+        Args:
+            value (object): The right-hand side of the assignment.
+            index_str (str): Formatted index string for error messages.
+
+        Returns:
+            Handle: A handle of the element type whose ``value`` carries
+                the stored scalar (a constant ``Value`` for literals).
+
+        Raises:
+            TypeError: If ``value`` is a handle of a different type, or a
+                Python object that cannot be promoted to the element type.
+        """
+        display = self.value.name or "array"
+        if isinstance(value, Handle):
+            if not isinstance(value, self.element_type):
+                raise TypeError(
+                    f"Cannot assign {type(value).__name__} to "
+                    f"'{display}[{index_str}]' of element type "
+                    f"{self.element_type.__name__}."
+                )
+            return value
+
+        if self.element_type is Bit:
+            if isinstance(value, bool):
+                return Bit(
+                    value=Value(type=BitType(), name="").with_const(value),
+                    init_value=value,
+                )
+            if is_plain_int(value) and isinstance(value, int) and value in (0, 1):
+                return Bit(
+                    value=Value(type=BitType(), name="").with_const(bool(value)),
+                    init_value=bool(value),
+                )
+        elif self.element_type is UInt:
+            if is_plain_int(value) and isinstance(value, int) and value >= 0:
+                return UInt(
+                    value=Value(type=UIntType(), name="").with_const(int(value)),
+                    init_value=int(value),
+                )
+        elif self.element_type is Float:
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return Float(
+                    value=Value(type=FloatType(), name="").with_const(float(value)),
+                    init_value=float(value),
+                )
+
+        raise TypeError(
+            f"Cannot assign {type(value).__name__} ({value!r}) to "
+            f"'{display}[{index_str}]' of element type "
+            f"{self.element_type.__name__}."
+        )
 
     def _copy_subclass_state_to(self, new_handle: Handle) -> None:
         """Copy ArrayBase-specific state to a new handle created by consume()."""
@@ -934,9 +1110,15 @@ class Vector(ArrayBase[T]):
     def __setitem__(self, index: "int | UInt | slice", value: "T | Vector[T]") -> None:
         """Set element at the given index, or return a view via slice assignment.
 
-        For an integer / ``UInt`` index this is the existing element
-        borrow-return path: the right-hand side handle is validated
-        against the borrow recorded for that index and consumed.
+        For an integer / ``UInt`` index on a **quantum** vector this is
+        the element borrow-return path: the right-hand side handle is
+        validated against the borrow recorded for that index and
+        consumed.  On a **classical** vector (``Bit`` / ``UInt`` /
+        ``Float`` elements) the same syntax is a genuine value store: a
+        ``StoreArrayElementOperation`` is emitted producing a fresh SSA
+        version of the array, and the right-hand side (a handle of the
+        element type, or a compatible Python literal) stays usable
+        afterwards.  See :meth:`ArrayBase._store_classical_element`.
 
         For a ``slice`` index, the assignment is treated as the
         **explicit borrow-return of a slice view**.  The right-hand
@@ -1620,7 +1802,19 @@ class Matrix(ArrayBase[T]):
         return self._get_element((i, j))
 
     def __setitem__(self, index: tuple[int | UInt, int | UInt], value: T) -> None:
-        """Set element at the given (row, col) index."""
+        """Set element at the given (row, col) index.
+
+        Args:
+            index (tuple[int | UInt, int | UInt]): The (row, col) element
+                position.
+            value (T): The handle being written back (the borrow-return
+                path for quantum matrices).
+
+        Raises:
+            NotImplementedError: For classical element types — multi-
+                dimensional classical element stores are not supported
+                yet (see ``ArrayBase._store_classical_element``).
+        """
         i, j = index
         if isinstance(i, int):
             i = self._make_uint_index(i)
@@ -1664,7 +1858,21 @@ class Tensor(ArrayBase[T]):
         return self._get_element(converted)
 
     def __setitem__(self, index: tuple[int | UInt, ...], value: T) -> None:
-        """Set element at the given indices."""
+        """Set element at the given indices.
+
+        Args:
+            index (tuple[int | UInt, ...]): One index per tensor
+                dimension.
+            value (T): The handle being written back (the borrow-return
+                path for quantum tensors).
+
+        Raises:
+            IndexError: If the number of indices does not match the
+                tensor rank.
+            NotImplementedError: For classical element types — multi-
+                dimensional classical element stores are not supported
+                yet (see ``ArrayBase._store_classical_element``).
+        """
         if len(index) != len(self._shape):
             raise IndexError(f"Expected {len(self._shape)} indices, got {len(index)}")
         converted = tuple(

--- a/qamomile/circuit/ir/operation/__init__.py
+++ b/qamomile/circuit/ir/operation/__init__.py
@@ -1,5 +1,5 @@
 from .cast import CastOperation
-from .classical_ops import DecodeQFixedOperation
+from .classical_ops import DecodeQFixedOperation, StoreArrayElementOperation
 from .composite_gate import (
     CompositeGateOperation,
     CompositeGateType,
@@ -38,6 +38,7 @@ __all__ = [
     "ConcreteControlledU",
     "SymbolicControlledU",
     "DecodeQFixedOperation",
+    "StoreArrayElementOperation",
     "CastOperation",
     # Control flow operations
     "ForItemsOperation",

--- a/qamomile/circuit/ir/operation/classical_ops.py
+++ b/qamomile/circuit/ir/operation/classical_ops.py
@@ -3,6 +3,7 @@
 import dataclasses
 
 from qamomile.circuit.ir.types.primitives import BitType, FloatType
+from qamomile.circuit.ir.value import ArrayValue, Value
 
 from .operation import Operation, OperationKind, ParamHint, Signature
 
@@ -41,6 +42,93 @@ class DecodeQFixedOperation(Operation):
         return Signature(
             operands=[ParamHint(name="bits", type=BitType())],
             results=[ParamHint(name="float_out", type=FloatType())],
+        )
+
+    @property
+    def operation_kind(self) -> OperationKind:
+        return OperationKind.CLASSICAL
+
+
+@dataclasses.dataclass
+class StoreArrayElementOperation(Operation):
+    """Store a classical scalar into one element of a classical array.
+
+    This is the IR form of ``array[index] = value`` for classical element
+    types (``Bit`` / ``UInt`` / ``Float``).  Classical values are freely
+    copyable, so the store is an ordinary SSA rewrite: the operation
+    consumes the current array version and produces a new ``ArrayValue``
+    version (same ``logical_id``, fresh ``uuid``) whose contents equal the
+    input array with the addressed element replaced.  Quantum arrays never
+    use this operation — qubit element assignment is the return half of
+    the borrow-return idiom and emits no IR.
+
+    The operation is evaluated in one of two places:
+
+    - **Compile time**: ``ConstantFoldingPass`` folds the store when the
+      source array contents, the index, and the stored value are all
+      compile-time resolvable, attaching the updated ``const_array``
+      metadata to the result value.
+    - **Runtime**: otherwise the store executes host-side in a classical
+      segment via ``ClassicalExecutor`` (e.g. for measurement-derived
+      ``Vector[Bit]`` contents).  It must never reach a quantum segment;
+      backend emit rejects it explicitly.
+
+    Operand convention:
+        operands: ``[array (ArrayValue), stored_value (Value), *index_values]``
+        results: ``[new_array (ArrayValue)]``
+
+    Example:
+        ```python
+        @qmc.qkernel
+        def k() -> qmc.Vector[qmc.Bit]:
+            qs = qmc.qubit_array(2, "qs")
+            qs[0] = qmc.x(qs[0])
+            bits = qmc.measure(qs)
+            bits[1] = bits[0]   # emits StoreArrayElementOperation
+            return bits
+        ```
+    """
+
+    @property
+    def array(self) -> ArrayValue:
+        """ArrayValue: The array version the store reads from.
+
+        Returns:
+            ArrayValue: ``operands[0]``.
+        """
+        return self.operands[0]  # type: ignore[return-value]
+
+    @property
+    def stored_value(self) -> Value:
+        """Value: The scalar being written into the array.
+
+        Returns:
+            Value: ``operands[1]``.
+        """
+        return self.operands[1]
+
+    @property
+    def index_values(self) -> tuple[Value, ...]:
+        """tuple[Value, ...]: The element indices being written.
+
+        Returns:
+            tuple[Value, ...]: ``operands[2:]`` — one entry per array
+                dimension (a single entry for ``Vector``).
+        """
+        return tuple(self.operands[2:])
+
+    @property
+    def signature(self) -> Signature:
+        return Signature(
+            operands=[
+                ParamHint(name="array", type=self.operands[0].type),
+                ParamHint(name="stored_value", type=self.operands[1].type),
+                *[
+                    ParamHint(name=f"index_{i}", type=idx.type)
+                    for i, idx in enumerate(self.operands[2:])
+                ],
+            ],
+            results=[ParamHint(name="new_array", type=self.results[0].type)],
         )
 
     @property

--- a/qamomile/circuit/ir/serialize/decode.py
+++ b/qamomile/circuit/ir/serialize/decode.py
@@ -46,7 +46,10 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
     RuntimeOpKind,
 )
 from qamomile.circuit.ir.operation.cast import CastOperation
-from qamomile.circuit.ir.operation.classical_ops import DecodeQFixedOperation
+from qamomile.circuit.ir.operation.classical_ops import (
+    DecodeQFixedOperation,
+    StoreArrayElementOperation,
+)
 from qamomile.circuit.ir.operation.composite_gate import ResourceMetadata
 from qamomile.circuit.ir.operation.control_flow import (
     ForOperation,
@@ -895,6 +898,22 @@ def _decode_decode_qfixed(
     )
 
 
+def _decode_store_array_element(
+    d: dict[str, Any], ctx: _DecodeContext
+) -> StoreArrayElementOperation:
+    """Decode :class:`StoreArrayElementOperation`.
+
+    Args:
+        d (dict[str, Any]): The op dict.
+        ctx (_DecodeContext): The active decode context.
+
+    Returns:
+        StoreArrayElementOperation: The reconstructed op.
+    """
+    operands, results = _operands_results(d, ctx)
+    return StoreArrayElementOperation(operands=operands, results=results)
+
+
 def _decode_cast(d: dict[str, Any], ctx: _DecodeContext) -> CastOperation:
     """Decode :class:`CastOperation`.
 
@@ -1442,6 +1461,7 @@ _OP_DECODERS: dict[str, Callable[[dict[str, Any], _DecodeContext], Operation]] =
     "MeasureVectorOperation": _decode_measure_vector,
     "MeasureQFixedOperation": _decode_measure_qfixed,
     "DecodeQFixedOperation": _decode_decode_qfixed,
+    "StoreArrayElementOperation": _decode_store_array_element,
     "CastOperation": _decode_cast,
     "QInitOperation": _decode_qinit,
     "CInitOperation": _decode_cinit,

--- a/qamomile/circuit/ir/serialize/encode.py
+++ b/qamomile/circuit/ir/serialize/encode.py
@@ -41,7 +41,10 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
 )
 from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
 from qamomile.circuit.ir.operation.cast import CastOperation
-from qamomile.circuit.ir.operation.classical_ops import DecodeQFixedOperation
+from qamomile.circuit.ir.operation.classical_ops import (
+    DecodeQFixedOperation,
+    StoreArrayElementOperation,
+)
 from qamomile.circuit.ir.operation.composite_gate import ResourceMetadata
 from qamomile.circuit.ir.operation.control_flow import (
     ForOperation,
@@ -804,6 +807,21 @@ def _encode_decode_qfixed(
     return d
 
 
+def _encode_store_array_element(
+    op: StoreArrayElementOperation, ctx: _EncodeContext
+) -> dict[str, Any]:
+    """Encode :class:`StoreArrayElementOperation`.
+
+    Args:
+        op (StoreArrayElementOperation): The op.
+        ctx (_EncodeContext): The active encoding context.
+
+    Returns:
+        dict[str, Any]: Base op dict (the op carries no extra fields).
+    """
+    return _base_op_dict("StoreArrayElementOperation", op)
+
+
 def _encode_cast(op: CastOperation, ctx: _EncodeContext) -> dict[str, Any]:
     """Encode :class:`CastOperation`.
 
@@ -1274,6 +1292,7 @@ _OP_ENCODERS: dict[type, Callable[[Any, _EncodeContext], dict[str, Any]]] = {
     MeasureVectorOperation: _encode_measure_vector,
     MeasureQFixedOperation: _encode_measure_qfixed,
     DecodeQFixedOperation: _encode_decode_qfixed,
+    StoreArrayElementOperation: _encode_store_array_element,
     CastOperation: _encode_cast,
     QInitOperation: _encode_qinit,
     CInitOperation: _encode_cinit,

--- a/qamomile/circuit/transpiler/classical_executor.py
+++ b/qamomile/circuit/transpiler/classical_executor.py
@@ -273,21 +273,27 @@ class ClassicalExecutor:
         addressed element with the stored value, and records the updated
         container under the result value's UUID.
 
-        Inside a loop body the same store op executes once per iteration
+        Inside a loop body each store op executes once per iteration
         while the IR carries a single ``source -> result`` version pair.
-        To keep iterations cumulative, the base contents are taken from
-        the op's own previous result (``results[result.uuid]``) when
-        present, falling back to the source array otherwise.  Stores that
-        read an element of the same logical array they write (which would
-        see stale pre-loop contents in this loop-carried mode) are
-        rejected earlier, at compile time, by ``AnalyzePass``.
+        To keep iterations cumulative — including bodies with multiple
+        stores to the same logical array — the running contents are
+        shared across all stores to that array via a namespaced
+        ``results`` key derived from the array's ``logical_id`` (stable
+        across SSA versions). Each store bases its update on that shared
+        snapshot when present (falling back to the source array on the
+        very first store) and writes the updated contents back to both
+        the shared key and its own ``result.uuid``. Stores that read an
+        element of the same logical array they write (which would see
+        stale pre-loop contents in this loop-carried mode) are rejected
+        earlier, at compile time, by ``AnalyzePass``.
 
         Args:
             op (StoreArrayElementOperation): The store to execute.
             context (ExecutionContext): Execution context holding
                 measurements and bindings.
             results (dict[str, Any]): Mutable results map; the updated
-                container is recorded under ``op.results[0].uuid``.
+                container is recorded under ``op.results[0].uuid`` and
+                under the array's shared running-state key.
             scoped_locals (dict[str, Any]): Loop-scoped variables.
 
         Raises:
@@ -296,10 +302,15 @@ class ClassicalExecutor:
         """
         result_value = op.results[0]
 
-        if result_value.uuid in results:
-            # Loop-carried iteration: continue from the previous
-            # iteration's contents.
-            base = results[result_value.uuid]
+        # The store's array and its result share one logical_id across SSA
+        # versions; the prefix keeps this running-state key from colliding
+        # with value-uuid / name keys in ``results``.
+        state_key = f"__store_array_state__:{result_value.logical_id}"
+
+        if state_key in results:
+            # A previous store to the same logical array (earlier in this
+            # iteration or in a previous one): continue from its contents.
+            base = results[state_key]
         else:
             base = self._resolve_store_base(op.array, context, results, scoped_locals)
 
@@ -320,7 +331,12 @@ class ClassicalExecutor:
         elements[index] = self._get_value(
             op.stored_value, context, results, scoped_locals
         )
-        results[result_value.uuid] = tuple(elements)
+        updated = tuple(elements)
+        # The shared key chains subsequent stores to the same logical array;
+        # the per-version uuid entry keeps downstream reads of this SSA
+        # version and block-output resolution via output_refs working.
+        results[state_key] = updated
+        results[result_value.uuid] = updated
 
     def _resolve_store_base(
         self,

--- a/qamomile/circuit/transpiler/classical_executor.py
+++ b/qamomile/circuit/transpiler/classical_executor.py
@@ -12,7 +12,10 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
     NotOp,
     PhiOp,
 )
-from qamomile.circuit.ir.operation.classical_ops import DecodeQFixedOperation
+from qamomile.circuit.ir.operation.classical_ops import (
+    DecodeQFixedOperation,
+    StoreArrayElementOperation,
+)
 from qamomile.circuit.ir.operation.control_flow import (
     ForItemsOperation,
     ForOperation,
@@ -20,7 +23,13 @@ from qamomile.circuit.ir.operation.control_flow import (
     IfOperation,
     WhileOperation,
 )
-from qamomile.circuit.ir.value import ArrayValue, DictValue, TupleValue, Value
+from qamomile.circuit.ir.value import (
+    ArrayValue,
+    DictValue,
+    TupleValue,
+    Value,
+    resolve_root_array_index,
+)
 from qamomile.circuit.transpiler.errors import ExecutionError
 from qamomile.circuit.transpiler.execution_context import ExecutionContext
 from qamomile.circuit.transpiler.segments import ClassicalSegment
@@ -72,6 +81,8 @@ class ClassicalExecutor:
             self._execute_phi(op, context, results, scoped_locals)
         elif isinstance(op, DecodeQFixedOperation):
             self._execute_decode_qfixed(op, context, results, scoped_locals)
+        elif isinstance(op, StoreArrayElementOperation):
+            self._execute_store_array_element(op, context, results, scoped_locals)
         elif isinstance(op, ForOperation):
             self._execute_for(op, context, results, scoped_locals)
         elif isinstance(op, ForItemsOperation):
@@ -249,6 +260,149 @@ class ClassicalExecutor:
         if op.results:
             results[op.results[0].uuid] = value
 
+    def _execute_store_array_element(
+        self,
+        op: StoreArrayElementOperation,
+        context: ExecutionContext,
+        results: dict[str, Any],
+        scoped_locals: dict[str, Any],
+    ) -> None:
+        """Execute a classical array element store.
+
+        Reads the current contents of the source array, replaces the
+        addressed element with the stored value, and records the updated
+        container under the result value's UUID.
+
+        Inside a loop body the same store op executes once per iteration
+        while the IR carries a single ``source -> result`` version pair.
+        To keep iterations cumulative, the base contents are taken from
+        the op's own previous result (``results[result.uuid]``) when
+        present, falling back to the source array otherwise.  In that
+        loop-carried mode, an operand that reads an element of the *same
+        logical array* would see the pre-loop contents instead of the
+        previous iteration's — a silent divergence from Python
+        semantics — so such stores are rejected loudly.
+
+        Args:
+            op (StoreArrayElementOperation): The store to execute.
+            context (ExecutionContext): Execution context holding
+                measurements and bindings.
+            results (dict[str, Any]): Mutable results map; the updated
+                container is recorded under ``op.results[0].uuid``.
+            scoped_locals (dict[str, Any]): Loop-scoped variables.
+
+        Raises:
+            ExecutionError: If the source array contents cannot be
+                resolved, the index is out of range, or a loop-carried
+                store reads an element of the same logical array.
+        """
+        result_value = op.results[0]
+
+        if result_value.uuid in results:
+            # Loop-carried iteration: continue from the previous
+            # iteration's contents and reject same-array element reads
+            # (they would silently see stale pre-loop data).
+            self._reject_stale_same_array_read(op)
+            base = results[result_value.uuid]
+        else:
+            base = self._resolve_store_base(op.array, context, results, scoped_locals)
+
+        index_values = op.index_values
+        if len(index_values) != 1:
+            raise ExecutionError(
+                f"StoreArrayElementOperation supports 1-D arrays only; "
+                f"got {len(index_values)} indices."
+            )
+        index = int(self._get_value(index_values[0], context, results, scoped_locals))
+
+        elements = list(base)
+        if not 0 <= index < len(elements):
+            raise ExecutionError(
+                f"Store index {index} is out of range for array "
+                f"'{op.array.name}' of length {len(elements)}."
+            )
+        elements[index] = self._get_value(
+            op.stored_value, context, results, scoped_locals
+        )
+        results[result_value.uuid] = tuple(elements)
+
+    def _reject_stale_same_array_read(self, op: StoreArrayElementOperation) -> None:
+        """Reject loop-carried stores that read the same logical array.
+
+        The IR carries one ``source -> result`` array version pair per
+        store op, so operand element reads always reference a fixed
+        source version.  Across loop iterations that version no longer
+        reflects earlier iterations' writes; evaluating such a read
+        would silently diverge from Python's sequential semantics (e.g.
+        ``bits[i] = bits[i - 1]`` would copy the original contents
+        instead of propagating).  Called only in loop-carried mode.
+
+        Args:
+            op (StoreArrayElementOperation): The store being executed.
+
+        Raises:
+            ExecutionError: If the stored value or any index reads an
+                element of the same logical array the store writes.
+        """
+        result_logical = op.results[0].logical_id
+        for operand in (op.stored_value, *op.index_values):
+            parent = getattr(operand, "parent_array", None)
+            if parent is not None and parent.logical_id == result_logical:
+                raise ExecutionError(
+                    f"Classical array element store into "
+                    f"'{op.array.name}' reads an element of the same "
+                    f"array inside a loop; self-referential in-loop "
+                    f"updates are not supported yet.  Restructure the "
+                    f"kernel to read from a different array or perform "
+                    f"the update outside the loop."
+                )
+
+    def _resolve_store_base(
+        self,
+        array_value: ArrayValue,
+        context: ExecutionContext,
+        results: dict[str, Any],
+        scoped_locals: dict[str, Any],
+    ) -> Any:
+        """Resolve the full contents of a store's source array.
+
+        Tries the whole-container lookup used for reads
+        (:meth:`_get_array_data`) first, then falls back to assembling
+        per-element composite carrier keys (``"<uuid>_<index>"``) — the
+        format under which measurement results are loaded into the
+        execution context.
+
+        Args:
+            array_value (ArrayValue): The store's source array operand.
+            context (ExecutionContext): Execution context holding
+                measurements and bindings.
+            results (dict[str, Any]): Results map of the current segment.
+            scoped_locals (dict[str, Any]): Loop-scoped variables.
+
+        Returns:
+            Any: A sequence with the array's current contents.
+
+        Raises:
+            ExecutionError: If neither a whole container nor per-element
+                keys can be resolved.
+        """
+        container = self._get_array_data(array_value, context, results, scoped_locals)
+        if container is not None:
+            return container
+
+        elements: list[Any] = []
+        i = 0
+        while context.has(f"{array_value.uuid}_{i}"):
+            elements.append(context.get(f"{array_value.uuid}_{i}"))
+            i += 1
+        if elements:
+            return tuple(elements)
+
+        raise ExecutionError(
+            f"Array contents for '{array_value.name}' could not be "
+            f"resolved for element store."
+        )
+
     def _execute_for(
         self,
         op: ForOperation,
@@ -389,6 +543,16 @@ class ClassicalExecutor:
             indexed_key = f"{parent.name}[{indices[0]}]"
             if context.has(indexed_key):
                 return context.get(indexed_key)
+            # Measurement results are loaded into the context under
+            # per-element composite carrier keys ("<root_uuid>_<index>").
+            # Compose slice views back onto the root so a view-local
+            # index addresses the right physical slot.
+            resolved = resolve_root_array_index(parent, indices[0])
+            if resolved is not None:
+                root_array, root_index = resolved
+                composite_key = f"{root_array.uuid}_{root_index}"
+                if context.has(composite_key):
+                    return context.get(composite_key)
 
         raise ExecutionError(
             f"Array element {parent.name}{indices} could not be resolved"

--- a/qamomile/circuit/transpiler/classical_executor.py
+++ b/qamomile/circuit/transpiler/classical_executor.py
@@ -277,11 +277,10 @@ class ClassicalExecutor:
         while the IR carries a single ``source -> result`` version pair.
         To keep iterations cumulative, the base contents are taken from
         the op's own previous result (``results[result.uuid]``) when
-        present, falling back to the source array otherwise.  In that
-        loop-carried mode, an operand that reads an element of the *same
-        logical array* would see the pre-loop contents instead of the
-        previous iteration's — a silent divergence from Python
-        semantics — so such stores are rejected loudly.
+        present, falling back to the source array otherwise.  Stores that
+        read an element of the same logical array they write (which would
+        see stale pre-loop contents in this loop-carried mode) are
+        rejected earlier, at compile time, by ``AnalyzePass``.
 
         Args:
             op (StoreArrayElementOperation): The store to execute.
@@ -293,16 +292,13 @@ class ClassicalExecutor:
 
         Raises:
             ExecutionError: If the source array contents cannot be
-                resolved, the index is out of range, or a loop-carried
-                store reads an element of the same logical array.
+                resolved or the index is out of range.
         """
         result_value = op.results[0]
 
         if result_value.uuid in results:
             # Loop-carried iteration: continue from the previous
-            # iteration's contents and reject same-array element reads
-            # (they would silently see stale pre-loop data).
-            self._reject_stale_same_array_read(op)
+            # iteration's contents.
             base = results[result_value.uuid]
         else:
             base = self._resolve_store_base(op.array, context, results, scoped_locals)
@@ -325,37 +321,6 @@ class ClassicalExecutor:
             op.stored_value, context, results, scoped_locals
         )
         results[result_value.uuid] = tuple(elements)
-
-    def _reject_stale_same_array_read(self, op: StoreArrayElementOperation) -> None:
-        """Reject loop-carried stores that read the same logical array.
-
-        The IR carries one ``source -> result`` array version pair per
-        store op, so operand element reads always reference a fixed
-        source version.  Across loop iterations that version no longer
-        reflects earlier iterations' writes; evaluating such a read
-        would silently diverge from Python's sequential semantics (e.g.
-        ``bits[i] = bits[i - 1]`` would copy the original contents
-        instead of propagating).  Called only in loop-carried mode.
-
-        Args:
-            op (StoreArrayElementOperation): The store being executed.
-
-        Raises:
-            ExecutionError: If the stored value or any index reads an
-                element of the same logical array the store writes.
-        """
-        result_logical = op.results[0].logical_id
-        for operand in (op.stored_value, *op.index_values):
-            parent = getattr(operand, "parent_array", None)
-            if parent is not None and parent.logical_id == result_logical:
-                raise ExecutionError(
-                    f"Classical array element store into "
-                    f"'{op.array.name}' reads an element of the same "
-                    f"array inside a loop; self-referential in-loop "
-                    f"updates are not supported yet.  Restructure the "
-                    f"kernel to read from a different array or perform "
-                    f"the update outside the loop."
-                )
 
     def _resolve_store_base(
         self,

--- a/qamomile/circuit/transpiler/classical_executor.py
+++ b/qamomile/circuit/transpiler/classical_executor.py
@@ -338,6 +338,73 @@ class ClassicalExecutor:
         results[state_key] = updated
         results[result_value.uuid] = updated
 
+    def _materialize_loop_store_defaults(
+        self,
+        operations: list[Operation],
+        context: ExecutionContext,
+        results: dict[str, Any],
+        scoped_locals: dict[str, Any],
+    ) -> None:
+        """Materialize zero-iteration defaults for loop-carried array stores.
+
+        Store operations inside a traced loop produce SSA result values
+        even when the loop executes zero times at runtime.  Python
+        semantics leave the array unchanged in that case, so each store
+        result in the loop body must resolve to the current pre-loop
+        contents until an executed iteration overwrites it.
+
+        Args:
+            operations (list[Operation]): Loop body operations to scan,
+                including nested control-flow bodies.
+            context (ExecutionContext): Execution context holding
+                measurements and bindings.
+            results (dict[str, Any]): Mutable results map seeded with
+                default store outputs.
+            scoped_locals (dict[str, Any]): Loop-scoped variables.
+
+        Raises:
+            ExecutionError: If a store's source array cannot be resolved.
+        """
+        for op in operations:
+            if isinstance(op, StoreArrayElementOperation):
+                self._materialize_store_default(op, context, results, scoped_locals)
+            elif isinstance(op, HasNestedOps):
+                for body in op.nested_op_lists():
+                    self._materialize_loop_store_defaults(
+                        body, context, results, scoped_locals
+                    )
+
+    def _materialize_store_default(
+        self,
+        op: StoreArrayElementOperation,
+        context: ExecutionContext,
+        results: dict[str, Any],
+        scoped_locals: dict[str, Any],
+    ) -> None:
+        """Record a store result as the current source-array contents.
+
+        Args:
+            op (StoreArrayElementOperation): Store whose result should
+                default to the pre-loop array state.
+            context (ExecutionContext): Execution context holding
+                measurements and bindings.
+            results (dict[str, Any]): Mutable results map updated under
+                both the store result UUID and the logical running-state key.
+            scoped_locals (dict[str, Any]): Loop-scoped variables.
+
+        Raises:
+            ExecutionError: If the source array cannot be resolved.
+        """
+        result_value = op.results[0]
+        state_key = f"__store_array_state__:{result_value.logical_id}"
+        base = (
+            results[state_key]
+            if state_key in results
+            else self._resolve_store_base(op.array, context, results, scoped_locals)
+        )
+        results[state_key] = base
+        results[result_value.uuid] = base
+
     def _resolve_store_base(
         self,
         array_value: ArrayValue,
@@ -411,6 +478,9 @@ class ClassicalExecutor:
         if step == 0:
             raise ExecutionError("ForOperation step must not be zero")
 
+        self._materialize_loop_store_defaults(
+            op.operations, context, results, scoped_locals
+        )
         for loop_value in range(start, stop, step):
             loop_scope = scoped_locals.copy()
             loop_scope[op.loop_var] = loop_value
@@ -429,6 +499,9 @@ class ClassicalExecutor:
 
         iterable = self._get_iterable(op.operands[0], context, results, scoped_locals)
 
+        self._materialize_loop_store_defaults(
+            op.operations, context, results, scoped_locals
+        )
         for key, value in iterable:
             loop_scope = scoped_locals.copy()
             self._bind_for_items_key(loop_scope, op, key)

--- a/qamomile/circuit/transpiler/passes/analyze.py
+++ b/qamomile/circuit/transpiler/passes/analyze.py
@@ -6,6 +6,8 @@ import dataclasses
 
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
+from qamomile.circuit.ir.operation.control_flow import HasNestedOps, IfOperation
 from qamomile.circuit.ir.operation.gate import MeasureOperation, MeasureVectorOperation
 from qamomile.circuit.ir.operation.operation import OperationKind
 from qamomile.circuit.ir.value import Value, ValueBase
@@ -168,6 +170,9 @@ class AnalyzePass(Pass[Block, Block]):
         # Check inputs/outputs are classical
         self._validate_io_classical(input)
 
+        # Reject classical element stores inside runtime if/else branches
+        self._reject_stores_in_if_branches(input.operations)
+
         # Build dependency graph
         dependency_graph = self._build_dependency_graph(input.operations)
 
@@ -203,6 +208,63 @@ class AnalyzePass(Pass[Block, Block]):
                     f"got {value.type.label()}",
                     value_name=value.name,
                 )
+
+    def _reject_stores_in_if_branches(self, operations: list[Operation]) -> None:
+        """Reject classical element stores nested under a runtime if/else.
+
+        A ``StoreArrayElementOperation`` produces a fresh SSA version of
+        the array, but the frontend's branch tracing has no phi merge for
+        array values: post-if reads would reference the branch-local
+        version unconditionally, silently diverging from Python semantics
+        when the branch is not taken.  Compile-time ``if``s (classical
+        conditions resolvable from ``bindings``) were already flattened by
+        ``CompileTimeIfLoweringPass`` before this pass runs, so only
+        runtime (measurement-backed) branches reach this check.
+
+        Args:
+            operations (list[Operation]): Operations to scan.  Recurses
+                through all control flow; any store anywhere inside an
+                ``IfOperation`` branch (including nested loops) is
+                rejected.
+
+        Raises:
+            ValidationError: If a classical element store appears inside
+                an if/else branch.
+        """
+
+        def contains_store(ops: list[Operation]) -> bool:
+            """Return whether any (nested) op is a classical element store.
+
+            Args:
+                ops (list[Operation]): Operations to scan recursively.
+
+            Returns:
+                bool: ``True`` if a ``StoreArrayElementOperation`` is
+                    found at any nesting depth.
+            """
+            for op in ops:
+                if isinstance(op, StoreArrayElementOperation):
+                    return True
+                if isinstance(op, HasNestedOps) and any(
+                    contains_store(body) for body in op.nested_op_lists()
+                ):
+                    return True
+            return False
+
+        for op in operations:
+            if isinstance(op, IfOperation):
+                if any(contains_store(body) for body in op.nested_op_lists()):
+                    raise ValidationError(
+                        "Classical array element assignment inside an "
+                        "if/else branch is not supported: array values "
+                        "have no phi merge, so the write would apply "
+                        "regardless of the branch taken. Restructure the "
+                        "kernel to perform the assignment outside the "
+                        "branch."
+                    )
+            elif isinstance(op, HasNestedOps):
+                for body in op.nested_op_lists():
+                    self._reject_stores_in_if_branches(body)
 
     def _build_dependency_graph(
         self,

--- a/qamomile/circuit/transpiler/passes/analyze.py
+++ b/qamomile/circuit/transpiler/passes/analyze.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import Any
 
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation import Operation
+from qamomile.circuit.ir.operation.arithmetic_operations import PhiOp
 from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
 from qamomile.circuit.ir.operation.control_flow import (
     ForItemsOperation,
@@ -19,6 +21,10 @@ from qamomile.circuit.ir.operation.operation import OperationKind
 from qamomile.circuit.ir.value import Value, ValueBase
 from qamomile.circuit.transpiler.errors import DependencyError, ValidationError
 from qamomile.circuit.transpiler.passes import Pass
+from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
+    evaluate_classical_op_concrete,
+    resolve_compile_time_condition,
+)
 from qamomile.circuit.transpiler.passes.control_flow_visitor import ControlFlowVisitor
 
 # ---------------------------------------------------------------------------
@@ -152,7 +158,10 @@ def find_measurement_derived_values(
     return derived
 
 
-def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
+def reject_self_referential_loop_stores(
+    operations: list[Operation],
+    bindings: dict[str, Any] | None = None,
+) -> None:
     """Reject in-loop classical element stores that read the same array.
 
     A loop body is traced once, so a ``StoreArrayElementOperation``
@@ -164,6 +173,15 @@ def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
     (e.g. ``vals[i] = vals[0] + 1`` would write the same folded value
     every iteration).  Such stores are rejected at compile time.
 
+    ``IfOperation``s are classified with the same condition resolution
+    ``CompileTimeIfLoweringPass`` uses (via ``bindings``): a compile-time
+    condition contributes only its taken branch to the scan (a dead
+    branch is eliminated by the lowering pass, so a self-referential
+    store inside it never executes), while a runtime condition's
+    branches are skipped entirely — every store inside a runtime
+    if branch is rejected by ``AnalyzePass._reject_stores_in_if_branches``
+    regardless of self-reference.
+
     Exposed at module scope because it must run from two passes:
     ``PartialEvaluationPass`` calls it *before* constant folding (folding
     a bound element read to a constant erases the ``parent_array``
@@ -174,29 +192,106 @@ def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
     Args:
         operations (list[Operation]): Operations to scan.  Recurses
             through all control flow; every loop at any nesting depth is
-            checked against all stores anywhere inside its body.
+            checked against the stores inside its body (if branches per
+            the classification above).
+        bindings (dict[str, Any] | None): Compile-time parameter bindings
+            used to resolve ``IfOperation`` conditions, matching what
+            ``CompileTimeIfLoweringPass`` will later resolve.  Defaults
+            to None (no bindings): only constant conditions resolve and
+            all others are treated as runtime — correct for the
+            ``AnalyzePass`` safety-net call, where compile-time ifs are
+            already lowered away and any store left inside an if branch
+            was already rejected.
 
     Raises:
         ValidationError: If a store inside a loop transitively reads an
             element of the same logical array it writes.
     """
+    resolved_bindings = bindings or {}
 
-    def flatten_ops(ops: list[Operation]) -> list[Operation]:
+    def prune_compile_time_ifs(
+        ops: list[Operation],
+        concrete_values: dict[str, Any],
+    ) -> list[Operation]:
+        """Replace compile-time-decidable ``IfOperation``s by their taken branch.
+
+        Mirrors ``CompileTimeIfLoweringPass``: conditions are resolved
+        with the shared ``resolve_compile_time_condition`` /
+        ``evaluate_classical_op_concrete`` helpers so the taken / dead /
+        runtime classification here cannot disagree with the branch the
+        lowering pass will actually keep.  For a resolved condition the
+        taken branch's operations are inlined (recursively pruned) and
+        each ``PhiOp`` is reduced to its selected source operand, so
+        phi-mediated dataflow out of the branch stays visible to the
+        dependency scan without dead-branch edges.  Runtime
+        ``IfOperation``s are kept intact: their branch stores are
+        excluded from the store scan below, while their dataflow keeps
+        feeding the dependency graph exactly as before.
+
+        Args:
+            ops (list[Operation]): Operations to prune, in program order.
+            concrete_values (dict[str, Any]): UUID-keyed concrete
+                classical-op results accumulated along the walk.
+                Updated in place (nested non-if bodies get a copy,
+                matching the lowering pass's scoping).
+
+        Returns:
+            list[Operation]: The pruned view of ``ops``.
+        """
+        pruned: list[Operation] = []
+        for op in ops:
+            evaluate_classical_op_concrete(op, concrete_values, resolved_bindings)
+            if isinstance(op, IfOperation):
+                taken = resolve_compile_time_condition(
+                    op.condition, concrete_values, resolved_bindings
+                )
+                if taken is None:
+                    pruned.append(op)
+                    continue
+                branch = op.true_operations if taken else op.false_operations
+                pruned.extend(prune_compile_time_ifs(branch, concrete_values))
+                for phi in op.phi_ops:
+                    if isinstance(phi, PhiOp):
+                        selected = phi.true_value if taken else phi.false_value
+                        pruned.append(dataclasses.replace(phi, operands=[selected]))
+                continue
+            if isinstance(op, HasNestedOps):
+                op = op.rebuild_nested(
+                    [
+                        prune_compile_time_ifs(body, dict(concrete_values))
+                        for body in op.nested_op_lists()
+                    ]
+                )
+            pruned.append(op)
+        return pruned
+
+    def flatten_ops(
+        ops: list[Operation],
+        *,
+        into_if_branches: bool = True,
+    ) -> list[Operation]:
         """Flatten operations recursively through nested control flow.
 
         Args:
             ops (list[Operation]): Operations to flatten.
+            into_if_branches (bool): When ``True`` (default), recurse
+                into ``IfOperation`` bodies too.  ``False`` skips them —
+                used to collect the loops and stores this check scans,
+                since stores inside a (runtime) if branch are rejected
+                by ``AnalyzePass._reject_stores_in_if_branches`` instead.
 
         Returns:
-            list[Operation]: All operations at every nesting depth,
-                including the control flow ops themselves.
+            list[Operation]: All reachable operations, including the
+                control flow ops themselves.
         """
         flat: list[Operation] = []
         for op in ops:
             flat.append(op)
+            if not into_if_branches and isinstance(op, IfOperation):
+                continue
             if isinstance(op, HasNestedOps):
                 for body in op.nested_op_lists():
-                    flat.extend(flatten_ops(body))
+                    flat.extend(flatten_ops(body, into_if_branches=into_if_branches))
         return flat
 
     def register_value(value: ValueBase, table: dict[str, ValueBase]) -> None:
@@ -245,20 +340,26 @@ def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
         return False
 
     def check_loop_body(body_ops: list[Operation]) -> None:
-        """Reject self-referential stores anywhere inside one loop body.
+        """Reject self-referential stores inside one (pruned) loop body.
 
         Builds a dependency graph restricted to the loop body (reads
         performed before the loop are loop-invariant and fold correctly,
         so they must not trigger a rejection) and BFS-walks it from each
-        store's value and index operands.
+        store's value and index operands.  The graph and value table
+        cover the full body — including surviving runtime-if internals,
+        so a store after an if still sees phi-mediated reads — while the
+        store scan itself skips if branches (those stores are rejected
+        by ``AnalyzePass._reject_stores_in_if_branches``).
 
         Args:
             body_ops (list[Operation]): The loop's top-level body
-                operations.
+                operations, already pruned of compile-time-decidable
+                if branches.
 
         Raises:
-            ValidationError: If a store's value or index transitively
-                reads an element of the array the store writes.
+            ValidationError: If a scanned store's value or index
+                transitively reads an element of the array the store
+                writes.
         """
         dependency_graph = build_dependency_graph(body_ops)
         flat_ops = flatten_ops(body_ops)
@@ -268,7 +369,7 @@ def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
             for value in (*op.all_input_values(), *op.results):
                 register_value(value, value_table)
 
-        for op in flat_ops:
+        for op in flatten_ops(body_ops, into_if_branches=False):
             if not isinstance(op, StoreArrayElementOperation):
                 continue
             written_logical = op.results[0].logical_id
@@ -303,7 +404,8 @@ def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
                         worklist.append(parent.uuid)
                 worklist.extend(dependency_graph.get(current, ()))
 
-    for op in flatten_ops(operations):
+    pruned_operations = prune_compile_time_ifs(operations, {})
+    for op in flatten_ops(pruned_operations, into_if_branches=False):
         if isinstance(op, (ForOperation, ForItemsOperation, WhileOperation)):
             check_loop_body(
                 [body_op for body in op.nested_op_lists() for body_op in body]
@@ -442,7 +544,12 @@ class AnalyzePass(Pass[Block, Block]):
         Thin wrapper for the module-level
         :func:`reject_self_referential_loop_stores` so
         ``PartialEvaluationPass`` can reuse the same check without
-        instantiating ``AnalyzePass``.
+        instantiating ``AnalyzePass``.  Called without bindings: by this
+        stage ``CompileTimeIfLoweringPass`` has already eliminated
+        compile-time ifs, so any surviving ``IfOperation`` classifies as
+        runtime and its branches are skipped — safe, because
+        :meth:`_reject_stores_in_if_branches` (run just before this
+        check) already rejected every store inside an if branch.
 
         Args:
             operations (list[Operation]): Operations to scan recursively.

--- a/qamomile/circuit/transpiler/passes/analyze.py
+++ b/qamomile/circuit/transpiler/passes/analyze.py
@@ -7,7 +7,13 @@ import dataclasses
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation import Operation
 from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
-from qamomile.circuit.ir.operation.control_flow import HasNestedOps, IfOperation
+from qamomile.circuit.ir.operation.control_flow import (
+    ForItemsOperation,
+    ForOperation,
+    HasNestedOps,
+    IfOperation,
+    WhileOperation,
+)
 from qamomile.circuit.ir.operation.gate import MeasureOperation, MeasureVectorOperation
 from qamomile.circuit.ir.operation.operation import OperationKind
 from qamomile.circuit.ir.value import Value, ValueBase
@@ -146,6 +152,164 @@ def find_measurement_derived_values(
     return derived
 
 
+def reject_self_referential_loop_stores(operations: list[Operation]) -> None:
+    """Reject in-loop classical element stores that read the same array.
+
+    A loop body is traced once, so a ``StoreArrayElementOperation``
+    inside a loop references a fixed pre-loop version of the array it
+    writes.  If the stored value or the store index reads an element of
+    that same logical array — directly or through classical arithmetic —
+    later iterations would observe stale pre-loop contents instead of
+    earlier iterations' writes, silently diverging from Python semantics
+    (e.g. ``vals[i] = vals[0] + 1`` would write the same folded value
+    every iteration).  Such stores are rejected at compile time.
+
+    Exposed at module scope because it must run from two passes:
+    ``PartialEvaluationPass`` calls it *before* constant folding (folding
+    a bound element read to a constant erases the ``parent_array``
+    provenance this check relies on — the fold is exactly what bakes the
+    stale pre-loop value into the loop body), and ``AnalyzePass`` calls
+    it again as a safety net for pipelines that skip ``partial_eval``.
+
+    Args:
+        operations (list[Operation]): Operations to scan.  Recurses
+            through all control flow; every loop at any nesting depth is
+            checked against all stores anywhere inside its body.
+
+    Raises:
+        ValidationError: If a store inside a loop transitively reads an
+            element of the same logical array it writes.
+    """
+
+    def flatten_ops(ops: list[Operation]) -> list[Operation]:
+        """Flatten operations recursively through nested control flow.
+
+        Args:
+            ops (list[Operation]): Operations to flatten.
+
+        Returns:
+            list[Operation]: All operations at every nesting depth,
+                including the control flow ops themselves.
+        """
+        flat: list[Operation] = []
+        for op in ops:
+            flat.append(op)
+            if isinstance(op, HasNestedOps):
+                for body in op.nested_op_lists():
+                    flat.extend(flatten_ops(body))
+        return flat
+
+    def register_value(value: ValueBase, table: dict[str, ValueBase]) -> None:
+        """Record a value and its structural references in ``table``.
+
+        Recurses through ``element_indices``, ``parent_array``, and
+        ``slice_of`` chains so the BFS below can resolve every UUID the
+        dependency graph may reach back to a ``Value``.
+
+        Args:
+            value (ValueBase): Value to record, keyed by UUID.
+            table (dict[str, ValueBase]): Mutable UUID-to-value map.
+        """
+        if value.uuid in table:
+            return
+        table[value.uuid] = value
+        for index in getattr(value, "element_indices", ()):
+            register_value(index, table)
+        parent = getattr(value, "parent_array", None)
+        if parent is not None:
+            register_value(parent, table)
+        slice_of = getattr(value, "slice_of", None)
+        if slice_of is not None:
+            register_value(slice_of, table)
+
+    def reads_written_array(value: ValueBase, written_logical: str) -> bool:
+        """Check whether a value is an element read of the written array.
+
+        Walks the ``parent_array`` / ``slice_of`` chain so element reads
+        through strided views of the written array are caught too.
+
+        Args:
+            value (ValueBase): Value to inspect.
+            written_logical (str): ``logical_id`` of the array the store
+                writes.
+
+        Returns:
+            bool: ``True`` if the value reads an element of the written
+                logical array.
+        """
+        chain = getattr(value, "parent_array", None)
+        while chain is not None:
+            if chain.logical_id == written_logical:
+                return True
+            chain = getattr(chain, "slice_of", None)
+        return False
+
+    def check_loop_body(body_ops: list[Operation]) -> None:
+        """Reject self-referential stores anywhere inside one loop body.
+
+        Builds a dependency graph restricted to the loop body (reads
+        performed before the loop are loop-invariant and fold correctly,
+        so they must not trigger a rejection) and BFS-walks it from each
+        store's value and index operands.
+
+        Args:
+            body_ops (list[Operation]): The loop's top-level body
+                operations.
+
+        Raises:
+            ValidationError: If a store's value or index transitively
+                reads an element of the array the store writes.
+        """
+        dependency_graph = build_dependency_graph(body_ops)
+        flat_ops = flatten_ops(body_ops)
+
+        value_table: dict[str, ValueBase] = {}
+        for op in flat_ops:
+            for value in (*op.all_input_values(), *op.results):
+                register_value(value, value_table)
+
+        for op in flat_ops:
+            if not isinstance(op, StoreArrayElementOperation):
+                continue
+            written_logical = op.results[0].logical_id
+            worklist = [v.uuid for v in (op.stored_value, *op.index_values)]
+            visited: set[str] = set()
+            while worklist:
+                current = worklist.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                value = value_table.get(current)
+                if value is not None:
+                    if reads_written_array(value, written_logical):
+                        raise ValidationError(
+                            f"Classical array element assignment into "
+                            f"'{op.array.name}' inside a loop reads an "
+                            f"element of the same array (directly or "
+                            f"through classical arithmetic): the loop "
+                            f"body references a fixed pre-loop array "
+                            f"version, so the read would not observe "
+                            f"earlier iterations' writes. Restructure "
+                            f"the kernel to read from a different array "
+                            f"or perform the update outside the loop."
+                        )
+                    # Follow structural references so same-array reads
+                    # hiding inside an element address are found too.
+                    worklist.extend(
+                        index.uuid for index in getattr(value, "element_indices", ())
+                    )
+                    parent = getattr(value, "parent_array", None)
+                    if parent is not None:
+                        worklist.append(parent.uuid)
+                worklist.extend(dependency_graph.get(current, ()))
+
+    for op in flatten_ops(operations):
+        if isinstance(op, (ForOperation, ForItemsOperation, WhileOperation)):
+            check_loop_body(
+                [body_op for body in op.nested_op_lists() for body_op in body]
+            )
+
+
 class AnalyzePass(Pass[Block, Block]):
     """Analyze and validate an affine block.
 
@@ -172,6 +336,9 @@ class AnalyzePass(Pass[Block, Block]):
 
         # Reject classical element stores inside runtime if/else branches
         self._reject_stores_in_if_branches(input.operations)
+
+        # Reject in-loop classical element stores that read the same array
+        self._reject_self_referential_loop_stores(input.operations)
 
         # Build dependency graph
         dependency_graph = self._build_dependency_graph(input.operations)
@@ -265,6 +432,26 @@ class AnalyzePass(Pass[Block, Block]):
             elif isinstance(op, HasNestedOps):
                 for body in op.nested_op_lists():
                     self._reject_stores_in_if_branches(body)
+
+    def _reject_self_referential_loop_stores(
+        self,
+        operations: list[Operation],
+    ) -> None:
+        """Reject in-loop classical element stores that read the same array.
+
+        Thin wrapper for the module-level
+        :func:`reject_self_referential_loop_stores` so
+        ``PartialEvaluationPass`` can reuse the same check without
+        instantiating ``AnalyzePass``.
+
+        Args:
+            operations (list[Operation]): Operations to scan recursively.
+
+        Raises:
+            ValidationError: If a store inside a loop transitively reads
+                an element of the same logical array it writes.
+        """
+        reject_self_referential_loop_stores(operations)
 
     def _build_dependency_graph(
         self,

--- a/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
+++ b/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
@@ -40,6 +40,91 @@ from .eval_utils import FoldPolicy, fold_classical_op
 from .value_mapping import ValueSubstitutor
 
 
+def resolve_compile_time_condition(
+    condition: Any,
+    concrete_values: dict[str, Any],
+    bindings: dict[str, Any],
+) -> bool | None:
+    """Resolve an ``IfOperation`` condition to a compile-time bool.
+
+    Single source of truth for classifying an if-condition as
+    compile-time taken / dead / runtime.  Used by
+    :class:`CompileTimeIfLoweringPass` to decide which branches to lower
+    and by ``reject_self_referential_loop_stores`` to prune the same
+    branches from its scan — both callers must agree on the
+    classification, so they share this function.
+
+    Tries ``resolve_if_condition`` first (plain Python values, constant
+    Values, direct UUID / name bindings), then falls back to the
+    accumulated ``concrete_values`` map for expression-derived
+    conditions (``CompOp`` / ``CondOp`` / ``NotOp`` / ``BinOp`` chains
+    evaluated by :func:`evaluate_classical_op_concrete`).
+
+    Args:
+        condition (Any): The condition operand.  May be a plain Python
+            value or a ``Value``.
+        concrete_values (dict[str, Any]): UUID-keyed map of concrete
+            classical-op results accumulated in program order.
+        bindings (dict[str, Any]): Compile-time parameter bindings.
+
+    Returns:
+        bool | None: The condition's compile-time truth value, or
+            ``None`` when it is not compile-time resolvable (a runtime
+            condition).
+    """
+    resolved = resolve_if_condition(condition, bindings)
+    if resolved is not None:
+        return resolved
+    if hasattr(condition, "uuid") and condition.uuid in concrete_values:
+        return bool(concrete_values[condition.uuid])
+    return None
+
+
+def evaluate_classical_op_concrete(
+    op: Operation,
+    concrete_values: dict[str, Any],
+    bindings: dict[str, Any],
+) -> None:
+    """Try to evaluate a classical op and record its concrete result.
+
+    Supported operation types:
+
+    - ``CompOp``  — comparison (==, !=, <, <=, >, >=)
+    - ``CondOp``  — logical connective (and, or)
+    - ``NotOp``   — logical negation
+    - ``BinOp``   — arithmetic (+, -, *, /, //, %)
+
+    Delegates the actual fold to ``fold_classical_op`` under the
+    ``COMPILE_TIME`` policy, which bypasses the runtime-parameter
+    guard: everything in ``bindings`` is treated as a real
+    compile-time value.  Other operation types are silently ignored.
+    If evaluation fails, nothing is recorded and downstream
+    ``IfOperation``s referencing the result remain unresolved.
+
+    Args:
+        op (Operation): The operation to evaluate.
+        concrete_values (dict[str, Any]): UUID-keyed map of concrete
+            results; the op's result is recorded here on success.
+            Updated in place.
+        bindings (dict[str, Any]): Compile-time parameter bindings used
+            to resolve operands.
+    """
+    if not isinstance(op, (CompOp, CondOp, NotOp, BinOp)):
+        return
+    if not op.results:
+        return
+    result = fold_classical_op(
+        op,
+        lambda v: UnifiedValueResolver(
+            context=concrete_values, bindings=bindings
+        ).resolve(v),
+        parameters=set(),
+        policy=FoldPolicy.COMPILE_TIME,
+    )
+    if result is not None:
+        concrete_values[op.results[0].uuid] = result
+
+
 def _array_carrier_keys(
     source: ValueBase,
     num_bits: int,
@@ -150,21 +235,23 @@ class CompileTimeIfLoweringPass(Pass[Block, Block]):
     ) -> bool | None:
         """Resolve an IfOperation condition to a compile-time bool.
 
-        Tries ``resolve_if_condition`` first (handles plain Python values,
-        constants, direct bindings).  Then falls back to expression-aware
-        evaluation using the accumulated ``concrete_values`` map.
+        Thin wrapper for the module-level
+        :func:`resolve_compile_time_condition` bound to this pass's
+        bindings, so external callers (the self-referential loop-store
+        check) classify conditions exactly the way this pass does.
+
+        Args:
+            condition (Any): The condition operand to resolve.
+            concrete_values (dict[str, Any]): Accumulated concrete
+                classical-op results, keyed by UUID.
+
+        Returns:
+            bool | None: The compile-time truth value, or ``None`` when
+                the condition is runtime.
         """
-        # Fast path: direct resolution.
-        resolved = resolve_if_condition(condition, self._bindings)
-        if resolved is not None:
-            return resolved
-
-        # Expression-aware path: check if the condition's UUID is in
-        # concrete_values (produced by a prior CompOp/CondOp/NotOp).
-        if hasattr(condition, "uuid") and condition.uuid in concrete_values:
-            return bool(concrete_values[condition.uuid])
-
-        return None
+        return resolve_compile_time_condition(
+            condition, concrete_values, self._bindings
+        )
 
     def _try_evaluate_classical_op(
         self,
@@ -173,46 +260,18 @@ class CompileTimeIfLoweringPass(Pass[Block, Block]):
     ) -> None:
         """Try to evaluate a classical op and record its result.
 
-        Supported operation types:
-
-        - ``CompOp``  — comparison (==, !=, <, <=, >, >=)
-        - ``CondOp``  — logical connective (and, or)
-        - ``NotOp``   — logical negation
-        - ``BinOp``   — arithmetic (+, -, *, /, //, %)
-
-        Delegates the actual fold to ``fold_classical_op`` under the
-        ``COMPILE_TIME`` policy, which bypasses the runtime-parameter
-        guard. At this stage there are no runtime parameters in the
+        Thin wrapper for the module-level
+        :func:`evaluate_classical_op_concrete` bound to this pass's
+        bindings.  At this stage there are no runtime parameters in the
         concrete values map; everything in ``self._bindings`` is treated
         as a real compile-time value.
 
-        Other operation types are silently ignored. If all operands of a
-        supported op are concrete but evaluation still fails, the result
-        is not recorded and downstream IfOperations referencing it will
-        remain unresolved (emitted as runtime branches).
+        Args:
+            op (Operation): The operation to evaluate.
+            concrete_values (dict[str, Any]): UUID-keyed concrete-result
+                map, updated in place on success.
         """
-        if not isinstance(op, (CompOp, CondOp, NotOp, BinOp)):
-            return
-        if not op.results:
-            return
-        result = fold_classical_op(
-            op,
-            lambda v: self._resolve_operand(v, concrete_values),
-            parameters=set(),
-            policy=FoldPolicy.COMPILE_TIME,
-        )
-        if result is not None:
-            concrete_values[op.results[0].uuid] = result
-
-    def _resolve_operand(
-        self,
-        value: Any,
-        concrete_values: dict[str, Any],
-    ) -> Any:
-        """Resolve an operand to a concrete value, or None."""
-        return UnifiedValueResolver(
-            context=concrete_values, bindings=self._bindings
-        ).resolve(value)
+        evaluate_classical_op_concrete(op, concrete_values, self._bindings)
 
     # ------------------------------------------------------------------
     # Operation lowering

--- a/qamomile/circuit/transpiler/passes/constant_fold.py
+++ b/qamomile/circuit/transpiler/passes/constant_fold.py
@@ -12,12 +12,13 @@ from qamomile.circuit.ir.operation import (
     SliceArrayOperation,
 )
 from qamomile.circuit.ir.operation.arithmetic_operations import BinOp, BinOpKind
+from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
 from qamomile.circuit.ir.operation.gate import (
     ConcreteControlledU,
     ControlledUOperation,
     SymbolicControlledU,
 )
-from qamomile.circuit.ir.value import Value, ValueBase
+from qamomile.circuit.ir.value import ArrayValue, Value, ValueBase
 from qamomile.circuit.transpiler.errors import ValidationError
 from qamomile.circuit.transpiler.value_resolver import (
     ValueResolver as UnifiedValueResolver,
@@ -82,8 +83,13 @@ class ConstantFoldingPass(Pass[Block, Block]):
         # Track folded values: uuid -> constant Value
         folded_values: dict[str, Value] = {}
 
+        # Block-output UUIDs: a folded store whose result is returned must
+        # stay in the IR so the classical executor materializes the value
+        # at runtime (folding records compile-time metadata only).
+        output_uuids = {v.uuid for v in input.output_values if isinstance(v, ValueBase)}
+
         # Process operations
-        new_ops = self._fold_operations(input.operations, folded_values)
+        new_ops = self._fold_operations(input.operations, folded_values, output_uuids)
 
         return dataclasses.replace(input, operations=new_ops)
 
@@ -91,11 +97,32 @@ class ConstantFoldingPass(Pass[Block, Block]):
         self,
         operations: list[Operation],
         folded_values: dict[str, Value],
+        output_uuids: set[str] | None = None,
     ) -> list[Operation]:
         """Process operations, folding constant BinOps."""
         outer_self = self
+        block_output_uuids = output_uuids or set()
 
         class ConstantFoldingTransformer(OperationTransformer):
+            def __init__(self) -> None:
+                """Initialize the transformer with zero control-flow depth."""
+                self._nesting_depth = 0
+
+            def _transform_control_flow(self, op: Operation) -> Operation:
+                """Recurse into control-flow bodies, tracking nesting depth.
+
+                Args:
+                    op (Operation): The (possibly control-flow) operation.
+
+                Returns:
+                    Operation: The operation with nested bodies transformed.
+                """
+                self._nesting_depth += 1
+                try:
+                    return super()._transform_control_flow(op)
+                finally:
+                    self._nesting_depth -= 1
+
             def transform_operation(self, op: Operation) -> Operation | None:
                 if isinstance(op, BinOp):
                     folded = outer_self._try_fold_binop(op, folded_values)
@@ -104,6 +131,36 @@ class ConstantFoldingPass(Pass[Block, Block]):
                         # Just record the mapping for later substitution
                         folded_values[op.results[0].uuid] = folded
                         return None
+
+                # Classical array element stores fold only at the top
+                # level: inside a loop body the store executes once per
+                # iteration (possibly zero times), so a single folded
+                # contents snapshot would be wrong.
+                if (
+                    isinstance(op, StoreArrayElementOperation)
+                    and self._nesting_depth == 0
+                ):
+                    substituted = cast(
+                        StoreArrayElementOperation,
+                        outer_self._substitute_folded_operands(op, folded_values),
+                    )
+                    folded_array = outer_self._try_fold_store_array_element(
+                        substituted, folded_values
+                    )
+                    if folded_array is not None:
+                        folded_values[op.results[0].uuid] = folded_array
+                        if op.results[0].uuid in block_output_uuids:
+                            # Returned arrays still need a runtime store so
+                            # the executor can materialize the output; the
+                            # substituted result carries the folded
+                            # contents for compile-time readers.
+                            return outer_self._substitute_folded_results(
+                                substituted, folded_values
+                            )
+                        return None
+                    return outer_self._substitute_folded_results(
+                        substituted, folded_values
+                    )
 
                 # SliceArrayOperation is purely declarative: its result
                 # (a sliced ``ArrayValue``) already carries all required
@@ -182,6 +239,73 @@ class ConstantFoldingPass(Pass[Block, Block]):
             name=f"folded_{op.results[0].name}",
             uuid=op.results[0].uuid,  # Keep same UUID for substitution
         ).with_const(result_value)
+
+    def _try_fold_store_array_element(
+        self,
+        op: StoreArrayElementOperation,
+        folded_values: dict[str, Value],
+    ) -> ArrayValue | None:
+        """Try to fold a classical element store into constant array contents.
+
+        A store folds when the source array's contents, the index, and the
+        stored value are all compile-time resolvable (const metadata,
+        bindings, or previously folded values).  The folded result is the
+        op's result ``ArrayValue`` (same UUID) carrying the updated
+        ``const_array`` metadata, so downstream element reads resolve
+        against the post-store contents.
+
+        Args:
+            op (StoreArrayElementOperation): The store with operands
+                already substituted from ``folded_values``.
+            folded_values (dict[str, Value]): Map from folded value UUIDs
+                to their constant replacements.
+
+        Returns:
+            ArrayValue | None: The result value with updated
+                ``const_array`` metadata, or ``None`` when any input is
+                not compile-time resolvable (the store then executes at
+                runtime) or the constant index is out of range (left for
+                the runtime path to reject loudly).
+        """
+        if len(op.operands) != 3:
+            # Multi-dimensional stores are rejected at the frontend; leave
+            # any programmatically constructed op for runtime rejection.
+            return None
+
+        array_value = op.operands[0]
+        if not isinstance(array_value, ArrayValue):
+            return None
+
+        container = array_value.get_const_array()
+        if container is None:
+            name = array_value.name
+            if name and name in self._bindings:
+                container = self._bindings[name]
+            elif array_value.is_parameter():
+                param_name = array_value.parameter_name()
+                if param_name and param_name in self._bindings:
+                    container = self._bindings[param_name]
+        if container is None:
+            return None
+
+        stored = self._resolve_value(op.operands[1], folded_values)
+        index = self._resolve_value(op.operands[2], folded_values)
+        if stored is None or index is None:
+            return None
+
+        try:
+            concrete_index = int(index)
+            elements = list(container)
+        except (TypeError, ValueError):
+            return None
+        if not 0 <= concrete_index < len(elements):
+            return None
+
+        elements[concrete_index] = stored
+        result = op.results[0]
+        if not isinstance(result, ArrayValue):
+            return None
+        return result.with_array_runtime_metadata(const_array=tuple(elements))
 
     def _resolve_value(
         self,

--- a/qamomile/circuit/transpiler/passes/constant_fold.py
+++ b/qamomile/circuit/transpiler/passes/constant_fold.py
@@ -99,7 +99,30 @@ class ConstantFoldingPass(Pass[Block, Block]):
         folded_values: dict[str, Value],
         output_uuids: set[str] | None = None,
     ) -> list[Operation]:
-        """Process operations, folding constant BinOps."""
+        """Fold constant BinOps and top-level classical element stores.
+
+        Constant ``BinOp``s are removed from the stream and recorded in
+        ``folded_values`` for operand/result substitution.  Top-level
+        ``StoreArrayElementOperation``s whose inputs are all compile-time
+        resolvable are folded into updated ``const_array`` metadata on
+        the result; the folded store is stripped unless its result is a
+        block output (returned arrays keep the runtime store so the
+        executor materializes the final contents).  All other operations
+        get folded values substituted into their operands and results.
+
+        Args:
+            operations (list[Operation]): Operations to process.
+                Recurses through control-flow bodies; stores inside a
+                loop body never fold (they execute once per iteration).
+            folded_values (dict[str, Value]): Map from folded value
+                UUIDs to their constant replacements.  Updated in place.
+            output_uuids (set[str] | None): UUIDs of block output
+                values; a folded store producing one of these stays in
+                the IR.  Defaults to None (no outputs).
+
+        Returns:
+            list[Operation]: The transformed operation list.
+        """
         outer_self = self
         block_output_uuids = output_uuids or set()
 
@@ -277,7 +300,15 @@ class ConstantFoldingPass(Pass[Block, Block]):
             return None
 
         container = array_value.get_const_array()
-        if container is None:
+        if container is None and getattr(array_value, "version", 0) == 0:
+            # Name-keyed bindings (and parameter-name bindings) describe
+            # the *initial* (version-0) contents of a kernel argument.  A
+            # later SSA version — produced by a prior store that did NOT
+            # fold, so its result carries no ``const_array`` — must not
+            # fold against that stale pre-store snapshot.  Leaving
+            # ``container`` unresolved keeps the store as a correct
+            # runtime operation.  Mirrors the version guard in
+            # ``value_resolver._resolve_array_element``.
             name = array_value.name
             if name and name in self._bindings:
                 container = self._bindings[name]

--- a/qamomile/circuit/transpiler/passes/partial_eval.py
+++ b/qamomile/circuit/transpiler/passes/partial_eval.py
@@ -7,6 +7,9 @@ from typing import Any
 from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.transpiler.errors import ValidationError
 from qamomile.circuit.transpiler.passes import Pass
+from qamomile.circuit.transpiler.passes.analyze import (
+    reject_self_referential_loop_stores,
+)
 from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
     CompileTimeIfLoweringPass,
 )
@@ -24,6 +27,22 @@ class PartialEvaluationPass(Pass[Block, Block]):
         return "partial_eval"
 
     def run(self, input: Block) -> Block:
+        """Fold constants and lower compile-time control flow.
+
+        Args:
+            input (Block): Block to evaluate.  ``AFFINE`` in the normal
+                pipeline; ``HIERARCHICAL`` is also accepted for the
+                self-recursion unroll loop (see inline comment).
+
+        Returns:
+            Block: Block with constants folded and compile-time-resolvable
+                ``IfOperation``s lowered.
+
+        Raises:
+            ValidationError: If the block kind is not ``AFFINE`` /
+                ``HIERARCHICAL``, or if a classical element store inside a
+                loop reads an element of the array it writes.
+        """
         # HIERARCHICAL is accepted so that the self-recursion unroll loop
         # can interleave inline (which leaves one CallBlockOperation per
         # self-ref per iteration) with partial_eval (which folds the
@@ -34,6 +53,12 @@ class PartialEvaluationPass(Pass[Block, Block]):
                 f"PartialEvaluationPass expects AFFINE or HIERARCHICAL "
                 f"block, got {input.kind}",
             )
+
+        # Reject self-referential in-loop classical stores BEFORE folding:
+        # ConstantFoldingPass folds bound element reads to plain constants,
+        # which both erases the parent-array provenance this check needs
+        # and bakes the stale pre-loop value into every loop iteration.
+        reject_self_referential_loop_stores(input.operations)
 
         # Keep ``SliceArrayOperation`` nodes through partial_eval so
         # the downstream ``SliceBorrowCheckPass`` can use them as

--- a/qamomile/circuit/transpiler/passes/partial_eval.py
+++ b/qamomile/circuit/transpiler/passes/partial_eval.py
@@ -73,4 +73,10 @@ class PartialEvaluationPass(Pass[Block, Block]):
         # linearity check by ``StripSliceArrayOpsPass`` so segmentation
         # still sees a classical-op-free quantum segment stream.
         folded = ConstantFoldingPass(self._bindings, strip_slice_ops=False).run(input)
-        return CompileTimeIfLoweringPass(self._bindings).run(folded)
+        lowered = CompileTimeIfLoweringPass(self._bindings).run(folded)
+
+        # Compile-time-if lowering can hoist a live branch's store out of
+        # an IfOperation body. Run constant folding again so stores that
+        # were previously nested become top-level fold candidates before
+        # segmentation/emit decides whether they belong to a quantum segment.
+        return ConstantFoldingPass(self._bindings, strip_slice_ops=False).run(lowered)

--- a/qamomile/circuit/transpiler/passes/partial_eval.py
+++ b/qamomile/circuit/transpiler/passes/partial_eval.py
@@ -58,7 +58,12 @@ class PartialEvaluationPass(Pass[Block, Block]):
         # ConstantFoldingPass folds bound element reads to plain constants,
         # which both erases the parent-array provenance this check needs
         # and bakes the stale pre-loop value into every loop iteration.
-        reject_self_referential_loop_stores(input.operations)
+        # Bindings let the check resolve IfOperation conditions the same
+        # way CompileTimeIfLoweringPass will: a store inside a
+        # compile-time-dead branch is not rejected (the branch is about
+        # to be eliminated), while a compile-time-taken branch's store is
+        # still caught here, pre-fold.
+        reject_self_referential_loop_stores(input.operations, self._bindings)
 
         # Keep ``SliceArrayOperation`` nodes through partial_eval so
         # the downstream ``SliceBorrowCheckPass`` can use them as

--- a/qamomile/circuit/transpiler/passes/standard_emit.py
+++ b/qamomile/circuit/transpiler/passes/standard_emit.py
@@ -27,6 +27,7 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
     RuntimeClassicalExpr,
 )
 from qamomile.circuit.ir.operation.cast import CastOperation
+from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
 from qamomile.circuit.ir.operation.composite_gate import (
     CompositeGateOperation,
 )
@@ -249,6 +250,23 @@ class StandardEmitPass(EmitPass[T], Generic[T]):
                 emit_controlled_u(self, circuit, op, qubit_map, bindings)
             elif isinstance(op, PauliEvolveOp):
                 self._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+            elif isinstance(op, StoreArrayElementOperation):
+                # Classical element stores execute host-side in classical
+                # segments (ClassicalExecutor) or fold at compile time.
+                # One reaching a quantum segment means the stored contents
+                # feed a quantum op without being compile-time resolvable;
+                # silently skipping it would emit stale gate parameters.
+                from qamomile.circuit.transpiler.errors import EmitError
+
+                raise EmitError(
+                    f"Classical array element store into "
+                    f"'{op.array.name or 'array'}' reached the quantum "
+                    f"segment. Stored elements consumed by quantum gates "
+                    f"must be compile-time resolvable: bind the array and "
+                    f"the stored value via `bindings` instead of "
+                    f"`parameters`, or restructure the kernel so the "
+                    f"stored elements are not used as gate parameters."
+                )
             elif isinstance(op, CastOperation):
                 handle_cast(self, op, qubit_map)
             elif isinstance(op, BinOp):

--- a/qamomile/circuit/transpiler/value_resolver.py
+++ b/qamomile/circuit/transpiler/value_resolver.py
@@ -137,19 +137,35 @@ class ValueResolver:
         if root_array is None:
             return None
 
-        # Prefer const_array metadata because bound Vector inputs created
-        # by the frontend keep their compile-time payload on the root
-        # ArrayValue itself. Slice views intentionally walk back to the
-        # root before this lookup so view-local indices address the same
-        # compile-time container the user originally bound.
-        container = root_array.get_const_array()
+        # A folded classical element store records the post-store array
+        # (same UUID, updated ``const_array``) in the context map; prefer
+        # it so element reads observe the store instead of any stale
+        # metadata or name-based fallback below.
+        container = None
+        root_uuid = getattr(root_array, "uuid", None)
+        context_parent = self._context.get(root_uuid) if root_uuid else None
+        if isinstance(context_parent, ArrayValue):
+            container = context_parent.get_const_array()
+        if container is None:
+            # Prefer const_array metadata because bound Vector inputs created
+            # by the frontend keep their compile-time payload on the root
+            # ArrayValue itself. Slice views intentionally walk back to the
+            # root before this lookup so view-local indices address the same
+            # compile-time container the user originally bound.
+            container = root_array.get_const_array()
         if container is None:
             # Fall back to explicit bindings for callers that resolve an
             # element Value against a separate binding map instead of an
-            # ArrayValue carrying const_array metadata.
+            # ArrayValue carrying const_array metadata.  The name-keyed
+            # binding describes the *initial* (version-0) contents of a
+            # kernel argument; a later SSA version (produced by a classical
+            # element store) must not resolve to it — staying unresolved is
+            # a conservative, loud outcome, while a stale hit would bake
+            # pre-store contents into the compiled program silently.
             parent_name = getattr(root_array, "name", None)
             parent_uuid = getattr(root_array, "uuid", None)
-            if parent_name in self._bindings:
+            parent_version = getattr(root_array, "version", 0)
+            if parent_name in self._bindings and parent_version == 0:
                 container = self._bindings[parent_name]
             elif parent_uuid in self._bindings:
                 container = self._bindings[parent_uuid]

--- a/tests/circuit/test_classical_element_store.py
+++ b/tests/circuit/test_classical_element_store.py
@@ -300,6 +300,79 @@ def test_loop_index_cross_array_copy(seed, length):
 
 
 @qmc.qkernel
+def loop_two_store_kernel(
+    dst: qmc.Vector[qmc.UInt], src: qmc.Vector[qmc.UInt], n: qmc.UInt
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    for i in qmc.range(n):
+        dst[i] = src[i]
+        dst[0] = 99
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return dst, bits
+
+
+def test_loop_two_stores_same_array():
+    """Two stores to one array in a loop body share one running snapshot.
+
+    Keying the loop-carried accumulation by each store op's own result
+    uuid made the stores blind to each other across iterations: the
+    trailing ``dst[0] = 99`` store kept re-basing from the pre-loop
+    contents, yielding (99, 0, 0) instead of (99, 6, 7).
+    """
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_two_store_kernel,
+        bindings={"dst": [0, 0, 0], "src": [5, 6, 7]},
+        parameters=["n"],
+    )
+    out_vals, _ = exe.run(transpiler.executor(), bindings={"n": 3}).result()
+    assert tuple(int(v) for v in out_vals) == (99, 6, 7)
+
+
+@pytest.mark.parametrize("seed, length", [(0, 2), (1, 3), (42, 5)])
+def test_loop_two_stores_random_src(seed, length):
+    """Randomized sizes/contents keep both same-array stores cumulative."""
+    rng = np.random.default_rng(seed)
+    src = rng.integers(1, 50, size=length).tolist()
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_two_store_kernel,
+        bindings={"dst": [0] * length, "src": src},
+        parameters=["n"],
+    )
+    out_vals, _ = exe.run(transpiler.executor(), bindings={"n": length}).result()
+    assert tuple(int(v) for v in out_vals) == (99, *src[1:])
+
+
+@qmc.qkernel
+def loop_pair_fill_kernel(
+    dst: qmc.Vector[qmc.UInt], n: qmc.UInt
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    for i in qmc.range(n):
+        dst[2 * i] = 1
+        dst[2 * i + 1] = 2
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return dst, bits
+
+
+@pytest.mark.parametrize("pairs, expected", [(1, (1, 2, 0, 0)), (2, (1, 2, 1, 2))])
+def test_loop_pair_fill_same_array(pairs, expected):
+    """Even/odd stores to one array interleave correctly across iterations.
+
+    With per-store-uuid accumulation, n=2 over four slots yielded
+    (1, 2, 0, 2): iteration 1's even-slot store never saw iteration 0's
+    odd-slot write and vice versa.
+    """
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_pair_fill_kernel, bindings={"dst": [0, 0, 0, 0]}, parameters=["n"]
+    )
+    out_vals, _ = exe.run(transpiler.executor(), bindings={"n": pairs}).result()
+    assert tuple(int(v) for v in out_vals) == expected
+
+
+@qmc.qkernel
 def loop_self_referential_kernel(
     vals: qmc.Vector[qmc.UInt], n: qmc.UInt
 ) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:

--- a/tests/circuit/test_classical_element_store.py
+++ b/tests/circuit/test_classical_element_store.py
@@ -426,6 +426,55 @@ def test_loop_self_referential_store_via_arithmetic_rejected():
         )
 
 
+@qmc.qkernel
+def loop_conditional_self_referential_kernel(
+    dst: qmc.Vector[qmc.UInt],
+    src: qmc.Vector[qmc.UInt],
+    n: qmc.UInt,
+    flag: qmc.UInt,
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    for i in qmc.range(n):
+        dst[i] = src[i]
+        if flag:
+            dst[i] = dst[0]
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return dst, bits
+
+
+def test_loop_self_ref_in_dead_branch_allowed():
+    """A self-referential store in a compile-time-dead branch is not rejected.
+
+    With ``flag`` bound to 0 the ``if`` branch is eliminated before it can
+    execute, so the enclosed ``dst[i] = dst[0]`` never runs and the loop
+    reduces to the cross-array copy ``dst[i] = src[i]``.
+    """
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_conditional_self_referential_kernel,
+        bindings={"dst": [0, 0, 0], "src": [7, 8, 9], "flag": 0},
+        parameters=["n"],
+    )
+    out_vals, _ = exe.run(transpiler.executor(), bindings={"n": 3}).result()
+    assert tuple(int(v) for v in out_vals) == (7, 8, 9)
+
+
+def test_loop_self_ref_in_live_branch_rejected():
+    """A self-referential store in a compile-time-taken branch is still rejected.
+
+    With ``flag`` bound to 1 the ``if`` branch is hoisted into the loop, so
+    the enclosed ``dst[i] = dst[0]`` is a live self-referential store and
+    must be rejected at compile time (before folding erases provenance).
+    """
+    transpiler = QiskitTranspiler()
+    with pytest.raises(ValidationError, match="same array"):
+        transpiler.transpile(
+            loop_conditional_self_referential_kernel,
+            bindings={"dst": [0, 0, 0], "src": [7, 8, 9], "flag": 1},
+            parameters=["n"],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Rejected forms (loud errors instead of silent drops)
 # ---------------------------------------------------------------------------

--- a/tests/circuit/test_classical_element_store.py
+++ b/tests/circuit/test_classical_element_store.py
@@ -22,7 +22,6 @@ import qamomile.circuit as qmc
 from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
 from qamomile.circuit.transpiler.errors import (
     EmitError,
-    ExecutionError,
     ValidationError,
 )
 
@@ -302,9 +301,8 @@ def test_loop_index_cross_array_copy(seed, length):
 
 @qmc.qkernel
 def loop_self_referential_kernel(
-    vals: qmc.Vector[qmc.UInt],
+    vals: qmc.Vector[qmc.UInt], n: qmc.UInt
 ) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
-    n = vals.shape[0]
     for i in qmc.range(1, n):
         vals[i] = vals[0]
     qs = qmc.qubit_array(1, "qs")
@@ -313,18 +311,46 @@ def loop_self_referential_kernel(
 
 
 def test_loop_self_referential_store_raises():
-    """Reading the written array inside a multi-iteration loop fails loudly.
+    """Reading the written array inside a runtime loop fails at compile time.
 
     The single traced store references a fixed pre-loop array version, so
-    iteration >= 2 would silently read stale contents; the executor rejects
-    it instead of diverging from Python semantics.
+    iteration >= 2 would silently read stale contents; the transpiler
+    rejects the kernel at compile time (pre-fold in partial_eval, again in
+    analyze) instead of diverging from Python semantics.
     """
     transpiler = QiskitTranspiler()
-    exe = transpiler.transpile(
-        loop_self_referential_kernel, bindings={"vals": [5, 0, 0]}
-    )
-    with pytest.raises(ExecutionError, match="same +array inside a loop"):
-        exe.run(transpiler.executor()).result()
+    with pytest.raises(ValidationError, match="same array"):
+        transpiler.transpile(
+            loop_self_referential_kernel,
+            bindings={"vals": [5, 0, 0]},
+            parameters=["n"],
+        )
+
+
+@qmc.qkernel
+def loop_arithmetic_self_referential_kernel(
+    vals: qmc.Vector[qmc.UInt], n: qmc.UInt
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    for i in qmc.range(n):
+        vals[i] = vals[0] + 1
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return vals, bits
+
+
+def test_loop_self_referential_store_via_arithmetic_rejected():
+    """A same-array read behind a BinOp (``vals[i] = vals[0] + 1``) is rejected.
+
+    The old immediate-operand runtime guard missed this arithmetic-intermediary
+    form and silently wrote the folded pre-loop value every iteration.
+    """
+    transpiler = QiskitTranspiler()
+    with pytest.raises(ValidationError, match="same array"):
+        transpiler.transpile(
+            loop_arithmetic_self_referential_kernel,
+            bindings={"vals": [10, 0, 0]},
+            parameters=["n"],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/circuit/test_classical_element_store.py
+++ b/tests/circuit/test_classical_element_store.py
@@ -217,6 +217,17 @@ def angle_store_kernel(vals: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
     return qmc.measure(qs)
 
 
+@qmc.qkernel
+def compile_time_if_angle_store_kernel(
+    vals: qmc.Vector[qmc.Float], flag: qmc.UInt
+) -> qmc.Vector[qmc.Bit]:
+    qs = qmc.qubit_array(1, "qs")
+    if flag:
+        vals[1] = vals[0]
+    qs[0] = qmc.rx(qs[0], vals[1])
+    return qmc.measure(qs)
+
+
 @pytest.mark.parametrize("seed", [0, 1, 2, 42])
 def test_stored_element_folds_into_gate_angle(seed):
     """Reading a stored element as a gate angle bakes the post-store value.
@@ -235,6 +246,22 @@ def test_stored_element_folds_into_gate_angle(seed):
         if inst.operation.name == "rx"
     ]
     np.testing.assert_allclose(emitted, [angle], atol=1e-12)
+
+
+def test_compile_time_if_store_folds_into_gate_angle():
+    """A live compile-time-if branch store folds before feeding a gate angle."""
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        compile_time_if_angle_store_kernel,
+        bindings={"vals": [float(np.pi), 0.0], "flag": 1},
+    )
+    circuit = exe.compiled_quantum[0].circuit
+    emitted = [
+        float(inst.operation.params[0])
+        for inst in circuit.data
+        if inst.operation.name == "rx"
+    ]
+    np.testing.assert_allclose(emitted, [float(np.pi)], atol=1e-12)
 
 
 def test_stored_pi_angle_flips_qubit(backend):
@@ -327,6 +354,18 @@ def test_loop_two_stores_same_array():
     )
     out_vals, _ = exe.run(transpiler.executor(), bindings={"n": 3}).result()
     assert tuple(int(v) for v in out_vals) == (99, 6, 7)
+
+
+def test_loop_store_zero_iterations_returns_original_array():
+    """A zero-iteration loop preserves the pre-loop array contents."""
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_two_store_kernel,
+        bindings={"dst": [4, 5, 6], "src": [7, 8, 9]},
+        parameters=["n"],
+    )
+    out_vals, _ = exe.run(transpiler.executor(), bindings={"n": 0}).result()
+    assert tuple(int(v) for v in out_vals) == (4, 5, 6)
 
 
 @pytest.mark.parametrize("seed, length", [(0, 2), (1, 3), (42, 5)])

--- a/tests/circuit/test_classical_element_store.py
+++ b/tests/circuit/test_classical_element_store.py
@@ -1,0 +1,533 @@
+"""Regression tests for classical array element assignment in qkernels.
+
+Classical element assignment (``bits[1] = bits[0]``) used to emit no IR at
+all: ``ArrayBase._return_element`` only released frontend borrow
+bookkeeping for classical element types, so the write was silently dropped
+and the compiled program returned the pre-store contents (see the
+quantum-side counterpart fixed on the reject-foreign-qubit-assign branch).
+The write is now a real ``StoreArrayElementOperation``: compile-time
+resolvable stores fold into ``const_array`` metadata, measurement-derived
+stores execute host-side in a classical segment, and every unsupported
+route (slice views, multi-dimensional arrays, if/else branches, quantum
+segment leakage, self-referential loop updates) fails loudly instead of
+miscompiling.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.ir.operation.classical_ops import StoreArrayElementOperation
+from qamomile.circuit.transpiler.errors import (
+    EmitError,
+    ExecutionError,
+    ValidationError,
+)
+
+pytest.importorskip("qiskit")
+
+from qamomile.qiskit import QiskitTranspiler  # noqa: E402
+
+Backend = tuple[str, Any, Any]
+
+
+@pytest.fixture(
+    params=[
+        "qiskit",
+        pytest.param("quri_parts", marks=pytest.mark.quri_parts),
+        pytest.param("cudaq", marks=pytest.mark.cudaq),
+    ]
+)
+def backend(request) -> Backend:
+    """Yield ``(name, transpiler, executor)`` for each installed SDK backend."""
+    name = request.param
+    if name == "qiskit":
+        from qamomile.qiskit import QiskitTranspiler
+
+        transpiler = QiskitTranspiler()
+        return name, transpiler, transpiler.executor()
+    if name == "quri_parts":
+        pytest.importorskip("quri_parts")
+        pytest.importorskip("quri_parts.qulacs")
+        from qamomile.quri_parts import QuriPartsTranspiler
+
+        transpiler = QuriPartsTranspiler()
+        return name, transpiler, transpiler.executor()
+    if name == "cudaq":
+        pytest.importorskip("cudaq")
+        from qamomile.cudaq import CudaqTranspiler
+
+        transpiler = CudaqTranspiler()
+        return name, transpiler, transpiler.executor()
+    raise AssertionError(f"unknown backend {name}")
+
+
+def _counts(result: Any) -> dict[Any, int]:
+    """Convert a sample result to a count map keyed by output tuples."""
+    counts: dict[Any, int] = {}
+    for bits, count in result.results:
+        key = tuple(
+            tuple(int(b) for b in part) if isinstance(part, tuple) else int(part)
+            for part in bits
+        )
+        counts[key] = counts.get(key, 0) + int(count)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Vector[Bit] (measurement-derived)
+# ---------------------------------------------------------------------------
+
+
+@qmc.qkernel
+def copy_bit_kernel() -> qmc.Vector[qmc.Bit]:
+    qs = qmc.qubit_array(2, "qs")
+    qs[0] = qmc.x(qs[0])
+    bits = qmc.measure(qs)
+    bits[1] = bits[0]
+    return bits
+
+
+def test_measured_bit_store_repro(backend):
+    """The original silent-drop repro: bits[1] = bits[0] must yield (1, 1).
+
+    Before the fix the write was dropped and sampling returned (1, 0).
+    """
+    name, transpiler, executor = backend
+    exe = transpiler.transpile(copy_bit_kernel)
+    counts = _counts(exe.sample(executor, shots=100).result())
+    assert counts == {(1, 1): 100}, f"{name}: got {counts}"
+
+
+@qmc.qkernel
+def chained_bit_kernel() -> qmc.Vector[qmc.Bit]:
+    qs = qmc.qubit_array(3, "qs")
+    qs[0] = qmc.x(qs[0])
+    bits = qmc.measure(qs)
+    bits[1] = bits[0]
+    bits[2] = bits[1]
+    return bits
+
+
+def test_measured_bit_chained_stores(backend):
+    """Chained stores read the post-store contents of the previous store."""
+    name, transpiler, executor = backend
+    exe = transpiler.transpile(chained_bit_kernel)
+    counts = _counts(exe.sample(executor, shots=100).result())
+    assert counts == {(1, 1, 1): 100}, f"{name}: got {counts}"
+
+
+@qmc.qkernel
+def bit_literal_kernel() -> qmc.Vector[qmc.Bit]:
+    qs = qmc.qubit_array(2, "qs")
+    bits = qmc.measure(qs)
+    bits[1] = 1
+    return bits
+
+
+def test_measured_bit_literal_store(backend):
+    """A Python literal 0/1 can be stored into a measured Vector[Bit]."""
+    name, transpiler, executor = backend
+    exe = transpiler.transpile(bit_literal_kernel)
+    counts = _counts(exe.sample(executor, shots=100).result())
+    assert counts == {(0, 1): 100}, f"{name}: got {counts}"
+
+
+@qmc.qkernel
+def two_register_kernel() -> tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]:
+    qs = qmc.qubit_array(2, "qs")
+    zeros = qmc.qubit_array(2, "zeros")
+    for i in qmc.range(2):
+        qs[i] = qmc.x(qs[i])
+    bits = qmc.measure(qs)
+    dst = qmc.measure(zeros)
+    for i in qmc.range(2):
+        dst[i] = bits[i]
+    return dst, bits
+
+
+def test_measured_bit_loop_store_between_registers(backend):
+    """A loop-indexed store copies one register's readout into another's."""
+    name, transpiler, executor = backend
+    exe = transpiler.transpile(two_register_kernel)
+    counts = _counts(exe.sample(executor, shots=100).result())
+    assert counts == {((1, 1), (1, 1)): 100}, f"{name}: got {counts}"
+
+
+def test_run_returns_stored_bits():
+    """run() resolves the stored contents, matching the sample() path."""
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(copy_bit_kernel)
+    result = exe.run(transpiler.executor()).result()
+    assert tuple(int(b) for b in result) == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Vector[Float] / Vector[UInt] (binding-derived)
+# ---------------------------------------------------------------------------
+
+
+@qmc.qkernel
+def float_store_kernel(
+    vals: qmc.Vector[qmc.Float],
+) -> tuple[qmc.Vector[qmc.Float], qmc.Vector[qmc.Bit]]:
+    vals[1] = vals[0]
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return vals, bits
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42])
+def test_float_element_store_and_return(seed):
+    """A binding-derived Vector[Float] store is visible in the returned array."""
+    rng = np.random.default_rng(seed)
+    values = rng.uniform(-np.pi, np.pi, size=2).tolist()
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(float_store_kernel, bindings={"vals": values})
+    out_vals, out_bits = exe.run(transpiler.executor()).result()
+    np.testing.assert_allclose(out_vals, (values[0], values[0]), atol=1e-12)
+    assert tuple(out_bits) == (0,)
+
+
+@qmc.qkernel
+def uint_store_kernel(
+    vals: qmc.Vector[qmc.UInt],
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    vals[0] = vals[2]
+    vals[1] = 7
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return vals, bits
+
+
+def test_uint_element_and_literal_store():
+    """Element-copy and literal stores both land in a Vector[UInt] output."""
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(uint_store_kernel, bindings={"vals": [1, 2, 3]})
+    out_vals, _ = exe.run(transpiler.executor()).result()
+    assert tuple(int(v) for v in out_vals) == (3, 7, 3)
+
+
+@qmc.qkernel
+def angle_store_kernel(vals: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+    qs = qmc.qubit_array(1, "qs")
+    vals[1] = vals[0]
+    qs[0] = qmc.rx(qs[0], vals[1])
+    return qmc.measure(qs)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 42])
+def test_stored_element_folds_into_gate_angle(seed):
+    """Reading a stored element as a gate angle bakes the post-store value.
+
+    The store folds at compile time (all inputs bound), so the emitted rx
+    angle must equal the stored value — not the stale pre-store binding.
+    """
+    rng = np.random.default_rng(seed)
+    angle = float(rng.uniform(-np.pi, np.pi))
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(angle_store_kernel, bindings={"vals": [angle, 0.0]})
+    circuit = exe.compiled_quantum[0].circuit
+    emitted = [
+        float(inst.operation.params[0])
+        for inst in circuit.data
+        if inst.operation.name == "rx"
+    ]
+    np.testing.assert_allclose(emitted, [angle], atol=1e-12)
+
+
+def test_stored_pi_angle_flips_qubit(backend):
+    """End-to-end: rx(pi) through a stored element flips the qubit."""
+    name, transpiler, executor = backend
+    exe = transpiler.transpile(
+        angle_store_kernel, bindings={"vals": [float(np.pi), 0.0]}
+    )
+    counts = _counts(exe.sample(executor, shots=100).result())
+    assert counts == {(1,): 100}, f"{name}: got {counts}"
+
+
+# ---------------------------------------------------------------------------
+# Loop-index writes
+# ---------------------------------------------------------------------------
+
+
+@qmc.qkernel
+def loop_fill_kernel(
+    dst: qmc.Vector[qmc.UInt],
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    n = dst.shape[0]
+    for i in qmc.range(n):
+        dst[i] = 9
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return dst, bits
+
+
+@pytest.mark.parametrize("length", [1, 2, 3, 5])
+def test_loop_index_literal_fill(length):
+    """A loop-indexed literal store fills every slot across register sizes."""
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(loop_fill_kernel, bindings={"dst": [0] * length})
+    out_vals, _ = exe.run(transpiler.executor()).result()
+    assert tuple(int(v) for v in out_vals) == (9,) * length
+
+
+@qmc.qkernel
+def loop_copy_kernel(
+    src: qmc.Vector[qmc.Float], dst: qmc.Vector[qmc.Float]
+) -> tuple[qmc.Vector[qmc.Float], qmc.Vector[qmc.Bit]]:
+    n = dst.shape[0]
+    for i in qmc.range(n):
+        dst[i] = src[i]
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return dst, bits
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42])
+@pytest.mark.parametrize("length", [1, 2, 5])
+def test_loop_index_cross_array_copy(seed, length):
+    """A loop-indexed store copies another array element-by-element."""
+    rng = np.random.default_rng(seed)
+    src = rng.uniform(-1.0, 1.0, size=length).tolist()
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_copy_kernel, bindings={"src": src, "dst": [0.0] * length}
+    )
+    out_vals, _ = exe.run(transpiler.executor()).result()
+    np.testing.assert_allclose(out_vals, src, atol=1e-12)
+
+
+@qmc.qkernel
+def loop_self_referential_kernel(
+    vals: qmc.Vector[qmc.UInt],
+) -> tuple[qmc.Vector[qmc.UInt], qmc.Vector[qmc.Bit]]:
+    n = vals.shape[0]
+    for i in qmc.range(1, n):
+        vals[i] = vals[0]
+    qs = qmc.qubit_array(1, "qs")
+    bits = qmc.measure(qs)
+    return vals, bits
+
+
+def test_loop_self_referential_store_raises():
+    """Reading the written array inside a multi-iteration loop fails loudly.
+
+    The single traced store references a fixed pre-loop array version, so
+    iteration >= 2 would silently read stale contents; the executor rejects
+    it instead of diverging from Python semantics.
+    """
+    transpiler = QiskitTranspiler()
+    exe = transpiler.transpile(
+        loop_self_referential_kernel, bindings={"vals": [5, 0, 0]}
+    )
+    with pytest.raises(ExecutionError, match="same +array inside a loop"):
+        exe.run(transpiler.executor()).result()
+
+
+# ---------------------------------------------------------------------------
+# Rejected forms (loud errors instead of silent drops)
+# ---------------------------------------------------------------------------
+
+
+def test_type_mismatch_rejected():
+    """Storing a float literal into a Vector[UInt] raises TypeError at build."""
+
+    @qmc.qkernel
+    def bad_type(vals: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+        vals[0] = 1.5
+        qs = qmc.qubit_array(1, "qs")
+        return qmc.measure(qs)
+
+    with pytest.raises(TypeError, match="element type UInt"):
+        QiskitTranspiler().transpile(bad_type, bindings={"vals": [1]})
+
+
+def test_cross_type_handle_rejected():
+    """Storing a measured Bit handle into a Vector[UInt] raises TypeError."""
+
+    @qmc.qkernel
+    def bad_handle(vals: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(1, "qs")
+        bits = qmc.measure(qs)
+        vals[0] = bits[0]
+        return bits
+
+    with pytest.raises(TypeError, match="Cannot assign Bit"):
+        QiskitTranspiler().transpile(bad_handle, bindings={"vals": [1]})
+
+
+def test_bool_literal_rejected_for_uint():
+    """bool is not a valid UInt element value (mirrors index handling)."""
+
+    @qmc.qkernel
+    def bad_bool(vals: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+        vals[0] = True
+        qs = qmc.qubit_array(1, "qs")
+        return qmc.measure(qs)
+
+    with pytest.raises(TypeError, match="bool"):
+        QiskitTranspiler().transpile(bad_bool, bindings={"vals": [1]})
+
+
+def test_out_of_range_store_rejected():
+    """A constant index past the array length raises IndexError at build."""
+
+    @qmc.qkernel
+    def out_of_range(vals: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+        vals[5] = 1
+        qs = qmc.qubit_array(1, "qs")
+        return qmc.measure(qs)
+
+    with pytest.raises(IndexError, match="out of range"):
+        QiskitTranspiler().transpile(out_of_range, bindings={"vals": [1, 2]})
+
+
+def test_negative_index_store_rejected():
+    """Negative constant indices are rejected before any IR is built."""
+
+    @qmc.qkernel
+    def negative(vals: qmc.Vector[qmc.UInt]) -> qmc.Vector[qmc.Bit]:
+        vals[-1] = 1
+        qs = qmc.qubit_array(1, "qs")
+        return qmc.measure(qs)
+
+    with pytest.raises(NotImplementedError, match="Negative index"):
+        QiskitTranspiler().transpile(negative, bindings={"vals": [1, 2]})
+
+
+def test_view_store_rejected():
+    """Classical element stores through a slice view are rejected loudly."""
+
+    @qmc.qkernel
+    def view_store() -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(4, "qs")
+        bits = qmc.measure(qs)
+        view = bits[0:2]
+        view[0] = bits[3]
+        return bits
+
+    with pytest.raises(NotImplementedError, match="slice view"):
+        QiskitTranspiler().transpile(view_store)
+
+
+def test_matrix_store_rejected():
+    """Multi-dimensional classical stores are rejected loudly."""
+
+    @qmc.qkernel
+    def matrix_store(m: qmc.Matrix[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+        m[0, 1] = m[0, 0]
+        qs = qmc.qubit_array(1, "qs")
+        return qmc.measure(qs)
+
+    with pytest.raises(NotImplementedError, match="1-D"):
+        QiskitTranspiler().transpile(matrix_store, bindings={"m": [[1.0, 2.0]]})
+
+
+def test_if_branch_store_rejected():
+    """Stores inside a measurement-backed if/else branch are rejected.
+
+    Array values have no phi merge, so the store would apply regardless of
+    the branch taken.
+    """
+
+    @qmc.qkernel
+    def if_store() -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(2, "qs")
+        bits = qmc.measure(qs)
+        if bits[0]:
+            bits[1] = bits[0]
+        return bits
+
+    with pytest.raises(ValidationError, match="if/else branch"):
+        QiskitTranspiler().transpile(if_store)
+
+
+def test_store_in_quantum_loop_rejected():
+    """A store inside a mixed quantum/classical loop body fails at emit.
+
+    The mixed body routes the whole loop into the quantum segment; the
+    store cannot be emitted there and must not be silently skipped.
+    """
+
+    @qmc.qkernel
+    def mixed_loop(vals: qmc.Vector[qmc.Float]) -> qmc.Vector[qmc.Bit]:
+        qs = qmc.qubit_array(2, "qs")
+        for i in qmc.range(2):
+            qs[i] = qmc.h(qs[i])
+            vals[i] = 0.5
+        return qmc.measure(qs)
+
+    with pytest.raises(EmitError, match="reached the quantum segment"):
+        QiskitTranspiler().transpile(mixed_loop, bindings={"vals": [0.0, 0.0]})
+
+
+def test_runtime_parameter_store_feeding_gate_rejected():
+    """A non-foldable store whose element feeds a gate angle fails at emit.
+
+    With the array left as a runtime parameter the store cannot fold, so
+    the stale-metadata guard must surface an error instead of silently
+    emitting the pre-store binding as the angle.
+    """
+    with pytest.raises(EmitError, match="reached the quantum segment"):
+        QiskitTranspiler().transpile(angle_store_kernel, parameters=["vals"])
+
+
+# ---------------------------------------------------------------------------
+# IR structure and serialization
+# ---------------------------------------------------------------------------
+
+
+def test_store_op_shape_in_ir():
+    """The frontend emits one store op with [array, value, index] operands."""
+    transpiler = QiskitTranspiler()
+    block = transpiler.inline(transpiler.to_block(copy_bit_kernel))
+    stores = [
+        op for op in block.operations if isinstance(op, StoreArrayElementOperation)
+    ]
+    assert len(stores) == 1
+    store = stores[0]
+    assert len(store.operands) == 3
+    assert store.array.uuid != store.results[0].uuid
+    assert store.array.logical_id == store.results[0].logical_id
+    assert store.results[0].version == store.array.version + 1
+    # Stale compile-time payloads must not survive onto the result version.
+    assert store.results[0].metadata.scalar is None
+    assert store.results[0].metadata.array_runtime is None
+    # The block returns the post-store version, not the measure result.
+    assert block.output_values[0].uuid == store.results[0].uuid
+
+
+def test_store_op_serialize_roundtrip():
+    """A block containing a store op round-trips through JSON and msgpack."""
+    from qamomile.circuit.ir import serialize
+
+    transpiler = QiskitTranspiler()
+    block = transpiler.inline(transpiler.to_block(copy_bit_kernel))
+
+    for dump, load in (
+        (serialize.dump_json, serialize.load_json),
+        (serialize.dump_msgpack, serialize.load_msgpack),
+    ):
+        restored = load(dump(block))
+        restored_ops = [type(op).__name__ for op in restored.operations]
+        assert restored_ops == [type(op).__name__ for op in block.operations]
+        restored_store = next(
+            op
+            for op in restored.operations
+            if isinstance(op, StoreArrayElementOperation)
+        )
+        assert len(restored_store.operands) == 3
+        assert restored_store.results[0].uuid == block.output_values[0].uuid
+
+
+def test_store_op_canonicalize_stable():
+    """Canonicalization accepts store ops and hashes them stably."""
+    from qamomile.circuit.ir import canonical
+
+    transpiler = QiskitTranspiler()
+    block = transpiler.inline(transpiler.to_block(copy_bit_kernel))
+    canon = canonical.canonicalize(block)
+    assert canonical.content_hash(block) == canonical.content_hash(canon)


### PR DESCRIPTION
## Problem

Classical array element assignment inside a `@qkernel` was silently dropped. `ArrayBase._return_element` only released frontend borrow bookkeeping for classical element types and emitted no IR, so the write had no effect on the compiled program:

```python
@qmc.qkernel
def circuit() -> qmc.Vector[qmc.Bit]:
    qs = qmc.qubit_array(2, "qs")
    qs[0] = qmc.x(qs[0])
    bits = qmc.measure(qs)
    bits[1] = bits[0]   # silently dropped
    return bits
# sampling returned {(1, 0): N} — expected {(1, 1): N}
```

This is the classical counterpart of the foreign-qubit-assignment silent miscompile fixed in #541. Unlike qubits, classical values are freely copyable, so the correct semantics is to make the write actually work rather than reject it.

## Frontend / IR

A new `StoreArrayElementOperation` (CLASSICAL kind; operands `[array, stored_value, index]`; result is a fresh SSA version of the array with stale `scalar` / `array_runtime` metadata dropped) is emitted by the classical branch of `_return_element`. Quantum arrays are unchanged — qubit element assignment remains the return half of the borrow-return idiom and emits no IR. The op is registered in the serializer's closed dispatch tables (additive `$type` tag, no schema bump) and canonicalizes stably.

## Backend / pipeline

The store is evaluated in one of two places:

- **Compile time**: `ConstantFoldingPass` folds a top-level store whose contents, index, and stored value are all resolvable, recording the updated `const_array` on the result (the op is kept in the IR when its result is a block output so the executor still materializes it). Stores inside loops never fold — they run once per iteration.
- **Runtime**: otherwise the store executes host-side in a classical segment via `ClassicalExecutor`, assembling measured-array contents from per-element composite carrier keys and read-modify-writing its own previous result across loop iterations. `ValueResolver` prefers a context-recorded post-store array over `const_array`, and no longer resolves version≥1 arrays through name-keyed bindings (those describe the version-0 argument contents; a stale hit would bake pre-store data into gates).

Every unsupported route fails loudly instead of miscompiling: slice-view and multi-dimensional stores raise `NotImplementedError`, out-of-range constant indices raise `IndexError`, incompatible right-hand sides raise `TypeError`, stores inside runtime `if`/`else` branches (no phi merge for arrays) are rejected by `AnalyzePass`, and stores reaching a quantum segment (runtime-parameter arrays feeding gate angles, mixed quantum/classical loop bodies) raise `EmitError` instead of being silently skipped by the emit dispatcher.

## Self-referential in-loop stores (rejected at compile time)

A store inside a runtime (symbolic-bound) loop whose stored value or index reads an element of the same logical array — directly (`vals[i] = vals[0]`) or through arithmetic (`vals[i] = vals[0] + 1`) — bakes the pre-loop value into every iteration. `reject_self_referential_loop_stores` (module-level in `analyze.py`) walks each loop body's dependency graph and rejects these. It runs pre-fold in `PartialEvaluationPass` (folding erases the `parent_array` provenance the check needs and is itself what bakes the stale value) and again in `AnalyzePass` as a safety net. Cross-array copies, literal fills, and measured-bit copies between registers are unaffected. Same-index self-updates (`vals[i] = vals[i] + 1`) are conservatively rejected for now (they were silently dropped before this feature existed, so a loud error is a strict improvement); precise index analysis to admit them is a possible follow-up.

## Tests

`tests/circuit/test_classical_element_store.py` covers:

- measurement-derived `Vector[Bit]` (the original repro, chained stores, literal store, loop copies between registers) executed on **Qiskit, QURI Parts, and CUDA-Q**;
- binding-derived `Vector[Float]` / `Vector[UInt]` (returned contents and folded gate angles, randomized over seeds);
- loop-index writes across register sizes;
- every rejected form (type mismatch, cross-type handle, bool-into-UInt, out-of-range, negative index, slice view, matrix, if-branch, quantum-segment leakage, self-referential + arithmetic-self-referential);
- IR structure, JSON/msgpack round-trip, and canonical hashing.

Full unit suite green (`9035 passed`, one known local segfault deselected), `ruff check` / `ruff format --check` / `zuban check` all clean.

## Known limitations

- Same-index self-update (`vals[i] = vals[i] + 1`) is rejected rather than supported (see above).
- Classical element stores through a slice view and on multi-dimensional (`Matrix` / `Tensor`) arrays raise `NotImplementedError` — 1-D `Vector` only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
