### PR TITLE
Emit the Hamiltonian constant as a global phase in the Qiskit pauli_evolve fallback

### DIFF
--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -591,13 +591,32 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
                 validate_hamiltonian_within_register(num_h_qubits, n_resolved)
 
         # Validate Hermitian (real coefficients)
+        from qamomile.observable.hamiltonian import (
+            HERMITIAN_IMAG_ATOL,
+            PAULI_TERM_ZERO_ATOL,
+        )
+
         for operators, coeff in hamiltonian:
-            if abs(coeff.imag) > 1e-10:
+            if abs(coeff.imag) > HERMITIAN_IMAG_ATOL:
                 raise EmitError(
                     f"PauliEvolveOp requires a Hermitian Hamiltonian "
                     f"(real coefficients), but found complex coefficient "
                     f"{coeff} on term {operators}.",
                 )
+
+        # Hamiltonian.__iter__ yields only the Pauli terms, so the loop
+        # above never sees the constant (identity) term. Validate it here
+        # for ALL Hamiltonians so the native path rejects a non-real
+        # constant with the same clean EmitError as the gadget fallback,
+        # instead of letting it slip through to a raw Qiskit ValueError
+        # inside PauliEvolutionGate (for num_h_qubits > 0).
+        if abs(hamiltonian.constant.imag) > HERMITIAN_IMAG_ATOL:
+            raise EmitError(
+                f"PauliEvolveOp requires a Hermitian Hamiltonian "
+                f"(real coefficients), but found a complex constant "
+                f"{hamiltonian.constant}.",
+                operation="PauliEvolveOp",
+            )
 
         if num_h_qubits == 0:
             # An empty / constant-only Hamiltonian evolves the register by
@@ -616,20 +635,11 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             # qubit list. (For ``num_h_qubits > 0`` the constant is already
             # carried inside the ``SparsePauliOp``, so this branch must not
             # apply.) The result register stays resolvable through the
-            # allocator's element aliases.
-            from qamomile.observable.hamiltonian import (
-                HERMITIAN_IMAG_ATOL,
-                PAULI_TERM_ZERO_ATOL,
-            )
-
+            # allocator's element aliases. The constant's Hermiticity was
+            # already validated above for all Hamiltonians, so only the
+            # magnitude check remains here.
             constant = hamiltonian.constant
             if abs(constant) > PAULI_TERM_ZERO_ATOL:
-                if abs(constant.imag) > HERMITIAN_IMAG_ATOL:
-                    raise EmitError(
-                        f"PauliEvolveOp requires a Hermitian Hamiltonian "
-                        f"(real coefficients), but found a complex constant "
-                        f"{constant}.",
-                    )
                 # Works for both concrete float gamma and a backend
                 # Parameter (ParameterExpression global phase is bound
                 # together with the rest of the circuit parameters).

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -522,11 +522,33 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
         qubit_map: QubitMap,
         bindings: dict[str, Any],
     ) -> None:
-        """Emit Pauli evolution using Qiskit's PauliEvolutionGate."""
+        """Emit Pauli evolution using Qiskit's PauliEvolutionGate.
+
+        Falls back to the shared gadget decomposition — always via
+        ``_emit_gadget_pauli_evolve``, which completes the Hamiltonian's
+        constant term as a circuit global phase — when native composite
+        emission is disabled or the native path cannot resolve the
+        Hamiltonian, gamma, or qubit indices.
+
+        Args:
+            circuit (QuantumCircuit): Qiskit circuit being emitted into.
+            op (PauliEvolveOp): The Pauli evolution operation to emit.
+            qubit_map (QubitMap): Physical qubit map the operation's
+                quantum operands resolve against; updated in place with
+                the evolved-register result addresses.
+            bindings (dict[str, Any]): Active emit bindings used to
+                resolve the Hamiltonian, gamma, and register shape.
+
+        Raises:
+            EmitError: If the Hamiltonian is non-Hermitian (a term or the
+                constant has a non-real coefficient), the Hamiltonian is
+                larger than the register, or the gadget fallback cannot
+                resolve the Hamiltonian, gamma, or a term qubit.
+        """
         import qamomile.observable as qm_o
 
         if not self._use_native_composite:
