### PR TITLE
docs: add v0.12.7 release notes (EN/JA)

### DIFF
--- a/docs/en/myst.yml
+++ b/docs/en/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: Release Notes
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md
         - file: release_notes/v0_12_4.md

--- a/docs/en/release_notes/index.md
+++ b/docs/en/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # Release Notes
 
+- [v0.12.7](v0_12_7) — `Dict[K, Float]` coefficients as runtime parameters with `d[key]` subscript, `%` operator on `UInt`, and a batch of new compile-time errors (`QubitRebindError`, `QubitConsumedError`, `TypeError` on `bool` / mismatched args) that reject previously silent miscompiles
 - [v0.12.6](v0_12_6) — circuit inversion with `qmc.inverse` (built-in gates, `@qkernel`s, QFT/IQFT), `qmc.modular_increment` / `qmc.modular_decrement` basis-state arithmetic, job/result types importable from `qamomile.circuit`
 - [v0.12.5](v0_12_5) — `PCEConverter` / `PCEEncoder` for Pauli Correlation Encoding, seeded QURI Parts sampling, measured `Vector[Bit]` condition fixes, and `qmc.expval` fixes for `Vector` elements
 - [v0.12.4](v0_12_4) — `qmc.controlled` renamed to `qmc.control` with a more expressive symbolic mode, higher-order Ising model construction via `BinaryModel.from_higher_ising`, unary `-` on `Float` handles

--- a/docs/en/release_notes/v0_12_7.md
+++ b/docs/en/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also turns a broad class of programs that previously compiled into subtly wrong circuits into loud compile-time errors: discarding a qubit's state inside a runtime `if` / loop branch, updating a classical accumulator across loop iterations, aliasing the same register into two kernel arguments, passing an argument of the wrong type or shape, and allocating a multi-dimensional qubit register are now each rejected with a specific exception instead of miscompiling silently. Controlled `qmc.pauli_evolve` now produces consistent, correct results across Qiskit, QURI Parts, and CUDA-Q — including for Hamiltonians with a constant offset, and on QURI Parts for the first time. Internally, the IR serializer now round-trips bound `Hamiltonian`s so a compiled kernel that carries operator data survives `dump_json` / `load_json`.
+Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also adds a set of compile-time checks that reject several constructs which used to compile into wrong circuits — such as allocating a fresh qubit for a variable inside a branch without consuming the previous one, or passing the same `Vector[Qubit]` as two arguments of a kernel call — each now raising a specific error instead of miscompiling. Controlled `qmc.pauli_evolve` no longer drops the global phase of a Hamiltonian's constant term, so controlled evolution of a constant-offset Hamiltonian is now correct on Qiskit, QURI Parts, and CUDA-Q, and controlled `pauli_evolve` gained QURI Parts support. Internally, the IR serializer now round-trips bound `Hamiltonian`s through `dump_json` / `load_json`.
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## Breaking Changes
 
-This release adds a set of compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source — silent miscompiles or opaque backend crashes. Each pattern below now raises a specific, named exception at transpile time. If your code triggers one, the compiled circuit it used to produce was already wrong; the error tells you exactly which construct to rewrite.
+This release adds compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source. Each pattern below now raises a specific error at transpile time. If your code triggers one, the circuit it used to produce was already wrong; the error points at the exact construct to rewrite.
 
-- **Discarding a qubit's state inside a branch or loop body now raises `QubitRebindError`.** Rebinding a quantum variable to a fresh allocation dropped the pre-branch state with no diagnostic. For an `if`, the check applies to a measurement-driven (runtime) condition; for a `for` / `while` loop it applies to any loop body regardless of the trip count, since a loop cannot express a per-iteration quantum rebind ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
+- **Allocating a fresh qubit for a variable inside a branch or loop body, without consuming the previous one, now raises `QubitRebindError`.** Writing `q = qmc.qubit(...)` inside a measurement-driven `if`, or inside a `for` / `while` body, used to compile and silently drop `q`'s previous state. It is now rejected at compile time ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
 
   ```python
   @qmc.qkernel
@@ -19,27 +19,27 @@ This release adds a set of compile-time checks that reject programs which previo
       p = qmc.qubit("p")
       cond = qmc.measure(p)
       if cond:
-          q = qmc.qubit("fresh")   # QubitRebindError: discards q's pre-branch state
+          q = qmc.qubit("fresh")   # QubitRebindError: q's previous state was never consumed
       return qmc.measure(q)
   ```
 
