### PR TITLE
Add if-branch circuit visualization

### DIFF
--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1794,6 +1794,7 @@ class QKernel(Generic[P, R]):
         fold_loops: bool = True,
         expand_composite: bool = False,
         inline_depth: int | None = None,
+        fold_ifs: bool = False,
         **kwargs: Any,
     ) -> Any:
         """Visualize the circuit using Matplotlib.
@@ -1803,20 +1804,25 @@ class QKernel(Generic[P, R]):
         are shown as symbolic parameters.
 
         Args:
-            inline: If True, expand CallBlockOperation contents (inlining).
-                   If False (default), show CallBlockOperation as boxes.
-            fold_loops: If True (default), display ForOperation as blocks instead of unrolling.
-                       If False, expand loops and show all iterations.
-            expand_composite: If True, expand CompositeGateOperation (QFT, IQFT, etc.).
-                            If False (default), show as boxes. Independent of inline.
-            inline_depth: Maximum nesting depth for inline expansion. None means
-                         unlimited (default). 0 means no inlining, 1 means top-level
-                         only, etc. Only affects CallBlock/ControlledU, not CompositeGate.
-            **kwargs: Concrete values for arguments. Arguments not provided here
-                     (and without defaults) will be shown as symbolic parameters.
+            inline (bool): If True, expand CallBlockOperation contents
+                (inlining). If False (default), show CallBlockOperation as
+                boxes.
+            fold_loops (bool): If True (default), display ForOperation as
+                blocks instead of unrolling. If False, expand loops and show
+                all iterations.
+            expand_composite (bool): If True, expand CompositeGateOperation
+                nodes. If False (default), show them as boxes.
+            inline_depth (int | None): Maximum nesting depth for inline
+                expansion. None means unlimited. Only affects CallBlock and
+                ControlledU nodes, not CompositeGate.
+            fold_ifs (bool): If True, display IfOperation as folded summary
+                blocks. If False (default), show if/else branches side by side.
+            **kwargs (Any): Concrete values for arguments. Arguments not
+                provided here and without defaults will be shown as symbolic
+                parameters.
 
         Returns:
-            matplotlib.figure.Figure object.
+            Any: Matplotlib figure object.
 
         Raises:
             ImportError: If matplotlib is not installed.
@@ -1851,6 +1857,9 @@ class QKernel(Generic[P, R]):
             # Draw with loops folded (shown as blocks)
             fig = circuit.draw(fold_loops=True)
 
+            # Draw with if/else folded into a summary box
+            fig = circuit.draw(fold_ifs=True)
+
             # Draw with composite gates expanded
             fig = circuit.draw(expand_composite=True)
             ```
@@ -1861,6 +1870,7 @@ class QKernel(Generic[P, R]):
             self,
             inline=inline,
             fold_loops=fold_loops,
+            fold_ifs=fold_ifs,
             expand_composite=expand_composite,
             inline_depth=inline_depth,
             **kwargs,

--- a/qamomile/circuit/frontend/qkernel.py
+++ b/qamomile/circuit/frontend/qkernel.py
@@ -1826,6 +1826,10 @@ class QKernel(Generic[P, R]):
 
         Raises:
             ImportError: If matplotlib is not installed.
+            ValueError: If a ``Vector[Qubit]`` parameter requires a concrete
+                size for visualization and no size is provided.
+            ValidationError: If visualization-time compile-time if lowering
+                rejects the traced graph.
 
         Example:
             ```python

--- a/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
+++ b/qamomile/circuit/transpiler/passes/compile_time_if_lowering.py
@@ -100,12 +100,34 @@ class CompileTimeIfLoweringPass(Pass[Block, Block]):
         return "compile_time_if_lowering"
 
     def run(self, input: Block) -> Block:
-        """Run the compile-time if lowering pass."""
-        # HIERARCHICAL is accepted during the self-recursion unroll loop;
-        # surviving CallBlockOperations are passed through untouched.
-        if input.kind not in (BlockKind.AFFINE, BlockKind.HIERARCHICAL):
+        """Lower every compile-time resolvable IfOperation in the block.
+
+        Args:
+            input (Block): Block to lower. Must be ``TRACED``, ``AFFINE``, or
+                ``HIERARCHICAL``. ``TRACED`` is accepted so the circuit drawer
+                can resolve bound/constant ``if`` conditions on a freshly
+                traced block before the transpiler pipeline runs; ``HIERARCHICAL``
+                is accepted during the self-recursion unroll loop. Surviving
+                ``CallBlockOperation``s are passed through untouched in both cases.
+
+        Returns:
+            Block: New block with compile-time ``if``s replaced by their
+                selected-branch operations and phi outputs substituted. The
+                input's ``BlockKind`` is preserved.
+
+        Raises:
+            ValidationError: If ``input.kind`` is ``ANALYZED`` (the pass must
+                run before dependency analysis commits to a representation), or
+                if a compile-time branch selects a symbolic-bound slice-view
+                cast source whose root index space is not resolvable.
+        """
+        if input.kind not in (
+            BlockKind.TRACED,
+            BlockKind.AFFINE,
+            BlockKind.HIERARCHICAL,
+        ):
             raise ValidationError(
-                f"CompileTimeIfLoweringPass expects AFFINE or "
+                f"CompileTimeIfLoweringPass expects TRACED, AFFINE, or "
                 f"HIERARCHICAL block, got {input.kind}",
             )
 

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1845,7 +1845,8 @@ class CircuitAnalyzer:
 
         Returns:
             VFoldedBlock | VUnfoldedSequence: A folded summary box when
-                ``fold_ifs`` is set, otherwise an unfolded two-branch sequence.
+                ``fold_ifs`` is set, otherwise an unfolded sequence containing
+                the true branch and, when present, the false branch.
         """
         affected_qubits, affected_qubits_precise = self._collect_if_affected_qubits(
             op, qubit_map, logical_id_remap, param_values

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -13,7 +13,15 @@ from typing import TYPE_CHECKING
 
 from qamomile.circuit.ir.block import Block
 from qamomile.circuit.ir.operation import Operation
-from qamomile.circuit.ir.operation.arithmetic_operations import BinOp, BinOpKind
+from qamomile.circuit.ir.operation.arithmetic_operations import (
+    BinOp,
+    BinOpKind,
+    CompOp,
+    CompOpKind,
+    CondOp,
+    CondOpKind,
+    NotOp,
+)
 from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
 from qamomile.circuit.ir.operation.cast import CastOperation
 from qamomile.circuit.ir.operation.composite_gate import (
@@ -61,6 +69,15 @@ if TYPE_CHECKING:
 
 
 _INTERNAL_TMP_NAMES: frozenset[str] = frozenset({"uint_tmp", "float_tmp", "bit_tmp"})
+
+
+# String markers appended to a node's scope path for the true / else branch of
+# an ``IfOperation`` (see ``_build_vif`` and the layout engine's unfolded-if
+# placement). They are the only non-integer scope-path elements any node key
+# carries, so their presence uniquely identifies a node nested inside an
+# if/else branch — used to keep mid-circuit measurements from terminating a
+# wire that the other branch never measured.
+_IF_BRANCH_SCOPE_KEYS: frozenset[str] = frozenset({"true", "false"})
 
 
 # Single source of truth for the TeX rendering of every built-in
@@ -140,6 +157,35 @@ _BUILTIN_TEX_LABELS: dict[str, str] = {
 # rendered label reads ``_phase(theta=π/2)`` rather than
 # ``_phase(ctrl_param_theta=π/2)``.
 _CTRL_PARAM_PREFIX: str = "ctrl_param_"
+
+
+# Infix symbols for spelling out an ``IfOperation`` condition (see
+# ``CircuitAnalyzer._format_condition_expr``).  A symbolic ``if`` whose
+# condition is not compile-time resolved is drawn with its predicate
+# rendered as source, e.g. ``if flag == 1:`` rather than ``if cond:``.
+# ``BinOpKind.MIN`` is intentionally absent — it has no infix form and
+# falls back to the anonymous-condition label.
+_COMP_OP_SYMBOLS: dict[CompOpKind, str] = {
+    CompOpKind.EQ: "==",
+    CompOpKind.NEQ: "!=",
+    CompOpKind.LT: "<",
+    CompOpKind.LE: "<=",
+    CompOpKind.GT: ">",
+    CompOpKind.GE: ">=",
+}
+_COND_OP_SYMBOLS: dict[CondOpKind, str] = {
+    CondOpKind.AND: "and",
+    CondOpKind.OR: "or",
+}
+_BIN_OP_SYMBOLS: dict[BinOpKind, str] = {
+    BinOpKind.ADD: "+",
+    BinOpKind.SUB: "-",
+    BinOpKind.MUL: "*",
+    BinOpKind.DIV: "/",
+    BinOpKind.FLOORDIV: "//",
+    BinOpKind.MOD: "%",
+    BinOpKind.POW: "**",
+}
 
 
 class CircuitAnalyzer:
@@ -958,10 +1004,18 @@ class CircuitAnalyzer:
                 )
 
             if isinstance(op, IfOperation):
-                raise NotImplementedError(
-                    "Circuit visualization does not yet support IfOperation. "
-                    "This feature will be added in a future release."
+                node = self._build_vif(
+                    op,
+                    node_key,
+                    qubit_map,
+                    logical_id_remap,
+                    param_values,
+                    depth,
+                    scope_path,
+                    body_operations=ops,
                 )
+                result.append(node)
+                continue
 
             if isinstance(op, ForItemsOperation):
                 node = self._build_vfor_items(
@@ -1074,6 +1128,27 @@ class CircuitAnalyzer:
 
         return result
 
+    @staticmethod
+    def _node_key_in_if_branch(node_key: tuple) -> bool:
+        """Whether a node sits inside an if/else branch scope.
+
+        If-branch scopes are tagged with the ``"true"`` / ``"false"`` string
+        markers in the node key (see ``_build_vif`` and the layout engine's
+        unfolded-if placement). No other scope kind uses string markers, so
+        their presence uniquely identifies an if-branch nesting.
+
+        Args:
+            node_key (tuple): The node's scope key, of the form
+                ``(*scope_path, id(op))``.
+
+        Returns:
+            bool: True if any element of ``node_key`` is an if-branch marker,
+                meaning the node is nested inside a true/else branch.
+        """
+        return any(
+            isinstance(part, str) and part in _IF_BRANCH_SCOPE_KEYS for part in node_key
+        )
+
     def _build_vgate(
         self,
         op: Operation,
@@ -1118,6 +1193,7 @@ class CircuitAnalyzer:
                 qubit_indices=qubit_indices,
                 estimated_width=gate_width,
                 kind=VGateKind.MEASURE,
+                terminates_wire=not self._node_key_in_if_branch(node_key),
             )
 
         if isinstance(op, MeasureVectorOperation):
@@ -1135,6 +1211,7 @@ class CircuitAnalyzer:
                 qubit_indices=qubit_indices,
                 estimated_width=gate_width,
                 kind=VGateKind.MEASURE_VECTOR,
+                terminates_wire=not self._node_key_in_if_branch(node_key),
             )
 
         if isinstance(op, MeasureQFixedOperation):
@@ -1165,6 +1242,7 @@ class CircuitAnalyzer:
                 qubit_indices=qubit_indices,
                 estimated_width=self.style.gate_width,
                 kind=VGateKind.MEASURE_VECTOR,
+                terminates_wire=not self._node_key_in_if_branch(node_key),
             )
 
         if isinstance(op, CallBlockOperation):
@@ -1722,23 +1800,45 @@ class CircuitAnalyzer:
         param_values: dict,
         depth: int,
         scope_path: tuple,
+        body_operations: list[Operation] | None = None,
     ) -> VFoldedBlock | VUnfoldedSequence:
         """Build a Visual IR node for an IfOperation.
 
-        Note: This method is implemented for future use but currently not called,
-        because ``_build_visual_nodes`` raises ``NotImplementedError`` for
-        ``IfOperation``.  It will be connected once If-operation visualization
-        is fully enabled.
+        Compile-time resolvable ``if``s are already lowered away by
+        ``CompileTimeIfLoweringPass`` before visual analysis runs, so this method
+        only handles conditions that survive — measurement-backed runtime
+        ``if`` and symbolic (unbound) classical ``if``. In folded mode it
+        returns a single ``VFoldedBlock`` summarizing the true branch; in
+        unfolded mode it returns a ``VUnfoldedSequence`` carrying both
+        branches for side-by-side rendering.
+
+        Args:
+            op (IfOperation): The if/else operation to visualize.
+            node_key (tuple): Stable identity key for layout/render lookup.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+            depth (int): Current nesting depth for child expansion.
+            scope_path (tuple): Path of enclosing scope keys for child node keys.
+            body_operations (list[Operation] | None): Operations of the scope
+                enclosing ``op``, used to spell the condition predicate (e.g.
+                ``flag == 1``). Defaults to None, which falls back to the
+                anonymous ``if cond:`` label.
+
+        Returns:
+            VFoldedBlock | VUnfoldedSequence: A folded summary box when
+                ``fold_loops`` is set, otherwise an unfolded two-branch
+                sequence.
         """
         affected_qubits, affected_qubits_precise = self._collect_if_affected_qubits(
             op, qubit_map, logical_id_remap, param_values
         )
 
-        cond = op.condition
-        cond_name = getattr(cond, "name", None)
-        if cond_name is None or self._is_internal_temp_name(cond_name):
-            cond_name = "cond"
-        condition_label = f"if {cond_name}:"
+        condition_expr = self._format_condition_expr(
+            op.condition, body_operations, param_values
+        )
+        condition_label = f"if {condition_expr}:" if condition_expr else "if cond:"
 
         if self.fold_loops:
             local_param_values = dict(param_values)
@@ -1795,9 +1895,15 @@ class CircuitAnalyzer:
 
         iterations = [true_children]
         iteration_widths = [true_width]
+        branch_labels = [condition_label]
         if false_children:
             iterations.append(false_children)
             iteration_widths.append(false_width)
+            branch_labels.append("else:")
+
+        branch_label_widths = [
+            self._estimate_label_box_width(label) for label in branch_labels
+        ]
 
         return VUnfoldedSequence(
             node_key=node_key,
@@ -1807,7 +1913,109 @@ class CircuitAnalyzer:
             iteration_widths=iteration_widths,
             condition_label=condition_label,
             affected_qubits_precise=affected_qubits_precise,
+            condition_label_width=branch_label_widths[0],
+            branch_label_widths=branch_label_widths,
         )
+
+    def _format_condition_expr(
+        self,
+        value: ValueBase | None,
+        body_operations: list[Operation] | None,
+        param_values: dict | None,
+        depth: int = 0,
+    ) -> str | None:
+        """Spell an IfOperation condition as source-like text.
+
+        Walks the classical producer chain (CompOp / CondOp / NotOp / BinOp)
+        that computes ``value`` so a symbolic ``if`` renders as, e.g.,
+        ``flag == 1`` instead of an anonymous placeholder. A value with a
+        meaningful name (a measurement bit such as ``q0_measured``, or a bound
+        parameter) short-circuits to that name; a constant to its literal.
+
+        Args:
+            value (ValueBase | None): The condition value
+                (``IfOperation.condition``) or a sub-operand reached during
+                recursion. None yields None.
+            body_operations (list[Operation] | None): Operations of the scope
+                enclosing the ``if``, searched to find the producer of
+                ``value``. None disables producer lookup (name/const only).
+            param_values (dict | None): Resolved loop/parameter values used to
+                fold a symbolic operand to a constant when possible.
+            depth (int): Current recursion depth; guards against runaway or
+                cyclic producer chains. Defaults to 0.
+
+        Returns:
+            str | None: A human-readable predicate (e.g. ``"flag == 1"``,
+                ``"not done"``, ``"i < n"``), or None when ``value`` cannot be
+                described from name, constant, or a recognized producer.
+        """
+        if value is None:
+            return None
+
+        # A meaningful name (measurement bit, bound parameter) wins.
+        name = getattr(value, "name", None)
+        if name and not self._is_internal_temp_name(name):
+            return name
+
+        # Constant literal, possibly via param_values resolution.
+        if isinstance(value, Value):
+            const = self._evaluate_value(value, param_values or {})
+            if const is not None:
+                return str(const)
+
+        if depth >= 4 or not body_operations:
+            return None
+
+        producer = self._find_producer_op(value, body_operations)
+        if producer is None:
+            return None
+
+        def sub(operand: ValueBase | None) -> str:
+            """Format a binary operand, falling back to ``?`` when unknown."""
+            return (
+                self._format_condition_expr(
+                    operand, body_operations, param_values, depth + 1
+                )
+                or "?"
+            )
+
+        if isinstance(producer, CompOp) and producer.kind in _COMP_OP_SYMBOLS:
+            symbol = _COMP_OP_SYMBOLS[producer.kind]
+            return f"{sub(producer.operands[0])} {symbol} {sub(producer.operands[1])}"
+        if isinstance(producer, CondOp) and producer.kind in _COND_OP_SYMBOLS:
+            symbol = _COND_OP_SYMBOLS[producer.kind]
+            return f"{sub(producer.operands[0])} {symbol} {sub(producer.operands[1])}"
+        if isinstance(producer, NotOp):
+            return f"not {sub(producer.operands[0])}"
+        if isinstance(producer, BinOp) and producer.kind in _BIN_OP_SYMBOLS:
+            symbol = _BIN_OP_SYMBOLS[producer.kind]
+            return f"{sub(producer.operands[0])} {symbol} {sub(producer.operands[1])}"
+        return None
+
+    def _find_producer_op(
+        self,
+        value: ValueBase,
+        body_operations: list[Operation],
+    ) -> Operation | None:
+        """Find the operation in scope whose result is ``value``.
+
+        Args:
+            value (ValueBase): The value whose producing operation is sought.
+            body_operations (list[Operation]): Operations of the scope to scan.
+
+        Returns:
+            Operation | None: The first operation whose results include a value
+                with the same UUID as ``value``, or None if no producer is in
+                ``body_operations`` (e.g. ``value`` is a block input).
+        """
+        target = getattr(value, "uuid", None)
+        if target is None:
+            return None
+        for candidate in body_operations:
+            for result in candidate.results:
+                if getattr(result, "uuid", None) == target:
+                    return candidate
+        return None
 
     def _build_vfor_items(
         self,

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1862,11 +1862,14 @@ class CircuitAnalyzer:
             if op.false_operations:
                 if not body_lines:
                     body_lines.append("pass")
-                body_lines.append("else:")
                 false_lines = self._format_folded_body_lines(
                     op.false_operations, param_values
                 )
-                body_lines.extend(false_lines or ["pass"])
+                if false_lines:
+                    body_lines.append(f"else: {false_lines[0].lstrip()}")
+                    body_lines.extend(false_lines[1:])
+                else:
+                    body_lines.append("else: pass")
             if len(body_lines) > 3:
                 body_lines = body_lines[:3] + ["..."]
 

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1824,9 +1824,10 @@ class CircuitAnalyzer:
         ``CompileTimeIfLoweringPass`` before visual analysis runs, so this method
         only handles conditions that survive — measurement-backed runtime
         ``if`` and symbolic (unbound) classical ``if``. When ``fold_ifs`` is
-        enabled it returns a single ``VFoldedBlock`` summarizing the true
-        branch; otherwise it returns a ``VUnfoldedSequence`` carrying both
-        branches for side-by-side rendering.
+        enabled it returns a single ``VFoldedBlock`` summarizing the true branch
+        and, when present, the else branch; otherwise it returns a
+        ``VUnfoldedSequence`` carrying the surviving branch alternatives for
+        side-by-side rendering.
 
         Args:
             op (IfOperation): The if/else operation to visualize.

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1854,6 +1854,20 @@ class CircuitAnalyzer:
             op.condition, body_operations, param_values
         )
         condition_label = f"if {condition_expr}:" if condition_expr else "if cond:"
+        condition_measure_info = self._condition_measure_info(
+            op.condition,
+            body_operations,
+            qubit_map,
+            logical_id_remap,
+            param_values,
+            scope_path,
+        )
+        condition_measure_node_key: tuple | None = None
+        condition_measure_qubit_indices: list[int] = []
+        if condition_measure_info is not None:
+            condition_measure_node_key, condition_measure_qubit_indices = (
+                condition_measure_info
+            )
 
         if self.fold_ifs:
             body_lines = self._format_folded_body_lines(
@@ -1883,6 +1897,8 @@ class CircuitAnalyzer:
                 folded_width=folded_width,
                 kind=VFoldedKind.IF,
                 affected_qubits_precise=affected_qubits_precise,
+                condition_measure_node_key=condition_measure_node_key,
+                condition_measure_qubit_indices=condition_measure_qubit_indices,
             )
 
         # Unfolded: build both branches
@@ -1930,7 +1946,119 @@ class CircuitAnalyzer:
             affected_qubits_precise=affected_qubits_precise,
             condition_label_width=branch_label_widths[0],
             branch_label_widths=branch_label_widths,
+            condition_measure_node_key=condition_measure_node_key,
+            condition_measure_qubit_indices=condition_measure_qubit_indices,
         )