-            super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+            self._emit_gadget_pauli_evolve(circuit, op, qubit_map, bindings)
             return
 
         # Resolve Hamiltonian from bindings
@@ -537,7 +559,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
         if hamiltonian is None and hasattr(obs_value, "uuid"):
             hamiltonian = bindings.get(obs_value.uuid)
         if not isinstance(hamiltonian, qm_o.Hamiltonian):
-            super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+            self._emit_gadget_pauli_evolve(circuit, op, qubit_map, bindings)
             return
 
         # Resolve gamma: concrete float OR backend Parameter for parametric
@@ -550,7 +572,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
 
         gamma = _resolve_gamma(self, op, bindings)
         if gamma is None:
-            super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+            self._emit_gadget_pauli_evolve(circuit, op, qubit_map, bindings)
             return
 
         # Validate qubit count: logical array size vs Hamiltonian. A
@@ -620,7 +642,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             if addr in qubit_map:
                 qubit_indices.append(qubit_map[addr])
             else:
-                super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+                self._emit_gadget_pauli_evolve(circuit, op, qubit_map, bindings)
                 return
 
         try:
@@ -636,7 +658,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             circuit.append(evo_gate, qubit_indices)
         except ImportError:
             # Fallback to manual decomposition when Qiskit library unavailable
-            super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+            self._emit_gadget_pauli_evolve(circuit, op, qubit_map, bindings)
             return
 
         # Map result array to same physical qubits
@@ -645,6 +667,109 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
             result_addr = QubitAddress(result_array.uuid, i)
             if result_addr not in qubit_map:
                 qubit_map[result_addr] = phys_idx
