### PR TITLE
Consolidate limitations documentation

### DIFF
--- a/LIMITATION.md
+++ b/LIMITATION.md
@@ -1,9 +1,0 @@
-# Limitations
-
-## Dict Subscript Lookup Does Not Yet Support Container Values
-
-When `Dict[K, V]` uses a container value type such as `qmc.Tuple` or `qmc.Vector`, `Dict.__getitem__` raises `NotImplementedError`.
-
-The current lookup path represents the result of `d[key]` as a single scalar `Value`. It does not yet rebuild frontend handles for structured lookup results or represent multi-value results in `DictGetItemOperation`, serialization, emission, and the classical executor.
-
-A future implementation should allow `DictGetItemOperation` to produce `TupleValue` or `ArrayValue` results, then extend frontend handle reconstruction plus serialize, emit, and classical executor support for those structured results.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-This file collects known limitations of the Qamomile compiler — gaps deliberately left open by recent fixes and trade-offs the codebase carries on purpose. Each entry documents what the limitation is, when it bites, why the simpler fix was deferred, and the future fix path. Entries here cover the call-time specialization fix for issue #392, the eager qkernel rebind-detection change, structured dictionary lookup, and the slice/control-flow work tracked by recent controlled-view fixes.
+This file collects known limitations of the Qamomile compiler — gaps deliberately left open by recent fixes and trade-offs the codebase carries on purpose. Each entry documents what the limitation is, when it bites, why the simpler fix was deferred, and the future fix path. Entries here cover the call-time specialization fix for issue #392, the eager qkernel rebind-detection change, dict subscript lookup for container values, and the slice/control-flow work tracked by recent controlled-view fixes.
 
 ## Container-valued operands outgrow the current `Operation.operands` type annotation
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-This file collects known limitations of the Qamomile compiler — gaps deliberately left open by recent fixes and trade-offs the codebase carries on purpose. Each entry documents what the limitation is, when it bites, why the simpler fix was deferred, and the future fix path. Entries here cover the call-time specialization fix for issue #392, the eager qkernel rebind-detection change, and the slice/control-flow work tracked by recent controlled-view fixes.
+This file collects known limitations of the Qamomile compiler — gaps deliberately left open by recent fixes and trade-offs the codebase carries on purpose. Each entry documents what the limitation is, when it bites, why the simpler fix was deferred, and the future fix path. Entries here cover the call-time specialization fix for issue #392, the eager qkernel rebind-detection change, structured dictionary lookup, and the slice/control-flow work tracked by recent controlled-view fixes.
 
 ## Container-valued operands outgrow the current `Operation.operands` type annotation
 
@@ -11,6 +11,16 @@ Some IR operations legitimately carry container-valued operands even though the 
 **Why this trade-off was chosen**: widening `Operation.operands` globally to `list[ValueBase]` or a `ValueLike` alias would touch many passes and emitters whose local logic genuinely assumes scalar / array `Value` operands. Splitting container operands into dedicated fields would be cleaner for those operations but requires an IR-contract migration and encoder / decoder schema cleanup. The current fix keeps the behavioral repair local to the block-I/O and container-carrying-operation decoder paths, without weakening `_materialize_as_value`, which still guards positions where containers are invalid.
 
 **Future fix**: make the container operand contract explicit. Either widen `Operation.operands` to a shared `ValueLike` / `ValueBase` type and audit all passes for places that require scalar / array `Value`, or move container parameters onto operation-specific fields for `ForItemsOperation` and `InverseBlockOperation` so the base operand list stays strictly scalar / array. Once that contract is explicit, the decoder-side casts can be removed.
+
+## Dict subscript lookup does not yet support container values
+
+When `Dict[K, V]` uses a container value type such as `qmc.Tuple` or `qmc.Vector`, `Dict.__getitem__` raises `NotImplementedError`.
+
+**When it bites**: a symbolic dictionary lookup such as `d[key]` currently represents the result as a single scalar `Value`. That is sufficient for scalar values, but it cannot rebuild frontend handles for structured lookup results and cannot represent multi-value results in `DictGetItemOperation`, serialization, emission, or the classical executor.
+
+**Why this trade-off was chosen**: the existing dictionary lookup path is scalar-oriented end to end. Supporting structured values would require the frontend, IR operation result model, wire formats, emit passes, and classical executor to agree on how a single lookup produces multiple structured values. The current guard fails explicitly instead of tracing an incomplete container result that later stages cannot materialize correctly.
+
+**Future fix**: allow `DictGetItemOperation` to produce `TupleValue` or `ArrayValue` results, then extend frontend handle reconstruction, serialization, emission, and classical executor support for those structured results.
 
 ## Re-trace cost is uncached
 


### PR DESCRIPTION
## Summary
- Move the dict subscript lookup limitation into LIMITATIONS.md.
- Remove the duplicate LIMITATION.md file.

## Verification
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- uv run zuban check qamomile/