+
+    def _condition_measure_info(
+        self,
+        value: ValueBase | None,
+        body_operations: list[Operation] | None,
+        qubit_map: dict[str, int],
+        logical_id_remap: dict[str, str],
+        param_values: dict,
+        scope_path: tuple,
+    ) -> tuple[tuple, list[int]] | None:
+        """Return the direct measurement node that produced an IF condition.
+
+        Only a condition value produced directly by a measurement operation is
+        treated as measurement-derived. Compound predicates such as
+        ``not bit`` or ``bit and flag`` are produced by classical operations and
+        intentionally return None.
+
+        Args:
+            value (ValueBase | None): The IF condition value to inspect.
+            body_operations (list[Operation] | None): Operations in the scope
+                enclosing the IF operation.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+            scope_path (tuple): Path of enclosing scope keys.
+
+        Returns:
+            tuple[tuple, list[int]] | None: The producer node key and measured
+                qubit indices, or None when the condition is not produced
+                directly by a measurement operation.
+        """
+        if value is None or not body_operations:
+            return None
+
+        producer = self._find_direct_measure_producer_op(value, body_operations)
+        if producer is None:
+            return None
+
+        qubit_indices = self._measure_qubit_indices(
+            producer, qubit_map, logical_id_remap, param_values
+        )
+        return (*scope_path, id(producer)), qubit_indices
+
+    def _find_direct_measure_producer_op(
+        self,
+        value: ValueBase,
+        body_operations: list[Operation],
+    ) -> MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation | None:
+        """Find a measurement operation that directly produced ``value``.
+
+        Args:
+            value (ValueBase): The condition value to match against
+                measurement results.
+            body_operations (list[Operation]): Operations in the enclosing
+                scope.
+
+        Returns:
+            MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation | None:
+                The direct measurement producer, or None if ``value`` is
+                produced by another operation.
+        """
+        target_uuid = getattr(value, "uuid", None)
+        parent_array = getattr(value, "parent_array", None)
+        parent_uuid = getattr(parent_array, "uuid", None)
+        for candidate in body_operations:
+            if not isinstance(
+                candidate,
+                (MeasureOperation, MeasureVectorOperation, MeasureQFixedOperation),
+            ):
+                continue
+            for result in candidate.results:
+                result_uuid = getattr(result, "uuid", None)
+                if target_uuid is not None and result_uuid == target_uuid:
+                    return candidate
+                if parent_uuid is not None and result_uuid == parent_uuid:
+                    return candidate
+        return None
+
+    def _measure_qubit_indices(
+        self,
+        op: MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation,
+        qubit_map: dict[str, int],
+        logical_id_remap: dict[str, str],
+        param_values: dict,
+    ) -> list[int]:
+        """Resolve the qubit wires touched by a measurement operation.
+
+        Args:
+            op (MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation):
+                Measurement operation whose quantum operand should be resolved.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            list[int]: Wire indices touched by ``op``. Empty when the operand
+                cannot be resolved.
+        """
+        if not op.operands:
+            return []
+        if isinstance(op, MeasureQFixedOperation):
+            return self._resolve_qfixed_carrier_indices(
+                op.operands[0], qubit_map, logical_id_remap
+            )
+        indices = self._resolve_operand_to_qubit_indices(
+            op.operands[0], qubit_map, logical_id_remap, param_values
+        )
+        return indices or []
 
     def _format_folded_body_lines(
         self,

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -221,13 +221,29 @@ class CircuitAnalyzer:
         fold_loops: bool = True,
         expand_composite: bool = False,
         inline_depth: int | None = None,
+        fold_ifs: bool = False,
     ):
+        """Initialize the visualization analyzer.
+
+        Args:
+            graph (Block): Computation graph to analyze for rendering.
+            style (CircuitStyle): Visual style configuration.
+            inline (bool): Whether to inline CallBlockOperation contents.
+            fold_loops (bool): Whether to render loop operations as folded
+                summary blocks instead of materialized iterations.
+            expand_composite (bool): Whether to expand composite gates.
+            inline_depth (int | None): Maximum nesting depth for inline
+                expansion, or None for unlimited depth.
+            fold_ifs (bool): Whether to render IfOperation nodes as folded
+                summary blocks instead of side-by-side branches.
+        """
         self.graph = graph
         self.style = style
         self.inline = inline
         self.fold_loops = fold_loops
         self.expand_composite = expand_composite
         self.inline_depth = inline_depth
+        self.fold_ifs = fold_ifs
 
     def _should_inline_at_depth(self, depth: int) -> bool:
         """Whether to inline CallBlock/ControlledU at this nesting depth."""
@@ -1807,9 +1823,9 @@ class CircuitAnalyzer:
         Compile-time resolvable ``if``s are already lowered away by
         ``CompileTimeIfLoweringPass`` before visual analysis runs, so this method
         only handles conditions that survive — measurement-backed runtime
-        ``if`` and symbolic (unbound) classical ``if``. In folded mode it
-        returns a single ``VFoldedBlock`` summarizing the true branch; in
-        unfolded mode it returns a ``VUnfoldedSequence`` carrying both
+        ``if`` and symbolic (unbound) classical ``if``. When ``fold_ifs`` is
+        enabled it returns a single ``VFoldedBlock`` summarizing the true
+        branch; otherwise it returns a ``VUnfoldedSequence`` carrying both
         branches for side-by-side rendering.
 
         Args:
@@ -1828,8 +1844,7 @@ class CircuitAnalyzer:
 
         Returns:
             VFoldedBlock | VUnfoldedSequence: A folded summary box when
-                ``fold_loops`` is set, otherwise an unfolded two-branch
-                sequence.
+                ``fold_ifs`` is set, otherwise an unfolded two-branch sequence.
         """
         affected_qubits, affected_qubits_precise = self._collect_if_affected_qubits(
             op, qubit_map, logical_id_remap, param_values
@@ -1840,21 +1855,18 @@ class CircuitAnalyzer:
         )
         condition_label = f"if {condition_expr}:" if condition_expr else "if cond:"
 
-        if self.fold_loops:
-            local_param_values = dict(param_values)
-            self._evaluate_loop_body_intermediates(
-                op.true_operations, local_param_values
+        if self.fold_ifs:
+            body_lines = self._format_folded_body_lines(
+                op.true_operations, param_values
             )
-            body_lines: list[str] = []
-            for body_op in op.true_operations:
-                expr = self._format_operation_as_expression(
-                    body_op,
-                    set(),
-                    body_operations=op.true_operations,
-                    param_values=local_param_values,
+            if op.false_operations:
+                if not body_lines:
+                    body_lines.append("pass")
+                body_lines.append("else:")
+                false_lines = self._format_folded_body_lines(
+                    op.false_operations, param_values
                 )
-                if expr:
-                    body_lines.extend(expr.split("\n"))
+                body_lines.extend(false_lines or ["pass"])
             if len(body_lines) > 3:
                 body_lines = body_lines[:3] + ["..."]
 
@@ -1917,6 +1929,35 @@ class CircuitAnalyzer:
             branch_label_widths=branch_label_widths,
         )
 
+    def _format_folded_body_lines(
+        self,
+        operations: list[Operation],
+        param_values: dict,
+    ) -> list[str]:
+        """Format operations for a folded control-flow summary body.
+
+        Args:
+            operations (list[Operation]): Branch or loop body operations to
+                summarize.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            list[str]: Human-readable operation expressions in order.
+        """
+        local_param_values = dict(param_values)
+        self._evaluate_loop_body_intermediates(operations, local_param_values)
+        body_lines: list[str] = []
+        for body_op in operations:
+            expr = self._format_operation_as_expression(
+                body_op,
+                set(),
+                body_operations=operations,
+                param_values=local_param_values,
+            )
+            if expr:
+                body_lines.extend(expr.split("\n"))
+        return body_lines
+
     def _format_condition_expr(
         self,
         value: ValueBase | None,
@@ -1971,7 +2012,14 @@ class CircuitAnalyzer:
             return None
 
         def sub(operand: ValueBase | None) -> str:
-            """Format a binary operand, falling back to ``?`` when unknown."""
+            """Format a binary operand.
+
+            Args:
+                operand (ValueBase | None): Operand to format recursively.
+
+            Returns:
+                str: Formatted operand, or ``?`` when unknown.
+            """
             return (
                 self._format_condition_expr(
                     operand, body_operations, param_values, depth + 1

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1988,8 +1988,8 @@ class CircuitAnalyzer:
         if producer is None:
             return None
 
-        qubit_indices = self._measure_qubit_indices(
-            producer, qubit_map, logical_id_remap, param_values
+        qubit_indices = self._measure_condition_qubit_indices(
+            value, producer, qubit_map, logical_id_remap, param_values
         )
         return (*scope_path, id(producer)), qubit_indices
 
@@ -2026,6 +2026,150 @@ class CircuitAnalyzer:
                     return candidate
                 if parent_uuid is not None and result_uuid == parent_uuid:
                     return candidate
+        return None
+
+    def _measure_condition_qubit_indices(
+        self,
+        value: ValueBase,
+        op: MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation,
+        qubit_map: dict[str, int],
+        logical_id_remap: dict[str, str],
+        param_values: dict,
+    ) -> list[int]:
+        """Resolve the measurement wires used by an IF condition value.
+
+        Args:
+            value (ValueBase): IF condition value produced by ``op``.
+            op (MeasureOperation | MeasureVectorOperation | MeasureQFixedOperation):
+                Measurement operation that directly produced ``value``.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            list[int]: Wire indices relevant to the condition. For a vector
+                measurement element such as ``bits[1]``, this narrows to the
+                corresponding measured qubit when the element index resolves.
+        """
+        if isinstance(op, MeasureVectorOperation):
+            wire = self._measure_vector_condition_wire(
+                value, op, qubit_map, logical_id_remap, param_values
+            )
+            if wire is not None:
+                return [wire]
+        return self._measure_qubit_indices(
+            op, qubit_map, logical_id_remap, param_values
+        )
+
+    def _measure_vector_condition_wire(
+        self,
+        value: ValueBase,
+        op: MeasureVectorOperation,
+        qubit_map: dict[str, int],
+        logical_id_remap: dict[str, str],
+        param_values: dict,
+    ) -> int | None:
+        """Resolve ``measure(qs)[i]`` to the measured ``qs[i]`` wire.
+
+        Args:
+            value (ValueBase): IF condition value, possibly an element of the
+                vector measurement result.
+            op (MeasureVectorOperation): Vector measurement producer.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            int | None: The corresponding measured qubit wire, or None when
+                the condition is not a resolvable vector element.
+        """
+        if not op.operands:
+            return None
+        index = self._condition_array_element_index(value, param_values)
+        if index is None:
+            return None
+        return self._resolve_array_operand_index_to_qubit(
+            op.operands[0], index, qubit_map, logical_id_remap, param_values
+        )
+
+    def _condition_array_element_index(
+        self,
+        value: ValueBase,
+        param_values: dict,
+    ) -> int | None:
+        """Resolve the first array-element index of a condition value.
+
+        Args:
+            value (ValueBase): Condition value to inspect.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            int | None: The concrete element index, or None when ``value`` is
+                not a resolvable array element.
+        """
+        if not isinstance(value, Value):
+            return None
+        if not (hasattr(value, "parent_array") and value.parent_array is not None):
+            return None
+        if not (hasattr(value, "element_indices") and value.element_indices):
+            return None
+
+        index_value = value.element_indices[0]
+        if index_value.is_constant():
+            index = index_value.get_const()
+        else:
+            index = self._evaluate_value(index_value, param_values)
+        if index is None:
+            return None
+        return int(index)
+
+    def _resolve_array_operand_index_to_qubit(
+        self,
+        operand: Value,
+        index: int,
+        qubit_map: dict[str, int],
+        logical_id_remap: dict[str, str],
+        param_values: dict,
+    ) -> int | None:
+        """Resolve one element of a measured qubit array operand.
+
+        Args:
+            operand (Value): Quantum array operand of ``MeasureVectorOperation``.
+            index (int): Concrete element index selected from the measurement
+                result.
+            qubit_map (dict[str, int]): Mapping from logical_id to wire index.
+            logical_id_remap (dict[str, str]): Mapping from formal-parameter
+                logical_ids to actual-argument logical_ids in scope.
+            param_values (dict): Resolved loop/parameter values in scope.
+
+        Returns:
+            int | None: The qubit wire corresponding to ``operand[index]``, or
+                None when the array operand cannot be resolved.
+        """
+        if not isinstance(operand, ArrayValue):
+            return None
+        resolved_lid = logical_id_remap.get(operand.logical_id, operand.logical_id)
+        if getattr(operand, "slice_of", None) is not None:
+            chain = self._resolve_view_chain_to_root(operand, param_values)
+            if chain is None:
+                return None
+            root_av, start, step = chain
+            root_lid = logical_id_remap.get(root_av.logical_id, root_av.logical_id)
+            root_index = start + step * index
+            root_element_key = f"{root_lid}_[{root_index}]"
+            if root_element_key in qubit_map:
+                return qubit_map[root_element_key]
+            if root_lid in qubit_map:
+                return qubit_map[root_lid] + root_index
+            return None
+
+        element_key = f"{resolved_lid}_[{index}]"
+        if element_key in qubit_map:
+            return qubit_map[element_key]
+        if resolved_lid in qubit_map:
+            return qubit_map[resolved_lid] + index
         return None
 
     def _measure_qubit_indices(

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1869,6 +1869,9 @@ class CircuitAnalyzer:
             condition_measure_node_key, condition_measure_qubit_indices = (
                 condition_measure_info
             )
+        if not affected_qubits and condition_measure_qubit_indices:
+            affected_qubits = list(dict.fromkeys(condition_measure_qubit_indices))
+            affected_qubits_precise = True
 
         if self.fold_ifs:
             body_lines = self._format_folded_body_lines(

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -47,6 +47,9 @@ from qamomile.circuit.ir.operation.operation import QInitOperation
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.types.primitives import QubitType
 from qamomile.circuit.ir.value import ArrayValue, DictValue, Value, ValueBase
+from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
+    CompileTimeIfLoweringPass,
+)
 
 from .geometry import compute_border_padding
 from .style import CircuitStyle
@@ -1604,6 +1607,11 @@ class CircuitAnalyzer:
             logical_id_remap,
             param_values,
             qubit_map=qubit_map,
+        )
+        # Inline expansion sees actual arguments, so callee-local compile-time IFs
+        # can be lowered before building child visual nodes.
+        block_value = CompileTimeIfLoweringPass(bindings=child_param_values).run(
+            block_value
         )
 
         self._evaluate_loop_body_intermediates(

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1872,6 +1872,10 @@ class CircuitAnalyzer:
         if not affected_qubits and condition_measure_qubit_indices:
             affected_qubits = list(dict.fromkeys(condition_measure_qubit_indices))
             affected_qubits_precise = True
+        elif not affected_qubits and qubit_map:
+            # Empty symbolic IFs still need a display wire for their branch box.
+            affected_qubits = [min(qubit_map.values())]
+            affected_qubits_precise = False
 
         if self.fold_ifs:
             body_lines = self._format_folded_body_lines(

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
 _INTERNAL_TMP_NAMES: frozenset[str] = frozenset({"uint_tmp", "float_tmp", "bit_tmp"})
 
 
-# String markers appended to a node's scope path for the true / else branch of
+# String markers appended to a node's scope path for the true / false branch of
 # an ``IfOperation`` (see ``_build_vif`` and the layout engine's unfolded-if
 # placement). They are the only non-integer scope-path elements any node key
 # carries, so their presence uniquely identifies a node nested inside an
@@ -1159,7 +1159,7 @@ class CircuitAnalyzer:
 
         Returns:
             bool: True if any element of ``node_key`` is an if-branch marker,
-                meaning the node is nested inside a true/else branch.
+                meaning the node is nested inside a true/false branch.
         """
         return any(
             isinstance(part, str) and part in _IF_BRANCH_SCOPE_KEYS for part in node_key

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -1920,23 +1920,25 @@ class CircuitAnalyzer:
             )
 
         # Unfolded: build both branches
-        self._evaluate_loop_body_intermediates(op.true_operations, param_values)
+        true_param_values = dict(param_values)
+        self._evaluate_loop_body_intermediates(op.true_operations, true_param_values)
         true_children = self._build_visual_nodes(
             op.true_operations,
             qubit_map,
             logical_id_remap,
-            param_values,
+            true_param_values,
             depth + 1,
             (*node_key, "true"),
         )
         true_width = self._sum_visual_widths(true_children)
 
-        self._evaluate_loop_body_intermediates(op.false_operations, param_values)
+        false_param_values = dict(param_values)
+        self._evaluate_loop_body_intermediates(op.false_operations, false_param_values)
         false_children = self._build_visual_nodes(
             op.false_operations,
             qubit_map,
             logical_id_remap,
-            param_values,
+            false_param_values,
             depth + 1,
             (*node_key, "false"),
         )

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -47,9 +47,6 @@ from qamomile.circuit.ir.operation.operation import QInitOperation
 from qamomile.circuit.ir.operation.return_operation import ReturnOperation
 from qamomile.circuit.ir.types.primitives import QubitType
 from qamomile.circuit.ir.value import ArrayValue, DictValue, Value, ValueBase
-from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
-    CompileTimeIfLoweringPass,
-)
 
 from .geometry import compute_border_padding
 from .style import CircuitStyle
@@ -1610,6 +1607,10 @@ class CircuitAnalyzer:
         )
         # Inline expansion sees actual arguments, so callee-local compile-time IFs
         # can be lowered before building child visual nodes.
+        from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
+            CompileTimeIfLoweringPass,
+        )
+
         block_value = CompileTimeIfLoweringPass(bindings=child_param_values).run(
             block_value
         )

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -25,9 +25,12 @@ def _prepare_graph_for_visualization(graph: Block) -> Block:
         graph (Block): Freshly traced block to visualize.
 
     Returns:
-        Block: Graph with compile-time resolvable ``IfOperation`` nodes lowered
-            to their selected branch, while runtime/symbolic conditions remain
-            available for branch-box rendering.
+        Block: For ``TRACED``, ``AFFINE``, and ``HIERARCHICAL`` graphs, a graph
+            with compile-time resolvable ``IfOperation`` nodes lowered to their
+            selected branch while runtime/symbolic conditions remain available
+            for branch-box rendering. ``ANALYZED`` graphs are returned
+            unchanged because compile-time lowering must run before dependency
+            analysis.
 
     Raises:
         AssertionError: If the graph has an unknown ``BlockKind``.

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -33,7 +33,7 @@ def _prepare_graph_for_visualization(graph: Block) -> Block:
             analysis.
 
     Raises:
