### PR TITLE
Give each sub-kernel call site fresh result Values

### DIFF
--- a/qamomile/circuit/ir/block.py
+++ b/qamomile/circuit/ir/block.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import uuid
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
@@ -85,7 +86,36 @@ class Block:
         return self.kind in (BlockKind.AFFINE, BlockKind.ANALYZED)
 
     def call(self, **kwargs: Value) -> "CallBlockOperation":
-        """Create a CallBlockOperation against this block."""
+        """Create a CallBlockOperation against this block.
+
+        SSA contract: every result Value is unique to the call site. A
+        pass-through output (one whose ``logical_id`` matches a block
+        input, i.e. the callee returns an argument it received)
+        continues the caller argument's wire via ``next_version()`` —
+        fresh ``uuid``, caller's ``logical_id``. A non-pass-through
+        output (a value created inside the callee) is re-issued with a
+        fresh ``uuid`` **and** a fresh ``logical_id``: it is a new
+        logical variable in the caller's scope, matching the fresh
+        identities ``UUIDRemapper`` assigns to the callee's internals
+        when the call is inlined. Returning the callee's output Value
+        verbatim would make every call site of this block share one SSA
+        identity, so downstream consumers (inline value mapping, block
+        outputs, clbit allocation) would silently collapse the results
+        of repeated calls onto the last call.
+
+        Args:
+            **kwargs (Value): Call arguments keyed by this block's
+                ``label_args`` names. Every label must be present.
+
+        Returns:
+            CallBlockOperation: Call operation whose ``operands`` follow
+                ``label_args`` order and whose ``results`` are
+                call-site-unique Values mirroring ``output_values``.
+
+        Raises:
+            KeyError: If a name in ``label_args`` is missing from
+                ``kwargs``.
+        """
         from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
 
         inputs = [kwargs[label] for label in self.label_args]
@@ -97,7 +127,16 @@ class Block:
                 input_idx = dummy_inputs[dummy_return.logical_id]
                 results.append(inputs[input_idx].next_version())
             else:
-                results.append(dummy_return)
+                # dataclasses.replace keeps every other field (type,
+                # shape, slice metadata, ...) for Value and ArrayValue
+                # alike, unlike the per-class next_version() overrides.
+                results.append(
+                    dataclasses.replace(
+                        dummy_return,
+                        uuid=str(uuid.uuid4()),
+                        logical_id=str(uuid.uuid4()),
+                    )
+                )
 
         return CallBlockOperation(
             block=self,

--- a/qamomile/circuit/visualization/analyzer.py
+++ b/qamomile/circuit/visualization/analyzer.py
@@ -367,9 +367,10 @@ class CircuitAnalyzer:
 
             For QInitOperation, registers new qubits (scalar or array elements).
             For CallBlockOperation (inline=True), builds a logical_id_remap from
-            block formal parameters to actual arguments, then recurses into the
-            block body. For CastOperation, propagates the source qubit's wire
-            index to the cast result.
+            block formal parameters to actual arguments, recurses into the
+            block body, then aliases each call-site-unique result Value to
+            the wire of the callee output it mirrors. For CastOperation,
+            propagates the source qubit's wire index to the cast result.
 
             GateOperation and similar are no-ops because next_version() preserves
             logical_id.
@@ -570,6 +571,45 @@ class CircuitAnalyzer:
                             depth + 1,
                             child_param_values,
                         )