+
+    def _emit_gadget_pauli_evolve(
+        self,
+        circuit: "QuantumCircuit",
+        op: "PauliEvolveOp",
+        qubit_map: QubitMap,
+        bindings: dict[str, Any],
+    ) -> None:
+        """Delegate to the shared gadget emitter and complete the constant term.
+
+        The shared gadget decomposition emits only the Hamiltonian's
+        Pauli terms — a constant (identity) term contributes no gates
+        there, so it is silently dropped. Every gadget delegation from
+        ``_emit_pauli_evolve`` goes through this wrapper so the dropped
+        constant is re-applied as a Qiskit global phase exactly once,
+        keeping the fallback's phase behavior aligned with the native
+        ``PauliEvolutionGate`` path (whose ``SparsePauliOp`` carries the
+        constant).
+
+        Args:
+            circuit (QuantumCircuit): Qiskit circuit being emitted into.
+            op (PauliEvolveOp): The Pauli evolution operation to emit.
+            qubit_map (QubitMap): Physical qubit map the operation's
+                quantum operands resolve against; updated in place with
+                the evolved-register result addresses.
+            bindings (dict[str, Any]): Active emit bindings used to
+                resolve the Hamiltonian, gamma, and register shape.
+
+        Raises:
+            EmitError: Propagated from the shared gadget emitter
+                (unresolvable Hamiltonian / gamma / term qubit,
+                non-Hermitian term coefficient, or a Hamiltonian larger
+                than the register), or raised by the constant-phase
+                completion when the constant term has a non-real
+                coefficient.
+        """
+        super()._emit_pauli_evolve(circuit, op, qubit_map, bindings)
+        self._emit_gadget_constant_phase(circuit, op, bindings)
+
+    def _emit_gadget_constant_phase(
+        self,
+        circuit: "QuantumCircuit",
+        op: "PauliEvolveOp",
+        bindings: dict[str, Any],
+    ) -> None:
+        """Re-apply the constant term dropped by the gadget decomposition.
+
+        ``exp(-i*gamma*H)`` with ``H = ... + c`` carries the phase
+        ``exp(-i*gamma*c)``. Standalone this is an unobservable global
+        phase, but when the emitted circuit is converted to a gate and
+        placed under controls (``_blockvalue_to_gate`` + ``Gate.control``)
+        Qiskit promotes the definition's global phase to the observable
+        relative phase on the all-controls-on subspace — matching the
+        native ``PauliEvolutionGate`` path, the shared controlled path's
+        explicit ``P(-gamma*c)`` on a control, and CUDA-Q's controlled
+        constant re-application. Hamiltonian and gamma resolution mirrors
+        the shared gadget emitter (same resolver and ``_resolve_gamma``),
+        so whenever the gadget emission succeeded the constant resolves
+        identically; if either is unresolvable this method is a no-op
+        (every such reachable case has already raised inside the gadget
+        emission).
+
+        Args:
+            circuit (QuantumCircuit): Circuit the gadget fallback just
+                emitted into; its ``global_phase`` is updated in place.
+            op (PauliEvolveOp): The Pauli evolution operation being
+                emitted.
+            bindings (dict[str, Any]): Active emit bindings used to
+                resolve the Hamiltonian and gamma.
+
+        Raises:
+            EmitError: If the constant term has a non-real coefficient
+                (non-Hermitian Hamiltonian).
+        """
+        import qamomile.observable as qm_o
+        from qamomile.circuit.transpiler.passes.emit_support.pauli_evolve_emission import (
+            _resolve_gamma,
+        )
+        from qamomile.observable.hamiltonian import (
+            HERMITIAN_IMAG_ATOL,
+            PAULI_TERM_ZERO_ATOL,
+        )
+
+        hamiltonian = self._resolver.resolve_bound_value(op.observable, bindings)
+        if not isinstance(hamiltonian, qm_o.Hamiltonian):
+            return
+        constant = hamiltonian.constant
+        if abs(constant) <= PAULI_TERM_ZERO_ATOL:
+            return
+        if abs(constant.imag) > HERMITIAN_IMAG_ATOL:
+            raise EmitError(
+                f"PauliEvolveOp requires a Hermitian Hamiltonian "
+                f"(real coefficients), but found a complex constant "
+                f"{constant}.",
+                operation="PauliEvolveOp",
+            )
+        gamma = _resolve_gamma(self, op, bindings)
+        if gamma is None:
+            return
+        # Works for both concrete float gamma and a backend Parameter
+        # (ParameterExpression global phase is bound together with the
+        # rest of the circuit parameters).
+        circuit.global_phase += -float(constant.real) * gamma
 
 
 class QiskitExecutor(QuantumExecutor["QuantumCircuit"]):

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -602,6 +602,7 @@ class QiskitEmitPass(StandardEmitPass["QuantumCircuit"]):
                     f"PauliEvolveOp requires a Hermitian Hamiltonian "
                     f"(real coefficients), but found complex coefficient "
                     f"{coeff} on term {operators}.",
+                    operation="PauliEvolveOp",
                 )
 
         # Hamiltonian.__iter__ yields only the Pauli terms, so the loop

--- a/tests/circuit/test_qrao_qaoa.py
+++ b/tests/circuit/test_qrao_qaoa.py
@@ -626,14 +626,18 @@ def test_larger_hamiltonian_raises(use_native):
         )
 
 
-def test_complex_coefficient_raises():
-    """Hamiltonian with complex (non-Hermitian) coefficients should error."""
+@pytest.mark.parametrize("use_native", [True, False])
+def test_complex_coefficient_raises(use_native):
+    """Hamiltonian with complex (non-Hermitian) coefficients should error.
+
+    Covers both the native PauliEvolutionGate path and the gadget fallback.
+    """
     from qamomile.circuit.transpiler.errors import EmitError
 
     H = qm_o.Hamiltonian()
     H.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0 + 0.5j)  # complex
 
