### PR TITLE
Preserve compile-time-constant block outputs through folding

### DIFF
--- a/qamomile/circuit/transpiler/passes/separate.py
+++ b/qamomile/circuit/transpiler/passes/separate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
+from typing import Any
 
 from qamomile.circuit.ir.block import Block
 from qamomile.circuit.ir.operation import Operation
@@ -188,6 +189,7 @@ class NisqSegmentationStrategy(SegmentationStrategy):
         abi = ProgramABI(
             public_inputs={name: value for name, value in block.parameters.items()},
             output_refs=[v.uuid for v in block.output_values],
+            output_constants=self._collect_output_constants(block.output_values),
         )
 
         return ProgramPlan(
@@ -196,6 +198,46 @@ class NisqSegmentationStrategy(SegmentationStrategy):
             boundaries=boundaries,
             parameters=block.parameters,
         )
+
+    @staticmethod
+    def _collect_output_constants(
+        output_values: list[Value],
+    ) -> dict[str, Any]:
+        """Collect compile-time-known values among a block's outputs.
+
+        A block output whose value folded to a compile-time constant —
+        a ``bindings``-bound classical argument returned directly, or a
+        classical expression fully evaluated by ``partial_eval`` (e.g.
+        ``return x * 2.0`` with ``x`` bound) — has no producing operation
+        left in the IR. It therefore never lands in the runtime execution
+        context, and resolving it by UUID alone yields ``None``. Recording
+        the constant here lets ``ProgramOrchestrator._resolve_outputs``
+        return the correct value.
+
+        Non-constant outputs (measurement results, runtime-parameter
+        expressions, arrays materialized by classical stores) are left out;
+        they resolve from the execution context at run time.
+
+        Args:
+            output_values (list[Value]): The block's return values, in
+                order, as produced by ``materialize_return``.
+
+        Returns:
+            dict[str, Any]: Map from output value UUID to its constant
+                Python value, containing only the outputs that are
+                compile-time constants.
+        """
+        constants: dict[str, Any] = {}
+        for value in output_values:
+            if not isinstance(value, ValueBase):
+                continue
+            if isinstance(value, ArrayValue):
+                const_array = value.get_const_array()
+                if const_array is not None:
+                    constants[value.uuid] = tuple(const_array)
+            elif value.is_constant():
+                constants[value.uuid] = value.get_const()
+        return constants
 
 
 class SegmentationPass(Pass[Block, ProgramPlan]):

--- a/qamomile/circuit/transpiler/program_orchestrator.py
+++ b/qamomile/circuit/transpiler/program_orchestrator.py
@@ -465,7 +465,38 @@ class ProgramOrchestrator(Generic[T]):
     # ------------------------------------------------------------------
 
     def _resolve_outputs(self, context: ExecutionContext) -> Any:
-        """Read final output values from execution context."""
+        """Read final output values from the execution context.
+
+        Each output ref is resolved in order:
+
+        1. A direct context entry (the common case — a measured bit,
+           a runtime-parameter expression, or a value materialized by a
+           classical segment).
+        2. Per-element composite carrier keys ``"<ref>_<i>"`` reassembled
+           into a tuple (a measured Vector's bits).
+        3. The compile-time ``output_constants`` map from the program ABI
+           — for outputs that folded to a constant during compilation
+           (e.g. a ``bindings``-bound classical argument returned directly,
+           or ``return x * 2.0`` with ``x`` bound). These have no producing
+           operation left in the IR, so they never enter the context.
+
+        Args:
+            context (ExecutionContext): Execution context populated by the
+                quantum measurement load and any classical segments.
+
+        Returns:
+            Any: The single output value when the program returns one
+                output, or a tuple of output values otherwise.
+
+        Raises:
+            ExecutionError: If an output ref resolves to nothing through
+                any of the paths above, indicating a compiler or runtime
+                invariant was violated rather than a legitimate ``None``.
+        """
+        output_constants = (
+            self._program.plan.abi.output_constants if self._program.plan else {}
+        )
+
         output_values = []
         for ref in self._program.output_refs:
             val = context.get(ref) if context.has(ref) else None