+
+                        # ``Block.call`` issues call-site-unique result
+                        # Values, so a non-pass-through result's
+                        # logical_id never appears in the callee body
+                        # walked above. Alias each result to the wire of
+                        # the callee output it mirrors so downstream
+                        # caller ops (and the fresh-return loop below)
+                        # resolve to the body's wires instead of
+                        # allocating phantom ones.
+                        for dummy_output, call_result in zip(
+                            block_value.output_values, op.results
+                        ):
+                            if not isinstance(call_result.type, QubitType):
+                                continue
+                            if call_result.logical_id in qubit_map:
+                                continue
+                            source_lid = self._resolve_array_element_lid(
+                                dummy_output,
+                                qubit_map,
+                                new_remap,
+                                child_param_values,
+                            )
+                            wire_idx = qubit_map.get(source_lid)
+                            if wire_idx is None:
+                                continue
+                            qubit_map[call_result.logical_id] = wire_idx
+                            if isinstance(dummy_output, ArrayValue) and isinstance(
+                                call_result, ArrayValue
+                            ):
+                                prefix = f"{source_lid}_["
+                                prefix_len = len(prefix)
+                                for key, idx in list(qubit_map.items()):
+                                    if key.startswith(prefix) and key.endswith("]"):
+                                        new_key = (
+                                            f"{call_result.logical_id}_"
+                                            f"[{key[prefix_len:]}"
+                                        )
+                                        if new_key not in qubit_map:
+                                            qubit_map[new_key] = idx
 
                     qubit_operands = [
                         v for v in op.operands if isinstance(v.type, QubitType)

--- a/tests/circuit/test_composite_gate.py
+++ b/tests/circuit/test_composite_gate.py
@@ -1121,7 +1121,13 @@ class TestNestedQKernelNoPhantomQubits:
         assert qc.num_qubits == 4, f"Expected 4 qubits, got {qc.num_qubits}"
 
     def test_same_qkernel_called_twice(self, qiskit_transpiler):
-        """No phantom qubits when same qkernel is called twice on same array."""
+        """No phantom qubits when same qkernel is called twice on same array.
+
+        Also pins the ``Block.call`` SSA contract (issue #563): the two
+        call sites must not share result Value identities, even for
+        pass-through outputs.
+        """
+        from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
 
         @qkernel
         def apply_h_first(qs: Vector[Qubit]) -> Vector[Qubit]:
@@ -1134,6 +1140,11 @@ class TestNestedQKernelNoPhantomQubits:
             qs = apply_h_first(qs)
             qs = apply_h_first(qs)
             return qmc.measure(qs)
+
+        block = call_twice.build()
+        call_ops = [op for op in block.operations if isinstance(op, CallBlockOperation)]
+        assert len(call_ops) == 2
+        assert call_ops[0].results[0].uuid != call_ops[1].results[0].uuid
 
         qc = qiskit_transpiler.to_circuit(call_twice)
         assert qc.num_qubits == 3, f"Expected 3 qubits, got {qc.num_qubits}"

--- a/tests/circuit/test_subkernel_call_results.py
+++ b/tests/circuit/test_subkernel_call_results.py
@@ -1,0 +1,121 @@
+"""Regression tests for call-site-unique sub-kernel result Values (issue #563).
+
+``Block.call`` used to return the callee block's cached output Value
+instance for non-pass-through outputs, so every call site of the same
+sub-kernel shared one result UUID. With a Bit-returning sub-kernel both
+measurements collapsed onto a single clbit and always agreed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import qamomile.circuit as qmc
+from qamomile.circuit.frontend.constructors import qubit_array
+from qamomile.circuit.frontend.qkernel import QKernel
+from qamomile.circuit.ir.operation.call_block_ops import CallBlockOperation
+
+
+@qmc.qkernel
+def measure_one(q: qmc.Qubit) -> qmc.Bit:
+    """Measure a single qubit inside a sub-kernel."""
+    return qmc.measure(q)
+
+
+@qmc.qkernel
+def double_call() -> tuple[qmc.Bit, qmc.Bit]:
+    """Call the same Bit-returning sub-kernel at two call sites."""
+    q0 = qmc.qubit("q0")
+    q1 = qmc.qubit("q1")
+    q1 = qmc.x(q1)
+    b0 = measure_one(q0)
+    b1 = measure_one(q1)
+    return b0, b1
+
+
+@qmc.qkernel
+def measure_pair(qs: qmc.Vector[qmc.Qubit]) -> qmc.Vector[qmc.Bit]:
+    """Measure a two-qubit register inside a sub-kernel."""
+    return qmc.measure(qs)
+
+
+@qmc.qkernel
+def double_call_vector() -> tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]:
+    """Call the same Vector[Bit]-returning sub-kernel at two call sites."""
+    a = qubit_array(2, "a")
+    b = qubit_array(2, "b")
+    b[0] = qmc.x(b[0])
+    r0 = measure_pair(a)
+    r1 = measure_pair(b)
+    return r0, r1
+
+
+def _call_ops(kernel: QKernel[Any, Any]) -> list[CallBlockOperation]:
+    """Collect top-level CallBlockOperations from a kernel's traced block.
+
+    Args:
+        kernel (QKernel[Any, Any]): A qkernel whose built block is inspected.
+
+    Returns:
+        list[CallBlockOperation]: Call operations in program order.
+    """
+    block = kernel.build()
+    return [op for op in block.operations if isinstance(op, CallBlockOperation)]
+
+
+class TestSubkernelCallSiteResults:
+    """Each call site of a sub-kernel owns fresh result Value identities."""
+
+    def test_subkernel_double_call_distinct_results(self):
+        """Two calls to one Bit-returning sub-kernel get distinct result Values."""
+        call_ops = _call_ops(double_call)
+        assert len(call_ops) == 2
+        first, second = (op.results[0] for op in call_ops)
+        assert first.uuid != second.uuid
+        assert first.logical_id != second.logical_id
+
+    def test_subkernel_double_call_vector_distinct_results(self):
+        """Two calls returning Vector[Bit] get distinct results with shape intact."""
+        call_ops = _call_ops(double_call_vector)
+        assert len(call_ops) == 2
+        first, second = (op.results[0] for op in call_ops)
+        assert first.uuid != second.uuid
+        assert first.logical_id != second.logical_id
+        assert first.shape and second.shape
+
+    def test_call_results_do_not_alias_callee_outputs(self):
+        """Call results never reuse the callee block's cached output instances."""
+        call_ops = _call_ops(double_call)
+        callee_output_uuids = {
+            v.uuid for op in call_ops for v in op.block.output_values
+        }
+        for op in call_ops:
+            assert op.results[0].uuid not in callee_output_uuids
+
+    def test_subkernel_double_call_two_clbits(self, qiskit_transpiler):
+        """The transpiled circuit allocates one clbit per call site."""
+        qc = qiskit_transpiler.to_circuit(double_call)
+        assert qc.num_clbits == 2, f"Expected 2 clbits, got {qc.num_clbits}"
+
+    def test_subkernel_double_call_independent_measurements(self, sdk_transpiler):
+        """X applied to one qubit flips only that call site's measurement."""
+        transpiler = sdk_transpiler.transpiler
+        executable = transpiler.transpile(double_call)
+        result = executable.sample(transpiler.executor(), shots=128).result()
+
+        assert result.results == [((False, True), 128)]
+
+    def test_subkernel_double_call_vector_independent_measurements(
+        self, sdk_transpiler
+    ):
+        """Register-returning sub-kernel calls measure their own registers."""
+        transpiler = sdk_transpiler.transpiler
+        executable = transpiler.transpile(double_call_vector)
+        result = executable.sample(transpiler.executor(), shots=128).result()
+
+        assert len(result.results) == 1
+        (outputs, count) = result.results[0]
+        r0, r1 = outputs
+        assert count == 128
+        assert tuple(bool(bit) for bit in r0) == (False, False)
+        assert tuple(bool(bit) for bit in r1) == (True, False)


### PR DESCRIPTION
## Summary

`Block.call` returned the callee block's cached output `Value` instance for non-pass-through outputs, so every call site of the same sub-kernel shared one result UUID. Calling a `Bit`-returning sub-kernel twice made both measurements collapse onto a single clbit — the two results were always identical, with no error raised (issue #563, a silent miscompilation).

## Fix

- **`Block.call`** (`qamomile/circuit/ir/block.py`): non-pass-through results are re-issued with a fresh `uuid` **and** a fresh `logical_id` via `dataclasses.replace`, which preserves every other field (type, shape, slice metadata) for `Value` and `ArrayValue` alike. A call result is a new logical variable in the caller's scope — this matches the fresh identities `UUIDRemapper` assigns to the callee's internals at inline time, and the fresh Values the self-recursive forward-ref path (`_emit_self_call_forward_ref`) already emits. Pass-through outputs keep the existing behavior (`next_version()` on the caller argument, continuing its wire). The SSA contract is documented on `Block.call`.
- **Visualization analyzer** (`qamomile/circuit/visualization/analyzer.py`): the inline walk implicitly relied on the old aliasing — it registered callee-internal wires under the callee output's `logical_id`, which used to double as the call result's. It now aliases each call result to the resolved callee output wire explicitly, so downstream caller ops resolve to body wires instead of allocating phantom ones (caught by `test_drawer_inline_depth.py`).

Consumers verified unaffected: the inline pass maps call results by explicit UUID lookup (`value_map[call_result.uuid]`), `inverse()` builds an explicit `block_output.uuid -> call_result` map, and the estimator's resolver scopes callees separately without back-propagating results.

## Tests

- New `tests/circuit/test_subkernel_call_results.py`:
  - IR-level: two `CallBlockOperation.results` have distinct `uuid` / `logical_id`, and never alias the callee's cached output instances (fails before the fix).
  - Execution: two clbits after transpile; `X` applied to one qubit flips only that call site's bit, sampled deterministically on all three backends (Qiskit / QURI Parts / CUDA-Q via the `sdk_transpiler` fixture; fails before the fix with both bits collapsed).
  - A `Vector[Bit]`-returning variant covering the `ArrayValue` branch (shape preserved through the fresh identity).
- `test_same_qkernel_called_twice` (`tests/circuit/test_composite_gate.py`) now also pins UUID distinctness for pass-through results.

## Verification

- `uv run pytest tests/` — 9438 passed (before review-fix amend; targeted suites re-run green after).
- `uv run pytest -m quri_parts tests/` — 1273 passed; `uv run pytest -m cudaq tests/` — 1228 passed, 48 xfailed.
- `uv run ruff check` / `ruff format --check` / `zuban check` — clean.
- `/local-review` — clean (mechanical checks pass; findings during review were fixed in place: docstring types on the test helper, drawer docstring sync, formatting).

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)