-        AssertionError: If the graph has an unknown ``BlockKind``.
+        ValueError: If the graph has an unknown ``BlockKind``.
     """
     from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
         CompileTimeIfLoweringPass,
@@ -43,7 +43,7 @@ def _prepare_graph_for_visualization(graph: Block) -> Block:
         return CompileTimeIfLoweringPass().run(graph)
     if graph.kind == BlockKind.ANALYZED:
         return graph
-    raise AssertionError(f"Unknown block kind for visualization: {graph.kind}")
+    raise ValueError(f"Unknown block kind for visualization: {graph.kind}")
 
 
 class MatplotlibDrawer:

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -63,6 +63,10 @@ class MatplotlibDrawer:
             graph (Block): Computation graph to visualize.
             style (CircuitStyle | None): Visual style configuration. Uses
                 DEFAULT_STYLE if None.
+
+        Raises:
+            ValidationError: If compile-time if lowering rejects ``graph``.
+            ValueError: If ``graph`` has an unknown ``BlockKind``.
         """
         self.graph = _prepare_graph_for_visualization(graph)
         self.style = style or DEFAULT_STYLE

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -33,6 +33,7 @@ def _prepare_graph_for_visualization(graph: Block) -> Block:
             analysis.
 
     Raises:
+        ValidationError: If compile-time if lowering rejects the input graph.
         ValueError: If the graph has an unknown ``BlockKind``.
     """
     from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -59,8 +59,9 @@ class MatplotlibDrawer:
         """Initialize the drawer.
 
         Args:
-            graph: Computation graph to visualize.
-            style: Visual style configuration. Uses DEFAULT_STYLE if None.
+            graph (Block): Computation graph to visualize.
+            style (CircuitStyle | None): Visual style configuration. Uses
+                DEFAULT_STYLE if None.
         """
         self.graph = _prepare_graph_for_visualization(graph)
         self.style = style or DEFAULT_STYLE
@@ -71,24 +72,35 @@ class MatplotlibDrawer:
         fold_loops: bool = True,
         expand_composite: bool = False,
         inline_depth: int | None = None,
+        fold_ifs: bool = False,
     ) -> Figure:
         """Generate a matplotlib Figure of the circuit.
 
         Args:
-            inline: If True, expand CallBlockOperation. If False, show as boxes.
-            fold_loops: If True (default), display ForOperation as blocks instead of unrolling.
-                       If False, expand loops and show all iterations.
-            expand_composite: If True, expand CompositeGateOperation (QFT, IQFT, etc.).
-                            If False (default), show as boxes. Independent of inline.
-            inline_depth: Maximum nesting depth for inline expansion. None means
-                         unlimited (default). 0 means no inlining, 1 means top-level
-                         only, etc. Only affects CallBlock/ControlledU, not CompositeGate.
+            inline (bool): If True, expand CallBlockOperation. If False, show
+                calls as boxes.
+            fold_loops (bool): If True (default), display ForOperation as
+                blocks instead of unrolling. If False, expand loops and show
+                all iterations.
+            expand_composite (bool): If True, expand CompositeGateOperation
+                nodes. If False (default), show them as boxes.
+            inline_depth (int | None): Maximum nesting depth for inline
+                expansion. None means unlimited. Only affects CallBlock and
+                ControlledU nodes, not CompositeGate.
+            fold_ifs (bool): If True, display IfOperation as folded summary
+                blocks. If False (default), show if/else branches side by side.
 
         Returns:
-            Figure object.
+            Figure: Matplotlib figure object.
         """
         analyzer = CircuitAnalyzer(
-            self.graph, self.style, inline, fold_loops, expand_composite, inline_depth
+            self.graph,
+            self.style,
+            inline=inline,
+            fold_loops=fold_loops,
+            expand_composite=expand_composite,
+            inline_depth=inline_depth,
+            fold_ifs=fold_ifs,
         )
         qubit_map, qubit_names, num_qubits = analyzer.build_qubit_map(self.graph)
 
@@ -107,6 +119,7 @@ class MatplotlibDrawer:
         *,
         inline: bool = False,
         fold_loops: bool = True,
+        fold_ifs: bool = False,
         expand_composite: bool = False,
         inline_depth: int | None = None,
         style: CircuitStyle | None = None,
@@ -118,23 +131,28 @@ class MatplotlibDrawer:
         specify the array size (e.g., ``inputs=3`` for a 3-qubit vector).
 
         Args:
-            kernel: A QKernel instance to visualize.
-            inline: If True, expand CallBlockOperation contents.
-            fold_loops: If True (default), display ForOperation as blocks.
-            expand_composite: If True, expand CompositeGateOperation.
-            inline_depth: Maximum nesting depth for inline expansion.
-            style: Visual style configuration.
-            **kwargs: Concrete values for kernel arguments. For Vector[Qubit]
-                     parameters, pass an integer size.
+            kernel (Any): A QKernel instance to visualize.
+            inline (bool): If True, expand CallBlockOperation contents.
+            fold_loops (bool): If True (default), display ForOperation as
+                blocks.
+            fold_ifs (bool): If True, display IfOperation as folded summary
+                blocks. If False (default), show if/else branches side by side.
+            expand_composite (bool): If True, expand CompositeGateOperation.
+            inline_depth (int | None): Maximum nesting depth for inline
+                expansion.
+            style (CircuitStyle | None): Visual style configuration.
+            **kwargs (Any): Concrete values for kernel arguments. For
+                Vector[Qubit] parameters, pass an integer size.
 
         Returns:
-            Figure object.
+            Figure: Matplotlib figure object.
         """
         graph = kernel._build_graph_for_visualization(**kwargs)
         drawer = cls(graph, style)
         return drawer.draw(
             inline=inline,
             fold_loops=fold_loops,
+            fold_ifs=fold_ifs,
             expand_composite=expand_composite,
             inline_depth=inline_depth,
         )

--- a/qamomile/circuit/visualization/drawer.py
+++ b/qamomile/circuit/visualization/drawer.py
@@ -10,12 +10,37 @@ from typing import Any
 
 from matplotlib.figure import Figure
 
-from qamomile.circuit.ir.block import Block
+from qamomile.circuit.ir.block import Block, BlockKind
 
 from .analyzer import CircuitAnalyzer
 from .layout import CircuitLayoutEngine
 from .renderer import MatplotlibRenderer
 from .style import DEFAULT_STYLE, CircuitStyle
+
+
+def _prepare_graph_for_visualization(graph: Block) -> Block:
+    """Apply visualization-only IR preparation before analysis.
+
+    Args:
+        graph (Block): Freshly traced block to visualize.
+
+    Returns:
+        Block: Graph with compile-time resolvable ``IfOperation`` nodes lowered
+            to their selected branch, while runtime/symbolic conditions remain
+            available for branch-box rendering.
+
+    Raises:
+        AssertionError: If the graph has an unknown ``BlockKind``.
+    """
+    from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
+        CompileTimeIfLoweringPass,
+    )
+
+    if graph.kind in (BlockKind.TRACED, BlockKind.AFFINE, BlockKind.HIERARCHICAL):
+        return CompileTimeIfLoweringPass().run(graph)
+    if graph.kind == BlockKind.ANALYZED:
+        return graph
+    raise AssertionError(f"Unknown block kind for visualization: {graph.kind}")
 
 
 class MatplotlibDrawer:
@@ -34,7 +59,7 @@ class MatplotlibDrawer:
             graph: Computation graph to visualize.
             style: Visual style configuration. Uses DEFAULT_STYLE if None.
         """
-        self.graph = graph
+        self.graph = _prepare_graph_for_visualization(graph)
         self.style = style or DEFAULT_STYLE
 
     def draw(

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -441,7 +441,10 @@ class CircuitLayoutEngine:
         state.actual_width = max(state.actual_width, state.column)
 
         qubit_y, max_above, max_below = self._compute_qubit_y_positions(
-            vc.num_qubits, state.block_ranges, state.label_extents
+            vc.num_qubits,
+            state.block_ranges,
+            state.label_extents,
+            state.folded_block_extents,
         )
 
         return LayoutResult(
@@ -467,6 +470,7 @@ class CircuitLayoutEngine:
         num_qubits: int,
         block_ranges: list[dict],
         label_extents: list[dict] | None = None,
+        folded_block_extents: dict[tuple, dict] | None = None,
     ) -> tuple[list[float], dict[int, float], dict[int, float]]:
         """Compute y-positions with variable spacing based on block borders.
 
@@ -483,12 +487,17 @@ class CircuitLayoutEngine:
                 ``{"top_qubit": int, "num_lines": int}`` and only widens the
                 clearance above its top qubit. Defaults to None (treated as
                 empty).
+            folded_block_extents: Folded summary boxes keyed by node key. Each
+                value contains ``affected_qubits`` and ``num_text_lines`` so the
+                vertical spacing can reserve the same text height rendered by
+                ``MatplotlibRenderer``. Defaults to None (treated as empty).
 
         Returns:
             Tuple of (y_positions, max_above, max_below).
         """
         label_extents = label_extents or []
-        if not block_ranges and not label_extents:
+        folded_block_extents = folded_block_extents or {}
+        if not block_ranges and not label_extents and not folded_block_extents:
             max_above: dict[int, float] = {}
             max_below: dict[int, float] = {}
             if num_qubits <= 1:
@@ -571,6 +580,27 @@ class CircuitLayoutEngine:
                     max_above[q] = max(max_above[q], gate_half + padding)
                 if q != bottom_q:
                     max_below[q] = max(max_below[q], gate_half + padding)
+
+        # Folded control-flow blocks are centered on their affected qubits and
+        # may be taller than a gate because they contain a multi-line summary.
+        # Reserve the rendered half-height plus a neighboring gate half-height
+        # so adjacent wires and gates do not collide with the summary box.
+        for folded_extent in folded_block_extents.values():
+            qubits = sorted(folded_extent.get("affected_qubits", []))
+            if not qubits:
+                continue
+            num_lines = folded_extent.get("num_text_lines", 1)
+            min_text_height = (
+                num_lines * self.style.line_height
+                + 2 * self.style.folded_box_text_v_padding
+            )
+            extent = max(gate_half, min_text_height / 2) + gate_half
+            top_q = qubits[0]
+            bottom_q = qubits[-1]
+            max_above[top_q] = max(max_above[top_q], extent)
+            max_below[bottom_q] = max(max_below[bottom_q], extent)
+            if len(qubits) == 1:
+                max_below[top_q] = max(max_below[top_q], extent)
 
         # Header-only labels (unfolded if/else boxes) have no block border but
         # still draw a label above their top qubit; reserve room for it the

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -362,6 +362,7 @@ class CircuitLayoutEngine:
         label_width = node.condition_label_width if is_if else 0.0
 
         # x where the if construct begins, used to anchor label-room reservation.
+        condition_measure_box_left: float | None = None
         if is_if and affected_qubits:
             if_start = max(state.qubit_right_edges.get(q, 0.0) for q in affected_qubits)
             condition_measure_right = self._condition_measure_right_edge(
@@ -370,6 +371,9 @@ class CircuitLayoutEngine:
             if condition_measure_right is not None:
                 branch_box_pad = compute_border_padding(self.style, depth=0)
                 if_start = max(if_start, condition_measure_right + branch_box_pad)
+                condition_measure_box_left = (
+                    condition_measure_right + self.style.gate_gap
+                )
         else:
             if_start = 0.0
 
@@ -403,6 +407,8 @@ class CircuitLayoutEngine:
         # (no else) header and the trailing else header are not clipped.
         if is_if and affected_qubits:
             min_end = if_start + label_width
+            if condition_measure_box_left is not None:
+                min_end = max(min_end, condition_measure_box_left + label_width)
             for q in affected_qubits:
                 if state.qubit_right_edges.get(q, 0.0) < min_end:
                     state.qubit_right_edges[q] = min_end

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -101,11 +101,14 @@ class CircuitLayoutEngine:
             state.qubit_columns[q] = right_edge + self.style.gate_gap
             state.qubit_right_edges[q] = right_edge
 
-        # Record measurement positions for wire termination
-        if node.kind == VGateKind.MEASURE:
-            for q in affected_qubits:
-                state.qubit_end_positions[q] = min_column + op_half_width
-        elif node.kind == VGateKind.MEASURE_VECTOR:
+        # Record measurement positions for wire termination. A measurement
+        # inside an if/else branch is mid-circuit (``terminates_wire`` is
+        # False): the wire must continue past it so the other branch's range —
+        # where this qubit is never measured — still shows a wire.
+        if (
+            node.kind in (VGateKind.MEASURE, VGateKind.MEASURE_VECTOR)
+            and node.terminates_wire
+        ):
             for q in affected_qubits:
                 state.qubit_end_positions[q] = min_column + op_half_width
         elif node.kind == VGateKind.EXPVAL:
@@ -326,11 +329,22 @@ class CircuitLayoutEngine:
     ) -> None:
         """Place a VUnfoldedSequence node (unfolded For/ForItems/If)."""
         affected_qubits = node.affected_qubits
+        is_if = node.kind == VUnfoldedKind.IF
+        # Horizontal room the ``if <cond>:`` header needs; the else branch is
+        # pushed right by at least this much so the header neither overlaps the
+        # else box nor is clipped by the figure edge.
+        label_width = node.condition_label_width if is_if else 0.0
+
+        # x where the if construct begins, used to anchor label-room reservation.
+        if is_if and affected_qubits:
+            if_start = max(state.qubit_right_edges.get(q, 0.0) for q in affected_qubits)
+        else:
+            if_start = 0.0
 
         for i, iteration_children in enumerate(node.iterations):
             # For If: i=0 is "true", i=1 is "false"
             # For loops: i is iteration index
-            if node.kind == VUnfoldedKind.IF:  # Future use: not yet dispatched
+            if is_if:
                 iter_key = (*node.node_key, "true" if i == 0 else "false")
             else:
                 iter_key = (*node.node_key, i)
@@ -338,15 +352,37 @@ class CircuitLayoutEngine:
             # Align affected qubits only for IF branches (mutually exclusive
             # alternatives).  For FOR/FOR_ITEMS, skip synchronization so gates
             # on independent qubits pack at the same x-position.
-            if affected_qubits and node.kind == VUnfoldedKind.IF:
+            if affected_qubits and is_if:
                 max_edge = max(
                     state.qubit_right_edges.get(q, 0.0) for q in affected_qubits
                 )
+                # Branches after the first start past the previous branch's
+                # header label, not merely past its gates.
+                if i > 0:
+                    max_edge = max(max_edge, if_start + label_width)
                 for q in affected_qubits:
                     state.qubit_right_edges[q] = max_edge
                     state.qubit_columns[q] = max_edge + self.style.gate_gap
 
             self._place_visual_nodes(iteration_children, state, depth + 1, iter_key)
+
+        # Reserve header room past the last branch too, so a single-branch
+        # (no else) header and the trailing else header are not clipped.
+        if is_if and affected_qubits:
+            min_end = if_start + label_width
+            for q in affected_qubits:
+                if state.qubit_right_edges.get(q, 0.0) < min_end:
+                    state.qubit_right_edges[q] = min_end
+                    state.qubit_columns[q] = min_end + self.style.gate_gap
+            state.column = max(state.column, min_end + 1)
+            state.actual_width = max(state.actual_width, min_end + 0.5)
+
+            # Reserve vertical clearance for the ``if <cond>:`` / ``else:``
+            # headers, which are drawn above the topmost branch wire. Without
+            # this the header would collide with the wire directly above.
+            state.label_extents.append(
+                {"top_qubit": min(affected_qubits), "num_lines": 1}
+            )
 
     def _place_visual_nodes(
         self,
@@ -405,7 +441,7 @@ class CircuitLayoutEngine:
         state.actual_width = max(state.actual_width, state.column)
 
         qubit_y, max_above, max_below = self._compute_qubit_y_positions(
-            vc.num_qubits, state.block_ranges
+            vc.num_qubits, state.block_ranges, state.label_extents
         )
 
         return LayoutResult(
@@ -427,7 +463,10 @@ class CircuitLayoutEngine:
         )
 
     def _compute_qubit_y_positions(
-        self, num_qubits: int, block_ranges: list[dict]
+        self,
+        num_qubits: int,
+        block_ranges: list[dict],
+        label_extents: list[dict] | None = None,
     ) -> tuple[list[float], dict[int, float], dict[int, float]]:
         """Compute y-positions with variable spacing based on block borders.
 
@@ -439,11 +478,17 @@ class CircuitLayoutEngine:
             num_qubits: Total number of qubits.
             block_ranges: List of block range dicts from layout phase, each
                 containing 'qubit_indices', 'depth', 'start_x', 'end_x'.