@@ -477,6 +508,17 @@ class ProgramOrchestrator(Generic[T]):
                     i += 1
                 if array_bits:
                     val = tuple(array_bits)
+            if val is None:
+                if ref in output_constants:
+                    val = output_constants[ref]
+                else:
+                    raise ExecutionError(
+                        f"Output '{ref}' could not be resolved from the "
+                        f"execution context or compile-time constants. This "
+                        f"indicates a missing materialization step in the "
+                        f"compiler pipeline rather than a legitimate null "
+                        f"output."
+                    )
             output_values.append(val)
 
         output_tuple = tuple(output_values)

--- a/qamomile/circuit/transpiler/segments.py
+++ b/qamomile/circuit/transpiler/segments.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 from qamomile.circuit.ir.operation import Operation
 from qamomile.circuit.ir.value import Value
@@ -158,10 +158,29 @@ class MultipleQuantumSegmentsError(Exception):
 
 @dataclasses.dataclass
 class ProgramABI:
-    """Runtime-visible ABI for a segmented program."""
+    """Runtime-visible ABI for a segmented program.
+
+    Attributes:
+        public_inputs (dict[str, Value]): Runtime parameters, keyed by
+            kernel argument name.
+        output_refs (list[str]): UUIDs of the block's output values, in
+            return order. The orchestrator reads these from the execution
+            context after running the program.
+        output_constants (dict[str, Any]): Compile-time-known values for
+            output refs that resolved to constants during compilation
+            (e.g. a ``bindings``-bound classical argument returned
+            directly, or a fully folded classical expression like
+            ``return x * 2.0`` with ``x`` bound). Such values have no
+            producing operation left in the IR, so they never appear in
+            the runtime context; the orchestrator falls back to this map
+            keyed by output ref UUID. Non-constant outputs (measurement
+            results, runtime-parameter expressions) are absent here and
+            resolved from the context instead.
+    """
 
     public_inputs: dict[str, Value] = dataclasses.field(default_factory=dict)
     output_refs: list[str] = dataclasses.field(default_factory=list)