-    transpiler = QiskitTranspiler(use_native_composite=False)
+    transpiler = QiskitTranspiler(use_native_composite=use_native)
     with pytest.raises(EmitError, match="Hermitian"):
         transpiler.transpile(
             _wrap_pauli_evolve,

--- a/tests/circuit/test_qrao_qaoa.py
+++ b/tests/circuit/test_qrao_qaoa.py
@@ -661,3 +661,25 @@ def test_complex_constant_raises(use_native):
             _wrap_pauli_evolve,
             bindings={"n": 1, "hamiltonian": H, "gamma": 0.5},
         )
+
+
+@pytest.mark.parametrize("use_native", [True, False])
+def test_complex_constant_with_pauli_term_raises(use_native):
+    """A Pauli term plus a non-real constant raises the same clean EmitError on both paths.
+
+    Pins native/fallback alignment for num_h_qubits > 0: previously the
+    native path only validated the constant in its 0-qubit branch, letting
+    this Hamiltonian reach a raw Qiskit ValueError inside PauliEvolutionGate.
+    """
+    from qamomile.circuit.transpiler.errors import EmitError
+
+    H = qm_o.Hamiltonian()
+    H.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0)
+    H += 2.0j
+
+    transpiler = QiskitTranspiler(use_native_composite=use_native)
+    with pytest.raises(EmitError, match="complex constant"):
+        transpiler.transpile(
+            _wrap_pauli_evolve,
+            bindings={"n": 1, "hamiltonian": H, "gamma": 0.5},
+        )

--- a/tests/circuit/test_qrao_qaoa.py
+++ b/tests/circuit/test_qrao_qaoa.py
@@ -373,11 +373,11 @@ def test_zero_qubit_hamiltonian_evolves_as_global_phase(use_native, constant):
     transpile (the native path previously crashed with a raw Qiskit
     ``CircuitError``: the 0-qubit Hamiltonian widens to a 1-qubit
     ``SparsePauliOp(["I"])`` whose gate cannot be appended onto an empty
-    qubit list) and leave the state on |00>. The native path additionally
-    records the phase on ``circuit.global_phase`` so that it survives as
-    an observable relative phase when the circuit is placed under
-    ``qmc.control``; the shared gadget fallback drops it (a documented
-    limitation of the gadget decomposition).
+    qubit list) and leave the state on |00>. Both paths record the phase
+    on ``circuit.global_phase`` — the native path in its 0-qubit branch,
+    the gadget fallback through the constant-phase completion — so that
+    it survives as an observable relative phase when the circuit is
+    placed under ``qmc.control``.
     """
     import numpy as np
     from qiskit.quantum_info import Statevector
@@ -394,8 +394,7 @@ def test_zero_qubit_hamiltonian_evolves_as_global_phase(use_native, constant):
     state = np.asarray(Statevector(circuit).data)
     expected = np.zeros(4, dtype=complex)
     # exp(-i*gamma*H) on |00> with H = constant*I is exp(-i*gamma*constant)|00>.
-    # The fallback gadget cannot express a global phase, so it yields |00>.
-    expected[0] = np.exp(-1j * gamma * constant) if use_native else 1.0
+    expected[0] = np.exp(-1j * gamma * constant)
     np.testing.assert_allclose(
         state,
         expected,
@@ -431,8 +430,9 @@ def _inverse_evolve_register(
     return q
 
 
+@pytest.mark.parametrize("use_native", [True, False])
 @pytest.mark.parametrize("invert", [False, True])
-def test_controlled_constant_only_hamiltonian_relative_phase(invert):
+def test_controlled_constant_only_hamiltonian_relative_phase(use_native, invert):
     """A controlled constant-only evolution keeps the relative phase.
 
     Uncontrolled, ``exp(-i*gamma*c*I)`` is an unobservable global phase,