+            label_extents: Header labels drawn above a wire that have no
+                block_ranges entry (unfolded if/else branch boxes). Each is
+                ``{"top_qubit": int, "num_lines": int}`` and only widens the
+                clearance above its top qubit. Defaults to None (treated as
+                empty).
 
         Returns:
             Tuple of (y_positions, max_above, max_below).
         """
-        if not block_ranges:
+        label_extents = label_extents or []
+        if not block_ranges and not label_extents:
             max_above: dict[int, float] = {}
             max_below: dict[int, float] = {}
             if num_qubits <= 1:
@@ -526,6 +571,15 @@ class CircuitLayoutEngine:
                     max_above[q] = max(max_above[q], gate_half + padding)
                 if q != bottom_q:
                     max_below[q] = max(max_below[q], gate_half + padding)
+
+        # Header-only labels (unfolded if/else boxes) have no block border but
+        # still draw a label above their top qubit; reserve room for it the
+        # same way a block border reserves room for its top label.
+        for label_extent in label_extents:
+            top_q = label_extent["top_qubit"]
+            num_lines = label_extent.get("num_lines", 1)
+            extent_above = gate_half + base_padding + num_lines * label_height
+            max_above[top_q] = max(max_above[top_q], extent_above)
 
         if num_qubits <= 1:
             return [0.0] * num_qubits, max_above, max_below

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -406,15 +406,18 @@ class CircuitLayoutEngine:
         # Reserve header room past the last branch too, so a single-branch
         # (no else) header and the trailing else header are not clipped.
         if is_if and affected_qubits:
-            min_end = if_start + label_width
+            branch_min_width = max(label_width, self.style.gate_width)
+            min_end = if_start + branch_min_width
             if condition_measure_box_left is not None:
-                min_end = max(min_end, condition_measure_box_left + label_width)
+                min_end = max(min_end, condition_measure_box_left + branch_min_width)
             for q in affected_qubits:
                 if state.qubit_right_edges.get(q, 0.0) < min_end:
                     state.qubit_right_edges[q] = min_end
                     state.qubit_columns[q] = min_end + self.style.gate_gap
             state.column = max(state.column, min_end + 1)
             state.actual_width = max(state.actual_width, min_end + 0.5)
+            state.positions[node.node_key] = if_start + branch_min_width / 2
+            state.block_widths[node.node_key] = branch_min_width
 
             # Reserve vertical clearance for the ``if <cond>:`` / ``else:``
             # headers, which are drawn above the topmost branch wire. Without

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 
-from .geometry import compute_block_box_bounds
+from .geometry import compute_block_box_bounds, compute_border_padding
 from .style import CircuitStyle
 from .types import (
     LayoutResult,
@@ -40,6 +40,25 @@ class CircuitLayoutEngine:
 
     def __init__(self, style: CircuitStyle):
         self.style = style
+
+    def _condition_measure_right_edge(
+        self, node_key: tuple | None, state: LayoutState
+    ) -> float | None:
+        """Return the right edge of a condition-producing measurement gate.
+
+        Args:
+            node_key (tuple | None): Node key of the measurement gate that
+                feeds an IF condition.
+            state (LayoutState): Current layout placement state.
+
+        Returns:
+            float | None: The measurement gate's right edge, or None when the
+                measurement has not been placed.
+        """
+        if node_key is None or node_key not in state.positions:
+            return None
+        width = state.gate_widths.get(node_key, self.style.gate_width)
+        return state.positions[node_key] + width / 2
 
     # ------------------------------------------------------------------
     # Place Phase: assign coordinates from pre-resolved Visual IR nodes
@@ -299,6 +318,13 @@ class CircuitLayoutEngine:
         loop_width = node.folded_width
         op_half_width = loop_width / 2
         gap = self.style.gate_gap
+        condition_measure_right = self._condition_measure_right_edge(
+            node.condition_measure_node_key, state
+        )
+        if condition_measure_right is not None:
+            start_column = max(
+                start_column, condition_measure_right + gap + op_half_width
+            )
 
         for q in affected_qubits:
             if q in state.qubit_right_edges:
@@ -338,6 +364,12 @@ class CircuitLayoutEngine:
         # x where the if construct begins, used to anchor label-room reservation.
         if is_if and affected_qubits:
             if_start = max(state.qubit_right_edges.get(q, 0.0) for q in affected_qubits)
+            condition_measure_right = self._condition_measure_right_edge(
+                node.condition_measure_node_key, state
+            )
+            if condition_measure_right is not None:
+                branch_box_pad = compute_border_padding(self.style, depth=0)
+                if_start = max(if_start, condition_measure_right + branch_box_pad)
         else:
             if_start = 0.0
 
@@ -356,6 +388,7 @@ class CircuitLayoutEngine:
                 max_edge = max(
                     state.qubit_right_edges.get(q, 0.0) for q in affected_qubits
                 )
+                max_edge = max(max_edge, if_start)
                 # Branches after the first start past the previous branch's
                 # header label, not merely past its gates.
                 if i > 0:

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -521,21 +521,23 @@ class CircuitLayoutEngine:
         the topmost qubit.
 
         Args:
-            num_qubits: Total number of qubits.
-            block_ranges: List of block range dicts from layout phase, each
+            num_qubits (int): Total number of qubits.
+            block_ranges (list[dict]): Block range dicts from layout phase, each
                 containing 'qubit_indices', 'depth', 'start_x', 'end_x'.
-            label_extents: Header labels drawn above a wire that have no
-                block_ranges entry (unfolded if/else branch boxes). Each is
-                ``{"top_qubit": int, "num_lines": int}`` and only widens the
-                clearance above its top qubit. Defaults to None (treated as
-                empty).
-            folded_block_extents: Folded summary boxes keyed by node key. Each
-                value contains ``affected_qubits`` and ``num_text_lines`` so the
-                vertical spacing can reserve the same text height rendered by
-                ``MatplotlibRenderer``. Defaults to None (treated as empty).
+            label_extents (list[dict] | None): Header labels drawn above a wire
+                that have no block_ranges entry (unfolded if/else branch boxes).
+                Each is ``{"top_qubit": int, "num_lines": int}`` and only
+                widens the clearance above its top qubit. Defaults to None
+                (treated as empty).
+            folded_block_extents (dict[tuple, dict] | None): Folded summary
+                boxes keyed by node key. Each value contains ``affected_qubits``
+                and ``num_text_lines`` so the vertical spacing can reserve the
+                same text height rendered by ``MatplotlibRenderer``. Defaults to
+                None (treated as empty).
 
         Returns:
-            Tuple of (y_positions, max_above, max_below).
+            tuple[list[float], dict[int, float], dict[int, float]]: Tuple of
+                ``(y_positions, max_above, max_below)``.
         """
         label_extents = label_extents or []
         folded_block_extents = folded_block_extents or {}

--- a/qamomile/circuit/visualization/layout.py
+++ b/qamomile/circuit/visualization/layout.py
@@ -356,10 +356,19 @@ class CircuitLayoutEngine:
         """Place a VUnfoldedSequence node (unfolded For/ForItems/If)."""
         affected_qubits = node.affected_qubits
         is_if = node.kind == VUnfoldedKind.IF
-        # Horizontal room the ``if <cond>:`` header needs; the else branch is
-        # pushed right by at least this much so the header neither overlaps the
-        # else box nor is clipped by the figure edge.
+        # Horizontal room each branch header needs; branch starts and trailing
+        # gates are pushed right so header boxes neither overlap nor get
+        # clipped by the figure edge.
         label_width = node.condition_label_width if is_if else 0.0
+        branch_min_widths: list[float] = []
+        if is_if:
+            for i in range(len(node.iterations)):
+                width = (
+                    node.branch_label_widths[i]
+                    if i < len(node.branch_label_widths)
+                    else 0.0
+                )
+                branch_min_widths.append(max(width, self.style.gate_width))
 
         # x where the if construct begins, used to anchor label-room reservation.
         condition_measure_box_left: float | None = None
@@ -394,9 +403,9 @@ class CircuitLayoutEngine:
                 )
                 max_edge = max(max_edge, if_start)
                 # Branches after the first start past the previous branch's
-                # header label, not merely past its gates.
+                # header boxes, not merely past their gates.
                 if i > 0:
-                    max_edge = max(max_edge, if_start + label_width)
+                    max_edge = max(max_edge, if_start + sum(branch_min_widths[:i]))
                 for q in affected_qubits:
                     state.qubit_right_edges[q] = max_edge
                     state.qubit_columns[q] = max_edge + self.style.gate_gap
@@ -406,18 +415,25 @@ class CircuitLayoutEngine:
         # Reserve header room past the last branch too, so a single-branch
         # (no else) header and the trailing else header are not clipped.
         if is_if and affected_qubits:
-            branch_min_width = max(label_width, self.style.gate_width)
-            min_end = if_start + branch_min_width
+            first_branch_min_width = (
+                branch_min_widths[0]
+                if branch_min_widths
+                else max(label_width, self.style.gate_width)
+            )
+            total_branch_min_width = sum(branch_min_widths) or first_branch_min_width
+            min_end = if_start + total_branch_min_width
             if condition_measure_box_left is not None:
-                min_end = max(min_end, condition_measure_box_left + branch_min_width)
+                min_end = max(
+                    min_end, condition_measure_box_left + total_branch_min_width
+                )
             for q in affected_qubits:
                 if state.qubit_right_edges.get(q, 0.0) < min_end:
                     state.qubit_right_edges[q] = min_end
                     state.qubit_columns[q] = min_end + self.style.gate_gap
             state.column = max(state.column, min_end + 1)
             state.actual_width = max(state.actual_width, min_end + 0.5)
-            state.positions[node.node_key] = if_start + branch_min_width / 2
-            state.block_widths[node.node_key] = branch_min_width
+            state.positions[node.node_key] = if_start + first_branch_min_width / 2
+            state.block_widths[node.node_key] = first_branch_min_width
 
             # Reserve vertical clearance for the ``if <cond>:`` / ``else:``
             # headers, which are drawn above the topmost branch wire. Without

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -533,20 +533,70 @@ class MatplotlibRenderer:
         # always sit clear of this box.
         prev_right: float | None = None
         for i, span in enumerate(spans):
-            if span is None:
-                continue
-            gate_left, gate_right = span
             label = labels[i] if i < len(labels) else ""
+            label_width = label_widths[i] if i < len(label_widths) else 0.0
+
+            if span is None:
+                empty_span = self._empty_branch_x_span(
+                    i, spans, prev_right, pad, label_width
+                )
+                if empty_span is None:
+                    continue
+                box_left, box_right = empty_span
+                self._draw_if_branch_box(
+                    ax, box_left, box_right, box_bottom, box_top, label
+                )
+                prev_right = box_right
+                continue
+
+            gate_left, gate_right = span
 
             box_left = gate_left - pad if prev_right is None else prev_right
             box_right = gate_right + pad
-            if i < len(label_widths):
-                box_right = max(box_right, box_left + label_widths[i])
+            if label_width > 0:
+                box_right = max(box_right, box_left + label_width)
 
             self._draw_if_branch_box(
                 ax, box_left, box_right, box_bottom, box_top, label
             )
             prev_right = box_right
+
+    def _empty_branch_x_span(
+        self,
+        branch_index: int,
+        spans: list[tuple[float, float] | None],
+        prev_right: float | None,
+        pad: float,
+        label_width: float,
+    ) -> tuple[float, float] | None:
+        """Compute a minimal x-span for an empty IF branch label box.
+
+        Args:
+            branch_index (int): Index of the empty branch within ``spans``.
+            spans (list[tuple[float, float] | None]): Per-branch positioned
+                child extents. Empty branches have ``None`` entries.
+            prev_right (float | None): Right edge of the previously drawn
+                branch box, if any.
+            pad (float): Horizontal border padding used by branch boxes.
+            label_width (float): Reserved width for this branch's header label.
+
+        Returns:
+            tuple[float, float] | None: ``(left, right)`` extent for the empty
+                branch box, or None when no neighboring positioned branch can
+                anchor it.
+        """
+        min_width = max(label_width, self.style.gate_width)
+        if prev_right is not None:
+            return prev_right, prev_right + min_width
+
+        for next_span in spans[branch_index + 1 :]:
+            if next_span is None:
+                continue
+            next_left, _ = next_span
+            box_right = next_left - pad
+            return box_right - min_width, box_right
+
+        return None
 
     def _draw_if_branch_box(
         self,

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -1342,7 +1342,22 @@ class MatplotlibRenderer:
         positions: dict[tuple, float],
         gate_widths: dict[tuple, float],
     ) -> None:
-        """Draw a folded control-flow block from VFoldedBlock."""
+        """Draw a folded control-flow block from a ``VFoldedBlock``.
+
+        Args:
+            fig (Figure): Target matplotlib figure carrying ``_qm_ax``.
+            node (VFoldedBlock): Folded block node to render.
+            x_pos (float): Center x-coordinate for the folded block.
+            block_width (float | None): Precomputed block width, or None to use
+                the width stored on ``node``.
+            positions (dict[tuple, float]): Node-key to center-x mapping, used
+                for IF condition-measurement connectors.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping,
+                used for IF condition-measurement connectors.
+
+        Returns:
+            None
+        """
         affected_qubits = node.affected_qubits
         if not affected_qubits:
             return

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -547,6 +547,10 @@ class MatplotlibRenderer:
                     empty_span = self._condition_measure_empty_branch_x_span(
                         node, positions, gate_widths, label_width
                     )
+                if empty_span is None and i == 0:
+                    empty_span = self._standalone_empty_branch_x_span(
+                        node, positions, block_widths, label_width
+                    )
                 if empty_span is None:
                     continue
                 box_left, box_right = empty_span
@@ -670,6 +674,33 @@ class MatplotlibRenderer:
         box_left = measure_right + self.style.gate_gap
         min_width = max(label_width, self.style.gate_width)
         return box_left, box_left + min_width
+
+    def _standalone_empty_branch_x_span(
+        self,
+        node: VUnfoldedSequence,
+        positions: dict[tuple, float],
+        block_widths: dict[tuple, float],
+        label_width: float,
+    ) -> tuple[float, float] | None:
+        """Return an x-span for an empty IF with no child or measurement anchor.
+
+        Args:
+            node (VUnfoldedSequence): IF node whose layout position was reserved.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            block_widths (dict[tuple, float]): Node-key to block width mapping.
+            label_width (float): Reserved width for the branch header label.
+
+        Returns:
+            tuple[float, float] | None: ``(left, right)`` extent for the empty
+                branch box, or None when layout did not reserve the IF node.
+        """
+        if node.node_key not in positions:
+            return None
+        min_width = max(
+            block_widths.get(node.node_key, 0.0), label_width, self.style.gate_width
+        )
+        center = positions[node.node_key]
+        return center - min_width / 2, center + min_width / 2
 
     def _empty_branch_x_span(
         self,

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -620,7 +620,8 @@ class MatplotlibRenderer:
         measure_key = node.condition_measure_node_key
         if measure_key is None or measure_key not in positions:
             return
-        if not node.condition_measure_qubit_indices:
+        # Ambiguous vector-measurement elements cannot identify one source wire.
+        if len(node.condition_measure_qubit_indices) != 1:
             return
 
         measure_qubit = node.condition_measure_qubit_indices[0]

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -544,12 +544,12 @@ class MatplotlibRenderer:
                     i, spans, prev_right, pad, label_width
                 )
                 if empty_span is None and i == 0:
-                    empty_span = self._condition_measure_empty_branch_x_span(
-                        node, positions, gate_widths, label_width
-                    )
-                if empty_span is None and i == 0:
                     empty_span = self._standalone_empty_branch_x_span(
                         node, positions, block_widths, label_width
+                    )
+                if empty_span is None and i == 0:
+                    empty_span = self._condition_measure_empty_branch_x_span(
+                        node, positions, gate_widths, label_width
                     )
                 if empty_span is None:
                     continue

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -1228,7 +1228,7 @@ class MatplotlibRenderer:
             edge_color = self.style.for_loop_edge_color
             text_color = self.style.for_loop_text_color
             linestyle = "-"
-        elif node.kind == VFoldedKind.IF:  # Future use: not yet dispatched
+        elif node.kind == VFoldedKind.IF:
             face_color = self.style.if_face_color
             edge_color = self.style.if_edge_color
             text_color = self.style.if_text_color

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -40,6 +40,7 @@ from .visual_ir import (
     VisualCircuit,
     VisualNode,
     VSkip,
+    VUnfoldedKind,
     VUnfoldedSequence,
 )
 
@@ -460,6 +461,13 @@ class MatplotlibRenderer:
                 continue
 
             if isinstance(node, VUnfoldedSequence):
+                if node.kind == VUnfoldedKind.IF:
+                    # Draw the if/else branch boxes first (behind gates), then
+                    # the gates of each branch on top, so the boxes read as
+                    # mutually exclusive alternatives rather than a sequence.
+                    self._draw_vif_branch_boxes(
+                        fig, node, positions, block_widths, gate_widths
+                    )
                 for iteration_children in node.iterations:
                     self._draw_visual_nodes(
                         fig,
@@ -469,6 +477,214 @@ class MatplotlibRenderer:
                         gate_widths,
                     )
                 continue