+    output_constants: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/tests/circuit/test_bound_classical_output.py
+++ b/tests/circuit/test_bound_classical_output.py
@@ -1,0 +1,181 @@
+"""Regression tests for compile-time-constant block outputs.
+
+A block output whose value is fixed at compile time — a ``bindings``-bound
+classical argument returned directly, or a classical expression fully folded
+by ``partial_eval`` such as ``return x * 2.0`` with ``x`` bound — has no
+producing operation left in the IR after constant folding. It therefore never
+enters the runtime execution context, and previously ``sample`` / ``run``
+returned ``None`` for that output instead of the constant.
+
+These tests pin the fix across every supported local SDK backend (Qiskit,
+QURI Parts, CUDA-Q): the segmentation pass records such outputs in
+``ProgramABI.output_constants`` and ``ProgramOrchestrator._resolve_outputs``
+falls back to that map. Both the computed and pass-through forms are covered,
+together with the ``parameters=[...]`` (runtime) variant that must keep
+resolving from the execution context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.transpiler.errors import ExecutionError
+
+
+@pytest.fixture(
+    params=[
+        "qiskit",
+        pytest.param("quri_parts", marks=pytest.mark.quri_parts),
+        pytest.param("cudaq", marks=pytest.mark.cudaq),
+    ]
+)
+def backend(request) -> tuple[str, Any, Any]:
+    """Yield ``(name, transpiler, executor)`` for each installed SDK backend."""
+    name = request.param
+    if name == "qiskit":
+        pytest.importorskip("qiskit")
+        from qamomile.qiskit import QiskitTranspiler
+
+        transpiler = QiskitTranspiler()
+        return name, transpiler, transpiler.executor()
+    if name == "quri_parts":
+        pytest.importorskip("quri_parts")
+        pytest.importorskip("quri_parts.qulacs")
+        from qamomile.quri_parts import QuriPartsTranspiler
+
+        transpiler = QuriPartsTranspiler()
+        return name, transpiler, transpiler.executor()
+    if name == "cudaq":
+        pytest.importorskip("cudaq")
+        from qamomile.cudaq import CudaqTranspiler
+
+        transpiler = CudaqTranspiler()
+        return name, transpiler, transpiler.executor()
+    raise AssertionError(f"unknown backend {name}")
+
+
+@qmc.qkernel
+def _computed_output(
+    x: qmc.Float, n: qmc.UInt
+) -> tuple[qmc.Float, qmc.Vector[qmc.Bit]]:
+    """Return a folded classical expression alongside a measured register."""
+    y = x * 2.0
+    qs = qmc.qubit_array(n, name="qs")
+    qs = qmc.h(qs)
+    bits = qmc.measure(qs)
+    return y, bits
+
+
+@qmc.qkernel
+def _passthrough_output(
+    x: qmc.Float, n: qmc.UInt
+) -> tuple[qmc.Float, qmc.Vector[qmc.Bit]]:
+    """Return a bound classical argument directly alongside a measured register."""
+    qs = qmc.qubit_array(n, name="qs")
+    qs = qmc.h(qs)
+    bits = qmc.measure(qs)
+    return x, bits
+
+
+@pytest.mark.parametrize("x", [0.0, 1.5, 3.0, -0.8])
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_computed_bound_output_survives_fold(
+    backend: tuple[str, Any, Any], x: float, n: int
+) -> None:
+    """A folded ``x * 2.0`` output resolves to the constant via sample and run."""
+    name, transpiler, executor = backend
+    executable = transpiler.transpile(_computed_output, bindings={"x": x, "n": n})
+
+    run_out = executable.run(executor).result()
+    assert run_out[0] == pytest.approx(x * 2.0), name
+    assert len(run_out[1]) == n, name
+
+    sample = executable.sample(executor, shots=32).result()
+    assert sample.results, f"{name}: sampler returned no counts"
+    for output, _count in sample.results:
+        assert output[0] == pytest.approx(x * 2.0), name
+        assert len(output[1]) == n, name
+
+
+@pytest.mark.parametrize("x", [0.0, 2.0, 7.0, -1.25])
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_passthrough_bound_output_survives_fold(
+    backend: tuple[str, Any, Any], x: float, n: int
+) -> None:
+    """A directly returned bound argument resolves to its value, not ``None``."""
+    name, transpiler, executor = backend
+    executable = transpiler.transpile(_passthrough_output, bindings={"x": x, "n": n})
+
+    run_out = executable.run(executor).result()
+    assert run_out[0] == pytest.approx(x), name
+    assert len(run_out[1]) == n, name
+
+    sample = executable.sample(executor, shots=32).result()
+    assert sample.results, f"{name}: sampler returned no counts"
+    for output, _count in sample.results:
+        assert output[0] == pytest.approx(x), name
+        assert len(output[1]) == n, name
+
+
+@pytest.mark.parametrize("x", [0.0, 3.0, -2.5])
+def test_runtime_parameter_output_still_resolves(
+    backend: tuple[str, Any, Any], x: float
+) -> None:
+    """A runtime-parameter output keeps resolving from the execution context.
+
+    When ``x`` is a runtime parameter the classical expression is not folded;
+    it materializes through a classical segment. This must remain correct so
+    the compile-time-constant fallback does not shadow the context path.
+    """
+    name, transpiler, executor = backend
+    computed = transpiler.transpile(
+        _computed_output, bindings={"n": 2}, parameters=["x"]
+    )
+    run_out = computed.run(executor, bindings={"x": x}).result()
+    assert run_out[0] == pytest.approx(x * 2.0), name
+
+    passthrough = transpiler.transpile(
+        _passthrough_output, bindings={"n": 2}, parameters=["x"]
+    )
+    run_out = passthrough.run(executor, bindings={"x": x}).result()
+    assert run_out[0] == pytest.approx(x), name
+
+
+def test_output_constants_recorded_in_abi() -> None:
+    """The segmentation ABI records folded scalar outputs as constants."""
+    pytest.importorskip("qiskit")
+    from qamomile.qiskit import QiskitTranspiler
+
+    transpiler = QiskitTranspiler()
+    executable = transpiler.transpile(_computed_output, bindings={"x": 3.0, "n": 2})
+
+    abi = executable.plan.abi
+    # The first output ref (the folded Float) is a compile-time constant; the
+    # second (the measured Vector) is not and resolves from the context.
+    float_ref = abi.output_refs[0]
+    assert abi.output_constants[float_ref] == pytest.approx(6.0)
+    assert abi.output_refs[1] not in abi.output_constants
+
+
+def test_unresolvable_output_raises_execution_error() -> None:
+    """An output ref with no context value or constant raises ``ExecutionError``.
+
+    Guards the diagnostic path: rather than silently returning ``None`` for a
+    block output the pipeline failed to materialize, ``_resolve_outputs`` now
+    raises so the miscompilation surfaces loudly.
+    """
+    pytest.importorskip("qiskit")
+    from qamomile.qiskit import QiskitTranspiler
+
+    transpiler = QiskitTranspiler()
+    executable = transpiler.transpile(_passthrough_output, bindings={"x": 3.0, "n": 2})
+
+    # Corrupt the ABI so the pass-through output can be resolved neither from
+    # the context nor from the recorded constants, mimicking a compiler bug.
+    executable.plan.abi.output_constants = {}
+
+    with pytest.raises(ExecutionError, match="could not be resolved"):
+        executable.run(transpiler.executor()).result()


### PR DESCRIPTION
## Summary

A qkernel that returns a compile-time-constant classical value as a block output previously returned `None` at runtime instead of the constant. This affected two shapes:

- a classical expression fully folded by `partial_eval`, e.g. `return x * 2.0` with `bindings={"x": 3.0}` (expected `6.0`, got `None`);
- a `bindings`-bound argument returned directly, e.g. `return x` with `x` bound (pass-through form).

Root cause: constant folding removes the producing operation and the output value becomes a compile-time constant, but `ProgramABI` kept only the output UUIDs, so `ProgramOrchestrator._resolve_outputs` found nothing in the execution context and returned `None`. The runtime-parameter path (`parameters=["x"]`) was already correct — its expression is not folded and materializes through a classical segment.

Fix:

- `ProgramABI` gains an `output_constants` map (`segments.py`).
- `NisqSegmentationStrategy._collect_output_constants` records outputs that are compile-time constants — scalars via `Value.is_constant()` / `get_const()`, const arrays via `ArrayValue.get_const_array()` (`separate.py`).
- `ProgramOrchestrator._resolve_outputs` falls back to that map, using `val is None` (not truthiness) so a genuine `0` / `0.0` / `False` constant is not mistaken for an unresolved output. It now raises `ExecutionError` when an output resolves to neither a context value nor a constant, surfacing pipeline materialization gaps instead of silently returning `None` (`program_orchestrator.py`).

This keeps the constant knowledge in the execution ABI and resolves it at output time, rather than keeping a redundant classical op in the IR to recompute a compile-time-known value — consistent with the project's IR-abstraction principle. The IR itself is unchanged; no new IR op or pass.

## Test plan

New `tests/circuit/test_bound_classical_output.py`, run across every supported local backend (Qiskit / QURI Parts / CUDA-Q) with `importorskip` guards, both `sample` and `run` paths:

- computed form (`return x * 2.0`) and pass-through form (`return x`), parametrized over `x` (including the `0.0` boundary and negative values) and register sizes `n ∈ {1, 2, 3}`;
- the runtime-parameter (`parameters=["x"]`) variant, asserting the compile-time-constant fallback does not shadow the context path;
- an assertion that the segmentation ABI records the folded scalar output as a constant while the measured Vector is not recorded;
- the new `ExecutionError` path for a genuinely unresolvable output.

Verified locally:

- `uv run pytest tests/` — 9377 passed, 4 skipped, 1 xfailed (no regressions).
- New tests pass on Qiskit and QURI Parts (CUDA-Q covered by CI).
- `uv run ruff check qamomile/ tests/`, `uv run ruff format --check qamomile/ tests/`, `uv run zuban check qamomile/` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKDEtZT7b552gsZbmE9DvG)_