-- **Updating a classical scalar across loop iterations now raises `ValidationError`.** A `@qkernel` `for` body is traced once, so a loop-carried accumulator (`total = total + i`) froze its right-hand side to the pre-loop value and diverged from Python semantics ([#552](https://github.com/Jij-Inc/Qamomile/pull/552)).
+- **Updating a classical variable across loop iterations now raises `ValidationError`.** A `@qkernel` `for` body is traced once, so an accumulator like `total = total + i` used to have its right-hand side frozen to the pre-loop value. This pattern is now rejected ([#552](https://github.com/Jij-Inc/Qamomile/pull/552)).
 
-- **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** `arr[i] = arr[i - 1]` inside a loop read a fixed pre-loop version of `arr`, so it never observed earlier iterations' writes ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
+- **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** `arr[i] = arr[i - 1]` inside a loop used to read a pre-loop snapshot of `arr` and never observe earlier iterations' writes. It is now rejected ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
 
-- **Multi-dimensional quantum registers are now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes previously advertised a `Matrix[Qubit]` / `Tensor[Qubit]` return and then miscompiled or crashed opaquely downstream. They now raise `NotImplementedError` at construction (or `EmitError` for a rank-2 register reaching emit); the quantum addressing path is rank-1. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
+- **Allocating a multi-dimensional qubit array is now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes used to be accepted and then miscompile or crash later. They now raise `NotImplementedError` at construction (or `EmitError` if a rank-2 array reaches emit); the quantum addressing path is one-dimensional. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
 
-- **Passing a kernel argument of the wrong type or shape now raises `TypeError`.** Handing a scalar `Qubit` to a `Vector[Qubit]` parameter previously leaked an `AttributeError` from deep inside sizing, and handing a `Qubit` to a `Float` parameter silently emitted `rx(0)`. Argument handles are now validated against the declared parameter type at every call site — plain kernel calls, `qmc.control`, and `qmc.inverse` ([#473](https://github.com/Jij-Inc/Qamomile/pull/473)).
+- **Passing a kernel argument of the wrong type or shape now raises `TypeError`.** Passing a scalar `Qubit` to a `Vector[Qubit]` parameter used to leak an unrelated `AttributeError`, and passing a `Qubit` to a `Float` parameter used to silently emit `rx(0)`. Arguments are now checked against the declared parameter type at every call site — plain kernel calls, `qmc.control`, and `qmc.inverse` ([#473](https://github.com/Jij-Inc/Qamomile/pull/473)).
 
-- **Passing a Python `bool` where a plain int is required now raises `TypeError`.** Because `bool` subclasses `int`, `q[True]`, `q[False:2]`, and `qmc.uint(True)` were silently accepted as index / bound / size `1` / `0`. Array indices, slice bounds, and `qmc.uint` now reject `bool` ([#539](https://github.com/Jij-Inc/Qamomile/pull/539)).
+- **Passing a Python `bool` where a plain int is required now raises `TypeError`.** Because `bool` subclasses `int`, `q[True]`, `q[False:2]`, and `qmc.uint(True)` used to be silently accepted as `1` / `0`. Array indices, slice bounds, and `qmc.uint` now reject `bool` ([#539](https://github.com/Jij-Inc/Qamomile/pull/539)).
 
-- **Aliasing the same quantum register into two arguments of a kernel call now raises `QubitConsumedError`.** Calling `sub(qs, qs)` — or passing overlapping views — mapped both formal registers onto the same physical qubits, which either miscompiled or surfaced later as a raw backend `duplicate qubit` error. The affine type checker now rejects the alias at the call site ([#543](https://github.com/Jij-Inc/Qamomile/pull/543)).
+- **Passing the same qubit array as two arguments of a kernel call now raises `QubitConsumedError`.** `sub(qs, qs)` — or two overlapping views — used to map both parameters onto the same physical qubits, which miscompiled or later surfaced as a raw `duplicate qubit` error from the SDK. The alias is now rejected at the call site ([#543](https://github.com/Jij-Inc/Qamomile/pull/543)).
 
 ## New Features
 
 ### Dictionary coefficients as runtime parameters
 
-A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one backend parameter named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`; leaving the dictionary out of both `bindings` and `parameters` keeps the previous compile-time behavior. Keys may be a single component or a tuple `d[(i, j)]` matched component-wise; symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
+A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one runtime parameter of the emitted circuit named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`; leaving the dictionary out of both `bindings` and `parameters` keeps the previous compile-time behavior. Keys may be a single component or a tuple `d[(i, j)]` matched component-wise; symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
 
 ```python
 import numpy as np
@@ -85,6 +85,26 @@ executable = transpiler.transpile(even_indices)
 [((1, 0, 1, 0), 256)]
 ```
 
+### `qmc.pauli_evolve` accepts a Hamiltonian smaller than the target
+
+`qmc.pauli_evolve` now accepts a Hamiltonian that acts on fewer qubits than the target `Vector[Qubit]`. Each Pauli term addresses array elements positionally (a term on index `i` acts on `q[i]`), and the qubits beyond the Hamiltonian's size evolve under the identity. A 0-qubit (constant-only) Hamiltonian contributes its global phase. A Hamiltonian acting on *more* qubits than the target now fails with a clear `EmitError` at transpile time ([#471](https://github.com/Jij-Inc/Qamomile/pull/471)).
+
+```python
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def evolve(h: qmc.Observable, t: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(2, name="q")
+    q = qmc.h(q)
+    q = qmc.pauli_evolve(q, h, t)   # h acts on 1 qubit; q[1] evolves under the identity
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(evolve, bindings={"h": qm_o.Z(0), "t": 0.5})
+```
+
 ## Internal Changes
 
 ### Hamiltonian serialization round-trip
@@ -118,13 +138,12 @@ print(slot.bound_value)
 
 ## Bug Fixes
 
-- **Controlled `qmc.pauli_evolve` is now correct and consistent across backends.** A Hamiltonian's constant (identity) term contributes a global phase that the shared Pauli-gadget emitter dropped; under `qmc.control` that phase becomes an observable relative phase on the controls-on subspace, so controlled evolution of any constant-offset Hamiltonian gave wrong results. The constant is now re-applied as a controlled phase on Qiskit's fallback path ([#547](https://github.com/Jij-Inc/Qamomile/pull/547)) and on CUDA-Q ([#540](https://github.com/Jij-Inc/Qamomile/pull/540)), and a shared controlled lowering makes controlled `pauli_evolve` transpile on QURI Parts for the first time ([#537](https://github.com/Jij-Inc/Qamomile/pull/537)). A non-real constant now raises a clear `EmitError` on all paths.
-- **A Hamiltonian smaller than its target register is identity-padded correctly.** `qmc.pauli_evolve` with a Hamiltonian acting on fewer qubits than the register now emits correctly on Qiskit and CUDA-Q, and a 0-qubit (constant-only) Hamiltonian emits as a Qiskit global phase ([#471](https://github.com/Jij-Inc/Qamomile/pull/471)).
-- **Controlled sub-kernels over a whole `Vector[Qubit]` now emit on every backend.** The shared controlled-U fallback previously routed every inner gate to a single target and rejected multi-target inner blocks and nested controlled-U operations; it now maps each inner qubit onto the caller's physical targets, so a controlled multi-qubit sub-kernel (such as the modular-arithmetic shift) transpiles on QURI Parts and CUDA-Q as well as Qiskit ([#472](https://github.com/Jij-Inc/Qamomile/pull/472)).
-- **Controlled gates with a symbolic array-index control qubit now allocate the right wire.** When the control is a binding-driven array element (`q[control_index]`), the physical qubit is now resolved through the qubit map instead of allocating a fresh slot, which previously mis-aligned the control and silently produced a wrong circuit ([#541](https://github.com/Jij-Inc/Qamomile/pull/541)).
+- **Controlled `qmc.pauli_evolve` no longer drops the constant term's global phase.** A Hamiltonian's constant (identity) term contributes a global phase `exp(-i·gamma·c)`, which the emitter used to drop. On a standalone evolution this is unobservable, but under `qmc.control` that phase becomes a real relative phase on the controls-on subspace — so controlled evolution of any constant-offset Hamiltonian produced a wrong result. The constant is now re-applied under control on Qiskit ([#471](https://github.com/Jij-Inc/Qamomile/pull/471), [#547](https://github.com/Jij-Inc/Qamomile/pull/547)) and CUDA-Q ([#540](https://github.com/Jij-Inc/Qamomile/pull/540)), and a shared controlled lowering makes controlled `pauli_evolve` transpile on QURI Parts for the first time ([#537](https://github.com/Jij-Inc/Qamomile/pull/537)). A non-real constant now raises a clear `EmitError`.
+- **Controlled sub-kernels over a whole `Vector[Qubit]` now emit on every SDK.** The shared controlled-U fallback used to route every inner gate to a single target and reject multi-target inner blocks and nested controlled-U operations; it now maps each inner qubit onto the caller's targets, so a controlled multi-qubit sub-kernel (such as the modular-arithmetic shift) transpiles on QURI Parts and CUDA-Q as well as Qiskit ([#472](https://github.com/Jij-Inc/Qamomile/pull/472)).
+- **Controlled gates with a symbolic array-index control qubit now use the right wire.** When the control is a binding-driven array element (`q[control_index]`), the physical qubit is now resolved through the qubit map instead of allocating a fresh one, which previously misaligned the control and silently produced a wrong circuit ([#541](https://github.com/Jij-Inc/Qamomile/pull/541)).
 - **Möttönen amplitude-encoding / inverse state-prep wrappers route qubits correctly.** A qubit-resolution bug in the inverse state-preparation wrapper produced wrong qubit routing ([#465](https://github.com/Jij-Inc/Qamomile/pull/465)).
 - **Out-of-range array indices during loop unrolling fail fast.** An out-of-range or shape-mismatched array index encountered while unrolling a loop now raises a clear `EmitError` instead of silently miscompiling ([#477](https://github.com/Jij-Inc/Qamomile/pull/477)).
-- **`canonicalize` preserves the classical parameter manifest.** Canonicalization previously dropped `Block.param_slots`; the manifest now survives, so content hashing and serialization of a canonicalized block keep the parameter contract ([#476](https://github.com/Jij-Inc/Qamomile/pull/476)).
+- **`canonicalize` preserves the classical parameter manifest.** Canonicalization used to drop `Block.param_slots`; the manifest now survives, so content hashing and serialization of a canonicalized block keep the parameter contract ([#476](https://github.com/Jij-Inc/Qamomile/pull/476)).
 - **Qubit sizing derived from array elements is fixed.** Resource sizing now preserves zero sizes and rejects non-positive and negative element indices instead of producing a wrong allocation ([#456](https://github.com/Jij-Inc/Qamomile/pull/456)).
 - **Composite cast-carrier keys remap correctly.** Cast-carrier references are now remapped through canonicalize / inline / compile-time-`if` lowering, and fail fast on symbolic-bound slice-view carriers ([#468](https://github.com/Jij-Inc/Qamomile/pull/468)).
 - **Runtime-parameter-indexed loop bounds get a clear diagnostic.** A loop bound derived from a runtime-parameter index is now reported with a targeted error before segmentation instead of an obscure downstream failure ([#557](https://github.com/Jij-Inc/Qamomile/pull/557)).
@@ -132,8 +151,8 @@ print(slot.bound_value)
 ## Documentation
 
 - [**Estimating Nanosheet Material Properties with the Multidimensional Quantum Fourier Transform**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/algorithm/multidimensional_qft.ipynb) — a new algorithm article applying a multidimensional QFT to a materials-science estimation problem ([#405](https://github.com/Jij-Inc/Qamomile/pull/405)).
-- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/cudaq_support.ipynb) — a new integration page for transpiling and executing Qamomile kernels on the CUDA-Q backend ([#440](https://github.com/Jij-Inc/Qamomile/pull/440)).
-- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/qiskit_support.ipynb) — a new integration page for the Qiskit backend ([#464](https://github.com/Jij-Inc/Qamomile/pull/464)).
+- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/cudaq_support.ipynb) — a new integration page for transpiling and executing Qamomile kernels on the CUDA-Q SDK ([#440](https://github.com/Jij-Inc/Qamomile/pull/440)).
+- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/qiskit_support.ipynb) — a new integration page for the Qiskit SDK ([#464](https://github.com/Jij-Inc/Qamomile/pull/464)).
 - The documentation site was redesigned, with reworked landing pages and card metadata, and a new [**Installation**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/installation_guide.md) guide ([#461](https://github.com/Jij-Inc/Qamomile/pull/461)).
 
 ## Learn More

--- a/docs/en/release_notes/v0_12_7.md
+++ b/docs/en/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also adds a set of compile-time checks that reject several constructs which used to compile into wrong circuits — such as allocating a fresh qubit for a variable inside a branch without consuming the previous one, or passing the same `Vector[Qubit]` as two arguments of a kernel call — each now raising a specific error instead of miscompiling. Controlled `qmc.pauli_evolve` is now supported on QURI Parts, and it no longer drops the global phase of a Hamiltonian's constant term, so controlled evolution of a constant-offset Hamiltonian is now correct on Qiskit, QURI Parts, and CUDA-Q.
+Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also adds a set of transpile-time checks that reject several constructs which used to transpile into wrong circuits — such as allocating a fresh qubit for a variable inside a branch without consuming the previous one, or passing the same `Vector[Qubit]` as two arguments of a kernel call — each now raising a specific error instead of producing a wrong circuit. Controlled `qmc.pauli_evolve` is now supported on QURI Parts, and it no longer drops the global phase of a Hamiltonian's constant term, so controlled evolution of a constant-offset Hamiltonian is now correct on Qiskit, QURI Parts, and CUDA-Q.
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## Breaking Changes
 
-This release adds compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source. Each pattern below now raises a specific error at transpile time.
+This release adds transpile-time checks that reject programs which previously *transpiled* but produced a circuit that did not match the Python source. Each pattern below now raises a specific error at transpile time.
 
-- **Allocating a fresh qubit for a variable inside a branch or loop body, without consuming the previous one, now raises `QubitRebindError`.** Writing `q = qmc.qubit(...)` inside a measurement-driven `if`, or inside a `for` / `while` body, used to compile and silently drop `q`'s previous state ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
+- **Allocating a fresh qubit for a variable inside a branch or loop body, without consuming the previous one, now raises `QubitRebindError`.** Writing `q = qmc.qubit(...)` inside a measurement-driven `if`, or inside a `for` / `while` body, used to transpile and silently drop `q`'s previous state ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
 
   ```python
   @qmc.qkernel
@@ -27,19 +27,19 @@ This release adds compile-time checks that reject programs which previously *com
 
 - **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** Inside a loop, `arr[i] = arr[i - 1]` used to read a pre-loop snapshot of `arr` — so earlier iterations' writes were never observed — and silently produced a wrong circuit ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
 
-- **Allocating a multi-dimensional qubit array is now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes used to be accepted and then miscompile or crash later. They now raise `NotImplementedError` at construction. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
+- **Allocating a multi-dimensional qubit array is now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes used to be accepted and then produce a wrong circuit or crash later. They now raise `NotImplementedError` at construction. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
 
 - **Passing a kernel argument of the wrong type or shape now raises `TypeError`.** Passing a scalar `Qubit` to a `Vector[Qubit]` parameter used to leak an unrelated `AttributeError`, and passing a `Qubit` to a `Float` parameter used to silently emit `rx(0)`. Arguments are now checked against the declared parameter type at every call site — plain kernel calls, `qmc.control`, and `qmc.inverse` ([#473](https://github.com/Jij-Inc/Qamomile/pull/473)).
 
 - **Passing a Python `bool` where a plain int is required now raises `TypeError`.** Because `bool` subclasses `int`, `q[True]`, `q[False:2]`, and `qmc.uint(True)` used to be silently accepted as `1` / `0`. Array indices, slice bounds, and `qmc.uint` now reject `bool` ([#539](https://github.com/Jij-Inc/Qamomile/pull/539)).
 
-- **Passing the same qubit array as two arguments of a kernel call now raises `QubitConsumedError`.** `sub(qs, qs)` — or two overlapping views — used to map both parameters onto the same physical qubits, which miscompiled or later surfaced as a raw `duplicate qubit` error from the SDK. The alias is now rejected at the call site ([#543](https://github.com/Jij-Inc/Qamomile/pull/543)).
+- **Passing the same qubit array as two arguments of a kernel call now raises `QubitConsumedError`.** `sub(qs, qs)` — or two overlapping views — used to map both parameters onto the same physical qubits, which produced a wrong circuit or later surfaced as a raw `duplicate qubit` error from the SDK. The alias is now rejected at the call site ([#543](https://github.com/Jij-Inc/Qamomile/pull/543)).
 
 ## New Features
 
 ### Dictionary coefficients as runtime parameters
 
-A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one runtime parameter of the emitted circuit named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`. Symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
+A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one runtime parameter of the emitted circuit named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same transpiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`. Symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
 
 ```python
 import numpy as np
@@ -63,7 +63,7 @@ executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["an
 
 ### Modulo operator on `UInt`
 
-`UInt` handles now support the `%` operator (and `int % UInt`). This makes index expressions such as `i % 2` inside a `qmc.range` loop compile directly instead of raising a `TypeError` at trace time ([#466](https://github.com/Jij-Inc/Qamomile/pull/466)).
+`UInt` handles now support the `%` operator (and `int % UInt`). This makes index expressions such as `i % 2` inside a `qmc.range` loop transpile directly instead of raising a `TypeError` at trace time ([#466](https://github.com/Jij-Inc/Qamomile/pull/466)).
 
 ```python
 import qamomile.circuit as qmc
@@ -140,7 +140,7 @@ print(slot.bound_value)
 - **Controlled sub-kernels over a whole `Vector[Qubit]` now emit on every SDK.** The shared controlled-U fallback used to route every inner gate to a single target and reject multi-target inner blocks and nested controlled-U operations; it now maps each inner qubit onto the caller's targets, so a controlled multi-qubit sub-kernel (such as the modular-arithmetic shift) transpiles on QURI Parts and CUDA-Q as well as Qiskit ([#472](https://github.com/Jij-Inc/Qamomile/pull/472)).
 - **Controlled gates with a symbolic array-index control qubit now use the right wire.** When the control is a binding-driven array element (`q[control_index]`), the physical qubit is now resolved through the qubit map instead of allocating a fresh one, which previously misaligned the control and silently produced a wrong circuit ([#541](https://github.com/Jij-Inc/Qamomile/pull/541)).
 - **Möttönen amplitude-encoding / inverse state-prep wrappers route qubits correctly.** A qubit-resolution bug in the inverse state-preparation wrapper produced wrong qubit routing ([#465](https://github.com/Jij-Inc/Qamomile/pull/465)).
-- **Out-of-range array indices during loop unrolling fail fast.** An out-of-range or shape-mismatched array index encountered while unrolling a loop now raises a clear `EmitError` instead of silently miscompiling ([#477](https://github.com/Jij-Inc/Qamomile/pull/477)).
+- **Out-of-range array indices during loop unrolling fail fast.** An out-of-range or shape-mismatched array index encountered while unrolling a loop now raises a clear `EmitError` instead of silently producing a wrong circuit ([#477](https://github.com/Jij-Inc/Qamomile/pull/477)).
 - **`canonicalize` preserves the classical parameter manifest.** Canonicalization used to drop `Block.param_slots`; the manifest now survives, so content hashing and serialization of a canonicalized block keep the parameter contract ([#476](https://github.com/Jij-Inc/Qamomile/pull/476)).
 - **Sizing a qubit array from a classical array element now resolves correctly.** When the size of a qubit array comes from an element of a classical `Vector[UInt]` — `qmc.qubit_array(sizes[i], ...)` — the size used to be resolved wrongly and allocate the wrong number of qubits. It now resolves correctly through slices and indexed elements, keeps a size of 0, and rejects invalid sizes (negative sizes, unsupported negative indices) with a clear error ([#456](https://github.com/Jij-Inc/Qamomile/pull/456)).
 - **A `QFixed` value made with `qmc.cast` keeps pointing at the right qubits through IR transforms.** `qmc.cast(q, qmc.QFixed, ...)` reinterprets a `Vector[Qubit]` as a fixed-point value, and the cast internally remembers which qubits it wraps. Passing the kernel through inlining, canonicalization, or compile-time-`if` lowering used to fail to remap that reference, so the cast could point at the wrong qubits. It now keeps pointing at the right qubits through all of these transforms ([#468](https://github.com/Jij-Inc/Qamomile/pull/468)).

--- a/docs/en/release_notes/v0_12_7.md
+++ b/docs/en/release_notes/v0_12_7.md
@@ -1,0 +1,141 @@
+# Qamomile v0.12.7
+
+Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also turns a broad class of programs that previously compiled into subtly wrong circuits into loud compile-time errors: discarding a qubit's state inside a runtime `if` / loop branch, updating a classical accumulator across loop iterations, aliasing the same register into two kernel arguments, passing an argument of the wrong type or shape, and allocating a multi-dimensional qubit register are now each rejected with a specific exception instead of miscompiling silently. Controlled `qmc.pauli_evolve` now produces consistent, correct results across Qiskit, QURI Parts, and CUDA-Q — including for Hamiltonians with a constant offset, and on QURI Parts for the first time. Internally, the IR serializer now round-trips bound `Hamiltonian`s so a compiled kernel that carries operator data survives `dump_json` / `load_json`.
+
+```
+pip install qamomile==0.12.7
+```
+
+## Breaking Changes
+
+This release adds a set of compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source — silent miscompiles or opaque backend crashes. Each pattern below now raises a specific, named exception at transpile time. If your code triggers one, the compiled circuit it used to produce was already wrong; the error tells you exactly which construct to rewrite.
+
+- **Discarding a qubit's state inside a branch or loop body now raises `QubitRebindError`.** Rebinding a quantum variable to a fresh allocation dropped the pre-branch state with no diagnostic. For an `if`, the check applies to a measurement-driven (runtime) condition; for a `for` / `while` loop it applies to any loop body regardless of the trip count, since a loop cannot express a per-iteration quantum rebind ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
+
+  ```python
+  @qmc.qkernel
+  def kernel() -> qmc.Bit:
+      q = qmc.qubit("q")
+      p = qmc.qubit("p")
+      cond = qmc.measure(p)
+      if cond:
+          q = qmc.qubit("fresh")   # QubitRebindError: discards q's pre-branch state
+      return qmc.measure(q)
+  ```
+
+- **Updating a classical scalar across loop iterations now raises `ValidationError`.** A `@qkernel` `for` body is traced once, so a loop-carried accumulator (`total = total + i`) froze its right-hand side to the pre-loop value and diverged from Python semantics ([#552](https://github.com/Jij-Inc/Qamomile/pull/552)).
+
+- **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** `arr[i] = arr[i - 1]` inside a loop read a fixed pre-loop version of `arr`, so it never observed earlier iterations' writes ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
+
+- **Multi-dimensional quantum registers are now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes previously advertised a `Matrix[Qubit]` / `Tensor[Qubit]` return and then miscompiled or crashed opaquely downstream. They now raise `NotImplementedError` at construction (or `EmitError` for a rank-2 register reaching emit); the quantum addressing path is rank-1. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
+
+- **Passing a kernel argument of the wrong type or shape now raises `TypeError`.** Handing a scalar `Qubit` to a `Vector[Qubit]` parameter previously leaked an `AttributeError` from deep inside sizing, and handing a `Qubit` to a `Float` parameter silently emitted `rx(0)`. Argument handles are now validated against the declared parameter type at every call site — plain kernel calls, `qmc.control`, and `qmc.inverse` ([#473](https://github.com/Jij-Inc/Qamomile/pull/473)).
+
+- **Passing a Python `bool` where a plain int is required now raises `TypeError`.** Because `bool` subclasses `int`, `q[True]`, `q[False:2]`, and `qmc.uint(True)` were silently accepted as index / bound / size `1` / `0`. Array indices, slice bounds, and `qmc.uint` now reject `bool` ([#539](https://github.com/Jij-Inc/Qamomile/pull/539)).
+
+- **Aliasing the same quantum register into two arguments of a kernel call now raises `QubitConsumedError`.** Calling `sub(qs, qs)` — or passing overlapping views — mapped both formal registers onto the same physical qubits, which either miscompiled or surfaced later as a raw backend `duplicate qubit` error. The affine type checker now rejects the alias at the call site ([#543](https://github.com/Jij-Inc/Qamomile/pull/543)).
+
+## New Features
+
+### Dictionary coefficients as runtime parameters
+
+A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one backend parameter named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`; leaving the dictionary out of both `bindings` and `parameters` keeps the previous compile-time behavior. Keys may be a single component or a tuple `d[(i, j)]` matched component-wise; symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
+
+```python
+import numpy as np
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def rx_by_dict(n: qmc.UInt, angles: qmc.Dict[qmc.UInt, qmc.Float]) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(n, name="q")
+    for i in qmc.range(n):
+        q[i] = qmc.rx(q[i], angle=angles[i])   # subscript a runtime-parameter dict
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["angles"])
+# executable.parameter_names -> ['angles[0]', 'angles[1]', 'angles[2]']
+# re-bind the dict per execution:
+#   executable.sample(transpiler.executor(), shots=256,
+#                     bindings={"angles": {0: np.pi, 1: 0.0, 2: np.pi}})
+```
+
+### Modulo operator on `UInt`
+
+`UInt` handles now support the `%` operator (and `int % UInt`), completing the classical index arithmetic already available for `+ - * / // **`. This makes index expressions such as `i % 2` inside a `qmc.range` loop compile directly instead of raising a `TypeError` at trace time ([#466](https://github.com/Jij-Inc/Qamomile/pull/466)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def even_indices() -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(4, name="q")
+    for i in qmc.range(4):
+        if i % 2 == 0:            # modulo on a loop variable
+            q[i] = qmc.x(q[i])
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(even_indices)
+```
+
+```text
+[((1, 0, 1, 0), 256)]
+```
+
+## Internal Changes
+
+### Hamiltonian serialization round-trip
+
+The IR serializer now understands bound `Hamiltonian`s. A compiled `Block` that carries operator data — for example a `Vector[Observable]` argument bound to a list of Pauli Hamiltonians, held in a `ParamSlot.bound_value` — now survives `dump_json` / `load_json` (and the msgpack pair) and comes back Hamiltonian-for-Hamiltonian identical. This works through the existing serialization entry points; no schema version bump was needed, because the Hamiltonian payload is an additive tagged-dict form ([#475](https://github.com/Jij-Inc/Qamomile/pull/475), [#548](https://github.com/Jij-Inc/Qamomile/pull/548)).
+
+```python
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.circuit.transpiler.passes.inline import InlinePass
+from qamomile.circuit.ir.serialize import dump_json, load_json
+
+@qmc.qkernel
+def trotter(q: qmc.Vector[qmc.Qubit], hs: qmc.Vector[qmc.Observable], t: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    for i in qmc.range(hs.shape[0]):
+        q = qmc.pauli_evolve(q, hs[i], t)
+    return qmc.measure(q)
+
+hamiltonians = [1.2 * qm_o.Z(0), 0.8 * qm_o.X(0)]
+block = InlinePass().run(trotter.build(hs=hamiltonians, parameters=["t"]))
+restored = load_json(dump_json(block))
+slot = next(s for s in restored.param_slots if s.name == "hs")
+print(slot.bound_value)
+```
+
+```text
+[Hamiltonian((Z0,): 1.2), Hamiltonian((X0,): 0.8)]
+```
+
+**Why**: unlike the items above, this is not part of the dictionary-parameter feature. It extends the wire format so that a compiled kernel embedding operator data is portable, closing a gap where such a `Block` previously failed to round-trip.
+
+## Bug Fixes
+
+- **Controlled `qmc.pauli_evolve` is now correct and consistent across backends.** A Hamiltonian's constant (identity) term contributes a global phase that the shared Pauli-gadget emitter dropped; under `qmc.control` that phase becomes an observable relative phase on the controls-on subspace, so controlled evolution of any constant-offset Hamiltonian gave wrong results. The constant is now re-applied as a controlled phase on Qiskit's fallback path ([#547](https://github.com/Jij-Inc/Qamomile/pull/547)) and on CUDA-Q ([#540](https://github.com/Jij-Inc/Qamomile/pull/540)), and a shared controlled lowering makes controlled `pauli_evolve` transpile on QURI Parts for the first time ([#537](https://github.com/Jij-Inc/Qamomile/pull/537)). A non-real constant now raises a clear `EmitError` on all paths.
+- **A Hamiltonian smaller than its target register is identity-padded correctly.** `qmc.pauli_evolve` with a Hamiltonian acting on fewer qubits than the register now emits correctly on Qiskit and CUDA-Q, and a 0-qubit (constant-only) Hamiltonian emits as a Qiskit global phase ([#471](https://github.com/Jij-Inc/Qamomile/pull/471)).
+- **Controlled sub-kernels over a whole `Vector[Qubit]` now emit on every backend.** The shared controlled-U fallback previously routed every inner gate to a single target and rejected multi-target inner blocks and nested controlled-U operations; it now maps each inner qubit onto the caller's physical targets, so a controlled multi-qubit sub-kernel (such as the modular-arithmetic shift) transpiles on QURI Parts and CUDA-Q as well as Qiskit ([#472](https://github.com/Jij-Inc/Qamomile/pull/472)).
+- **Controlled gates with a symbolic array-index control qubit now allocate the right wire.** When the control is a binding-driven array element (`q[control_index]`), the physical qubit is now resolved through the qubit map instead of allocating a fresh slot, which previously mis-aligned the control and silently produced a wrong circuit ([#541](https://github.com/Jij-Inc/Qamomile/pull/541)).
+- **Möttönen amplitude-encoding / inverse state-prep wrappers route qubits correctly.** A qubit-resolution bug in the inverse state-preparation wrapper produced wrong qubit routing ([#465](https://github.com/Jij-Inc/Qamomile/pull/465)).
+- **Out-of-range array indices during loop unrolling fail fast.** An out-of-range or shape-mismatched array index encountered while unrolling a loop now raises a clear `EmitError` instead of silently miscompiling ([#477](https://github.com/Jij-Inc/Qamomile/pull/477)).
+- **`canonicalize` preserves the classical parameter manifest.** Canonicalization previously dropped `Block.param_slots`; the manifest now survives, so content hashing and serialization of a canonicalized block keep the parameter contract ([#476](https://github.com/Jij-Inc/Qamomile/pull/476)).
+- **Qubit sizing derived from array elements is fixed.** Resource sizing now preserves zero sizes and rejects non-positive and negative element indices instead of producing a wrong allocation ([#456](https://github.com/Jij-Inc/Qamomile/pull/456)).
+- **Composite cast-carrier keys remap correctly.** Cast-carrier references are now remapped through canonicalize / inline / compile-time-`if` lowering, and fail fast on symbolic-bound slice-view carriers ([#468](https://github.com/Jij-Inc/Qamomile/pull/468)).
+- **Runtime-parameter-indexed loop bounds get a clear diagnostic.** A loop bound derived from a runtime-parameter index is now reported with a targeted error before segmentation instead of an obscure downstream failure ([#557](https://github.com/Jij-Inc/Qamomile/pull/557)).
+
+## Documentation
+
+- [**Estimating Nanosheet Material Properties with the Multidimensional Quantum Fourier Transform**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/algorithm/multidimensional_qft.ipynb) — a new algorithm article applying a multidimensional QFT to a materials-science estimation problem ([#405](https://github.com/Jij-Inc/Qamomile/pull/405)).
+- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/cudaq_support.ipynb) — a new integration page for transpiling and executing Qamomile kernels on the CUDA-Q backend ([#440](https://github.com/Jij-Inc/Qamomile/pull/440)).
+- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/integration/qiskit_support.ipynb) — a new integration page for the Qiskit backend ([#464](https://github.com/Jij-Inc/Qamomile/pull/464)).
+- The documentation site was redesigned, with reworked landing pages and card metadata, and a new [**Installation**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/en/installation_guide.md) guide ([#461](https://github.com/Jij-Inc/Qamomile/pull/461)).
+
+## Learn More
+
+- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)

--- a/docs/en/release_notes/v0_12_7.md
+++ b/docs/en/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also adds a set of compile-time checks that reject several constructs which used to compile into wrong circuits — such as allocating a fresh qubit for a variable inside a branch without consuming the previous one, or passing the same `Vector[Qubit]` as two arguments of a kernel call — each now raising a specific error instead of miscompiling. Controlled `qmc.pauli_evolve` no longer drops the global phase of a Hamiltonian's constant term, so controlled evolution of a constant-offset Hamiltonian is now correct on Qiskit, QURI Parts, and CUDA-Q, and controlled `pauli_evolve` gained QURI Parts support. Internally, the IR serializer now round-trips bound `Hamiltonian`s through `dump_json` / `load_json`.
+Qamomile v0.12.7 lets you pass a Python dictionary of coefficients into a `@qkernel` as a runtime parameter and index it by a loop variable — `angles[i]` inside the kernel, re-bound to different values on each execution — and adds the `%` operator on `UInt` handles. This release also adds a set of compile-time checks that reject several constructs which used to compile into wrong circuits — such as allocating a fresh qubit for a variable inside a branch without consuming the previous one, or passing the same `Vector[Qubit]` as two arguments of a kernel call — each now raising a specific error instead of miscompiling. Controlled `qmc.pauli_evolve` is now supported on QURI Parts, and it no longer drops the global phase of a Hamiltonian's constant term, so controlled evolution of a constant-offset Hamiltonian is now correct on Qiskit, QURI Parts, and CUDA-Q.
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## Breaking Changes
 
-This release adds compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source. Each pattern below now raises a specific error at transpile time. If your code triggers one, the circuit it used to produce was already wrong; the error points at the exact construct to rewrite.
+This release adds compile-time checks that reject programs which previously *compiled* but produced a circuit that did not match the Python source. Each pattern below now raises a specific error at transpile time.
 
-- **Allocating a fresh qubit for a variable inside a branch or loop body, without consuming the previous one, now raises `QubitRebindError`.** Writing `q = qmc.qubit(...)` inside a measurement-driven `if`, or inside a `for` / `while` body, used to compile and silently drop `q`'s previous state. It is now rejected at compile time ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
+- **Allocating a fresh qubit for a variable inside a branch or loop body, without consuming the previous one, now raises `QubitRebindError`.** Writing `q = qmc.qubit(...)` inside a measurement-driven `if`, or inside a `for` / `while` body, used to compile and silently drop `q`'s previous state ([#561](https://github.com/Jij-Inc/Qamomile/pull/561)).
 
   ```python
   @qmc.qkernel
@@ -23,11 +23,11 @@ This release adds compile-time checks that reject programs which previously *com
       return qmc.measure(q)
   ```
 
-- **Updating a classical variable across loop iterations now raises `ValidationError`.** A `@qkernel` `for` body is traced once, so an accumulator like `total = total + i` used to have its right-hand side frozen to the pre-loop value. This pattern is now rejected ([#552](https://github.com/Jij-Inc/Qamomile/pull/552)).
+- **Updating a classical variable across loop iterations now raises `ValidationError`.** A `@qkernel` `for` body is traced once, so an accumulator like `total = total + i` used to have its right-hand side frozen to the pre-loop value ([#552](https://github.com/Jij-Inc/Qamomile/pull/552)).
 
-- **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** `arr[i] = arr[i - 1]` inside a loop used to read a pre-loop snapshot of `arr` and never observe earlier iterations' writes. It is now rejected ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
+- **A classical array element that reads another element of the same array inside a loop now raises `ValidationError`.** Inside a loop, `arr[i] = arr[i - 1]` used to read a pre-loop snapshot of `arr` — so earlier iterations' writes were never observed — and silently produced a wrong circuit ([#545](https://github.com/Jij-Inc/Qamomile/pull/545)).
 
-- **Allocating a multi-dimensional qubit array is now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes used to be accepted and then miscompile or crash later. They now raise `NotImplementedError` at construction (or `EmitError` if a rank-2 array reaches emit); the quantum addressing path is one-dimensional. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
+- **Allocating a multi-dimensional qubit array is now rejected up front.** `qmc.qubit_array((2, 3), ...)` and other rank-≥2 quantum shapes used to be accepted and then miscompile or crash later. They now raise `NotImplementedError` at construction. Classical `Matrix` / `Tensor` arguments are unaffected ([#558](https://github.com/Jij-Inc/Qamomile/pull/558)).
 
 - **Passing a kernel argument of the wrong type or shape now raises `TypeError`.** Passing a scalar `Qubit` to a `Vector[Qubit]` parameter used to leak an unrelated `AttributeError`, and passing a `Qubit` to a `Float` parameter used to silently emit `rx(0)`. Arguments are now checked against the declared parameter type at every call site — plain kernel calls, `qmc.control`, and `qmc.inverse` ([#473](https://github.com/Jij-Inc/Qamomile/pull/473)).
 
@@ -39,7 +39,7 @@ This release adds compile-time checks that reject programs which previously *com
 
 ### Dictionary coefficients as runtime parameters
 
-A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one runtime parameter of the emitted circuit named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`; leaving the dictionary out of both `bindings` and `parameters` keeps the previous compile-time behavior. Keys may be a single component or a tuple `d[(i, j)]` matched component-wise; symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
+A `Dict[K, Float]` kernel argument can now be kept as a **runtime parameter** and indexed by a key inside the kernel — including by a `qmc.range` / `qmc.items` loop variable. Each looked-up key becomes one runtime parameter of the emitted circuit named `"<dict>[<key>]"` (e.g. `angles[0]`, `coeffs[(0, 1)]`), so the same compiled executable can be re-bound with different dictionary values on each execution. Declare it by listing the argument in `parameters=[...]`. Symbolic key components must be `UInt` handles, while a fully constant key against a compile-time-bound dictionary folds to a constant ([#556](https://github.com/Jij-Inc/Qamomile/pull/556), [#562](https://github.com/Jij-Inc/Qamomile/pull/562)).
 
 ```python
 import numpy as np
@@ -63,7 +63,7 @@ executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["an
 
 ### Modulo operator on `UInt`
 
-`UInt` handles now support the `%` operator (and `int % UInt`), completing the classical index arithmetic already available for `+ - * / // **`. This makes index expressions such as `i % 2` inside a `qmc.range` loop compile directly instead of raising a `TypeError` at trace time ([#466](https://github.com/Jij-Inc/Qamomile/pull/466)).
+`UInt` handles now support the `%` operator (and `int % UInt`). This makes index expressions such as `i % 2` inside a `qmc.range` loop compile directly instead of raising a `TypeError` at trace time ([#466](https://github.com/Jij-Inc/Qamomile/pull/466)).
 
 ```python
 import qamomile.circuit as qmc
@@ -87,7 +87,7 @@ executable = transpiler.transpile(even_indices)
 
 ### `qmc.pauli_evolve` accepts a Hamiltonian smaller than the target
 
-`qmc.pauli_evolve` now accepts a Hamiltonian that acts on fewer qubits than the target `Vector[Qubit]`. Each Pauli term addresses array elements positionally (a term on index `i` acts on `q[i]`), and the qubits beyond the Hamiltonian's size evolve under the identity. A 0-qubit (constant-only) Hamiltonian contributes its global phase. A Hamiltonian acting on *more* qubits than the target now fails with a clear `EmitError` at transpile time ([#471](https://github.com/Jij-Inc/Qamomile/pull/471)).
+`qmc.pauli_evolve` now accepts a Hamiltonian that acts on fewer qubits than the target `Vector[Qubit]`. Each Pauli term addresses array elements positionally (a term on index `i` acts on `q[i]`), and the qubits beyond the Hamiltonian's size evolve under the identity. A Hamiltonian acting on *more* qubits than the target now fails with a clear `EmitError` at transpile time ([#471](https://github.com/Jij-Inc/Qamomile/pull/471)).
 
 ```python
 import qamomile.circuit as qmc
@@ -109,7 +109,7 @@ executable = transpiler.transpile(evolve, bindings={"h": qm_o.Z(0), "t": 0.5})
 
 ### Hamiltonian serialization round-trip
 
-The IR serializer now understands bound `Hamiltonian`s. A compiled `Block` that carries operator data — for example a `Vector[Observable]` argument bound to a list of Pauli Hamiltonians, held in a `ParamSlot.bound_value` — now survives `dump_json` / `load_json` (and the msgpack pair) and comes back Hamiltonian-for-Hamiltonian identical. This works through the existing serialization entry points; no schema version bump was needed, because the Hamiltonian payload is an additive tagged-dict form ([#475](https://github.com/Jij-Inc/Qamomile/pull/475), [#548](https://github.com/Jij-Inc/Qamomile/pull/548)).
+The IR serializer now understands bound `Hamiltonian`s. A compiled `Block` that carries operator data — for example a `Vector[Observable]` argument bound to a list of Pauli Hamiltonians, held in a `ParamSlot.bound_value` — used to silently lose that data when passed through `dump_json` / `load_json` (and the msgpack pair). As of this release, each Hamiltonian round-trips back identical ([#475](https://github.com/Jij-Inc/Qamomile/pull/475), [#548](https://github.com/Jij-Inc/Qamomile/pull/548)).
 
 ```python
 import qamomile.circuit as qmc
@@ -134,19 +134,17 @@ print(slot.bound_value)
 [Hamiltonian((Z0,): 1.2), Hamiltonian((X0,): 0.8)]
 ```
 
-**Why**: unlike the items above, this is not part of the dictionary-parameter feature. It extends the wire format so that a compiled kernel embedding operator data is portable, closing a gap where such a `Block` previously failed to round-trip.
-
 ## Bug Fixes
 
-- **Controlled `qmc.pauli_evolve` no longer drops the constant term's global phase.** A Hamiltonian's constant (identity) term contributes a global phase `exp(-i·gamma·c)`, which the emitter used to drop. On a standalone evolution this is unobservable, but under `qmc.control` that phase becomes a real relative phase on the controls-on subspace — so controlled evolution of any constant-offset Hamiltonian produced a wrong result. The constant is now re-applied under control on Qiskit ([#471](https://github.com/Jij-Inc/Qamomile/pull/471), [#547](https://github.com/Jij-Inc/Qamomile/pull/547)) and CUDA-Q ([#540](https://github.com/Jij-Inc/Qamomile/pull/540)), and a shared controlled lowering makes controlled `pauli_evolve` transpile on QURI Parts for the first time ([#537](https://github.com/Jij-Inc/Qamomile/pull/537)). A non-real constant now raises a clear `EmitError`.
+- **Controlled `qmc.pauli_evolve` no longer drops the constant term's global phase.** A Hamiltonian's constant (identity) term contributes a global phase `exp(-i·gamma·c)`, which the emitter used to drop. On a standalone evolution this is unobservable, but under `qmc.control` that phase becomes a real relative phase on the controls-on subspace — so controlled evolution of any constant-offset Hamiltonian produced a wrong result. The constant is now re-applied under control on Qiskit ([#471](https://github.com/Jij-Inc/Qamomile/pull/471), [#547](https://github.com/Jij-Inc/Qamomile/pull/547)) and CUDA-Q ([#540](https://github.com/Jij-Inc/Qamomile/pull/540)), and a shared controlled lowering makes controlled `pauli_evolve` transpile on QURI Parts ([#537](https://github.com/Jij-Inc/Qamomile/pull/537)). A non-real constant now raises a clear `EmitError`.
 - **Controlled sub-kernels over a whole `Vector[Qubit]` now emit on every SDK.** The shared controlled-U fallback used to route every inner gate to a single target and reject multi-target inner blocks and nested controlled-U operations; it now maps each inner qubit onto the caller's targets, so a controlled multi-qubit sub-kernel (such as the modular-arithmetic shift) transpiles on QURI Parts and CUDA-Q as well as Qiskit ([#472](https://github.com/Jij-Inc/Qamomile/pull/472)).
 - **Controlled gates with a symbolic array-index control qubit now use the right wire.** When the control is a binding-driven array element (`q[control_index]`), the physical qubit is now resolved through the qubit map instead of allocating a fresh one, which previously misaligned the control and silently produced a wrong circuit ([#541](https://github.com/Jij-Inc/Qamomile/pull/541)).
 - **Möttönen amplitude-encoding / inverse state-prep wrappers route qubits correctly.** A qubit-resolution bug in the inverse state-preparation wrapper produced wrong qubit routing ([#465](https://github.com/Jij-Inc/Qamomile/pull/465)).
 - **Out-of-range array indices during loop unrolling fail fast.** An out-of-range or shape-mismatched array index encountered while unrolling a loop now raises a clear `EmitError` instead of silently miscompiling ([#477](https://github.com/Jij-Inc/Qamomile/pull/477)).
 - **`canonicalize` preserves the classical parameter manifest.** Canonicalization used to drop `Block.param_slots`; the manifest now survives, so content hashing and serialization of a canonicalized block keep the parameter contract ([#476](https://github.com/Jij-Inc/Qamomile/pull/476)).
-- **Qubit sizing derived from array elements is fixed.** Resource sizing now preserves zero sizes and rejects non-positive and negative element indices instead of producing a wrong allocation ([#456](https://github.com/Jij-Inc/Qamomile/pull/456)).
-- **Composite cast-carrier keys remap correctly.** Cast-carrier references are now remapped through canonicalize / inline / compile-time-`if` lowering, and fail fast on symbolic-bound slice-view carriers ([#468](https://github.com/Jij-Inc/Qamomile/pull/468)).
-- **Runtime-parameter-indexed loop bounds get a clear diagnostic.** A loop bound derived from a runtime-parameter index is now reported with a targeted error before segmentation instead of an obscure downstream failure ([#557](https://github.com/Jij-Inc/Qamomile/pull/557)).
+- **Sizing a qubit array from a classical array element now resolves correctly.** When the size of a qubit array comes from an element of a classical `Vector[UInt]` — `qmc.qubit_array(sizes[i], ...)` — the size used to be resolved wrongly and allocate the wrong number of qubits. It now resolves correctly through slices and indexed elements, keeps a size of 0, and rejects invalid sizes (negative sizes, unsupported negative indices) with a clear error ([#456](https://github.com/Jij-Inc/Qamomile/pull/456)).
+- **A `QFixed` value made with `qmc.cast` keeps pointing at the right qubits through IR transforms.** `qmc.cast(q, qmc.QFixed, ...)` reinterprets a `Vector[Qubit]` as a fixed-point value, and the cast internally remembers which qubits it wraps. Passing the kernel through inlining, canonicalization, or compile-time-`if` lowering used to fail to remap that reference, so the cast could point at the wrong qubits. It now keeps pointing at the right qubits through all of these transforms ([#468](https://github.com/Jij-Inc/Qamomile/pull/468)).
+- **Deriving a loop count from a runtime parameter now gives a clear error.** A `qmc.range(...)` count must be known at compile time so the loop can be unrolled. Using a runtime parameter (or one of its array elements) — a value only fixed at execution time — as the count used to fail with an obscure, unrelated error. It now raises a clear error early in transpilation, telling you to supply that value through `bindings` ([#557](https://github.com/Jij-Inc/Qamomile/pull/557)).
 
 ## Documentation
 

--- a/docs/ja/myst.yml
+++ b/docs/ja/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: リリースノート
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md
         - file: release_notes/v0_12_4.md

--- a/docs/ja/release_notes/index.md
+++ b/docs/ja/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # リリースノート
 
+- [v0.12.7](v0_12_7) — `Dict[K, Float]`の係数を`d[key]`添字付きでruntime parameterとして扱う、`UInt`の`%`演算子、これまでsilentなmiscompileだったパターンを拒否する一連の新しいコンパイル時エラー(`QubitRebindError`、`QubitConsumedError`、`bool` / 型不一致引数への`TypeError`)
 - [v0.12.6](v0_12_6) — `qmc.inverse`による回路の逆操作(ビルトインゲート・`@qkernel`・QFT/IQFT)、計算基底レジスタの算術`qmc.modular_increment` / `qmc.modular_decrement`、job型・結果型を`qamomile.circuit`からimport可能に
 - [v0.12.5](v0_12_5) — Pauli Correlation Encoding用の`PCEConverter` / `PCEEncoder`、QURI Partsサンプリングへのseed指定、測定済み`Vector[Bit]`を使う条件分岐の修正、`Vector`要素の`qmc.expval`修正
 - [v0.12.4](v0_12_4) — `qmc.controlled`を`qmc.control`に改名しsymbolic modeの表現力を強化、`BinaryModel.from_higher_ising`による高次Isingモデルからの構築をサポート、`Float`ハンドルへの単項マイナス`-`を追加

--- a/docs/ja/release_notes/v0_12_7.md
+++ b/docs/ja/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。`angles[i]`のように量子カーネル内で記述でき、実行ごとに別の値を指定し直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。また本リリースでは、これまでコンパイルは通るのに誤った回路を生成していたいくつかの書き方、たとえば分岐内で以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てる、同じ`Vector[Qubit]`を量子カーネル呼び出しの2つの引数に渡す、といったものを、コンパイル時にそれぞれ専用のエラーで拒否するようにしました。制御化した`qmc.pauli_evolve`をQURI Partsでも使えるようにしました。またHamiltonianの定数項の大域位相を正しく保持するように修正し、定数項を持つHamiltonianの制御化した発展がQiskit・QURI Parts・CUDA-Qのいずれでも正しく動くようになりました。
+Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。`angles[i]`のように量子カーネル内で記述でき、実行ごとに別の値を指定し直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。また本リリースでは、これまでトランスパイルは通るのに誤った回路を生成していたいくつかの書き方、たとえば分岐内で以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てる、同じ`Vector[Qubit]`を量子カーネル呼び出しの2つの引数に渡す、といったものを、トランスパイル時にそれぞれ専用のエラーで拒否するようにしました。制御化した`qmc.pauli_evolve`をQURI Partsでも使えるようにしました。またHamiltonianの定数項の大域位相を正しく保持するように修正し、定数項を持つHamiltonianの制御化した発展がQiskit・QURI Parts・CUDA-Qのいずれでも正しく動くようになりました。
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## 破壊的変更
 
-本リリースでは、これまで*コンパイルは通る*もののPythonソースと一致しない回路を生成していたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用のエラーを送出します。
+本リリースでは、これまで*トランスパイルは通る*もののPythonソースと一致しない回路を生成していたプログラムを拒否するトランスパイル時のチェックを追加しました。以下の各パターンは、トランスパイル時に専用のエラーを送出します。
 
-- **分岐やループ本体で、以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てると`QubitRebindError`を送出します。** 測定結果に基づく`if`や`for` / `while`の本体で`q = qmc.qubit(...)`と書くと、以前はコンパイルが通り、`q`の以前の状態が黙って失われていました([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
+- **分岐やループ本体で、以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てると`QubitRebindError`を送出します。** 測定結果に基づく`if`や`for` / `while`の本体で`q = qmc.qubit(...)`と書くと、以前はトランスパイルが通り、`q`の以前の状態が黙って失われていました([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
 
   ```python
   @qmc.qkernel
@@ -39,7 +39,7 @@ pip install qamomile==0.12.7
 
 ### 辞書の係数をruntime parameterとして扱う
 
-`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照した各キーは、生成回路の`"<dict>[<key>]"`という名前のruntime parameter(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableに対して、実行ごとに別の辞書値を指定し直せます。引数を`parameters=[...]`に列挙して宣言します。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindした辞書に対して完全に定数のキーはコンパイル時に定数へ畳み込みます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
+`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照した各キーは、生成回路の`"<dict>[<key>]"`という名前のruntime parameter(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じトランスパイル済みexecutableに対して、実行ごとに別の辞書値を指定し直せます。引数を`parameters=[...]`に列挙して宣言します。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindした辞書に対して完全に定数のキーはコンパイル時に定数へ畳み込みます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
 
 ```python
 import numpy as np
@@ -63,7 +63,7 @@ executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["an
 
 ### `UInt`のmodulo演算子
 
-`UInt`ハンドルが`%`演算子(および`int % UInt`)をサポートしました。これにより`qmc.range`ループ内の`i % 2`のような添字式が、以前はトレース時に`TypeError`になっていましたが、直接コンパイルできるようになりました([#466](https://github.com/Jij-Inc/Qamomile/pull/466))。
+`UInt`ハンドルが`%`演算子(および`int % UInt`)をサポートしました。これにより`qmc.range`ループ内の`i % 2`のような添字式が、以前はトレース時に`TypeError`になっていましたが、直接トランスパイルできるようになりました([#466](https://github.com/Jij-Inc/Qamomile/pull/466))。
 
 ```python
 import qamomile.circuit as qmc

--- a/docs/ja/release_notes/v0_12_7.md
+++ b/docs/ja/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。量子カーネル内では`angles[i]`のように書け、実行ごとに別の値でbindし直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。さらに本リリースでは、これまでトランスパイルは通るもののPythonソースと一致しない回路を生成していた一群のプログラムを、トランスパイル時に専用の例外で明示的に拒否するようにしました。対象は、runtimeの`if`やループ本体で量子ビットの状態を破棄する、ループ反復をまたいで古典アキュムレータを更新する、同じレジスタを量子カーネル呼び出しの2つの引数にaliasする、型やshapeの合わない引数を渡す、多次元の量子レジスタを確保する、といったパターンです。制御化した`qmc.pauli_evolve`は、Qiskit・QURI Parts・CUDA-Qのいずれでも一貫して正しい結果を返すようになり、定数項を持つHamiltonianでも正しくなりました。QURI Partsでは今回初めて動作します。内部的には、IR serializerがbind済みの`Hamiltonian`をround-tripできるようになり、演算子データを含むコンパイル済み量子カーネルも`dump_json` / `load_json`を通して保持されます。
+Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。`angles[i]`のように量子カーネル内で記述でき、実行ごとに別の値を指定し直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。また本リリースでは、これまでコンパイルは通るのに誤った回路を生成していたいくつかの書き方、たとえば分岐内で以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てる、同じ`Vector[Qubit]`をカーネル呼び出しの2つの引数に渡す、といったものを、コンパイル時にそれぞれ専用のエラーで拒否するようにしました。制御化した`qmc.pauli_evolve`は、Hamiltonianの定数項の大域位相を落とさなくなり、定数項を持つHamiltonianの制御化した発展がQiskit・QURI Parts・CUDA-Qのいずれでも正しくなりました。制御化した`pauli_evolve`はQURI Partsでも新たにサポートしました。内部的には、IR serializerがbind済みの`Hamiltonian`を`dump_json` / `load_json`でround-tripできるようになりました。
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## 破壊的変更
 
-本リリースでは、これまで*コンパイルは通る*もののソースと一致しない回路、すなわちsilentなmiscompileや不透明なバックエンドのクラッシュを生んでいたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用の名前付き例外を送出します。該当するコードがある場合、以前生成されていた回路はすでに誤っており、例外がどの構文を書き直すべきかを正確に示します。
+本リリースでは、これまで*コンパイルは通る*もののPythonソースと一致しない回路を生成していたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用のエラーを送出します。該当する場合、以前生成されていた回路はすでに誤っており、エラーは書き直すべき構文を正確に示します。
 
-- **runtimeの分岐やループ本体で量子ビットの状態を捨てると`QubitRebindError`を送出します。** 量子変数を新しく確保した量子ビットへbindし直すと、分岐前の状態が診断なしに破棄されていました。`if`については、測定由来(runtime)の条件に対してチェックが適用されます。`for` / `while`ループについては、ループが反復ごとの量子再bindを表現できないため、反復回数に関係なく、すべてのループ本体に適用されます([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
+- **分岐やループ本体で、以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てると`QubitRebindError`を送出します。** 測定結果に基づく`if`や`for` / `while`の本体で`q = qmc.qubit(...)`と書くと、以前はコンパイルが通り、`q`の以前の状態が黙って破棄されていました。今はコンパイル時に拒否します([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
 
   ```python
   @qmc.qkernel
@@ -19,27 +19,27 @@ pip install qamomile==0.12.7
       p = qmc.qubit("p")
       cond = qmc.measure(p)
       if cond:
-          q = qmc.qubit("fresh")   # QubitRebindError: qの分岐前の状態を破棄している
+          q = qmc.qubit("fresh")   # QubitRebindError: qの以前の状態をconsumeしていない
       return qmc.measure(q)
   ```
 
-- **ループ反復をまたいで古典スカラーを更新すると`ValidationError`を送出します。** `@qkernel`の`for`本体は一度だけトレースされるため、ループをまたぐアキュムレータ(`total = total + i`)は右辺がループ前の値に固定され、Pythonの意味論から乖離していました([#552](https://github.com/Jij-Inc/Qamomile/pull/552))。
+- **ループの反復をまたいで古典変数を更新すると`ValidationError`を送出します。** `@qkernel`の`for`本体は一度だけトレースされるため、`total = total + i`のような書き方では、右辺がループ前の値に固定されるという不具合が発生していました。今はこのパターンを拒否します([#552](https://github.com/Jij-Inc/Qamomile/pull/552))。
 
-- **ループ内で同じ配列の別要素を読む古典配列要素の代入は`ValidationError`を送出します。** ループ内の`arr[i] = arr[i - 1]`は`arr`のループ前の固定バージョンを読むため、それより前の反復での書き込みを一切観測しませんでした([#545](https://github.com/Jij-Inc/Qamomile/pull/545))。
+- **ループ内で同じ配列の別要素を読む古典配列要素の代入は`ValidationError`を送出します。** ループ内の`arr[i] = arr[i - 1]`は、以前は`arr`のループ前のスナップショットを読み、それ以前の反復での書き込みを反映していませんでした。今は拒否します([#545](https://github.com/Jij-Inc/Qamomile/pull/545))。
 
-- **多次元の量子レジスタは事前に拒否するようになりました。** `qmc.qubit_array((2, 3), ...)`などのrank2以上の量子形状は、以前は`Matrix[Qubit]` / `Tensor[Qubit]`を返すように見えていましたが、後段で誤った回路を生成したり、不透明な形でクラッシュしたりしていました。量子ビットのアドレッシング経路はrank1であるため、確保時に`NotImplementedError`(rank2のレジスタがemitまで到達した場合は`EmitError`)を送出します。古典の`Matrix` / `Tensor`引数は影響を受けません([#558](https://github.com/Jij-Inc/Qamomile/pull/558))。
+- **多次元のQubit配列の確保を事前に拒否するようになりました。** `qmc.qubit_array((2, 3), ...)`などのrank2以上の量子shapeは、以前は受理された後で誤った回路を生成したり、後段でクラッシュしていました。今は確保時に`NotImplementedError`(rank2の配列がemitまで到達した場合は`EmitError`)を送出します。量子ビットの添字付けは1次元のみです。古典の`Matrix` / `Tensor`引数は影響を受けません([#558](https://github.com/Jij-Inc/Qamomile/pull/558))。
 
-- **型やshapeの合わないカーネル引数を渡すと`TypeError`を送出します。** スカラーの`Qubit`を`Vector[Qubit]`パラメータに渡すと、以前はサイズ算出の深い箇所から`AttributeError`が漏れていました。また、`Qubit`を`Float`パラメータに渡すと、警告なしに`rx(0)`を生成していました。引数ハンドルは、通常のカーネル呼び出し・`qmc.control`・`qmc.inverse`のいずれの呼び出し箇所でも、宣言されたパラメータ型に対して検証されるようになりました([#473](https://github.com/Jij-Inc/Qamomile/pull/473))。
+- **型やshapeの合わない量子カーネル引数を渡すと`TypeError`を送出します。** スカラーの`Qubit`を`Vector[Qubit]`パラメータに渡すと、以前は無関係な`AttributeError`が漏れ出ていました。また`Qubit`を`Float`パラメータに渡すと黙って`rx(0)`を生成していました。引数は、通常のカーネル呼び出し・`qmc.control`・`qmc.inverse`のいずれの呼び出し箇所でも、宣言されたパラメータ型に対して検証されるようになりました([#473](https://github.com/Jij-Inc/Qamomile/pull/473))。
 
-- **plainなintが必要な箇所にPythonの`bool`を渡すと`TypeError`を送出します。** `bool`は`int`のサブクラスであるため、`q[True]`、`q[False:2]`、`qmc.uint(True)`は添字・境界・サイズの`1` / `0`として黙って受理されていました。配列の添字、slice境界、`qmc.uint`は`bool`を拒否するようになりました([#539](https://github.com/Jij-Inc/Qamomile/pull/539))。
+- **通常の`int`が必要な箇所にPythonの`bool`を渡すと`TypeError`を送出します。** `bool`は`int`のサブクラスであるため、`q[True]`、`q[False:2]`、`qmc.uint(True)`は以前は`1` / `0`として黙って受理されていました。配列の添字、slice境界、`qmc.uint`は`bool`を拒否するようになりました([#539](https://github.com/Jij-Inc/Qamomile/pull/539))。
 
-- **同じ量子レジスタをカーネル呼び出しの2つの引数にaliasすると`QubitConsumedError`を送出します。** `sub(qs, qs)`のような呼び出し、あるいは重なり合うviewを渡すと、両方の仮引数レジスタが同じ物理量子ビットに写像され、miscompileするかバックエンドの生の`duplicate qubit`エラーとして後から表面化していました。affine type checkerが呼び出し箇所でaliasを拒否するようになりました([#543](https://github.com/Jij-Inc/Qamomile/pull/543))。
+- **同じQubit配列をカーネル呼び出しの2つの引数に渡すと`QubitConsumedError`を送出します。** `sub(qs, qs)`、または重なり合う2つのviewを渡すと、以前は両方のパラメータが同じ物理量子ビットに写像され、誤った回路を生成するか、量子プログラミングSDKが出す生の`duplicate qubit`エラーとして後から表面化していました。今は呼び出し箇所でaliasを拒否します([#543](https://github.com/Jij-Inc/Qamomile/pull/543))。
 
 ## 新機能
 
 ### 辞書の係数をruntime parameterとして扱う
 
-`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照された各キーは`"<dict>[<key>]"`という名前のバックエンドパラメータ(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableを、実行ごとに別の辞書値でbindし直せます。引数を`parameters=[...]`に列挙して宣言します。辞書を`bindings`にも`parameters`にも入れなければ、従来どおりコンパイル時の挙動になります。キーは単一の要素でも、要素ごとに突き合わせるタプル`d[(i, j)]`でも構いません。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindされた辞書に対して完全に定数のキーは定数へ畳み込まれます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
+`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照された各キーは、生成回路の`"<dict>[<key>]"`という名前のruntime parameter(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableに対して、実行ごとに別の辞書値を指定し直せます。引数を`parameters=[...]`に列挙して宣言します。辞書を`bindings`にも`parameters`にも入れなければ、従来どおりコンパイル時の挙動になります。キーは単一の要素でも、要素ごとに突き合わせるタプル`d[(i, j)]`でも構いません。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindされた辞書に対して完全に定数のキーは定数へ畳み込まれます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
 
 ```python
 import numpy as np
@@ -56,7 +56,7 @@ def rx_by_dict(n: qmc.UInt, angles: qmc.Dict[qmc.UInt, qmc.Float]) -> qmc.Vector
 transpiler = QiskitTranspiler()
 executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["angles"])
 # executable.parameter_names -> ['angles[0]', 'angles[1]', 'angles[2]']
-# 実行ごとに辞書を再bindする:
+# 実行ごとに辞書値を指定し直す:
 #   executable.sample(transpiler.executor(), shots=256,
 #                     bindings={"angles": {0: np.pi, 1: 0.0, 2: np.pi}})
 ```
@@ -85,11 +85,31 @@ executable = transpiler.transpile(even_indices)
 [((1, 0, 1, 0), 256)]
 ```
 
+### `qmc.pauli_evolve`がtargetより小さいHamiltonianを受け付ける
+
+`qmc.pauli_evolve`が、targetの`Vector[Qubit]`より少ない量子ビットに作用するHamiltonianを受け付けるようになりました。各Pauli項は配列要素を位置で指し(添字`i`の項は`q[i]`に作用)、Hamiltonianのサイズを超える量子ビットは恒等で発展します。0量子ビット(定数のみ)のHamiltonianは大域位相に寄与します。targetより*多い*量子ビットに作用するHamiltonianは、トランスパイル時に明確な`EmitError`で失敗するようになりました([#471](https://github.com/Jij-Inc/Qamomile/pull/471))。
+
+```python
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def evolve(h: qmc.Observable, t: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(2, name="q")
+    q = qmc.h(q)
+    q = qmc.pauli_evolve(q, h, t)   # hは1量子ビットに作用し、q[1]は恒等で発展する
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(evolve, bindings={"h": qm_o.Z(0), "t": 0.5})
+```
+
 ## 内部的な変更
 
 ### Hamiltonianのserialization round-trip
 
-IR serializerがbind済みの`Hamiltonian`を扱えるようになりました。演算子データを埋め込んだコンパイル済み`Block`、たとえばPauli Hamiltonianのリストにbindされた`Vector[Observable]`引数を`ParamSlot.bound_value`に保持しているものが、`dump_json` / `load_json`(およびmsgpackの対)を通っても、Hamiltonian単位で同一のまま戻ってくるようになりました。既存のserializationエントリポイントを通じて動作し、Hamiltonianのペイロードは付加的なtagged-dict形式であるため、schemaのバージョンを上げる必要はありませんでした([#475](https://github.com/Jij-Inc/Qamomile/pull/475)、[#548](https://github.com/Jij-Inc/Qamomile/pull/548))。
+IR serializerがbind済みの`Hamiltonian`を扱えるようになりました。演算子データを埋め込んだコンパイル済み`Block`、たとえばPauli Hamiltonianのリストにbindされた`Vector[Observable]`引数を`ParamSlot.bound_value`に保持しているものが、`dump_json` / `load_json`(およびmsgpackの対)を通っても、各Hamiltonianが同一のまま復元されるようになりました。既存のserializationエントリポイントを通じて動作し、Hamiltonianのペイロードは付加的なtagged-dict形式であるため、schemaのバージョンを上げる必要はありませんでした([#475](https://github.com/Jij-Inc/Qamomile/pull/475)、[#548](https://github.com/Jij-Inc/Qamomile/pull/548))。
 
 ```python
 import qamomile.circuit as qmc
@@ -114,26 +134,25 @@ print(slot.bound_value)
 [Hamiltonian((Z0,): 1.2), Hamiltonian((X0,): 0.8)]
 ```
 
-**Why**: 上記の項目とは異なり、これは辞書パラメータ機能の一部ではありません。演算子データを埋め込んだコンパイル済み量子カーネルにも可搬性を持たせるため、wire formatを拡張し、以前はそのような`Block`がround-tripに失敗していた問題を解消します。
+**Why**: 上記の項目とは異なり、これは辞書パラメータ機能の一部ではありません。演算子データを埋め込んだコンパイル済み量子カーネルにも可搬性を持たせるため、wire formatを拡張し、以前はそのような`Block`がround-tripに失敗していた問題を解消しました。
 
 ## バグ修正
 
-- **制御化した`qmc.pauli_evolve`がSDK間で一貫して正しくなりました。** Hamiltonianの定数(恒等)項は大域位相に寄与しますが、共有のPauli-gadget emitterがこれを落としていました。`qmc.control`のもとではこの位相が制御onの部分空間での観測可能な相対位相になるため、定数項を持つHamiltonianの制御化した発展が誤った結果を返していました。定数はQiskitのフォールバック経路([#547](https://github.com/Jij-Inc/Qamomile/pull/547))とCUDA-Q([#540](https://github.com/Jij-Inc/Qamomile/pull/540))で制御化した位相として再適用されるようになり、共有の制御化loweringにより制御化した`pauli_evolve`がQURI Partsで初めてトランスパイルできるようになりました([#537](https://github.com/Jij-Inc/Qamomile/pull/537))。実数でない定数はどの経路でも明確な`EmitError`を送出します。
-- **ターゲットレジスタより小さいHamiltonianは、恒等演算で正しくパディングされます。** レジスタより少ない量子ビットに作用するHamiltonianを渡した`qmc.pauli_evolve`が、QiskitとCUDA-Qで正しくemitされるようになり、0量子ビット(定数のみ)のHamiltonianはQiskitの大域位相としてemitされます([#471](https://github.com/Jij-Inc/Qamomile/pull/471))。
-- **`Vector[Qubit]`全体を対象とする制御化した量子カーネルがすべてのSDKでemitできるようになりました。** 共有の制御化Uフォールバックは以前、内側の各ゲートを単一のターゲットに回し、複数ターゲットの内側ブロックや入れ子の制御化U操作を拒否していました。内側の各量子ビットを呼び出し側の物理ターゲットへ写像するようになり、制御化した多量子ビットのサブカーネル(modular算術のシフトなど)がQiskitと同様にQURI PartsとCUDA-Qでもトランスパイルできます([#472](https://github.com/Jij-Inc/Qamomile/pull/472))。
-- **symbolicな配列添字を制御量子ビットに持つ制御化ゲートが正しいワイヤーを確保します。** 制御がbindingで決まる配列要素(`q[control_index]`)のとき、新しい量子ビットを確保するのではなく、qubit mapを通じて物理量子ビットを解決するようになりました。以前は制御の位置がずれ、黙って誤った回路を生成していました([#541](https://github.com/Jij-Inc/Qamomile/pull/541))。
+- **制御化した`qmc.pauli_evolve`がHamiltonianの定数項の大域位相を落とさなくなりました。** Hamiltonianの定数(恒等)項は大域位相`exp(-i·gamma·c)`に寄与しますが、emitterはこれを落としていました。単体の発展では観測できませんが、`qmc.control`下では、この位相が制御が有効な部分空間での実際の相対位相になるため、定数項を持つHamiltonianの制御化した発展が誤った結果を生んでいました。定数はQiskit([#471](https://github.com/Jij-Inc/Qamomile/pull/471)、[#547](https://github.com/Jij-Inc/Qamomile/pull/547))とCUDA-Q([#540](https://github.com/Jij-Inc/Qamomile/pull/540))で制御下でも再適用されるようになり、共有の制御化loweringにより制御化した`pauli_evolve`がQURI Partsで初めてトランスパイルできるようになりました([#537](https://github.com/Jij-Inc/Qamomile/pull/537))。実数でない定数は明確な`EmitError`を送出します。
+- **`Vector[Qubit]`全体を対象とする制御化した量子カーネルがすべての量子プログラミングSDKでemitできるようになりました。** 共有の制御化Uフォールバックは以前、内側の各ゲートを単一のtargetに割り当て、複数targetの内側ブロックや入れ子の制御化U操作を拒否していました。内側の各量子ビットを呼び出し側のtargetへ写像するようになり、制御化した多量子ビットの量子カーネル(modular算術のシフトなど)がQiskitと同様にQURI PartsとCUDA-Qでもトランスパイルできます([#472](https://github.com/Jij-Inc/Qamomile/pull/472))。
+- **symbolicな配列添字を制御量子ビットに持つ制御化ゲートが正しい配線を使うようになりました。** 制御がbindingで決まる配列要素(`q[control_index]`)のとき、新しい量子ビットを確保するのではなく、qubit mapを通じて物理量子ビットを解決するようになりました。以前は制御の位置がずれ、黙って誤った回路を生成していました([#541](https://github.com/Jij-Inc/Qamomile/pull/541))。
 - **Möttönenの振幅エンコーディング / 逆状態準備のwrapperが量子ビットを正しく配線します。** 逆状態準備wrapperの量子ビット解決の不具合が、誤った量子ビット配線を生んでいました([#465](https://github.com/Jij-Inc/Qamomile/pull/465))。
 - **ループunroll中の範囲外の配列添字を即座に失敗させます。** ループのunroll中に範囲外またはshapeの合わない配列添字に出会うと、黙って誤った回路を生成するのではなく、明確な`EmitError`を送出するようになりました([#477](https://github.com/Jij-Inc/Qamomile/pull/477))。
 - **`canonicalize`が古典パラメータのmanifestを保持します。** canonicalizeは以前`Block.param_slots`を落としていましたが、manifestが保たれるようになり、canonicalizeした`Block`のcontent hashとserializationがパラメータ契約を維持します([#476](https://github.com/Jij-Inc/Qamomile/pull/476))。
 - **配列要素から導かれる量子ビットのサイズ算出を修正しました。** リソースのサイズ算出がゼロサイズを保ち、非正および負の要素添字を拒否するようになり、誤った確保を生まなくなりました([#456](https://github.com/Jij-Inc/Qamomile/pull/456))。
-- **compositeのcast-carrierキーを正しく再写像します。** cast-carrierの参照がcanonicalize / inline / コンパイル時`if` loweringを通じて再写像されるようになり、symbolicにbindされたslice-viewのcarrierでは即座に失敗します([#468](https://github.com/Jij-Inc/Qamomile/pull/468))。
+- **compositeのcast-carrierキーを正しく再写像します。** cast-carrierの参照がcanonicalize / inline / コンパイル時`if` loweringを通じて再写像されるようになり、symbolicにbindされたslice-view carrierでは早期に失敗します([#468](https://github.com/Jij-Inc/Qamomile/pull/468))。
 - **runtime parameterの添字から導かれるループ境界に明確な診断を出します。** runtime parameterの添字から導かれるループ境界が、不透明な下流の失敗ではなくsegmentation前に的確なエラーとして報告されるようになりました([#557](https://github.com/Jij-Inc/Qamomile/pull/557))。
 
 ## ドキュメント
 
 - [**多次元量子フーリエ変換によるナノシート材料物性の推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/algorithm/multidimensional_qft.ipynb) — 多次元QFTを材料科学の推定問題に適用する新しいアルゴリズム記事です([#405](https://github.com/Jij-Inc/Qamomile/pull/405))。
-- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/cudaq_support.ipynb) — QamomileのカーネルをCUDA-Qバックエンドでトランスパイル・実行するための新しい統合ページです([#440](https://github.com/Jij-Inc/Qamomile/pull/440))。
-- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/qiskit_support.ipynb) — Qiskitバックエンド向けの新しい統合ページです([#464](https://github.com/Jij-Inc/Qamomile/pull/464))。
+- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/cudaq_support.ipynb) — QamomileのカーネルをCUDA-Q SDKでトランスパイル・実行するための新しい統合ページです([#440](https://github.com/Jij-Inc/Qamomile/pull/440))。
+- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/qiskit_support.ipynb) — Qiskit SDK向けの新しい統合ページです([#464](https://github.com/Jij-Inc/Qamomile/pull/464))。
 - ドキュメントサイトを再設計し、ランディングページとカードのメタデータを刷新し、新しい[**インストール**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/installation_guide.md)ガイドを追加しました([#461](https://github.com/Jij-Inc/Qamomile/pull/461))。
 
 ## さらに詳しく

--- a/docs/ja/release_notes/v0_12_7.md
+++ b/docs/ja/release_notes/v0_12_7.md
@@ -1,6 +1,6 @@
 # Qamomile v0.12.7
 
-Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。`angles[i]`のように量子カーネル内で記述でき、実行ごとに別の値を指定し直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。また本リリースでは、これまでコンパイルは通るのに誤った回路を生成していたいくつかの書き方、たとえば分岐内で以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てる、同じ`Vector[Qubit]`をカーネル呼び出しの2つの引数に渡す、といったものを、コンパイル時にそれぞれ専用のエラーで拒否するようにしました。制御化した`qmc.pauli_evolve`は、Hamiltonianの定数項の大域位相を落とさなくなり、定数項を持つHamiltonianの制御化した発展がQiskit・QURI Parts・CUDA-Qのいずれでも正しくなりました。制御化した`pauli_evolve`はQURI Partsでも新たにサポートしました。内部的には、IR serializerがbind済みの`Hamiltonian`を`dump_json` / `load_json`でround-tripできるようになりました。
+Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。`angles[i]`のように量子カーネル内で記述でき、実行ごとに別の値を指定し直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。また本リリースでは、これまでコンパイルは通るのに誤った回路を生成していたいくつかの書き方、たとえば分岐内で以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てる、同じ`Vector[Qubit]`を量子カーネル呼び出しの2つの引数に渡す、といったものを、コンパイル時にそれぞれ専用のエラーで拒否するようにしました。制御化した`qmc.pauli_evolve`をQURI Partsでも使えるようにしました。またHamiltonianの定数項の大域位相を正しく保持するように修正し、定数項を持つHamiltonianの制御化した発展がQiskit・QURI Parts・CUDA-Qのいずれでも正しく動くようになりました。
 
 ```
 pip install qamomile==0.12.7
@@ -8,9 +8,9 @@ pip install qamomile==0.12.7
 
 ## 破壊的変更
 
-本リリースでは、これまで*コンパイルは通る*もののPythonソースと一致しない回路を生成していたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用のエラーを送出します。該当する場合、以前生成されていた回路はすでに誤っており、エラーは書き直すべき構文を正確に示します。
+本リリースでは、これまで*コンパイルは通る*もののPythonソースと一致しない回路を生成していたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用のエラーを送出します。
 
-- **分岐やループ本体で、以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てると`QubitRebindError`を送出します。** 測定結果に基づく`if`や`for` / `while`の本体で`q = qmc.qubit(...)`と書くと、以前はコンパイルが通り、`q`の以前の状態が黙って破棄されていました。今はコンパイル時に拒否します([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
+- **分岐やループ本体で、以前の量子ビットをconsumeしないまま変数へ新しい量子ビットを割り当てると`QubitRebindError`を送出します。** 測定結果に基づく`if`や`for` / `while`の本体で`q = qmc.qubit(...)`と書くと、以前はコンパイルが通り、`q`の以前の状態が黙って失われていました([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
 
   ```python
   @qmc.qkernel
@@ -23,23 +23,23 @@ pip install qamomile==0.12.7
       return qmc.measure(q)
   ```
 
-- **ループの反復をまたいで古典変数を更新すると`ValidationError`を送出します。** `@qkernel`の`for`本体は一度だけトレースされるため、`total = total + i`のような書き方では、右辺がループ前の値に固定されるという不具合が発生していました。今はこのパターンを拒否します([#552](https://github.com/Jij-Inc/Qamomile/pull/552))。
+- **ループの反復をまたいで古典変数を更新すると`ValidationError`を送出します。** `@qkernel`の`for`本体は一度しかトレースしないため、`total = total + i`のような書き方では、右辺がループ前の値に固定されるという不具合が発生していました([#552](https://github.com/Jij-Inc/Qamomile/pull/552))。
 
-- **ループ内で同じ配列の別要素を読む古典配列要素の代入は`ValidationError`を送出します。** ループ内の`arr[i] = arr[i - 1]`は、以前は`arr`のループ前のスナップショットを読み、それ以前の反復での書き込みを反映していませんでした。今は拒否します([#545](https://github.com/Jij-Inc/Qamomile/pull/545))。
+- **ループ内で同じ配列の別要素を読む古典配列要素の代入は`ValidationError`を送出します。** ループ内で`arr[i] = arr[i - 1]`のように書くと、以前は各反復が`arr`のループ前の値を読み、それ以前の反復での書き込みを反映しないまま、エラーも出さずに誤った回路になっていました([#545](https://github.com/Jij-Inc/Qamomile/pull/545))。
 
-- **多次元のQubit配列の確保を事前に拒否するようになりました。** `qmc.qubit_array((2, 3), ...)`などのrank2以上の量子shapeは、以前は受理された後で誤った回路を生成したり、後段でクラッシュしていました。今は確保時に`NotImplementedError`(rank2の配列がemitまで到達した場合は`EmitError`)を送出します。量子ビットの添字付けは1次元のみです。古典の`Matrix` / `Tensor`引数は影響を受けません([#558](https://github.com/Jij-Inc/Qamomile/pull/558))。
+- **多次元のQubit配列の確保を事前に拒否するようになりました。** `qmc.qubit_array((2, 3), ...)`などのrank2以上の量子shapeは、以前は受理してしまい、その後で誤った回路を生成したり後段でクラッシュしたりしていました。今は確保時に`NotImplementedError`を送出します。古典の`Matrix` / `Tensor`引数は影響しません([#558](https://github.com/Jij-Inc/Qamomile/pull/558))。
 
-- **型やshapeの合わない量子カーネル引数を渡すと`TypeError`を送出します。** スカラーの`Qubit`を`Vector[Qubit]`パラメータに渡すと、以前は無関係な`AttributeError`が漏れ出ていました。また`Qubit`を`Float`パラメータに渡すと黙って`rx(0)`を生成していました。引数は、通常のカーネル呼び出し・`qmc.control`・`qmc.inverse`のいずれの呼び出し箇所でも、宣言されたパラメータ型に対して検証されるようになりました([#473](https://github.com/Jij-Inc/Qamomile/pull/473))。
+- **型やshapeの合わない量子カーネル引数を渡すと`TypeError`を送出します。** スカラーの`Qubit`を`Vector[Qubit]`パラメータに渡すと、以前は無関係な`AttributeError`が漏れ出ていました。また`Qubit`を`Float`パラメータに渡すと黙って`rx(0)`を生成していました。今は通常の量子カーネル呼び出し・`qmc.control`・`qmc.inverse`のいずれの呼び出し箇所でも、宣言した型に照らして引数を検証し、合わなければエラーを送出します([#473](https://github.com/Jij-Inc/Qamomile/pull/473))。
 
-- **通常の`int`が必要な箇所にPythonの`bool`を渡すと`TypeError`を送出します。** `bool`は`int`のサブクラスであるため、`q[True]`、`q[False:2]`、`qmc.uint(True)`は以前は`1` / `0`として黙って受理されていました。配列の添字、slice境界、`qmc.uint`は`bool`を拒否するようになりました([#539](https://github.com/Jij-Inc/Qamomile/pull/539))。
+- **通常の`int`が必要な箇所にPythonの`bool`を渡すと`TypeError`を送出します。** `bool`は`int`のサブクラスであるため、`q[True]`、`q[False:2]`、`qmc.uint(True)`は以前は`1` / `0`として黙って受理していました。配列の添字、slice境界、`qmc.uint`では`bool`を拒否します([#539](https://github.com/Jij-Inc/Qamomile/pull/539))。
 
-- **同じQubit配列をカーネル呼び出しの2つの引数に渡すと`QubitConsumedError`を送出します。** `sub(qs, qs)`、または重なり合う2つのviewを渡すと、以前は両方のパラメータが同じ物理量子ビットに写像され、誤った回路を生成するか、量子プログラミングSDKが出す生の`duplicate qubit`エラーとして後から表面化していました。今は呼び出し箇所でaliasを拒否します([#543](https://github.com/Jij-Inc/Qamomile/pull/543))。
+- **同じQubit配列を量子カーネル呼び出しの2つの引数に渡すと`QubitConsumedError`を送出します。** `sub(qs, qs)`、または重なり合う2つのviewを渡すと、以前は両方のパラメータが同じ物理量子ビットに写像され、誤った回路を生成するか、量子プログラミングSDKが出す生の`duplicate qubit`エラーとして後から表面化していました。今は呼び出し箇所でaliasを拒否します([#543](https://github.com/Jij-Inc/Qamomile/pull/543))。
 
 ## 新機能
 
 ### 辞書の係数をruntime parameterとして扱う
 
-`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照された各キーは、生成回路の`"<dict>[<key>]"`という名前のruntime parameter(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableに対して、実行ごとに別の辞書値を指定し直せます。引数を`parameters=[...]`に列挙して宣言します。辞書を`bindings`にも`parameters`にも入れなければ、従来どおりコンパイル時の挙動になります。キーは単一の要素でも、要素ごとに突き合わせるタプル`d[(i, j)]`でも構いません。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindされた辞書に対して完全に定数のキーは定数へ畳み込まれます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
+`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照した各キーは、生成回路の`"<dict>[<key>]"`という名前のruntime parameter(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableに対して、実行ごとに別の辞書値を指定し直せます。引数を`parameters=[...]`に列挙して宣言します。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindした辞書に対して完全に定数のキーはコンパイル時に定数へ畳み込みます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
 
 ```python
 import numpy as np
@@ -63,7 +63,7 @@ executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["an
 
 ### `UInt`のmodulo演算子
 
-`UInt`ハンドルが`%`演算子(および`int % UInt`)をサポートするようになり、すでに`+ - * / // **`で利用できた古典的な添字演算が揃いました。これにより`qmc.range`ループ内の`i % 2`のような添字式が、トレース時に`TypeError`を送出することなく直接コンパイルできます([#466](https://github.com/Jij-Inc/Qamomile/pull/466))。
+`UInt`ハンドルが`%`演算子(および`int % UInt`)をサポートしました。これにより`qmc.range`ループ内の`i % 2`のような添字式が、以前はトレース時に`TypeError`になっていましたが、直接コンパイルできるようになりました([#466](https://github.com/Jij-Inc/Qamomile/pull/466))。
 
 ```python
 import qamomile.circuit as qmc
@@ -87,7 +87,7 @@ executable = transpiler.transpile(even_indices)
 
 ### `qmc.pauli_evolve`がtargetより小さいHamiltonianを受け付ける
 
-`qmc.pauli_evolve`が、targetの`Vector[Qubit]`より少ない量子ビットに作用するHamiltonianを受け付けるようになりました。各Pauli項は配列要素を位置で指し(添字`i`の項は`q[i]`に作用)、Hamiltonianのサイズを超える量子ビットは恒等で発展します。0量子ビット(定数のみ)のHamiltonianは大域位相に寄与します。targetより*多い*量子ビットに作用するHamiltonianは、トランスパイル時に明確な`EmitError`で失敗するようになりました([#471](https://github.com/Jij-Inc/Qamomile/pull/471))。
+`qmc.pauli_evolve`が、targetの`Vector[Qubit]`より少ない量子ビットに作用するHamiltonianを受け付けるようになりました。各Pauli項は配列要素を位置で指し(添字`i`の項は`q[i]`に作用)、Hamiltonianのサイズを超える量子ビットは恒等で発展します。targetより*多い*量子ビットに作用するHamiltonianは、トランスパイル時に明確な`EmitError`で失敗します([#471](https://github.com/Jij-Inc/Qamomile/pull/471))。
 
 ```python
 import qamomile.circuit as qmc
@@ -109,7 +109,7 @@ executable = transpiler.transpile(evolve, bindings={"h": qm_o.Z(0), "t": 0.5})
 
 ### Hamiltonianのserialization round-trip
 
-IR serializerがbind済みの`Hamiltonian`を扱えるようになりました。演算子データを埋め込んだコンパイル済み`Block`、たとえばPauli Hamiltonianのリストにbindされた`Vector[Observable]`引数を`ParamSlot.bound_value`に保持しているものが、`dump_json` / `load_json`(およびmsgpackの対)を通っても、各Hamiltonianが同一のまま復元されるようになりました。既存のserializationエントリポイントを通じて動作し、Hamiltonianのペイロードは付加的なtagged-dict形式であるため、schemaのバージョンを上げる必要はありませんでした([#475](https://github.com/Jij-Inc/Qamomile/pull/475)、[#548](https://github.com/Jij-Inc/Qamomile/pull/548))。
+IR serializerがbind済みの`Hamiltonian`を扱えるようになりました。演算子データを埋め込んだコンパイル済み`Block`、たとえばPauli Hamiltonianのリストにbindした`Vector[Observable]`引数を`ParamSlot.bound_value`に保持しているものは、以前は`dump_json` / `load_json`(およびmsgpackの対)を通すと黙って情報を落としていましたが、本リリースで各Hamiltonianを同一のまま復元できるようになりました([#475](https://github.com/Jij-Inc/Qamomile/pull/475)、[#548](https://github.com/Jij-Inc/Qamomile/pull/548))。
 
 ```python
 import qamomile.circuit as qmc
@@ -134,19 +134,17 @@ print(slot.bound_value)
 [Hamiltonian((Z0,): 1.2), Hamiltonian((X0,): 0.8)]
 ```
 
-**Why**: 上記の項目とは異なり、これは辞書パラメータ機能の一部ではありません。演算子データを埋め込んだコンパイル済み量子カーネルにも可搬性を持たせるため、wire formatを拡張し、以前はそのような`Block`がround-tripに失敗していた問題を解消しました。
-
 ## バグ修正
 
-- **制御化した`qmc.pauli_evolve`がHamiltonianの定数項の大域位相を落とさなくなりました。** Hamiltonianの定数(恒等)項は大域位相`exp(-i·gamma·c)`に寄与しますが、emitterはこれを落としていました。単体の発展では観測できませんが、`qmc.control`下では、この位相が制御が有効な部分空間での実際の相対位相になるため、定数項を持つHamiltonianの制御化した発展が誤った結果を生んでいました。定数はQiskit([#471](https://github.com/Jij-Inc/Qamomile/pull/471)、[#547](https://github.com/Jij-Inc/Qamomile/pull/547))とCUDA-Q([#540](https://github.com/Jij-Inc/Qamomile/pull/540))で制御下でも再適用されるようになり、共有の制御化loweringにより制御化した`pauli_evolve`がQURI Partsで初めてトランスパイルできるようになりました([#537](https://github.com/Jij-Inc/Qamomile/pull/537))。実数でない定数は明確な`EmitError`を送出します。
+- **制御化した`qmc.pauli_evolve`がHamiltonianの定数項の大域位相を落とさなくなりました。** Hamiltonianの定数(恒等)項は大域位相`exp(-i·gamma·c)`に寄与しますが、今までemitterはこれを落としていました。単体の発展では観測できませんが、`qmc.control`下ではこの位相が制御が有効な部分空間での実際の相対位相になるため、定数項を持つHamiltonianの制御化した発展が誤った結果を生んでいました。定数をQiskit([#471](https://github.com/Jij-Inc/Qamomile/pull/471)、[#547](https://github.com/Jij-Inc/Qamomile/pull/547))とCUDA-Q([#540](https://github.com/Jij-Inc/Qamomile/pull/540))で制御下でも再適用するようになり、共有の制御化loweringにより制御化した`pauli_evolve`をQURI Partsでもトランスパイルできるようになりました([#537](https://github.com/Jij-Inc/Qamomile/pull/537))。実数でない定数は明確な`EmitError`を送出します。
 - **`Vector[Qubit]`全体を対象とする制御化した量子カーネルがすべての量子プログラミングSDKでemitできるようになりました。** 共有の制御化Uフォールバックは以前、内側の各ゲートを単一のtargetに割り当て、複数targetの内側ブロックや入れ子の制御化U操作を拒否していました。内側の各量子ビットを呼び出し側のtargetへ写像するようになり、制御化した多量子ビットの量子カーネル(modular算術のシフトなど)がQiskitと同様にQURI PartsとCUDA-Qでもトランスパイルできます([#472](https://github.com/Jij-Inc/Qamomile/pull/472))。
 - **symbolicな配列添字を制御量子ビットに持つ制御化ゲートが正しい配線を使うようになりました。** 制御がbindingで決まる配列要素(`q[control_index]`)のとき、新しい量子ビットを確保するのではなく、qubit mapを通じて物理量子ビットを解決するようになりました。以前は制御の位置がずれ、黙って誤った回路を生成していました([#541](https://github.com/Jij-Inc/Qamomile/pull/541))。
 - **Möttönenの振幅エンコーディング / 逆状態準備のwrapperが量子ビットを正しく配線します。** 逆状態準備wrapperの量子ビット解決の不具合が、誤った量子ビット配線を生んでいました([#465](https://github.com/Jij-Inc/Qamomile/pull/465))。
-- **ループunroll中の範囲外の配列添字を即座に失敗させます。** ループのunroll中に範囲外またはshapeの合わない配列添字に出会うと、黙って誤った回路を生成するのではなく、明確な`EmitError`を送出するようになりました([#477](https://github.com/Jij-Inc/Qamomile/pull/477))。
-- **`canonicalize`が古典パラメータのmanifestを保持します。** canonicalizeは以前`Block.param_slots`を落としていましたが、manifestが保たれるようになり、canonicalizeした`Block`のcontent hashとserializationがパラメータ契約を維持します([#476](https://github.com/Jij-Inc/Qamomile/pull/476))。
-- **配列要素から導かれる量子ビットのサイズ算出を修正しました。** リソースのサイズ算出がゼロサイズを保ち、非正および負の要素添字を拒否するようになり、誤った確保を生まなくなりました([#456](https://github.com/Jij-Inc/Qamomile/pull/456))。
-- **compositeのcast-carrierキーを正しく再写像します。** cast-carrierの参照がcanonicalize / inline / コンパイル時`if` loweringを通じて再写像されるようになり、symbolicにbindされたslice-view carrierでは早期に失敗します([#468](https://github.com/Jij-Inc/Qamomile/pull/468))。
-- **runtime parameterの添字から導かれるループ境界に明確な診断を出します。** runtime parameterの添字から導かれるループ境界が、不透明な下流の失敗ではなくsegmentation前に的確なエラーとして報告されるようになりました([#557](https://github.com/Jij-Inc/Qamomile/pull/557))。
+- **ループunroll中の範囲外の配列添字を即座に失敗させます。** ループのunroll中に範囲外またはshapeの合わない配列添字に出会うと、黙って誤った回路を生成するのではなく、明確な`EmitError`を送出します([#477](https://github.com/Jij-Inc/Qamomile/pull/477))。
+- **`canonicalize`が古典パラメータのmanifestを保持します。** canonicalizeは以前`Block.param_slots`を落としていましたが、これを保持するようになり、canonicalizeした`Block`のcontent hashやserializationがパラメータ契約を維持します([#476](https://github.com/Jij-Inc/Qamomile/pull/476))。
+- **古典配列の要素からQubit配列のサイズを決める場合も正しく解決します。** `qmc.qubit_array(sizes[i], ...)`のようにQubit配列の本数を古典配列(`Vector[UInt]`)の要素から決めるとき、以前はサイズを取り違えて誤った本数の量子ビットを確保することがありました。今はスライスや添字を経由した要素も正しくサイズとして解決し、サイズ0の配列も維持します。負のサイズや未対応の負の添字などの不正な指定は、明確なエラーで拒否します([#456](https://github.com/Jij-Inc/Qamomile/pull/456))。
+- **`qmc.cast`で作った`QFixed`値が、IR変換を通しても正しい量子ビットを指し続けます。** `qmc.cast(q, qmc.QFixed, ...)`は`Vector[Qubit]`を固定小数点として読み替え、そのcastはどの量子ビットを束ねているかを内部で覚えています。以前はカーネルのinlineやcanonicalize、コンパイル時`if`の解決を通すとこの対応付けを更新できず、別の量子ビットを指してしまうことがありました。今はこれらの変換を通しても正しい量子ビットを指し続けます([#468](https://github.com/Jij-Inc/Qamomile/pull/468))。
+- **runtime parameterからループ回数を決めようとした場合に、明確なエラーを出します。** `qmc.range(...)`の回数は、ループをunrollするためにコンパイル時に確定している必要があります。実行時にしか値が決まらないruntime parameter(やその配列要素)を回数に使うと、以前は分かりにくい別のエラーで失敗していました。今は「その値を`bindings`で与えてください」と促す明確なエラーを、トランスパイルの早い段階で出します([#557](https://github.com/Jij-Inc/Qamomile/pull/557))。
 
 ## ドキュメント
 

--- a/docs/ja/release_notes/v0_12_7.md
+++ b/docs/ja/release_notes/v0_12_7.md
@@ -1,0 +1,141 @@
+# Qamomile v0.12.7
+
+Qamomile v0.12.7では、係数のPython辞書を`@qkernel`のruntime parameterとして渡し、量子カーネル内でループ変数によって添字参照できるようになりました。量子カーネル内では`angles[i]`のように書け、実行ごとに別の値でbindし直せます。あわせて`UInt`ハンドルに`%`演算子を追加しました。さらに本リリースでは、これまでトランスパイルは通るもののPythonソースと一致しない回路を生成していた一群のプログラムを、トランスパイル時に専用の例外で明示的に拒否するようにしました。対象は、runtimeの`if`やループ本体で量子ビットの状態を破棄する、ループ反復をまたいで古典アキュムレータを更新する、同じレジスタを量子カーネル呼び出しの2つの引数にaliasする、型やshapeの合わない引数を渡す、多次元の量子レジスタを確保する、といったパターンです。制御化した`qmc.pauli_evolve`は、Qiskit・QURI Parts・CUDA-Qのいずれでも一貫して正しい結果を返すようになり、定数項を持つHamiltonianでも正しくなりました。QURI Partsでは今回初めて動作します。内部的には、IR serializerがbind済みの`Hamiltonian`をround-tripできるようになり、演算子データを含むコンパイル済み量子カーネルも`dump_json` / `load_json`を通して保持されます。
+
+```
+pip install qamomile==0.12.7
+```
+
+## 破壊的変更
+
+本リリースでは、これまで*コンパイルは通る*もののソースと一致しない回路、すなわちsilentなmiscompileや不透明なバックエンドのクラッシュを生んでいたプログラムを拒否するコンパイル時チェックを追加しました。以下の各パターンは、トランスパイル時に専用の名前付き例外を送出します。該当するコードがある場合、以前生成されていた回路はすでに誤っており、例外がどの構文を書き直すべきかを正確に示します。
+
+- **runtimeの分岐やループ本体で量子ビットの状態を捨てると`QubitRebindError`を送出します。** 量子変数を新しく確保した量子ビットへbindし直すと、分岐前の状態が診断なしに破棄されていました。`if`については、測定由来(runtime)の条件に対してチェックが適用されます。`for` / `while`ループについては、ループが反復ごとの量子再bindを表現できないため、反復回数に関係なく、すべてのループ本体に適用されます([#561](https://github.com/Jij-Inc/Qamomile/pull/561))。
+
+  ```python
+  @qmc.qkernel
+  def kernel() -> qmc.Bit:
+      q = qmc.qubit("q")
+      p = qmc.qubit("p")
+      cond = qmc.measure(p)
+      if cond:
+          q = qmc.qubit("fresh")   # QubitRebindError: qの分岐前の状態を破棄している
+      return qmc.measure(q)
+  ```
+
+- **ループ反復をまたいで古典スカラーを更新すると`ValidationError`を送出します。** `@qkernel`の`for`本体は一度だけトレースされるため、ループをまたぐアキュムレータ(`total = total + i`)は右辺がループ前の値に固定され、Pythonの意味論から乖離していました([#552](https://github.com/Jij-Inc/Qamomile/pull/552))。
+
+- **ループ内で同じ配列の別要素を読む古典配列要素の代入は`ValidationError`を送出します。** ループ内の`arr[i] = arr[i - 1]`は`arr`のループ前の固定バージョンを読むため、それより前の反復での書き込みを一切観測しませんでした([#545](https://github.com/Jij-Inc/Qamomile/pull/545))。
+
+- **多次元の量子レジスタは事前に拒否するようになりました。** `qmc.qubit_array((2, 3), ...)`などのrank2以上の量子形状は、以前は`Matrix[Qubit]` / `Tensor[Qubit]`を返すように見えていましたが、後段で誤った回路を生成したり、不透明な形でクラッシュしたりしていました。量子ビットのアドレッシング経路はrank1であるため、確保時に`NotImplementedError`(rank2のレジスタがemitまで到達した場合は`EmitError`)を送出します。古典の`Matrix` / `Tensor`引数は影響を受けません([#558](https://github.com/Jij-Inc/Qamomile/pull/558))。
+
+- **型やshapeの合わないカーネル引数を渡すと`TypeError`を送出します。** スカラーの`Qubit`を`Vector[Qubit]`パラメータに渡すと、以前はサイズ算出の深い箇所から`AttributeError`が漏れていました。また、`Qubit`を`Float`パラメータに渡すと、警告なしに`rx(0)`を生成していました。引数ハンドルは、通常のカーネル呼び出し・`qmc.control`・`qmc.inverse`のいずれの呼び出し箇所でも、宣言されたパラメータ型に対して検証されるようになりました([#473](https://github.com/Jij-Inc/Qamomile/pull/473))。
+
+- **plainなintが必要な箇所にPythonの`bool`を渡すと`TypeError`を送出します。** `bool`は`int`のサブクラスであるため、`q[True]`、`q[False:2]`、`qmc.uint(True)`は添字・境界・サイズの`1` / `0`として黙って受理されていました。配列の添字、slice境界、`qmc.uint`は`bool`を拒否するようになりました([#539](https://github.com/Jij-Inc/Qamomile/pull/539))。
+
+- **同じ量子レジスタをカーネル呼び出しの2つの引数にaliasすると`QubitConsumedError`を送出します。** `sub(qs, qs)`のような呼び出し、あるいは重なり合うviewを渡すと、両方の仮引数レジスタが同じ物理量子ビットに写像され、miscompileするかバックエンドの生の`duplicate qubit`エラーとして後から表面化していました。affine type checkerが呼び出し箇所でaliasを拒否するようになりました([#543](https://github.com/Jij-Inc/Qamomile/pull/543))。
+
+## 新機能
+
+### 辞書の係数をruntime parameterとして扱う
+
+`Dict[K, Float]`のカーネル引数を**runtime parameter**として保持し、カーネル内でキーによって添字参照できるようになりました。`qmc.range` / `qmc.items`のループ変数によるアクセスも可能です。参照された各キーは`"<dict>[<key>]"`という名前のバックエンドパラメータ(例: `angles[0]`、`coeffs[(0, 1)]`)になるため、同じコンパイル済みexecutableを、実行ごとに別の辞書値でbindし直せます。引数を`parameters=[...]`に列挙して宣言します。辞書を`bindings`にも`parameters`にも入れなければ、従来どおりコンパイル時の挙動になります。キーは単一の要素でも、要素ごとに突き合わせるタプル`d[(i, j)]`でも構いません。symbolicなキー要素は`UInt`ハンドルである必要があり、コンパイル時にbindされた辞書に対して完全に定数のキーは定数へ畳み込まれます([#556](https://github.com/Jij-Inc/Qamomile/pull/556)、[#562](https://github.com/Jij-Inc/Qamomile/pull/562))。
+
+```python
+import numpy as np
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def rx_by_dict(n: qmc.UInt, angles: qmc.Dict[qmc.UInt, qmc.Float]) -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(n, name="q")
+    for i in qmc.range(n):
+        q[i] = qmc.rx(q[i], angle=angles[i])   # runtime parameterの辞書を添字で参照する
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(rx_by_dict, bindings={"n": 3}, parameters=["angles"])
+# executable.parameter_names -> ['angles[0]', 'angles[1]', 'angles[2]']
+# 実行ごとに辞書を再bindする:
+#   executable.sample(transpiler.executor(), shots=256,
+#                     bindings={"angles": {0: np.pi, 1: 0.0, 2: np.pi}})
+```
+
+### `UInt`のmodulo演算子
+
+`UInt`ハンドルが`%`演算子(および`int % UInt`)をサポートするようになり、すでに`+ - * / // **`で利用できた古典的な添字演算が揃いました。これにより`qmc.range`ループ内の`i % 2`のような添字式が、トレース時に`TypeError`を送出することなく直接コンパイルできます([#466](https://github.com/Jij-Inc/Qamomile/pull/466))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def even_indices() -> qmc.Vector[qmc.Bit]:
+    q = qmc.qubit_array(4, name="q")
+    for i in qmc.range(4):
+        if i % 2 == 0:            # ループ変数でmoduloを使う
+            q[i] = qmc.x(q[i])
+    return qmc.measure(q)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(even_indices)
+```
+
+```text
+[((1, 0, 1, 0), 256)]
+```
+
+## 内部的な変更
+
+### Hamiltonianのserialization round-trip
+
+IR serializerがbind済みの`Hamiltonian`を扱えるようになりました。演算子データを埋め込んだコンパイル済み`Block`、たとえばPauli Hamiltonianのリストにbindされた`Vector[Observable]`引数を`ParamSlot.bound_value`に保持しているものが、`dump_json` / `load_json`(およびmsgpackの対)を通っても、Hamiltonian単位で同一のまま戻ってくるようになりました。既存のserializationエントリポイントを通じて動作し、Hamiltonianのペイロードは付加的なtagged-dict形式であるため、schemaのバージョンを上げる必要はありませんでした([#475](https://github.com/Jij-Inc/Qamomile/pull/475)、[#548](https://github.com/Jij-Inc/Qamomile/pull/548))。
+
+```python
+import qamomile.circuit as qmc
+import qamomile.observable as qm_o
+from qamomile.circuit.transpiler.passes.inline import InlinePass
+from qamomile.circuit.ir.serialize import dump_json, load_json
+
+@qmc.qkernel
+def trotter(q: qmc.Vector[qmc.Qubit], hs: qmc.Vector[qmc.Observable], t: qmc.Float) -> qmc.Vector[qmc.Bit]:
+    for i in qmc.range(hs.shape[0]):
+        q = qmc.pauli_evolve(q, hs[i], t)
+    return qmc.measure(q)
+
+hamiltonians = [1.2 * qm_o.Z(0), 0.8 * qm_o.X(0)]
+block = InlinePass().run(trotter.build(hs=hamiltonians, parameters=["t"]))
+restored = load_json(dump_json(block))
+slot = next(s for s in restored.param_slots if s.name == "hs")
+print(slot.bound_value)
+```
+
+```text
+[Hamiltonian((Z0,): 1.2), Hamiltonian((X0,): 0.8)]
+```
+
+**Why**: 上記の項目とは異なり、これは辞書パラメータ機能の一部ではありません。演算子データを埋め込んだコンパイル済み量子カーネルにも可搬性を持たせるため、wire formatを拡張し、以前はそのような`Block`がround-tripに失敗していた問題を解消します。
+
+## バグ修正
+
+- **制御化した`qmc.pauli_evolve`がSDK間で一貫して正しくなりました。** Hamiltonianの定数(恒等)項は大域位相に寄与しますが、共有のPauli-gadget emitterがこれを落としていました。`qmc.control`のもとではこの位相が制御onの部分空間での観測可能な相対位相になるため、定数項を持つHamiltonianの制御化した発展が誤った結果を返していました。定数はQiskitのフォールバック経路([#547](https://github.com/Jij-Inc/Qamomile/pull/547))とCUDA-Q([#540](https://github.com/Jij-Inc/Qamomile/pull/540))で制御化した位相として再適用されるようになり、共有の制御化loweringにより制御化した`pauli_evolve`がQURI Partsで初めてトランスパイルできるようになりました([#537](https://github.com/Jij-Inc/Qamomile/pull/537))。実数でない定数はどの経路でも明確な`EmitError`を送出します。
+- **ターゲットレジスタより小さいHamiltonianは、恒等演算で正しくパディングされます。** レジスタより少ない量子ビットに作用するHamiltonianを渡した`qmc.pauli_evolve`が、QiskitとCUDA-Qで正しくemitされるようになり、0量子ビット(定数のみ)のHamiltonianはQiskitの大域位相としてemitされます([#471](https://github.com/Jij-Inc/Qamomile/pull/471))。
+- **`Vector[Qubit]`全体を対象とする制御化した量子カーネルがすべてのSDKでemitできるようになりました。** 共有の制御化Uフォールバックは以前、内側の各ゲートを単一のターゲットに回し、複数ターゲットの内側ブロックや入れ子の制御化U操作を拒否していました。内側の各量子ビットを呼び出し側の物理ターゲットへ写像するようになり、制御化した多量子ビットのサブカーネル(modular算術のシフトなど)がQiskitと同様にQURI PartsとCUDA-Qでもトランスパイルできます([#472](https://github.com/Jij-Inc/Qamomile/pull/472))。
+- **symbolicな配列添字を制御量子ビットに持つ制御化ゲートが正しいワイヤーを確保します。** 制御がbindingで決まる配列要素(`q[control_index]`)のとき、新しい量子ビットを確保するのではなく、qubit mapを通じて物理量子ビットを解決するようになりました。以前は制御の位置がずれ、黙って誤った回路を生成していました([#541](https://github.com/Jij-Inc/Qamomile/pull/541))。
+- **Möttönenの振幅エンコーディング / 逆状態準備のwrapperが量子ビットを正しく配線します。** 逆状態準備wrapperの量子ビット解決の不具合が、誤った量子ビット配線を生んでいました([#465](https://github.com/Jij-Inc/Qamomile/pull/465))。
+- **ループunroll中の範囲外の配列添字を即座に失敗させます。** ループのunroll中に範囲外またはshapeの合わない配列添字に出会うと、黙って誤った回路を生成するのではなく、明確な`EmitError`を送出するようになりました([#477](https://github.com/Jij-Inc/Qamomile/pull/477))。
+- **`canonicalize`が古典パラメータのmanifestを保持します。** canonicalizeは以前`Block.param_slots`を落としていましたが、manifestが保たれるようになり、canonicalizeした`Block`のcontent hashとserializationがパラメータ契約を維持します([#476](https://github.com/Jij-Inc/Qamomile/pull/476))。
+- **配列要素から導かれる量子ビットのサイズ算出を修正しました。** リソースのサイズ算出がゼロサイズを保ち、非正および負の要素添字を拒否するようになり、誤った確保を生まなくなりました([#456](https://github.com/Jij-Inc/Qamomile/pull/456))。
+- **compositeのcast-carrierキーを正しく再写像します。** cast-carrierの参照がcanonicalize / inline / コンパイル時`if` loweringを通じて再写像されるようになり、symbolicにbindされたslice-viewのcarrierでは即座に失敗します([#468](https://github.com/Jij-Inc/Qamomile/pull/468))。
+- **runtime parameterの添字から導かれるループ境界に明確な診断を出します。** runtime parameterの添字から導かれるループ境界が、不透明な下流の失敗ではなくsegmentation前に的確なエラーとして報告されるようになりました([#557](https://github.com/Jij-Inc/Qamomile/pull/557))。
+
+## ドキュメント
+
+- [**多次元量子フーリエ変換によるナノシート材料物性の推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/algorithm/multidimensional_qft.ipynb) — 多次元QFTを材料科学の推定問題に適用する新しいアルゴリズム記事です([#405](https://github.com/Jij-Inc/Qamomile/pull/405))。
+- [**CUDA-Q Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/cudaq_support.ipynb) — QamomileのカーネルをCUDA-Qバックエンドでトランスパイル・実行するための新しい統合ページです([#440](https://github.com/Jij-Inc/Qamomile/pull/440))。
+- [**Qiskit Support**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/integration/qiskit_support.ipynb) — Qiskitバックエンド向けの新しい統合ページです([#464](https://github.com/Jij-Inc/Qamomile/pull/464))。
+- ドキュメントサイトを再設計し、ランディングページとカードのメタデータを刷新し、新しい[**インストール**](https://github.com/Jij-Inc/Qamomile/blob/v0.12.7/docs/ja/installation_guide.md)ガイドを追加しました([#461](https://github.com/Jij-Inc/Qamomile/pull/461))。
+
+## さらに詳しく
+
+- [GitHubリポジトリ](https://github.com/Jij-Inc/Qamomile)


### PR DESCRIPTION
## Summary

Adds the EN/JA release notes for the upcoming `v0.12.7` tag, covering everything on `main` since `v0.12.6`, written from the user's point of view.

**New Features**
- `Dict[K, Float]` kernel arguments can be kept as runtime parameters and indexed inside a kernel (`angles[i]`), each key becoming a `"<dict>[<key>]"` backend parameter re-bindable per execution (#556, #562).
- `%` (modulo) operator on `UInt` handles (#466).

**Breaking Changes** — a batch of new compile-time errors that reject programs which previously compiled into subtly wrong circuits (silent miscompiles / opaque backend crashes):
- `QubitRebindError` on discarding a qubit's state inside a branch / loop body (#561)
- `ValidationError` on loop-carried classical scalar updates (#552) and self-referential in-loop element stores (#545)
- `NotImplementedError` / `EmitError` on multi-dimensional quantum registers (#558)
- `TypeError` on argument type/shape mismatch (#473) and `bool` where a plain int is required (#539)
- `QubitConsumedError` on aliasing the same register into two kernel arguments (#543)

**Internal Changes**
- IR serializer now round-trips bound `Hamiltonian`s through `dump_json` / `load_json` (#475, #548).

**Bug Fixes**
- Controlled `pauli_evolve` constant-phase correctness across Qiskit / QURI Parts / CUDA-Q, incl. constant-offset Hamiltonians, and controlled `pauli_evolve` now works on QURI Parts (#537, #540, #547, #471); multi-target / symbolic-index controlled-U emission (#472, #541); plus #477, #476, #456, #468, #465, #557.

**Documentation**
- New multidimensional-QFT algorithm article (#405), CUDA-Q / Qiskit integration pages (#440, #464), and the site redesign + installation guide (#461).

## Verification

- Every New-Features / Internal-Changes snippet verified end-to-end via `QiskitTranspiler().transpile(...)` + `sample()`.
- Every Breaking-Changes snippet verified to raise its named exception.
- Technical claims cross-checked against the code with a read-only pass; one wording fix applied (the loop-body quantum-discard check is trip-count-agnostic, unlike the measurement-driven `if` check).
- JA prose reviewed for naturalness against the EN source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)