+
+    def _draw_vif_branch_boxes(
+        self,
+        fig: Figure,
+        node: VUnfoldedSequence,
+        positions: dict[tuple, float],
+        block_widths: dict[tuple, float],
+        gate_widths: dict[tuple, float],
+    ) -> None:
+        """Draw the if/else branch boxes for an unfolded IfOperation.
+
+        Each branch (``iterations[0]`` = true, ``iterations[1]`` = else) is
+        wrapped in a dash-dot rounded box spanning its gates' x-range and the
+        if's affected wires, labelled ``if <cond>:`` and ``else:`` respectively.
+        The boxes are drawn behind the gates so the gates remain legible; gates
+        themselves are drawn by the caller after this method returns.
+
+        Args:
+            fig (Figure): Target matplotlib figure (carries ``_qm_ax``).
+            node (VUnfoldedSequence): The unfolded IF sequence to box.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            block_widths (dict[tuple, float]): Node-key to block width mapping.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping.
+
+        Returns:
+            None
+        """
+        affected_qubits = node.affected_qubits
+        if not affected_qubits:
+            return
+
+        ax = fig._qm_ax  # type: ignore[attr-defined]
+        pad = compute_border_padding(self.style, depth=0)
+        y_coords = [self.qubit_y[q] for q in affected_qubits]
+        min_y = min(y_coords)
+        max_y = max(y_coords)
+
+        text_height = self._calculate_text_height(ax, "if", self.style.subfont_size)
+        label_height = text_height + 2 * self.style.label_padding
+        box_bottom = min_y - self.style.gate_height / 2 - pad
+        box_top = max_y + self.style.gate_height / 2 + pad + label_height
+
+        labels = [node.condition_label or "if cond:", "else:"]
+        label_widths = node.branch_label_widths
+        spans = [
+            self._visual_x_span(children, positions, block_widths, gate_widths)
+            for children in node.iterations
+        ]
+
+        # Lay the branch boxes out left-to-right with no gap between them: each
+        # box starts exactly where the previous one ended. A box is widened to
+        # hold its header label using the same width estimate the layout
+        # reserved, so the label never overflows and the next branch's gates
+        # always sit clear of this box.
+        prev_right: float | None = None
+        for i, span in enumerate(spans):
+            if span is None:
+                continue
+            gate_left, gate_right = span
+            label = labels[i] if i < len(labels) else ""
+
+            box_left = gate_left - pad if prev_right is None else prev_right
+            box_right = gate_right + pad
+            if i < len(label_widths):
+                box_right = max(box_right, box_left + label_widths[i])
+
+            self._draw_if_branch_box(
+                ax, box_left, box_right, box_bottom, box_top, label
+            )
+            prev_right = box_right
+
+    def _draw_if_branch_box(
+        self,
+        ax: Axes,
+        box_left: float,
+        box_right: float,
+        box_bottom: float,
+        box_top: float,
+        label: str,
+    ) -> None:
+        """Draw one dash-dot branch box with a top-left header label.
+
+        Args:
+            ax (Axes): Axes to draw on.
+            box_left (float): Left data-x edge of the box.
+            box_right (float): Right data-x edge of the box.
+            box_bottom (float): Bottom data-y edge of the box.
+            box_top (float): Top data-y edge of the box.
+            label (str): Header label drawn at the box's top-left (e.g.
+                ``"if flag == 1:"`` or ``"else:"``). Empty string draws no label.
+
+        Returns:
+            None
+        """
+        rect = mpatches.FancyBboxPatch(
+            (box_left, box_bottom),
+            box_right - box_left,
+            box_top - box_bottom,
+            boxstyle=mpatches.BoxStyle.Round(
+                pad=0, rounding_size=self.style.gate_corner_radius
+            ),
+            facecolor="none",
+            edgecolor=self.style.if_edge_color,
+            linewidth=1.5,
+            linestyle="-.",
+            zorder=PORDER_WIRE + 0.5,
+        )
+        ax.add_patch(rect)
+
+        if label:
+            ax.text(
+                box_left + self.style.label_horizontal_padding,
+                box_top - self.style.label_padding,
+                label,
+                ha="left",
+                va="top",
+                fontsize=self.style.subfont_size,
+                color=self.style.if_text_color,
+                fontweight="bold",
+                zorder=PORDER_TEXT,
+            )
+
+    def _visual_x_span(
+        self,
+        nodes: list[VisualNode],
+        positions: dict[tuple, float],
+        block_widths: dict[tuple, float],
+        gate_widths: dict[tuple, float],
+    ) -> tuple[float, float] | None:
+        """Compute the combined x-extent of a list of visual nodes.
+
+        Recurses into containers (``VInlineBlock`` children, nested
+        ``VUnfoldedSequence`` iterations) and bottoms out at ``VGate`` /
+        ``VFoldedBlock`` leaves, using each leaf's center position and width.
+
+        Args:
+            nodes (list[VisualNode]): Nodes to bound.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            block_widths (dict[tuple, float]): Node-key to block width mapping.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping.
+
+        Returns:
+            tuple[float, float] | None: ``(left, right)`` data-x extent, or None
+                when ``nodes`` contains no positioned leaf.
+        """
+        left: float | None = None
+        right: float | None = None
+        for node in nodes:
+            span = self._single_node_x_span(node, positions, block_widths, gate_widths)
+            if span is None:
+                continue
+            node_left, node_right = span
+            left = node_left if left is None else min(left, node_left)
+            right = node_right if right is None else max(right, node_right)
+        if left is None or right is None:
+            return None
+        return left, right
+
+    def _single_node_x_span(
+        self,
+        node: VisualNode,
+        positions: dict[tuple, float],
+        block_widths: dict[tuple, float],
+        gate_widths: dict[tuple, float],
+    ) -> tuple[float, float] | None:
+        """Compute the x-extent of a single visual node.
+
+        Args:
+            node (VisualNode): Node to bound.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            block_widths (dict[tuple, float]): Node-key to block width mapping.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping.
+
+        Returns:
+            tuple[float, float] | None: ``(left, right)`` data-x extent, or None
+                for zero-space nodes (``VSkip``) and unpositioned nodes.
+        """
+        if isinstance(node, VSkip):
+            return None
+        if isinstance(node, VInlineBlock):
+            return self._visual_x_span(
+                node.children, positions, block_widths, gate_widths
+            )
+        if isinstance(node, VUnfoldedSequence):
+            left: float | None = None
+            right: float | None = None
+            for branch_children in node.iterations:
+                span = self._visual_x_span(
+                    branch_children, positions, block_widths, gate_widths
+                )
+                if span is None:
+                    continue
+                node_left, node_right = span
+                left = node_left if left is None else min(left, node_left)
+                right = node_right if right is None else max(right, node_right)
+            if left is None or right is None:
+                return None
+            return left, right
+
+        key = node.node_key
+        if key not in positions:
+            return None
+        center = positions[key]
+        if isinstance(node, VFoldedBlock):
+            width = block_widths.get(key) or node.folded_width
+        else:  # VGate
+            width = gate_widths.get(key) or node.estimated_width
+        return center - width / 2, center + width / 2
 
     def _draw_vgate(
         self,

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -490,11 +490,12 @@ class MatplotlibRenderer:
     ) -> None:
         """Draw the if/else branch boxes for an unfolded IfOperation.
 
-        Each branch (``iterations[0]`` = true, ``iterations[1]`` = else) is
-        wrapped in a dash-dot rounded box spanning its gates' x-range and the
-        if's affected wires, labelled ``if <cond>:`` and ``else:`` respectively.
-        The boxes are drawn behind the gates so the gates remain legible; gates
-        themselves are drawn by the caller after this method returns.
+        The true branch (``iterations[0]``) and, when present, the else branch
+        (``iterations[1]``) are wrapped in dash-dot rounded boxes spanning their
+        gates' x-ranges and the if's affected wires. The boxes are labelled
+        ``if <cond>:`` and ``else:`` respectively, and are drawn behind the
+        gates so the gates remain legible; gates themselves are drawn by the
+        caller after this method returns.
 
         Args:
             fig (Figure): Target matplotlib figure (carries ``_qm_ax``).

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -457,6 +457,8 @@ class MatplotlibRenderer:
                         node,
                         positions[node.node_key],
                         block_widths.get(node.node_key),
+                        positions,
+                        gate_widths,
                     )
                 continue
 
@@ -543,6 +545,16 @@ class MatplotlibRenderer:
                 if empty_span is None:
                     continue
                 box_left, box_right = empty_span
+                if i == 0:
+                    self._draw_condition_measure_connector(
+                        ax,
+                        node,
+                        box_left,
+                        box_bottom,
+                        box_top,
+                        positions,
+                        gate_widths,
+                    )
                 self._draw_if_branch_box(
                     ax, box_left, box_right, box_bottom, box_top, label
                 )
@@ -556,10 +568,74 @@ class MatplotlibRenderer:
             if label_width > 0:
                 box_right = max(box_right, box_left + label_width)
 
+            if i == 0:
+                self._draw_condition_measure_connector(
+                    ax,
+                    node,
+                    box_left,
+                    box_bottom,
+                    box_top,
+                    positions,
+                    gate_widths,
+                )
             self._draw_if_branch_box(
                 ax, box_left, box_right, box_bottom, box_top, label
             )
             prev_right = box_right
+
+    def _draw_condition_measure_connector(
+        self,
+        ax: Axes,
+        node: VFoldedBlock | VUnfoldedSequence,
+        box_left: float,
+        box_bottom: float,
+        box_top: float,
+        positions: dict[tuple, float],
+        gate_widths: dict[tuple, float],
+    ) -> None:
+        """Draw a solid connector from a condition measurement to its IF box.
+
+        Args:
+            ax (Axes): Axes to draw on.
+            node (VFoldedBlock | VUnfoldedSequence): IF visual node carrying
+                condition-measurement metadata.
+            box_left (float): Left edge of the target IF box.
+            box_bottom (float): Bottom edge of the target IF box.
+            box_top (float): Top edge of the target IF box.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping.
+
+        Returns:
+            None
+        """
+        measure_key = node.condition_measure_node_key
+        if measure_key is None or measure_key not in positions:
+            return
+        if not node.condition_measure_qubit_indices:
+            return
+
+        measure_qubit = node.condition_measure_qubit_indices[0]
+        if measure_qubit < 0 or measure_qubit >= len(self.qubit_y):
+            return
+
+        measure_width = gate_widths.get(measure_key, self.style.gate_width)
+        start_x = positions[measure_key] + measure_width / 2
+        if box_left <= start_x:
+            return
+
+        source_y = self.qubit_y[measure_qubit]
+        target_y = min(max(source_y, box_bottom), box_top)
+        ax.add_line(
+            mlines.Line2D(
+                [start_x, box_left],
+                [source_y, target_y],
+                color=self.style.if_edge_color,
+                linewidth=1.5,
+                linestyle="-",
+                solid_capstyle="butt",
+                zorder=PORDER_LINE,
+            )
+        )
 
     def _empty_branch_x_span(
         self,
@@ -1197,6 +1273,8 @@ class MatplotlibRenderer:
         node: VFoldedBlock,
         x_pos: float,
         block_width: float | None,
+        positions: dict[tuple, float],
+        gate_widths: dict[tuple, float],
     ) -> None:
         """Draw a folded control-flow block from VFoldedBlock."""
         affected_qubits = node.affected_qubits
@@ -1250,9 +1328,15 @@ class MatplotlibRenderer:
         y_center = (min_y + max_y) / 2
         box_top = y_center + height / 2
         box_bottom = y_center - height / 2
+        box_left = x_pos - width / 2
+
+        if node.kind == VFoldedKind.IF:
+            self._draw_condition_measure_connector(
+                ax, node, box_left, box_bottom, box_top, positions, gate_widths
+            )
 
         rect = mpatches.FancyBboxPatch(
-            (x_pos - width / 2, box_bottom),
+            (box_left, box_bottom),
             width,
             height,
             boxstyle=mpatches.BoxStyle.Round(

--- a/qamomile/circuit/visualization/renderer.py
+++ b/qamomile/circuit/visualization/renderer.py
@@ -543,6 +543,10 @@ class MatplotlibRenderer:
                 empty_span = self._empty_branch_x_span(
                     i, spans, prev_right, pad, label_width
                 )
+                if empty_span is None and i == 0:
+                    empty_span = self._condition_measure_empty_branch_x_span(
+                        node, positions, gate_widths, label_width
+                    )
                 if empty_span is None:
                     continue
                 box_left, box_right = empty_span
@@ -637,6 +641,35 @@ class MatplotlibRenderer:
                 zorder=PORDER_LINE,
             )
         )
+
+    def _condition_measure_empty_branch_x_span(
+        self,
+        node: VUnfoldedSequence,
+        positions: dict[tuple, float],
+        gate_widths: dict[tuple, float],
+        label_width: float,
+    ) -> tuple[float, float] | None:
+        """Anchor an empty first IF branch to its condition measurement.
+
+        Args:
+            node (VUnfoldedSequence): IF node carrying condition-measurement
+                metadata.
+            positions (dict[tuple, float]): Node-key to center-x mapping.
+            gate_widths (dict[tuple, float]): Node-key to gate width mapping.
+            label_width (float): Reserved width for the branch header label.
+
+        Returns:
+            tuple[float, float] | None: ``(left, right)`` extent for the empty
+                branch box, or None when no condition measurement is positioned.
+        """
+        measure_key = node.condition_measure_node_key
+        if measure_key is None or measure_key not in positions:
+            return None
+        measure_width = gate_widths.get(measure_key, self.style.gate_width)
+        measure_right = positions[measure_key] + measure_width / 2
+        box_left = measure_right + self.style.gate_gap
+        min_width = max(label_width, self.style.gate_width)
+        return box_left, box_left + min_width
 
     def _empty_branch_x_span(
         self,

--- a/qamomile/circuit/visualization/types.py
+++ b/qamomile/circuit/visualization/types.py
@@ -109,6 +109,8 @@ class LayoutState:
     # entry (unfolded if/else branch boxes). Each entry is
     # ``{"top_qubit": int, "num_lines": int}`` and only contributes vertical
     # clearance above its top qubit; it never draws a border.
+    # Folded control-flow blocks use ``folded_block_extents`` instead because
+    # they draw a full bordered summary box centered on the affected qubits.
     label_extents: list[dict] = field(default_factory=list)
 
 

--- a/qamomile/circuit/visualization/types.py
+++ b/qamomile/circuit/visualization/types.py
@@ -105,6 +105,11 @@ class LayoutState:
     inlined_op_keys: set[tuple] = field(default_factory=set)
     gate_widths: dict[tuple, float] = field(default_factory=dict)
     folded_block_extents: dict[tuple, dict] = field(default_factory=dict)
+    # Header labels drawn above a wire that are not backed by a block_ranges
+    # entry (unfolded if/else branch boxes). Each entry is
+    # ``{"top_qubit": int, "num_lines": int}`` and only contributes vertical
+    # clearance above its top qubit; it never draws a border.
+    label_extents: list[dict] = field(default_factory=list)
 
 
 @dataclass

--- a/qamomile/circuit/visualization/visual_ir.py
+++ b/qamomile/circuit/visualization/visual_ir.py
@@ -83,6 +83,12 @@ class VGate:
     # around the inner controlled-U rectangle (matching the
     # ``VInlineBlock`` rendering of an expanded controlled-U block).
     power: int = 1
+    # Whether a measurement node terminates its wire at this x-position.
+    # True for a top-level measurement (the wire ends after it, the usual
+    # final-measure convention). False for a measurement inside an if/else
+    # branch: that is a mid-circuit measurement on one alternative, so the
+    # wire must keep going (the other branch never measured this qubit).
+    terminates_wire: bool = True
 
 
 @dataclass
@@ -144,6 +150,16 @@ class VUnfoldedSequence:
     iteration_widths: list[float] = field(default_factory=list)
     condition_label: str | None = None
     affected_qubits_precise: bool = True
+    # Estimated width of the ``if <cond>:`` header (IF only). The layout
+    # reserves this much horizontal room so the condition label does not
+    # collide with the else branch or get clipped by the figure edge.
+    # Equals ``branch_label_widths[0]``.
+    condition_label_width: float = 0.0
+    # Estimated header-box width per branch (IF only), aligned with
+    # ``iterations``: ``[width("if <cond>:"), width("else:")]``. The renderer
+    # sizes each branch box to its header using the same estimate the layout
+    # reserves, so the boxes butt together with no gap and no label overflow.
+    branch_label_widths: list[float] = field(default_factory=list)
 
 
 @dataclass

--- a/qamomile/circuit/visualization/visual_ir.py
+++ b/qamomile/circuit/visualization/visual_ir.py
@@ -67,6 +67,7 @@ class VGate:
     - estimated_width: pre-computed width for layout
     - kind: determines rendering strategy
     - gate_type: for CX/SWAP/TOFFOLI special drawing
+    - terminates_wire: whether a measurement node ends its measured wires
     """
 
     node_key: tuple

--- a/qamomile/circuit/visualization/visual_ir.py
+++ b/qamomile/circuit/visualization/visual_ir.py
@@ -133,6 +133,8 @@ class VFoldedBlock:
     folded_width: float
     kind: VFoldedKind
     affected_qubits_precise: bool = True
+    condition_measure_node_key: tuple | None = None
+    condition_measure_qubit_indices: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -160,6 +162,8 @@ class VUnfoldedSequence:
     # sizes each branch box to its header using the same estimate the layout
     # reserves, so the boxes butt together with no gap and no label overflow.
     branch_label_widths: list[float] = field(default_factory=list)
+    condition_measure_node_key: tuple | None = None
+    condition_measure_qubit_indices: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -166,6 +166,22 @@ def empty_single_branch_if(q0: Qubit, q1: Qubit) -> Qubit:
 
 
 @qmc.qkernel
+def symbolic_empty_single_branch_if(q0: Qubit, flag: UInt) -> Qubit:
+    """Build a symbolic if whose only branch is empty.
+
+    Args:
+        q0 (Qubit): Qubit returned unchanged.
+        flag (UInt): Symbolic value that keeps the IF at draw time.
+
+    Returns:
+        Qubit: Unchanged ``q0``.
+    """
+    if flag == 1:
+        pass
+    return q0
+
+
+@qmc.qkernel
 def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
     """Build a two-level nested if example.
 
@@ -666,3 +682,10 @@ class TestDrawEndToEnd:
             labels = [text.get_text() for text in ax.texts]
             assert any(label.startswith("if ") for label in labels)
             assert len(_if_connector_lines(fig)) == 1
+
+    def test_symbolic_empty_single_branch_draws_if_label(self):
+        """The renderer keeps an empty symbolic single-branch IF visible."""
+        fig = symbolic_empty_single_branch_if.draw(fold_loops=False)
+        ax = fig._qm_ax  # type: ignore[attr-defined]
+        labels = [text.get_text() for text in ax.texts]
+        assert any(label.startswith("if ") for label in labels)

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -14,9 +14,11 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import ast
 import math
 from collections.abc import Iterable, Iterator
 from dataclasses import replace
+from pathlib import Path
 from typing import Any, cast
 
 from matplotlib import colors as mcolors
@@ -724,6 +726,22 @@ class TestBranchMeasurementWire:
 
 class TestCompileTimeResolution:
     """Bound or constant conditions are lowered away before drawing."""
+
+    def test_analyzer_keeps_compile_time_lowering_import_local(self):
+        """Analyzer keeps compile-time lowering imports local to inline expansion."""
+        module_name = "qamomile.circuit.transpiler.passes.compile_time_if_lowering"
+        analyzer_path = (
+            Path(__file__).parents[2]
+            / "qamomile"
+            / "circuit"
+            / "visualization"
+            / "analyzer.py"
+        )
+        tree = ast.parse(analyzer_path.read_text())
+        top_level_imports = [
+            node.module for node in tree.body if isinstance(node, ast.ImportFrom)
+        ]
+        assert module_name not in top_level_imports
 
     def test_bound_condition_is_lowered_in_block(self):
         """Binding ``flag`` removes the IfOperation from the prepared block."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -14,10 +14,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import math
 from collections.abc import Iterable, Iterator
 from dataclasses import replace
-import math
-from typing import Any
+from typing import Any, cast
 
 from matplotlib import colors as mcolors
 from matplotlib.figure import Figure
@@ -363,7 +363,6 @@ def _if_branch_boxes(fig: Figure) -> list[FancyBboxPatch]:
         for patch in ax.patches
         if isinstance(patch, FancyBboxPatch)
         and patch.get_edgecolor() == if_edge
-        and patch.get_facecolor()[3] == 0
         and patch.get_linestyle() == "-."
     ]
 
@@ -756,7 +755,7 @@ class TestDrawEndToEnd:
             empty_single_branch_if._build_graph_for_visualization(), style
         ).draw(fold_loops=False)
         connector = _if_connector_lines(fig)[0]
-        measure_right = connector.get_xdata()[0]
+        measure_right = float(list(cast(Iterable[float], connector.get_xdata()))[0])
         expected_left = measure_right + compute_border_padding(style, depth=0)
         branch_box = _if_branch_boxes(fig)[0]
         assert math.isclose(branch_box.get_x(), expected_left)

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -28,8 +28,12 @@ from matplotlib.patches import FancyBboxPatch
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.handle import Qubit, UInt
+from qamomile.circuit.ir.block import Block
+from qamomile.circuit.ir.operation.arithmetic_operations import BinOp, BinOpKind
 from qamomile.circuit.ir.operation.control_flow import IfOperation
 from qamomile.circuit.ir.operation.gate import GateOperationType
+from qamomile.circuit.ir.types.primitives import BitType, UIntType
+from qamomile.circuit.ir.value import Value
 from qamomile.circuit.visualization.analyzer import CircuitAnalyzer
 from qamomile.circuit.visualization.drawer import (
     MatplotlibDrawer,
@@ -742,6 +746,38 @@ class TestCompileTimeResolution:
             node.module for node in tree.body if isinstance(node, ast.ImportFrom)
         ]
         assert module_name not in top_level_imports
+
+    def test_unfolded_if_uses_branch_local_intermediate_values(self):
+        """Branch-local BinOp results do not leak into enclosing param values."""
+        one = Value(UIntType(), "one").with_const(1)
+        two = Value(UIntType(), "two").with_const(2)
+        three = Value(UIntType(), "three").with_const(3)
+        true_result = Value(UIntType(), "true_tmp")
+        false_result = Value(UIntType(), "false_tmp")
+        if_op = IfOperation(
+            operands=[Value(BitType(), "cond")],
+            true_operations=[
+                BinOp(
+                    operands=[one, two],
+                    results=[true_result],
+                    kind=BinOpKind.ADD,
+                )
+            ],
+            false_operations=[
+                BinOp(
+                    operands=[one, three],
+                    results=[false_result],
+                    kind=BinOpKind.ADD,
+                )
+            ],
+        )
+        param_values = {"outer": 7}
+
+        analyzer = CircuitAnalyzer(Block(), DEFAULT_STYLE, fold_loops=False)
+        node = analyzer._build_vif(if_op, ("if",), {"q": 0}, {}, param_values, 0, ())
+
+        assert isinstance(node, VUnfoldedSequence)
+        assert param_values == {"outer": 7}
 
     def test_bound_condition_is_lowered_in_block(self):
         """Binding ``flag`` removes the IfOperation from the prepared block."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -685,7 +685,10 @@ class TestDrawEndToEnd:
 
     def test_symbolic_empty_single_branch_draws_if_label(self):
         """The renderer keeps an empty symbolic single-branch IF visible."""
-        fig = symbolic_empty_single_branch_if.draw(fold_loops=False)
-        ax = fig._qm_ax  # type: ignore[attr-defined]
-        labels = [text.get_text() for text in ax.texts]
-        assert any(label.startswith("if ") for label in labels)
+        for fig in (
+            symbolic_empty_single_branch_if.draw(fold_loops=False),
+            symbolic_empty_single_branch_if.draw(fold_loops=False, fold_ifs=True),
+        ):
+            ax = fig._qm_ax  # type: ignore[attr-defined]
+            labels = [text.get_text() for text in ax.texts]
+            assert any(label.startswith("if ") for label in labels)

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -79,6 +79,23 @@ def inline_measure_if(q0: Qubit, q1: Qubit) -> Qubit:
 
 
 @qmc.qkernel
+def vector_measure_element_if() -> Qubit:
+    """Build an if whose condition is one bit of a vector measurement.
+
+    Returns:
+        Qubit: Updated target qubit.
+    """
+    qs = qmc.qubit_array(3, "qs")
+    target = qmc.qubit("target")
+    bits = qmc.measure(qs)
+    if bits[1]:
+        target = qmc.x(target)
+    else:
+        target = qmc.h(target)
+    return target
+
+
+@qmc.qkernel
 def classical_if(q0: Qubit, flag: UInt) -> Qubit:
     """Build a symbolic classical-condition if/else example.
 
@@ -334,6 +351,19 @@ class TestUnfoldedIf:
         assert seq.condition_measure_node_key is not None
         assert seq.condition_measure_qubit_indices == [0]
 
+    def test_vector_measurement_element_condition_uses_selected_wire(self):
+        """``if bits[1]:`` connects from the measured vector's second wire."""
+        vc = _visual_circuit(vector_measure_element_if)
+        measure = next(
+            n
+            for n in _walk(vc.children)
+            if isinstance(n, VGate) and n.kind == VGateKind.MEASURE_VECTOR
+        )
+        seq = _unfolded_ifs(vc)[0]
+        assert measure.qubit_indices == [0, 1, 2]
+        assert seq.condition_measure_node_key == measure.node_key
+        assert seq.condition_measure_qubit_indices == [1]
+
     def test_symbolic_classical_condition_has_no_measurement_connector(self):
         """A non-measurement condition does not draw as measurement-derived."""
         vc = _visual_circuit(classical_if)