@@ -441,10 +441,11 @@ def test_controlled_constant_only_hamiltonian_relative_phase(invert):
     |+> the statevector amplitude ratio between the control-1 and
     control-0 subspaces must equal ``exp(-i*gamma*c)`` (and the conjugate
     ``exp(+i*gamma*c)`` when the body is wrapped in ``qmc.inverse``,
-    which negates gamma). This pins the Qiskit-native global-phase
-    emission for 0-qubit Hamiltonians through gate conversion and
-    ``Gate.control``, matching the QuriParts / CUDA-Q controlled paths
-    which re-apply the constant explicitly.
+    which negates gamma). This pins the constant's survival through gate
+    conversion and ``Gate.control`` on both Qiskit paths — the native
+    0-qubit global-phase branch and the gadget fallback's constant-phase
+    completion — matching the QuriParts / CUDA-Q controlled paths which
+    re-apply the constant explicitly.
     """
     import numpy as np
     from qiskit.quantum_info import Statevector
@@ -469,7 +470,7 @@ def test_controlled_constant_only_hamiltonian_relative_phase(invert):
         q[1:2] = targets
         return qmc.measure(q)
 
-    exe = QiskitTranspiler().transpile(
+    exe = QiskitTranspiler(use_native_composite=use_native).transpile(
         controlled_const, bindings={"hamiltonian": H, "gamma": gamma}
     )
     circuit = exe.compiled_quantum[0].circuit.remove_final_measurements(inplace=False)
@@ -481,7 +482,124 @@ def test_controlled_constant_only_hamiltonian_relative_phase(invert):
         np.exp(sign * 1j * gamma * constant),
         atol=1e-12,
         rtol=0.0,
-        err_msg=f"invert={invert}: controlled constant phase ratio wrong: {ratio}",
+        err_msg=(
+            f"use_native={use_native}, invert={invert}: "
+            f"controlled constant phase ratio wrong: {ratio}"
+        ),
+    )
+
+
+@pytest.mark.parametrize(("gamma", "constant"), [(0.5, 2.0), (-0.8, 1.3)])
+@pytest.mark.parametrize("invert", [False, True])
+def test_controlled_constant_plus_pauli_relative_phase(invert, gamma, constant):
+    """A controlled ``Z(0) + c`` evolution applies the constant exactly once.
+
+    With the control in |+> and the target on |0>, ``exp(-i*gamma*(Z+c))``
+    contributes ``exp(-i*gamma*(1+c))`` on the control-1 branch (Z
+    eigenvalue +1 on |0> plus the constant), so the amplitude ratio pins
+    both that the constant is emitted and that it is not double-counted:
+    the native path carries it inside the ``SparsePauliOp`` of the
+    evolution gate, the gadget fallback re-applies it as the definition's
+    global phase, and a double application would show up as an extra
+    ``exp(-i*gamma*c)`` factor. The two paths must also produce exactly
+    the same statevector (including global phase). ``qmc.inverse``
+    negates gamma, conjugating the expected ratio; a negative gamma
+    parametrization pins the sign convention independently.
+    """
+    import numpy as np
+    from qiskit.quantum_info import Statevector
+
+    H = qm_o.Hamiltonian()
+    H.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0)
+    H += constant
+
+    body = _inverse_evolve_register if invert else _evolve_register
+
+    @qmc.qkernel
+    def controlled_evolution(
+        hamiltonian: qmc.Observable, gamma: qmc.Float
+    ) -> qmc.Vector[qmc.Bit]:
+        q = qmc.qubit_array(2, "q")
+        q[0] = qmc.h(q[0])
+        controlled_evolve = qmc.control(body)
+        q[0], targets = controlled_evolve(
+            q[0], q[1:2], hamiltonian=hamiltonian, gamma=gamma
+        )
+        q[1:2] = targets
+        return qmc.measure(q)
+
+    states = {}
+    for use_native in (True, False):
+        exe = QiskitTranspiler(use_native_composite=use_native).transpile(
+            controlled_evolution, bindings={"hamiltonian": H, "gamma": gamma}
+        )
+        circuit = exe.compiled_quantum[0].circuit.remove_final_measurements(
+            inplace=False
+        )
+        states[use_native] = np.asarray(Statevector(circuit).data)
+
+    sign = +1.0 if invert else -1.0
+    for use_native, state in states.items():
+        ratio = state[1] / state[0]
+        np.testing.assert_allclose(
+            ratio,
+            np.exp(sign * 1j * gamma * (1.0 + constant)),
+            atol=1e-12,
+            rtol=0.0,
+            err_msg=(
+                f"use_native={use_native}, invert={invert}: "
+                f"controlled constant+Pauli phase ratio wrong: {ratio}"
+            ),
+        )
+    np.testing.assert_allclose(
+        states[False],
+        states[True],
+        atol=1e-12,
+        rtol=0.0,
+        err_msg=f"invert={invert}: fallback statevector diverges from native",
+    )
+
+
+@pytest.mark.parametrize(("gamma", "constant"), [(0.5, 2.0), (-0.8, 1.3)])
+@pytest.mark.parametrize("use_native", [True, False])
+def test_parametric_gamma_carries_constant_phase(use_native, gamma, constant):
+    """Runtime-parametric gamma keeps the constant's phase and binding.
+
+    With ``gamma`` preserved as a backend runtime parameter, both Qiskit
+    paths must carry the constant term of ``H = Z(0) + c`` as a
+    ``ParameterExpression`` phase that binds together with the circuit's
+    other parameters: after ``assign_parameters`` the exact statevector
+    (including global phase) on ``|0>`` must be
+    ``exp(-i*gamma*(1+c))|0>``.
+    """
+    import numpy as np
+    from qiskit.quantum_info import Statevector
+
+    H = qm_o.Hamiltonian()
+    H.add_term((qm_o.PauliOperator(qm_o.Pauli.Z, 0),), 1.0)
+    H += constant
+
+    exe = QiskitTranspiler(use_native_composite=use_native).transpile(
+        _wrap_pauli_evolve,
+        bindings={"n": 1, "hamiltonian": H},
+        parameters=["gamma"],
+    )
+    circuit = exe.compiled_quantum[0].circuit
+    bound = circuit.assign_parameters(
+        {param: gamma for param in circuit.parameters}
+    ).remove_final_measurements(inplace=False)
+    state = np.asarray(Statevector(bound).data)
+    expected = np.zeros(2, dtype=complex)
+    expected[0] = np.exp(-1j * gamma * (1.0 + constant))
+    np.testing.assert_allclose(
+        state,
+        expected,
+        atol=1e-12,
+        rtol=0.0,
+        err_msg=(
+            f"use_native={use_native}: "
+            f"parametric-gamma evolution lost the constant phase: {state}"
+        ),
     )
 
 
@@ -517,6 +635,28 @@ def test_complex_coefficient_raises():
 
     transpiler = QiskitTranspiler(use_native_composite=False)
     with pytest.raises(EmitError, match="Hermitian"):
+        transpiler.transpile(
+            _wrap_pauli_evolve,
+            bindings={"n": 1, "hamiltonian": H, "gamma": 0.5},
+        )
+
+
+@pytest.mark.parametrize("use_native", [True, False])
+def test_complex_constant_raises(use_native):
+    """A non-real constant term is rejected as non-Hermitian on both paths.
+
+    The native path validates the constant in its 0-qubit global-phase
+    branch; the gadget fallback validates it in the constant-phase
+    completion (previously the fallback silently dropped the complex
+    constant instead of erroring).
+    """
+    from qamomile.circuit.transpiler.errors import EmitError
+
+    H = qm_o.Hamiltonian()
+    H += 2.0j
+
+    transpiler = QiskitTranspiler(use_native_composite=use_native)
+    with pytest.raises(EmitError, match="complex constant"):
         transpiler.transpile(
             _wrap_pauli_evolve,
             bindings={"n": 1, "hamiltonian": H, "gamma": 0.5},


### PR DESCRIPTION
## Problem

`qmc.pauli_evolve(q, H, gamma)` implements `exp(-i*gamma*H)`. When `H` carries a constant (identity) term `c`, the evolution picks up the phase `exp(-i*gamma*c)`. Uncontrolled this is an unobservable global phase, but under `qmc.control` it becomes an observable relative phase on the control's |1> subspace.

The shared gadget emitter `emit_pauli_evolve` skips terms with empty operators, so it silently drops the constant. On Qiskit, `qmc.control` of a kernel converts the inner block to a gate (`_blockvalue_to_gate` + `Gate.control()`); a phase that was never emitted cannot be promoted. As a result, with `QiskitTranspiler(use_native_composite=False)` the controlled evolution of a Hamiltonian with a constant term produced the wrong relative phase, while the native Qiskit path, QuriParts, and CUDA-Q were all correct (each carries or re-applies the constant on its controlled path). This gap existed on `main` — it was documented as a known limitation in #471, which fixed the sibling native-path 0-qubit case.

Measured repro (control in |+>, controlled `pauli_evolve` on a 1-qubit target with `H = Z(0) + 2.0`, `gamma = 0.5`, then `<X(control)>`):

- Qiskit native: `0.070737 = cos(1.5)` — correct
- QuriParts / CUDA-Q: `0.070737` — correct
- Qiskit `use_native_composite=False` (before): `0.877583 = cos(0.5)` — constant's contribution missing
- Qiskit `use_native_composite=False` (after): `0.070737` — correct

## Fix

Route every gadget delegation in `QiskitEmitPass._emit_pauli_evolve` through a new `_emit_gadget_pauli_evolve`, which runs the shared gadget emission and then re-applies the dropped constant term as a Qiskit global phase exactly once (`_emit_gadget_constant_phase`: `circuit.global_phase += -c * gamma`). Gate conversion plus `Gate.control()` then promote the definition's global phase to the observable controlled relative phase, matching the native path (constant inside the `SparsePauliOp`), the shared controlled path (explicit `P(-gamma*c)` on a control), and CUDA-Q's controlled constant re-application.

The Qiskit-scoped approach was chosen over widening the shared `GateEmitter` protocol with a global-phase hook: the protocol is backend-generic and QuriParts circuits cannot express a global phase (QuriParts does not need one — its controlled path handles the constant separately). Uncontrolled behavior is unchanged (global phase only). A non-real constant now raises `EmitError` on the fallback path too, instead of being silently dropped.

## Tests

Extended `tests/circuit/test_qrao_qaoa.py`:

- `test_controlled_constant_only_hamiltonian_relative_phase` — now parametrized over `use_native` True/False.
- `test_zero_qubit_hamiltonian_evolves_as_global_phase` — both paths now assert the same `exp(-i*gamma*c)` phase (the fallback no longer drops it).
- `test_controlled_constant_plus_pauli_relative_phase` (new) — `Z(0) + c` under control; asserts the analytic relative phase, native/fallback statevector equality, and pins the double-count risk. Parametrized over `invert` and over `(gamma, constant)` including a negative gamma.
- `test_parametric_gamma_carries_constant_phase` (new) — runtime-parametric gamma carries the constant as a `ParameterExpression` phase that binds correctly, both paths.
- `test_complex_constant_raises` (new) — non-real constant raises `EmitError` on both paths.

Verified: full suite green (`uv run pytest tests/`), `ruff check` / `ruff format --check` / `zuban check` all clean, and a clean `/local-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