@@ -574,6 +604,10 @@ class TestDrawEndToEnd:
     def test_inline_measurement_if_draws_connector(self):
         """An inline measurement condition draws the same connector."""
         assert len(_if_connector_lines(inline_measure_if.draw())) == 1
+
+    def test_vector_measurement_element_if_draws_connector(self):
+        """A vector-measurement element condition draws one connector."""
+        assert len(_if_connector_lines(vector_measure_element_if.draw())) == 1
 
     def test_symbolic_classical_if_draws(self):
         """Unbound classical if draws in unfolded and folded-if modes."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -1,0 +1,368 @@
+"""Tests for IfOperation circuit visualization.
+
+Covers the three behaviors that make if/else drawable:
+
+- compile-time resolvable conditions (bindings or traced constants) are lowered
+  to the selected branch, so no if box is drawn;
+- surviving conditions (measurement-backed runtime ``if``, symbolic classical
+  ``if``) render as a folded summary box under ``fold_loops=True`` or as
+  side-by-side if/else branch boxes under ``fold_loops=False``;
+- nested ifs render recursively.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from matplotlib.figure import Figure
+
+import qamomile.circuit as qmc
+from qamomile.circuit.frontend.handle import Qubit, UInt
+from qamomile.circuit.ir.operation.control_flow import IfOperation
+from qamomile.circuit.ir.operation.gate import GateOperationType
+from qamomile.circuit.visualization.analyzer import CircuitAnalyzer
+from qamomile.circuit.visualization.drawer import _prepare_graph_for_visualization
+from qamomile.circuit.visualization.layout import CircuitLayoutEngine
+from qamomile.circuit.visualization.style import DEFAULT_STYLE
+from qamomile.circuit.visualization.visual_ir import (
+    VFoldedBlock,
+    VFoldedKind,
+    VGate,
+    VGateKind,
+    VInlineBlock,
+    VisualCircuit,
+    VUnfoldedKind,
+    VUnfoldedSequence,
+)
+
+
+@qmc.qkernel
+def runtime_if(q0: Qubit, q1: Qubit) -> Qubit:
+    """Measurement-backed if/else: X on the true branch, H on the else branch."""
+    cond = qmc.measure(q0)
+    if cond:
+        q1 = qmc.x(q1)
+    else:
+        q1 = qmc.h(q1)
+    return q1
+
+
+@qmc.qkernel
+def classical_if(q0: Qubit, flag: UInt) -> Qubit:
+    """Classical-condition if/else driven by an integer ``flag`` parameter."""
+    if flag == 1:
+        q0 = qmc.x(q0)
+    else:
+        q0 = qmc.h(q0)
+    return q0
+
+
+@qmc.qkernel
+def if_no_else(q0: Qubit, q1: Qubit) -> Qubit:
+    """Measurement-backed if with no else branch."""
+    cond = qmc.measure(q0)
+    if cond:
+        q1 = qmc.x(q1)
+    return q1
+
+
+@qmc.qkernel
+def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
+    """Two-level nested if so recursive branch rendering can be checked."""
+    c0 = qmc.measure(q0)
+    if c0:
+        c1 = qmc.measure(q1)
+        if c1:
+            q2 = qmc.x(q2)
+        else:
+            q2 = qmc.h(q2)
+    else:
+        q2 = qmc.z(q2)
+    return q2
+
+
+def _walk(nodes):
+    """Yield every VisualNode reachable from a list of root nodes."""
+    for node in nodes:
+        yield node
+        if isinstance(node, VInlineBlock):
+            yield from _walk(node.children)
+        elif isinstance(node, VUnfoldedSequence):
+            for iteration in node.iterations:
+                yield from _walk(iteration)
+
+
+def _visual_circuit(kernel, *, fold_loops, **bindings) -> VisualCircuit:
+    """Trace ``kernel`` and run the visualization analyzer in isolation."""
+    block = _prepare_graph_for_visualization(
+        kernel._build_graph_for_visualization(**bindings)
+    )
+    analyzer = CircuitAnalyzer(
+        block,
+        DEFAULT_STYLE,
+        inline=False,
+        fold_loops=fold_loops,
+        expand_composite=False,
+        inline_depth=None,
+    )
+    qubit_map, qubit_names, num_qubits = analyzer.build_qubit_map(block)
+    return analyzer.build_visual_ir(block, qubit_map, qubit_names, num_qubits)
+
+
+def _folded_ifs(vc: VisualCircuit) -> list[VFoldedBlock]:
+    """Collect every folded IF box in a visual circuit."""
+    return [
+        n
+        for n in _walk(vc.children)
+        if isinstance(n, VFoldedBlock) and n.kind == VFoldedKind.IF
+    ]
+
+
+def _unfolded_ifs(vc: VisualCircuit) -> list[VUnfoldedSequence]:
+    """Collect every unfolded IF sequence in a visual circuit."""
+    return [
+        n
+        for n in _walk(vc.children)
+        if isinstance(n, VUnfoldedSequence) and n.kind == VUnfoldedKind.IF
+    ]
+
+
+def _branch_gate_types(iteration) -> list[GateOperationType]:
+    """Return the gate types of the (non-measurement) gates in one branch."""
+    return [
+        n.gate_type
+        for n in _walk(iteration)
+        if isinstance(n, VGate) and n.gate_type is not None
+    ]
+
+
+class TestFoldedIf:
+    """``fold_loops=True`` renders a surviving if as a single folded box."""
+
+    def test_runtime_if_folds_to_one_if_box(self):
+        """A measurement-backed if becomes exactly one folded IF box."""
+        vc = _visual_circuit(runtime_if, fold_loops=True)
+        folded = _folded_ifs(vc)
+        assert len(folded) == 1
+        # The condition label spells the measurement bit, not a placeholder.
+        assert folded[0].header_label.startswith("if ")
+        assert "measured" in folded[0].header_label
+
+    def test_symbolic_classical_if_label_shows_predicate(self):
+        """An unbound classical if renders its predicate, e.g. ``if flag == 1:``."""
+        vc = _visual_circuit(classical_if, fold_loops=True)
+        folded = _folded_ifs(vc)
+        assert len(folded) == 1
+        assert folded[0].header_label == "if flag == 1:"
+
+
+class TestUnfoldedIf:
+    """``fold_loops=False`` renders a surviving if as side-by-side branches."""
+
+    def test_runtime_if_unfolds_into_two_branches(self):
+        """A measurement-backed if/else yields one IF sequence with two branches."""
+        vc = _visual_circuit(runtime_if, fold_loops=False)
+        unfolded = _unfolded_ifs(vc)
+        assert len(unfolded) == 1
+        assert len(unfolded[0].iterations) == 2
+        assert unfolded[0].condition_label is not None
+        assert "measured" in unfolded[0].condition_label
+
+    def test_branches_carry_their_own_gates(self):
+        """Iteration 0 holds the true-branch X; iteration 1 holds the else H."""
+        vc = _visual_circuit(runtime_if, fold_loops=False)
+        seq = _unfolded_ifs(vc)[0]
+        assert _branch_gate_types(seq.iterations[0]) == [GateOperationType.X]
+        assert _branch_gate_types(seq.iterations[1]) == [GateOperationType.H]
+
+    def test_if_without_else_has_single_branch(self):
+        """An if with no else unfolds to a single-branch IF sequence."""
+        vc = _visual_circuit(if_no_else, fold_loops=False)
+        unfolded = _unfolded_ifs(vc)
+        assert len(unfolded) == 1
+        assert len(unfolded[0].iterations) == 1
+        assert _branch_gate_types(unfolded[0].iterations[0]) == [GateOperationType.X]
+
+    def test_condition_label_width_reserved_for_layout(self):
+        """The IF sequence carries a positive header width for layout to reserve."""
+        vc = _visual_circuit(classical_if, fold_loops=False)
+        seq = _unfolded_ifs(vc)[0]
+        assert seq.condition_label == "if flag == 1:"
+        assert seq.condition_label_width > 0.0
+
+    def test_branch_label_widths_align_with_branches(self):
+        """One header-box width per branch; the first equals condition_label_width.
+
+        The renderer sizes each branch box to these estimates (the same numbers
+        the layout reserves), which is what keeps the boxes gap-free and the
+        labels from overflowing.
+        """
+        vc = _visual_circuit(classical_if, fold_loops=False)
+        seq = _unfolded_ifs(vc)[0]
+        assert len(seq.branch_label_widths) == len(seq.iterations) == 2
+        assert all(w > 0.0 for w in seq.branch_label_widths)
+        assert seq.branch_label_widths[0] == seq.condition_label_width
+
+
+class TestUnfoldedIfSpacing:
+    """The if/else header reserves vertical room so it clears the wire above."""
+
+    def test_header_label_does_not_crowd_wire_above(self):
+        """The gap above the if's top wire exceeds the default wire spacing."""
+        vc = _visual_circuit(runtime_if, fold_loops=False)
+        layout = CircuitLayoutEngine(DEFAULT_STYLE).compute_layout(vc)
+        # runtime_if: q0 carries the measurement, q1 carries the if/else box.
+        # The "if q0_measured:" header sits above q1 (between q0 and q1), so the
+        # q0->q1 gap must exceed the default wire spacing to make room for it.
+        gap = layout.qubit_y[0] - layout.qubit_y[1]
+        assert gap > DEFAULT_STYLE.qubit_base_spacing
+
+    def test_plain_two_qubit_circuit_keeps_base_spacing(self):
+        """Without an if header, adjacent wires keep the default spacing."""
+
+        @qmc.qkernel
+        def plain(q0: Qubit, q1: Qubit) -> tuple[Qubit, Qubit]:
+            q0 = qmc.h(q0)
+            q1 = qmc.x(q1)
+            return q0, q1
+
+        vc = _visual_circuit(plain, fold_loops=False)
+        layout = CircuitLayoutEngine(DEFAULT_STYLE).compute_layout(vc)
+        gap = layout.qubit_y[0] - layout.qubit_y[1]
+        assert gap == DEFAULT_STYLE.qubit_base_spacing
+
+
+class TestBranchMeasurementWire:
+    """A measurement inside an if branch is mid-circuit and keeps its wire."""
+
+    def _measures(self, vc: VisualCircuit) -> list[VGate]:
+        """Collect every measurement VGate in a visual circuit."""
+        return [
+            n
+            for n in _walk(vc.children)
+            if isinstance(n, VGate)
+            and n.kind in (VGateKind.MEASURE, VGateKind.MEASURE_VECTOR)
+        ]
+
+    def test_branch_measure_flagged_mid_circuit(self):
+        """nested_if: the top-level measure terminates, the branch one doesn't."""
+        vc = _visual_circuit(nested_if, fold_loops=False)
+        measures = self._measures(vc)
+        # nested_if measures q0 at top level and q1 inside the outer true branch.
+        terminating = [m for m in measures if m.terminates_wire]
+        mid_circuit = [m for m in measures if not m.terminates_wire]
+        assert len(terminating) == 1
+        assert len(mid_circuit) == 1
+
+    def test_branch_measure_wire_continues_in_layout(self):
+        """The mid-circuit measure's wire is not terminated by the layout."""
+        vc = _visual_circuit(nested_if, fold_loops=False)
+        measures = self._measures(vc)
+        terminating = next(m for m in measures if m.terminates_wire)
+        mid_circuit = next(m for m in measures if not m.terminates_wire)
+
+        layout = CircuitLayoutEngine(DEFAULT_STYLE).compute_layout(vc)
+        # The top-level measure ends its wire; the branch measure does not, so
+        # the qubit's wire keeps running through the else branch's x-range.
+        assert terminating.qubit_indices[0] in layout.qubit_end_positions
+        assert mid_circuit.qubit_indices[0] not in layout.qubit_end_positions
+
+    def test_top_level_measure_still_terminates(self):
+        """A plain top-level measurement keeps the usual wire termination."""
+        vc = _visual_circuit(runtime_if, fold_loops=False)
+        measures = self._measures(vc)
+        # runtime_if measures only q0, at top level.
+        assert len(measures) == 1
+        assert measures[0].terminates_wire is True
+        layout = CircuitLayoutEngine(DEFAULT_STYLE).compute_layout(vc)
+        assert measures[0].qubit_indices[0] in layout.qubit_end_positions
+
+
+class TestCompileTimeResolution:
+    """Bound or constant conditions are lowered away before drawing."""
+
+    def test_bound_condition_is_lowered_in_block(self):
+        """Binding ``flag`` removes the IfOperation from the prepared block."""
+        block = _prepare_graph_for_visualization(
+            classical_if._build_graph_for_visualization(flag=1)
+        )
+        assert not any(isinstance(op, IfOperation) for op in block.operations)
+
+    def test_symbolic_condition_keeps_ifoperation(self):
+        """Without a binding the prepared graph keeps the IfOperation."""
+        block = _prepare_graph_for_visualization(
+            classical_if._build_graph_for_visualization()
+        )
+        assert any(isinstance(op, IfOperation) for op in block.operations)
+
+    def test_bound_true_draws_only_selected_branch(self):
+        """``flag=1`` collapses to the true branch (X) with no if box."""
+        for fold in (True, False):
+            vc = _visual_circuit(classical_if, fold_loops=fold, flag=1)
+            assert not _folded_ifs(vc)
+            assert not _unfolded_ifs(vc)
+            gates = [
+                n.gate_type
+                for n in _walk(vc.children)
+                if isinstance(n, VGate) and n.gate_type is not None
+            ]
+            assert gates == [GateOperationType.X]
+
+    def test_bound_false_draws_only_else_branch(self):
+        """``flag=0`` collapses to the else branch (H) with no if box."""
+        vc = _visual_circuit(classical_if, fold_loops=True, flag=0)
+        assert not _folded_ifs(vc)
+        gates = [
+            n.gate_type
+            for n in _walk(vc.children)
+            if isinstance(n, VGate) and n.gate_type is not None
+        ]
+        assert gates == [GateOperationType.H]
+
+
+class TestNestedIf:
+    """Nested ifs render recursively."""
+
+    def test_nested_if_unfolds_recursively(self):
+        """The outer if's true branch contains the inner if as its own box."""
+        vc = _visual_circuit(nested_if, fold_loops=False)
+        top_level = [
+            n
+            for n in vc.children
+            if isinstance(n, VUnfoldedSequence) and n.kind == VUnfoldedKind.IF
+        ]
+        assert len(top_level) == 1
+        true_branch = top_level[0].iterations[0]
+        inner = [
+            n
+            for n in _walk(true_branch)
+            if isinstance(n, VUnfoldedSequence) and n.kind == VUnfoldedKind.IF
+        ]
+        assert len(inner) == 1
+        # Inner if/else carries X (true) and H (else); outer else carries Z.
+        assert _branch_gate_types(inner[0].iterations[0]) == [GateOperationType.X]
+        assert _branch_gate_types(inner[0].iterations[1]) == [GateOperationType.H]
+        assert _branch_gate_types(top_level[0].iterations[1]) == [GateOperationType.Z]
+
+
+class TestDrawEndToEnd:
+    """``QKernel.draw`` returns a Figure for every if flavor without raising."""
+
+    def test_runtime_if_draws(self):
+        """Measurement-backed if draws in both folded and unfolded modes."""
+        assert isinstance(runtime_if.draw(fold_loops=True), Figure)
+        assert isinstance(runtime_if.draw(fold_loops=False), Figure)
+
+    def test_symbolic_classical_if_draws(self):
+        """Unbound classical if draws in both modes."""
+        assert isinstance(classical_if.draw(fold_loops=True), Figure)
+        assert isinstance(classical_if.draw(fold_loops=False), Figure)
+
+    def test_bound_classical_if_draws(self):
+        """Bound classical if (compile-time resolved) draws without an if box."""
+        assert isinstance(classical_if.draw(fold_loops=False, flag=1), Figure)
+
+    def test_nested_if_draws(self):
+        """Nested if draws in both modes."""
+        assert isinstance(nested_if.draw(fold_loops=True), Figure)
+        assert isinstance(nested_if.draw(fold_loops=False), Figure)

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -244,7 +244,7 @@ class TestFoldedIf:
         # The condition label spells the measurement bit, not a placeholder.
         assert folded[0].header_label.startswith("if ")
         assert "measured" in folded[0].header_label
-        assert "else:" in folded[0].body_lines
+        assert any(line.startswith("else:") for line in folded[0].body_lines)
         assert any("h(" in line for line in folded[0].body_lines)
 
     def test_symbolic_classical_if_label_shows_predicate(self):
@@ -253,7 +253,7 @@ class TestFoldedIf:
         folded = _folded_ifs(vc)
         assert len(folded) == 1
         assert folded[0].header_label == "if flag == 1:"
-        assert "else:" in folded[0].body_lines
+        assert any(line.startswith("else:") for line in folded[0].body_lines)
 
     def test_empty_true_branch_folded_summary_keeps_else(self):
         """An empty true branch still shows pass and else in folded form."""
@@ -261,7 +261,7 @@ class TestFoldedIf:
         folded = _folded_ifs(vc)
         assert len(folded) == 1
         assert folded[0].body_lines[0] == "pass"
-        assert "else:" in folded[0].body_lines
+        assert any(line.startswith("else:") for line in folded[0].body_lines)
 
 
 class TestUnfoldedIf:
@@ -337,6 +337,15 @@ class TestUnfoldedIfSpacing:
         # runtime_if: q0 carries the measurement, q1 carries the if/else box.
         # The "if q0_measured:" header sits above q1 (between q0 and q1), so the
         # q0->q1 gap must exceed the default wire spacing to make room for it.
+        gap = layout.qubit_y[0] - layout.qubit_y[1]
+        assert gap > DEFAULT_STYLE.qubit_base_spacing
+
+    def test_folded_if_body_does_not_crowd_wire_above(self):
+        """A multi-line folded IF box reserves vertical room above its wire."""
+        vc = _visual_circuit(runtime_if, fold_ifs=True)
+        layout = CircuitLayoutEngine(DEFAULT_STYLE).compute_layout(vc)
+        # The folded IF is centered on q1 but has three text lines, so q0->q1
+        # spacing must grow to keep the box from overlapping q0's measurement.
         gap = layout.qubit_y[0] - layout.qubit_y[1]
         assert gap > DEFAULT_STYLE.qubit_base_spacing
 

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -5,14 +5,17 @@ Covers the three behaviors that make if/else drawable:
 - compile-time resolvable conditions (bindings or traced constants) are lowered
   to the selected branch, so no if box is drawn;
 - surviving conditions (measurement-backed runtime ``if``, symbolic classical
-  ``if``) render as a folded summary box under ``fold_loops=True`` or as
-  side-by-side if/else branch boxes under ``fold_loops=False``;
+  ``if``) render as side-by-side if/else branch boxes by default, or as a
+  folded summary box under ``fold_ifs=True``;
 - nested ifs render recursively.
 """
 
 import matplotlib
 
 matplotlib.use("Agg")
+
+from collections.abc import Iterable, Iterator
+from typing import Any
 
 from matplotlib.figure import Figure
 
@@ -31,6 +34,7 @@ from qamomile.circuit.visualization.visual_ir import (
     VGateKind,
     VInlineBlock,
     VisualCircuit,
+    VisualNode,
     VUnfoldedKind,
     VUnfoldedSequence,
 )
@@ -38,7 +42,15 @@ from qamomile.circuit.visualization.visual_ir import (
 
 @qmc.qkernel
 def runtime_if(q0: Qubit, q1: Qubit) -> Qubit:
-    """Measurement-backed if/else: X on the true branch, H on the else branch."""
+    """Build a measurement-backed if/else example.
+
+    Args:
+        q0 (Qubit): Qubit measured to decide the branch.
+        q1 (Qubit): Qubit transformed by the selected branch.
+
+    Returns:
+        Qubit: Updated ``q1``.
+    """
     cond = qmc.measure(q0)
     if cond:
         q1 = qmc.x(q1)
@@ -49,7 +61,15 @@ def runtime_if(q0: Qubit, q1: Qubit) -> Qubit:
 
 @qmc.qkernel
 def classical_if(q0: Qubit, flag: UInt) -> Qubit:
-    """Classical-condition if/else driven by an integer ``flag`` parameter."""
+    """Build a symbolic classical-condition if/else example.
+
+    Args:
+        q0 (Qubit): Qubit transformed by the selected branch.
+        flag (UInt): Classical flag compared with ``1``.
+
+    Returns:
+        Qubit: Updated ``q0``.
+    """
     if flag == 1:
         q0 = qmc.x(q0)
     else:
@@ -59,7 +79,15 @@ def classical_if(q0: Qubit, flag: UInt) -> Qubit:
 
 @qmc.qkernel
 def if_no_else(q0: Qubit, q1: Qubit) -> Qubit:
-    """Measurement-backed if with no else branch."""
+    """Build a measurement-backed if example with no else branch.
+
+    Args:
+        q0 (Qubit): Qubit measured to decide the branch.
+        q1 (Qubit): Qubit transformed only when the condition is true.
+
+    Returns:
+        Qubit: Updated ``q1``.
+    """
     cond = qmc.measure(q0)
     if cond:
         q1 = qmc.x(q1)
@@ -68,7 +96,15 @@ def if_no_else(q0: Qubit, q1: Qubit) -> Qubit:
 
 @qmc.qkernel
 def empty_true_if(q0: Qubit, q1: Qubit) -> Qubit:
-    """Measurement-backed if whose true branch is empty and else has a gate."""
+    """Build a measurement-backed if whose true branch is empty.
+
+    Args:
+        q0 (Qubit): Qubit measured to decide the branch.
+        q1 (Qubit): Qubit transformed only by the else branch.
+
+    Returns:
+        Qubit: Updated ``q1``.
+    """
     cond = qmc.measure(q0)
     if cond:
         pass
@@ -79,7 +115,16 @@ def empty_true_if(q0: Qubit, q1: Qubit) -> Qubit:
 
 @qmc.qkernel
 def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
-    """Two-level nested if so recursive branch rendering can be checked."""
+    """Build a two-level nested if example.
+
+    Args:
+        q0 (Qubit): Qubit measured by the outer if.
+        q1 (Qubit): Qubit measured by the nested if.
+        q2 (Qubit): Qubit transformed by the selected leaf branch.
+
+    Returns:
+        Qubit: Updated ``q2``.
+    """
     c0 = qmc.measure(q0)
     if c0:
         c1 = qmc.measure(q1)
@@ -92,8 +137,15 @@ def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
     return q2
 
 
-def _walk(nodes):
-    """Yield every VisualNode reachable from a list of root nodes."""
+def _walk(nodes: Iterable[VisualNode]) -> Iterator[VisualNode]:
+    """Yield every VisualNode reachable from a list of root nodes.
+
+    Args:
+        nodes (Iterable[VisualNode]): Root visual nodes to traverse.
+
+    Yields:
+        VisualNode: Each visual node reachable from ``nodes``.
+    """
     for node in nodes:
         yield node
         if isinstance(node, VInlineBlock):
@@ -103,8 +155,20 @@ def _walk(nodes):
                 yield from _walk(iteration)
 
 
-def _visual_circuit(kernel, *, fold_loops, **bindings) -> VisualCircuit:
-    """Trace ``kernel`` and run the visualization analyzer in isolation."""
+def _visual_circuit(
+    kernel: Any, *, fold_loops: bool = True, fold_ifs: bool = False, **bindings: Any
+) -> VisualCircuit:
+    """Trace ``kernel`` and run the visualization analyzer in isolation.
+
+    Args:
+        kernel (Any): QKernel-like object to trace.
+        fold_loops (bool): Whether loop operations should be folded.
+        fold_ifs (bool): Whether if operations should be folded.
+        **bindings (Any): Concrete draw-time bindings for kernel parameters.
+
+    Returns:
+        VisualCircuit: Visual IR produced by ``CircuitAnalyzer``.
+    """
     block = _prepare_graph_for_visualization(
         kernel._build_graph_for_visualization(**bindings)
     )
@@ -113,6 +177,7 @@ def _visual_circuit(kernel, *, fold_loops, **bindings) -> VisualCircuit:
         DEFAULT_STYLE,
         inline=False,
         fold_loops=fold_loops,
+        fold_ifs=fold_ifs,
         expand_composite=False,
         inline_depth=None,
     )
@@ -121,7 +186,14 @@ def _visual_circuit(kernel, *, fold_loops, **bindings) -> VisualCircuit:
 
 
 def _folded_ifs(vc: VisualCircuit) -> list[VFoldedBlock]:
-    """Collect every folded IF box in a visual circuit."""
+    """Collect every folded IF box in a visual circuit.
+
+    Args:
+        vc (VisualCircuit): Visual circuit to scan.
+
+    Returns:
+        list[VFoldedBlock]: Folded IF blocks in traversal order.
+    """
     return [
         n
         for n in _walk(vc.children)
@@ -130,7 +202,14 @@ def _folded_ifs(vc: VisualCircuit) -> list[VFoldedBlock]:
 
 
 def _unfolded_ifs(vc: VisualCircuit) -> list[VUnfoldedSequence]:
-    """Collect every unfolded IF sequence in a visual circuit."""
+    """Collect every unfolded IF sequence in a visual circuit.
+
+    Args:
+        vc (VisualCircuit): Visual circuit to scan.
+
+    Returns:
+        list[VUnfoldedSequence]: Unfolded IF sequences in traversal order.
+    """
     return [
         n
         for n in _walk(vc.children)
@@ -138,8 +217,15 @@ def _unfolded_ifs(vc: VisualCircuit) -> list[VUnfoldedSequence]:
     ]
 
 
-def _branch_gate_types(iteration) -> list[GateOperationType]:
-    """Return the gate types of the (non-measurement) gates in one branch."""
+def _branch_gate_types(iteration: Iterable[VisualNode]) -> list[GateOperationType]:
+    """Return the gate types of the non-measurement gates in one branch.
+
+    Args:
+        iteration (Iterable[VisualNode]): Visual nodes inside one IF branch.
+
+    Returns:
+        list[GateOperationType]: Gate types seen in traversal order.
+    """
     return [
         n.gate_type
         for n in _walk(iteration)
@@ -148,31 +234,42 @@ def _branch_gate_types(iteration) -> list[GateOperationType]:
 
 
 class TestFoldedIf:
-    """``fold_loops=True`` renders a surviving if as a single folded box."""
+    """``fold_ifs=True`` renders a surviving if as a single folded box."""
 
     def test_runtime_if_folds_to_one_if_box(self):
-        """A measurement-backed if becomes exactly one folded IF box."""
-        vc = _visual_circuit(runtime_if, fold_loops=True)
+        """A measurement-backed if becomes one folded IF box with both branches."""
+        vc = _visual_circuit(runtime_if, fold_ifs=True)
         folded = _folded_ifs(vc)
         assert len(folded) == 1
         # The condition label spells the measurement bit, not a placeholder.
         assert folded[0].header_label.startswith("if ")
         assert "measured" in folded[0].header_label
+        assert "else:" in folded[0].body_lines
+        assert any("h(" in line for line in folded[0].body_lines)
 
     def test_symbolic_classical_if_label_shows_predicate(self):
         """An unbound classical if renders its predicate, e.g. ``if flag == 1:``."""
-        vc = _visual_circuit(classical_if, fold_loops=True)
+        vc = _visual_circuit(classical_if, fold_ifs=True)
         folded = _folded_ifs(vc)
         assert len(folded) == 1
         assert folded[0].header_label == "if flag == 1:"
+        assert "else:" in folded[0].body_lines
+
+    def test_empty_true_branch_folded_summary_keeps_else(self):
+        """An empty true branch still shows pass and else in folded form."""
+        vc = _visual_circuit(empty_true_if, fold_ifs=True)
+        folded = _folded_ifs(vc)
+        assert len(folded) == 1
+        assert folded[0].body_lines[0] == "pass"
+        assert "else:" in folded[0].body_lines
 
 
 class TestUnfoldedIf:
-    """``fold_loops=False`` renders a surviving if as side-by-side branches."""
+    """The default renders surviving ifs as side-by-side branches."""
 
     def test_runtime_if_unfolds_into_two_branches(self):
         """A measurement-backed if/else yields one IF sequence with two branches."""
-        vc = _visual_circuit(runtime_if, fold_loops=False)
+        vc = _visual_circuit(runtime_if)
         unfolded = _unfolded_ifs(vc)
         assert len(unfolded) == 1
         assert len(unfolded[0].iterations) == 2
@@ -181,14 +278,14 @@ class TestUnfoldedIf:
 
     def test_branches_carry_their_own_gates(self):
         """Iteration 0 holds the true-branch X; iteration 1 holds the else H."""
-        vc = _visual_circuit(runtime_if, fold_loops=False)
+        vc = _visual_circuit(runtime_if)
         seq = _unfolded_ifs(vc)[0]
         assert _branch_gate_types(seq.iterations[0]) == [GateOperationType.X]
         assert _branch_gate_types(seq.iterations[1]) == [GateOperationType.H]
 
     def test_if_without_else_has_single_branch(self):
         """An if with no else unfolds to a single-branch IF sequence."""
-        vc = _visual_circuit(if_no_else, fold_loops=False)
+        vc = _visual_circuit(if_no_else)
         unfolded = _unfolded_ifs(vc)
         assert len(unfolded) == 1
         assert len(unfolded[0].iterations) == 1
@@ -196,7 +293,7 @@ class TestUnfoldedIf:
 
     def test_empty_true_branch_is_kept_for_rendering(self):
         """An empty true branch still occupies the IF branch slot."""
-        vc = _visual_circuit(empty_true_if, fold_loops=False)
+        vc = _visual_circuit(empty_true_if)
         unfolded = _unfolded_ifs(vc)
         assert len(unfolded) == 1
         assert len(unfolded[0].iterations) == 2
@@ -205,7 +302,7 @@ class TestUnfoldedIf:
 
     def test_condition_label_width_reserved_for_layout(self):
         """The IF sequence carries a positive header width for layout to reserve."""
-        vc = _visual_circuit(classical_if, fold_loops=False)
+        vc = _visual_circuit(classical_if)
         seq = _unfolded_ifs(vc)[0]
         assert seq.condition_label == "if flag == 1:"
         assert seq.condition_label_width > 0.0
@@ -217,11 +314,17 @@ class TestUnfoldedIf:
         the layout reserves), which is what keeps the boxes gap-free and the
         labels from overflowing.
         """
-        vc = _visual_circuit(classical_if, fold_loops=False)
+        vc = _visual_circuit(classical_if)
         seq = _unfolded_ifs(vc)[0]
         assert len(seq.branch_label_widths) == len(seq.iterations) == 2
         assert all(w > 0.0 for w in seq.branch_label_widths)
         assert seq.branch_label_widths[0] == seq.condition_label_width
+
+    def test_fold_loops_does_not_fold_if(self):
+        """Loop folding leaves if/else rendering expanded unless fold_ifs is set."""
+        vc = _visual_circuit(runtime_if, fold_loops=True)
+        assert not _folded_ifs(vc)
+        assert len(_unfolded_ifs(vc)) == 1
 
 
 class TestUnfoldedIfSpacing:
@@ -242,6 +345,15 @@ class TestUnfoldedIfSpacing:
 
         @qmc.qkernel
         def plain(q0: Qubit, q1: Qubit) -> tuple[Qubit, Qubit]:
+            """Build a plain two-qubit circuit without if labels.
+
+            Args:
+                q0 (Qubit): Qubit receiving an H gate.
+                q1 (Qubit): Qubit receiving an X gate.
+
+            Returns:
+                tuple[Qubit, Qubit]: Updated ``q0`` and ``q1``.
+            """
             q0 = qmc.h(q0)
             q1 = qmc.x(q1)
             return q0, q1
@@ -256,7 +368,14 @@ class TestBranchMeasurementWire:
     """A measurement inside an if branch is mid-circuit and keeps its wire."""
 
     def _measures(self, vc: VisualCircuit) -> list[VGate]:
-        """Collect every measurement VGate in a visual circuit."""
+        """Collect every measurement VGate in a visual circuit.
+
+        Args:
+            vc (VisualCircuit): Visual circuit to scan.
+
+        Returns:
+            list[VGate]: Measurement gates in traversal order.
+        """
         return [
             n
             for n in _walk(vc.children)
@@ -317,8 +436,8 @@ class TestCompileTimeResolution:
 
     def test_bound_true_draws_only_selected_branch(self):
         """``flag=1`` collapses to the true branch (X) with no if box."""
-        for fold in (True, False):
-            vc = _visual_circuit(classical_if, fold_loops=fold, flag=1)
+        for fold_ifs in (False, True):
+            vc = _visual_circuit(classical_if, fold_ifs=fold_ifs, flag=1)
             assert not _folded_ifs(vc)
             assert not _unfolded_ifs(vc)
             gates = [
@@ -330,7 +449,7 @@ class TestCompileTimeResolution:
 
     def test_bound_false_draws_only_else_branch(self):
         """``flag=0`` collapses to the else branch (H) with no if box."""
-        vc = _visual_circuit(classical_if, fold_loops=True, flag=0)
+        vc = _visual_circuit(classical_if, fold_ifs=True, flag=0)
         assert not _folded_ifs(vc)
         gates = [
             n.gate_type
@@ -369,23 +488,23 @@ class TestDrawEndToEnd:
     """``QKernel.draw`` returns a Figure for every if flavor without raising."""
 
     def test_runtime_if_draws(self):
-        """Measurement-backed if draws in both folded and unfolded modes."""
-        assert isinstance(runtime_if.draw(fold_loops=True), Figure)
-        assert isinstance(runtime_if.draw(fold_loops=False), Figure)
+        """Measurement-backed if draws in unfolded and folded-if modes."""
+        assert isinstance(runtime_if.draw(), Figure)
+        assert isinstance(runtime_if.draw(fold_ifs=True), Figure)
 
     def test_symbolic_classical_if_draws(self):
-        """Unbound classical if draws in both modes."""
-        assert isinstance(classical_if.draw(fold_loops=True), Figure)
-        assert isinstance(classical_if.draw(fold_loops=False), Figure)
+        """Unbound classical if draws in unfolded and folded-if modes."""
+        assert isinstance(classical_if.draw(), Figure)
+        assert isinstance(classical_if.draw(fold_ifs=True), Figure)
 
     def test_bound_classical_if_draws(self):
         """Bound classical if (compile-time resolved) draws without an if box."""
         assert isinstance(classical_if.draw(fold_loops=False, flag=1), Figure)
 
     def test_nested_if_draws(self):
-        """Nested if draws in both modes."""
-        assert isinstance(nested_if.draw(fold_loops=True), Figure)
-        assert isinstance(nested_if.draw(fold_loops=False), Figure)
+        """Nested if draws in unfolded and folded-if modes."""
+        assert isinstance(nested_if.draw(), Figure)
+        assert isinstance(nested_if.draw(fold_ifs=True), Figure)
 
     def test_empty_true_branch_draws_if_label(self):
         """The renderer keeps the IF label even when the true branch is empty."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -67,6 +67,17 @@ def if_no_else(q0: Qubit, q1: Qubit) -> Qubit:
 
 
 @qmc.qkernel
+def empty_true_if(q0: Qubit, q1: Qubit) -> Qubit:
+    """Measurement-backed if whose true branch is empty and else has a gate."""
+    cond = qmc.measure(q0)
+    if cond:
+        pass
+    else:
+        q1 = qmc.x(q1)
+    return q1
+
+
+@qmc.qkernel
 def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
     """Two-level nested if so recursive branch rendering can be checked."""
     c0 = qmc.measure(q0)
@@ -182,6 +193,15 @@ class TestUnfoldedIf:
         assert len(unfolded) == 1
         assert len(unfolded[0].iterations) == 1
         assert _branch_gate_types(unfolded[0].iterations[0]) == [GateOperationType.X]
+
+    def test_empty_true_branch_is_kept_for_rendering(self):
+        """An empty true branch still occupies the IF branch slot."""
+        vc = _visual_circuit(empty_true_if, fold_loops=False)
+        unfolded = _unfolded_ifs(vc)
+        assert len(unfolded) == 1
+        assert len(unfolded[0].iterations) == 2
+        assert unfolded[0].iterations[0] == []
+        assert _branch_gate_types(unfolded[0].iterations[1]) == [GateOperationType.X]
 
     def test_condition_label_width_reserved_for_layout(self):
         """The IF sequence carries a positive header width for layout to reserve."""
@@ -366,3 +386,11 @@ class TestDrawEndToEnd:
         """Nested if draws in both modes."""
         assert isinstance(nested_if.draw(fold_loops=True), Figure)
         assert isinstance(nested_if.draw(fold_loops=False), Figure)
+
+    def test_empty_true_branch_draws_if_label(self):
+        """The renderer keeps the IF label even when the true branch is empty."""
+        fig = empty_true_if.draw(fold_loops=False)
+        ax = fig._qm_ax  # type: ignore[attr-defined]
+        labels = [text.get_text() for text in ax.texts]
+        assert any(label.startswith("if ") for label in labels)
+        assert "else:" in labels

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -210,6 +210,39 @@ def symbolic_empty_single_branch_if(q0: Qubit, flag: UInt) -> Qubit:
 
 
 @qmc.qkernel
+def compile_time_if_callee(q0: Qubit, flag: UInt) -> Qubit:
+    """Build a callee with a compile-time resolvable if.
+
+    Args:
+        q0 (Qubit): Qubit transformed by the selected branch.
+        flag (UInt): Compile-time flag forwarded by the caller.
+
+    Returns:
+        Qubit: Updated ``q0``.
+    """
+    if flag == 1:
+        q0 = qmc.x(q0)
+    else:
+        q0 = qmc.h(q0)
+    return q0
+
+
+@qmc.qkernel
+def inline_compile_time_if(flag: UInt) -> Qubit:
+    """Call a callee whose IF resolves only after inline argument binding.
+
+    Args:
+        flag (UInt): Compile-time flag passed into the callee.
+
+    Returns:
+        Qubit: Updated qubit from the selected callee branch.
+    """
+    q0 = qmc.qubit("q0")
+    q0 = compile_time_if_callee(q0, flag)
+    return q0
+
+
+@qmc.qkernel
 def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
     """Build a two-level nested if example.
 
@@ -252,12 +285,18 @@ def _walk(nodes: Iterable[VisualNode]) -> Iterator[VisualNode]:
 
 
 def _visual_circuit(
-    kernel: Any, *, fold_loops: bool = True, fold_ifs: bool = False, **bindings: Any
+    kernel: Any,
+    *,
+    inline: bool = False,
+    fold_loops: bool = True,
+    fold_ifs: bool = False,
+    **bindings: Any,
 ) -> VisualCircuit:
     """Trace ``kernel`` and run the visualization analyzer in isolation.
 
     Args:
         kernel (Any): QKernel-like object to trace.
+        inline (bool): Whether CallBlockOperation contents should be inlined.
         fold_loops (bool): Whether loop operations should be folded.
         fold_ifs (bool): Whether if operations should be folded.
         **bindings (Any): Concrete draw-time bindings for kernel parameters.
@@ -271,7 +310,7 @@ def _visual_circuit(
     analyzer = CircuitAnalyzer(
         block,
         DEFAULT_STYLE,
-        inline=False,
+        inline=inline,
         fold_loops=fold_loops,
         fold_ifs=fold_ifs,
         expand_composite=False,
@@ -663,6 +702,18 @@ class TestCompileTimeResolution:
             if isinstance(n, VGate) and n.gate_type is not None
         ]
         assert gates == [GateOperationType.H]
+
+    def test_inline_bound_callee_if_draws_only_selected_branch(self):
+        """Inline callee IFs collapse after actual argument binding."""
+        vc = _visual_circuit(inline_compile_time_if, inline=True, flag=1)
+        assert not _folded_ifs(vc)
+        assert not _unfolded_ifs(vc)
+        gates = [
+            n.gate_type
+            for n in _walk(vc.children)
+            if isinstance(n, VGate) and n.gate_type is not None
+        ]
+        assert gates == [GateOperationType.X]
 
 
 class TestNestedIf:

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -287,6 +287,7 @@ def _walk(nodes: Iterable[VisualNode]) -> Iterator[VisualNode]:
 def _visual_circuit(
     kernel: Any,
     *,
+    style: Any = DEFAULT_STYLE,
     inline: bool = False,
     fold_loops: bool = True,
     fold_ifs: bool = False,
@@ -296,6 +297,7 @@ def _visual_circuit(
 
     Args:
         kernel (Any): QKernel-like object to trace.
+        style (Any): Visual style configuration used by the analyzer.
         inline (bool): Whether CallBlockOperation contents should be inlined.
         fold_loops (bool): Whether loop operations should be folded.
         fold_ifs (bool): Whether if operations should be folded.
@@ -309,7 +311,7 @@ def _visual_circuit(
     )
     analyzer = CircuitAnalyzer(
         block,
-        DEFAULT_STYLE,
+        style,
         inline=inline,
         fold_loops=fold_loops,
         fold_ifs=fold_ifs,
@@ -555,6 +557,64 @@ class TestUnfoldedIf:
         assert len(seq.branch_label_widths) == len(seq.iterations) == 2
         assert all(w > 0.0 for w in seq.branch_label_widths)
         assert seq.branch_label_widths[0] == seq.condition_label_width
+
+    def test_layout_reserves_all_branch_header_widths(self):
+        """Subsequent gates start after every IF branch header box."""
+        style = replace(DEFAULT_STYLE, gate_gap=0.1)
+        if_node = VUnfoldedSequence(
+            node_key=("if",),
+            iterations=[
+                [
+                    VGate(
+                        node_key=("if", "true", "x"),
+                        label="X",
+                        qubit_indices=[0],
+                        estimated_width=style.gate_width,
+                        kind=VGateKind.GATE,
+                        gate_type=GateOperationType.X,
+                    )
+                ],
+                [
+                    VGate(
+                        node_key=("if", "false", "h"),
+                        label="H",
+                        qubit_indices=[0],
+                        estimated_width=style.gate_width,
+                        kind=VGateKind.GATE,
+                        gate_type=GateOperationType.H,
+                    )
+                ],
+            ],
+            affected_qubits=[0],
+            kind=VUnfoldedKind.IF,
+            condition_label="if cond:",
+            condition_label_width=1.0,
+            branch_label_widths=[1.0, 3.0],
+        )
+        following = VGate(
+            node_key=("after",),
+            label="Z",
+            qubit_indices=[0],
+            estimated_width=style.gate_width,
+            kind=VGateKind.GATE,
+            gate_type=GateOperationType.Z,
+        )
+        vc = VisualCircuit(
+            children=[if_node, following],
+            qubit_map={"q": 0},
+            qubit_names={0: "q"},
+            num_qubits=1,
+        )
+
+        layout = CircuitLayoutEngine(style).compute_layout(vc)
+        following_left = (
+            layout.positions[following.node_key]
+            - layout.gate_widths[following.node_key] / 2
+        )
+        min_if_end = style.initial_wire_position + sum(
+            max(width, style.gate_width) for width in if_node.branch_label_widths
+        )
+        assert following_left >= min_if_end
 
     def test_fold_loops_does_not_fold_if(self):
         """Loop folding leaves if/else rendering expanded unless fold_ifs is set."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -96,6 +96,26 @@ def vector_measure_element_if() -> Qubit:
 
 
 @qmc.qkernel
+def symbolic_vector_measure_element_if(index: UInt) -> Qubit:
+    """Build an if whose vector-measurement element index is symbolic.
+
+    Args:
+        index (UInt): Symbolic measured-bit index used as the condition.
+
+    Returns:
+        Qubit: Updated target qubit.
+    """
+    qs = qmc.qubit_array(3, "qs")
+    target = qmc.qubit("target")
+    bits = qmc.measure(qs)
+    if bits[index]:
+        target = qmc.x(target)
+    else:
+        target = qmc.h(target)
+    return target
+
+
+@qmc.qkernel
 def classical_if(q0: Qubit, flag: UInt) -> Qubit:
     """Build a symbolic classical-condition if/else example.
 
@@ -396,6 +416,19 @@ class TestUnfoldedIf:
         assert seq.condition_measure_node_key == measure.node_key
         assert seq.condition_measure_qubit_indices == [1]
 
+    def test_symbolic_vector_measurement_element_keeps_all_candidate_wires(self):
+        """``if bits[i]:`` records all candidates when ``i`` is unresolved."""
+        vc = _visual_circuit(symbolic_vector_measure_element_if)
+        measure = next(
+            n
+            for n in _walk(vc.children)
+            if isinstance(n, VGate) and n.kind == VGateKind.MEASURE_VECTOR
+        )
+        seq = _unfolded_ifs(vc)[0]
+        assert measure.qubit_indices == [0, 1, 2]
+        assert seq.condition_measure_node_key == measure.node_key
+        assert seq.condition_measure_qubit_indices == [0, 1, 2]
+
     def test_symbolic_classical_condition_has_no_measurement_connector(self):
         """A non-measurement condition does not draw as measurement-derived."""
         vc = _visual_circuit(classical_if)
@@ -649,6 +682,10 @@ class TestDrawEndToEnd:
     def test_vector_measurement_element_if_draws_connector(self):
         """A vector-measurement element condition draws one connector."""
         assert len(_if_connector_lines(vector_measure_element_if.draw())) == 1
+
+    def test_symbolic_vector_measurement_element_skips_connector(self):
+        """Ambiguous vector-measurement elements do not draw a connector."""
+        assert len(_if_connector_lines(symbolic_vector_measure_element_if.draw())) == 0
 
     def test_symbolic_classical_if_draws(self):
         """Unbound classical if draws in unfolded and folded-if modes."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -658,8 +658,11 @@ class TestDrawEndToEnd:
 
     def test_empty_single_branch_draws_if_label(self):
         """The renderer keeps an empty single-branch IF visible."""
-        fig = empty_single_branch_if.draw(fold_loops=False)
-        ax = fig._qm_ax  # type: ignore[attr-defined]
-        labels = [text.get_text() for text in ax.texts]
-        assert any(label.startswith("if ") for label in labels)
-        assert len(_if_connector_lines(fig)) == 1
+        for fig in (
+            empty_single_branch_if.draw(fold_loops=False),
+            empty_single_branch_if.draw(fold_loops=False, fold_ifs=True),
+        ):
+            ax = fig._qm_ax  # type: ignore[attr-defined]
+            labels = [text.get_text() for text in ax.texts]
+            assert any(label.startswith("if ") for label in labels)
+            assert len(_if_connector_lines(fig)) == 1

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -18,6 +18,7 @@ from collections.abc import Iterable, Iterator
 from typing import Any
 
 from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.handle import Qubit, UInt
@@ -53,6 +54,24 @@ def runtime_if(q0: Qubit, q1: Qubit) -> Qubit:
     """
     cond = qmc.measure(q0)
     if cond:
+        q1 = qmc.x(q1)
+    else:
+        q1 = qmc.h(q1)
+    return q1
+
+
+@qmc.qkernel
+def inline_measure_if(q0: Qubit, q1: Qubit) -> Qubit:
+    """Build an if whose condition is an inline measurement call.
+
+    Args:
+        q0 (Qubit): Qubit measured directly in the condition.
+        q1 (Qubit): Qubit transformed by the selected branch.
+
+    Returns:
+        Qubit: Updated ``q1``.
+    """
+    if qmc.measure(q0):
         q1 = qmc.x(q1)
     else:
         q1 = qmc.h(q1)
@@ -233,6 +252,24 @@ def _branch_gate_types(iteration: Iterable[VisualNode]) -> list[GateOperationTyp
     ]
 
 
+def _if_connector_lines(fig: Figure) -> list[Line2D]:
+    """Collect solid IF-colored connector lines from a rendered figure.
+
+    Args:
+        fig (Figure): Rendered circuit figure.
+
+    Returns:
+        list[Line2D]: Lines that match the measurement-to-IF connector style.
+    """
+    ax = fig._qm_ax  # type: ignore[attr-defined]
+    return [
+        line
+        for line in ax.lines
+        if line.get_color() == DEFAULT_STYLE.if_edge_color
+        and line.get_linestyle() == "-"
+    ]
+
+
 class TestFoldedIf:
     """``fold_ifs=True`` renders a surviving if as a single folded box."""
 
@@ -246,6 +283,13 @@ class TestFoldedIf:
         assert "measured" in folded[0].header_label
         assert any(line.startswith("else:") for line in folded[0].body_lines)
         assert any("h(" in line for line in folded[0].body_lines)
+
+    def test_runtime_if_keeps_measurement_connector_metadata(self):
+        """A folded measurement-backed if knows which measurement feeds it."""
+        vc = _visual_circuit(runtime_if, fold_ifs=True)
+        folded = _folded_ifs(vc)[0]
+        assert folded.condition_measure_node_key is not None
+        assert folded.condition_measure_qubit_indices == [0]
 
     def test_symbolic_classical_if_label_shows_predicate(self):
         """An unbound classical if renders its predicate, e.g. ``if flag == 1:``."""
@@ -275,6 +319,27 @@ class TestUnfoldedIf:
         assert len(unfolded[0].iterations) == 2
         assert unfolded[0].condition_label is not None
         assert "measured" in unfolded[0].condition_label
+
+    def test_assigned_measurement_condition_carries_connector_metadata(self):
+        """``b = measure(q); if b:`` records the measurement feeding the IF."""
+        vc = _visual_circuit(runtime_if)
+        seq = _unfolded_ifs(vc)[0]
+        assert seq.condition_measure_node_key is not None
+        assert seq.condition_measure_qubit_indices == [0]
+
+    def test_inline_measurement_condition_carries_connector_metadata(self):
+        """``if measure(q):`` records the measurement feeding the IF."""
+        vc = _visual_circuit(inline_measure_if)
+        seq = _unfolded_ifs(vc)[0]
+        assert seq.condition_measure_node_key is not None
+        assert seq.condition_measure_qubit_indices == [0]
+
+    def test_symbolic_classical_condition_has_no_measurement_connector(self):
+        """A non-measurement condition does not draw as measurement-derived."""
+        vc = _visual_circuit(classical_if)
+        seq = _unfolded_ifs(vc)[0]
+        assert seq.condition_measure_node_key is None
+        assert seq.condition_measure_qubit_indices == []
 
     def test_branches_carry_their_own_gates(self):
         """Iteration 0 holds the true-branch X; iteration 1 holds the else H."""
@@ -500,6 +565,15 @@ class TestDrawEndToEnd:
         """Measurement-backed if draws in unfolded and folded-if modes."""
         assert isinstance(runtime_if.draw(), Figure)
         assert isinstance(runtime_if.draw(fold_ifs=True), Figure)
+
+    def test_runtime_if_draws_measurement_connector(self):
+        """Measurement-backed if draws a solid connector from measure to IF."""
+        assert len(_if_connector_lines(runtime_if.draw())) == 1
+        assert len(_if_connector_lines(runtime_if.draw(fold_ifs=True))) == 1
+
+    def test_inline_measurement_if_draws_connector(self):
+        """An inline measurement condition draws the same connector."""
+        assert len(_if_connector_lines(inline_measure_if.draw())) == 1
 
     def test_symbolic_classical_if_draws(self):
         """Unbound classical if draws in unfolded and folded-if modes."""

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -150,6 +150,22 @@ def empty_true_if(q0: Qubit, q1: Qubit) -> Qubit:
 
 
 @qmc.qkernel
+def empty_single_branch_if(q0: Qubit, q1: Qubit) -> Qubit:
+    """Build a measurement-backed if whose only branch is empty.
+
+    Args:
+        q0 (Qubit): Qubit measured to decide the branch.
+        q1 (Qubit): Qubit returned unchanged.
+
+    Returns:
+        Qubit: Unchanged ``q1``.
+    """
+    if qmc.measure(q0):
+        pass
+    return q1
+
+
+@qmc.qkernel
 def nested_if(q0: Qubit, q1: Qubit, q2: Qubit) -> Qubit:
     """Build a two-level nested if example.
 
@@ -395,6 +411,15 @@ class TestUnfoldedIf:
         assert unfolded[0].iterations[0] == []
         assert _branch_gate_types(unfolded[0].iterations[1]) == [GateOperationType.X]
 
+    def test_empty_single_branch_uses_condition_measure_wire(self):
+        """An empty single-branch IF anchors to its condition measurement wire."""
+        vc = _visual_circuit(empty_single_branch_if)
+        unfolded = _unfolded_ifs(vc)
+        assert len(unfolded) == 1
+        assert unfolded[0].iterations == [[]]
+        assert unfolded[0].affected_qubits == [0]
+        assert unfolded[0].condition_measure_qubit_indices == [0]
+
     def test_condition_label_width_reserved_for_layout(self):
         """The IF sequence carries a positive header width for layout to reserve."""
         vc = _visual_circuit(classical_if)
@@ -630,3 +655,11 @@ class TestDrawEndToEnd:
         labels = [text.get_text() for text in ax.texts]
         assert any(label.startswith("if ") for label in labels)
         assert "else:" in labels
+
+    def test_empty_single_branch_draws_if_label(self):
+        """The renderer keeps an empty single-branch IF visible."""
+        fig = empty_single_branch_if.draw(fold_loops=False)
+        ax = fig._qm_ax  # type: ignore[attr-defined]
+        labels = [text.get_text() for text in ax.texts]
+        assert any(label.startswith("if ") for label in labels)
+        assert len(_if_connector_lines(fig)) == 1

--- a/tests/circuit/test_drawer_if.py
+++ b/tests/circuit/test_drawer_if.py
@@ -15,17 +15,25 @@ import matplotlib
 matplotlib.use("Agg")
 
 from collections.abc import Iterable, Iterator
+from dataclasses import replace
+import math
 from typing import Any
 
+from matplotlib import colors as mcolors
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
+from matplotlib.patches import FancyBboxPatch
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.handle import Qubit, UInt
 from qamomile.circuit.ir.operation.control_flow import IfOperation
 from qamomile.circuit.ir.operation.gate import GateOperationType
 from qamomile.circuit.visualization.analyzer import CircuitAnalyzer
-from qamomile.circuit.visualization.drawer import _prepare_graph_for_visualization
+from qamomile.circuit.visualization.drawer import (
+    MatplotlibDrawer,
+    _prepare_graph_for_visualization,
+)
+from qamomile.circuit.visualization.geometry import compute_border_padding
 from qamomile.circuit.visualization.layout import CircuitLayoutEngine
 from qamomile.circuit.visualization.style import DEFAULT_STYLE
 from qamomile.circuit.visualization.visual_ir import (
@@ -336,6 +344,27 @@ def _if_connector_lines(fig: Figure) -> list[Line2D]:
         for line in ax.lines
         if line.get_color() == DEFAULT_STYLE.if_edge_color
         and line.get_linestyle() == "-"
+    ]
+
+
+def _if_branch_boxes(fig: Figure) -> list[FancyBboxPatch]:
+    """Collect IF branch boxes from a rendered figure.
+
+    Args:
+        fig (Figure): Rendered circuit figure.
+
+    Returns:
+        list[FancyBboxPatch]: IF-colored branch boxes.
+    """
+    ax = fig._qm_ax  # type: ignore[attr-defined]
+    if_edge = mcolors.to_rgba(DEFAULT_STYLE.if_edge_color)
+    return [
+        patch
+        for patch in ax.patches
+        if isinstance(patch, FancyBboxPatch)
+        and patch.get_edgecolor() == if_edge
+        and patch.get_facecolor()[3] == 0
+        and patch.get_linestyle() == "-."
     ]
 
 
@@ -719,6 +748,18 @@ class TestDrawEndToEnd:
             labels = [text.get_text() for text in ax.texts]
             assert any(label.startswith("if ") for label in labels)
             assert len(_if_connector_lines(fig)) == 1
+
+    def test_empty_single_branch_uses_layout_reserved_span(self):
+        """Empty IF branch boxes prefer the layout-reserved x-span."""
+        style = replace(DEFAULT_STYLE, gate_gap=0.1)
+        fig = MatplotlibDrawer(
+            empty_single_branch_if._build_graph_for_visualization(), style
+        ).draw(fold_loops=False)
+        connector = _if_connector_lines(fig)[0]
+        measure_right = connector.get_xdata()[0]
+        expected_left = measure_right + compute_border_padding(style, depth=0)
+        branch_box = _if_branch_boxes(fig)[0]
+        assert math.isclose(branch_box.get_x(), expected_left)
 
     def test_symbolic_empty_single_branch_draws_if_label(self):
         """The renderer keeps an empty symbolic single-branch IF visible."""

--- a/tests/transpiler/test_compile_time_if_lowering.py
+++ b/tests/transpiler/test_compile_time_if_lowering.py
@@ -2047,3 +2047,50 @@ class TestNoNameCollisionInTmpWrites:
         evaluate_classical_predicate(_StubEmitPass(), op, bindings)
         assert bindings[out.uuid] is False
         assert out.name not in bindings
+
+
+# ---------------------------------------------------------------------------
+# Block-kind acceptance (TRACED is accepted for the circuit drawer)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockKindAcceptance:
+    """The pass accepts TRACED/AFFINE/HIERARCHICAL and rejects ANALYZED."""
+
+    def test_traced_block_is_lowered(self):
+        """A TRACED block (the drawer's input kind) lowers and keeps its kind."""
+        q = _qubit_val()
+        flag = _uint_val("flag", const=1)
+        if_op, phi_out = _make_if_with_x_gate(flag, q)
+        block = Block(
+            name="traced",
+            operations=[if_op],
+            output_values=[phi_out],
+            kind=BlockKind.TRACED,
+        )
+
+        lowered = _run_pass(block)
+
+        assert not _find_ops(lowered.operations, IfOperation)
+        assert _find_gates(lowered.operations, GateOperationType.X)
+        # Kind is a normalization-neutral attribute: it must survive lowering.
+        assert lowered.kind == BlockKind.TRACED
+
+    def test_analyzed_block_is_rejected(self):
+        """ANALYZED is rejected: the pass must run before dependency analysis."""
+        import pytest
+
+        from qamomile.circuit.transpiler.errors import ValidationError
+
+        q = _qubit_val()
+        flag = _uint_val("flag", const=1)
+        if_op, phi_out = _make_if_with_x_gate(flag, q)
+        block = Block(
+            name="analyzed",
+            operations=[if_op],
+            output_values=[phi_out],
+            kind=BlockKind.ANALYZED,
+        )
+
+        with pytest.raises(ValidationError, match="TRACED, AFFINE, or"):
+            _run_pass(block)


### PR DESCRIPTION
## Summary
- Add visualization support for runtime and symbolic if/else branches, including folded summaries and unfolded branch boxes.
- Prepare graphs in MatplotlibDrawer before analysis so compile-time conditions collapse without adding a frontend-to-transpiler dependency.
- Add drawer tests for runtime, symbolic, bound, nested, and branch-measurement cases.

## Tests
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
- uv run pytest tests/circuit/test_drawer_if.py tests/circuit/test_drawer_inline_depth.py tests/circuit/test_drawer_for_items.py tests/circuit/test_drawer_slice.py tests/circuit/test_drawer_controlled.py tests/circuit/test_drawer_controlled_label.py
- uv run pytest tests/transpiler/test_compile_time_if_lowering.py