### PR TITLE
docs: update tutorial 10 for if-merge yield storage and merge terminology

### DIFF
--- a/docs/en/tutorial/10_compilation_and_transpilation.ipynb
+++ b/docs/en/tutorial/10_compilation_and_transpilation.ipynb
@@ -33,10 +33,10 @@
    "id": "cb91f013",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.911333Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.911167Z",
-     "iopub.status.idle": "2026-05-26T07:49:11.915330Z",
-     "shell.execute_reply": "2026-05-26T07:49:11.914742Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.409641Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.409576Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.412125Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.411774Z"
     }
    },
    "outputs": [],
@@ -181,10 +181,10 @@
    "id": "420e66e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.917442Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.917320Z",
-     "iopub.status.idle": "2026-05-26T07:49:11.987470Z",
-     "shell.execute_reply": "2026-05-26T07:49:11.987116Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.413424Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.413367Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.569852Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.569454Z"
     }
    },
    "outputs": [],
@@ -222,10 +222,10 @@
    "id": "f68d805e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.988587Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.988520Z",
-     "iopub.status.idle": "2026-05-26T07:49:11.992194Z",
-     "shell.execute_reply": "2026-05-26T07:49:11.991949Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.571227Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.571151Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.574528Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.574310Z"
     },
     "lines_to_next_cell": 2
    },
@@ -268,10 +268,10 @@
    "id": "cd9bf519",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.993178Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.993123Z",
-     "iopub.status.idle": "2026-05-26T07:49:11.994780Z",
-     "shell.execute_reply": "2026-05-26T07:49:11.994512Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.575650Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.575604Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.577162Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.576892Z"
     }
    },
    "outputs": [],
@@ -326,10 +326,10 @@
    "id": "d7351415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.995667Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.995626Z",
-     "iopub.status.idle": "2026-05-26T07:49:11.998337Z",
-     "shell.execute_reply": "2026-05-26T07:49:11.998049Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.578043Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.578003Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.580703Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.580400Z"
     }
    },
    "outputs": [
@@ -376,10 +376,10 @@
    "id": "dcc33a31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:11.999195Z",
-     "iopub.status.busy": "2026-05-26T07:49:11.999154Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.000638Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.000357Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.581597Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.581555Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.583033Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.582737Z"
     }
    },
    "outputs": [
@@ -424,10 +424,10 @@
    "id": "d13b87fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.001450Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.001402Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.002903Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.002576Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.583896Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.583854Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.585273Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.585016Z"
     }
    },
    "outputs": [
@@ -485,10 +485,10 @@
    "id": "dfde6ac2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.003752Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.003711Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.006004Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.005791Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.586130Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.586094Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.588706Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.588378Z"
     }
    },
    "outputs": [
@@ -539,10 +539,10 @@
    "id": "4e6af020",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.006909Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.006861Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.008298Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.007999Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.589561Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.589523Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.590939Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.590614Z"
     }
    },
    "outputs": [
@@ -612,10 +612,10 @@
    "id": "4a180a21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.009045Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.009001Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.010803Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.010518Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.591672Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.591639Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.594318Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.594026Z"
     }
    },
    "outputs": [
@@ -667,7 +667,7 @@
     "This rule **does not forbid dynamic quantum circuits**: `IfOperation` and\n",
     "`WhileOperation` are `OperationKind.CONTROL`, not QUANTUM, so control flow\n",
     "conditioned on a measurement `Bit` (`if bit: ...`, `while bit: ...`)\n",
-    "passes the check. Quantum-typed values that survive a phi merge are also\n",
+    "passes the check. Quantum-typed values that survive an if-merge are also\n",
     "explicitly exempt. Section 5 walks through which dynamic patterns are\n",
     "allowed and which are rejected, with code examples.\n",
     "\n",
@@ -680,10 +680,10 @@
    "id": "bcdd3492",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.011638Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.011591Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.013140Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.012903Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.595099Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.595067Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.597276Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.596977Z"
     }
    },
    "outputs": [
@@ -720,10 +720,10 @@
    "id": "b6be1bb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.013921Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.013880Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.015540Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.015250Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.598038Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.597998Z",
+     "iopub.status.idle": "2026-07-09T08:19:52.600443Z",
+     "shell.execute_reply": "2026-07-09T08:19:52.600190Z"
     }
    },
    "outputs": [
@@ -772,10 +772,10 @@
    "id": "7530895b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.016301Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.016269Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.104243Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.104007Z"
+     "iopub.execute_input": "2026-07-09T08:19:52.601413Z",
+     "iopub.status.busy": "2026-07-09T08:19:52.601362Z",
+     "iopub.status.idle": "2026-07-09T08:19:55.360981Z",
+     "shell.execute_reply": "2026-07-09T08:19:55.360191Z"
     }
    },
    "outputs": [
@@ -912,15 +912,18 @@
     "|-----------|-------------|--------------------|-------|\n",
     "| `ForOperation` | `operations` (body) | `operands = [start, stop, step]` (all `UInt`) | carries `loop_var` name |\n",
     "| `ForItemsOperation` | `operations` (body) | `operands[0]` is a `DictValue` | always unrolled at transpile time |\n",
-    "| `IfOperation` | `true_operations`, `false_operations` | `operands[0]` is a `Bit` | `phi_ops` merge values post-branch |\n",
+    "| `IfOperation` | `true_operations`, `false_operations` | `operands[0]` is a `Bit` | `true_yields` / `false_yields` merge values post-branch |\n",
     "| `WhileOperation` | `operations` (body) | `operands[0]` (initial), `operands[1]` (loop-carried) | measurement-backed `Bit` required; optional `max_iterations` hint |\n",
     "\n",
     "All four implement `HasNestedOps`, so passes walk into bodies uniformly via\n",
     "`nested_op_lists()` / `rebuild_nested()` — no isinstance chains.\n",
     "\n",
-    "`IfOperation` carries **Phi nodes** (`PhiOp`) to merge values. When both\n",
-    "branches update the same logical value, readers past the if refer through\n",
-    "the phi to know which branch's version they get.\n",
+    "`IfOperation` merges values through its parallel **`true_yields` /\n",
+    "`false_yields`** lists: `true_yields[i]` and `false_yields[i]` are the\n",
+    "branch values merged into `results[i]`. When both branches update the same\n",
+    "logical value, readers past the if refer to the merged result to know which\n",
+    "branch's version they get. Passes read the merges through\n",
+    "`IfOperation.iter_merges()` rather than touching the yield lists directly.\n",
     "\n",
     "### 5.3 Per-Pass Behavior\n",
     "\n",
@@ -928,7 +931,7 @@
     "|------|-------------|---------------|-----------------|\n",
     "| `inline` | recurses into both branch bodies | recurses into body | recurses into body |\n",
     "| `partial_eval` | constant condition → **replaced by selected branch** (`CompileTimeIfLoweringPass`); measurement condition preserved | bound `BinOp`s folded. **No unrolling** | untouched here |\n",
-    "| `analyze` | phi edges enter the dependency graph | `loop_var` enters body deps | measurement-condition treated like a quantum operand |\n",
+    "| `analyze` | merge edges enter the dependency graph | `loop_var` enters body deps | measurement-condition treated like a quantum operand |\n",
     "| `validate_symbolic_shapes` | — | unresolved `Vector` shape dim as a bound → rejected | — |\n",
     "| `plan` | `OperationKind.CONTROL` — creates a segment boundary | same | same |\n",
     "| `emit` | emitted as runtime `if` if the backend supports it | `LoopAnalyzer.should_unroll()` decides unroll vs native-loop | emitted as runtime `while` |\n",
@@ -1034,10 +1037,10 @@
    "id": "4070564f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.105458Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.105406Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.107638Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.107335Z"
+     "iopub.execute_input": "2026-07-09T08:19:55.362850Z",
+     "iopub.status.busy": "2026-07-09T08:19:55.362664Z",
+     "iopub.status.idle": "2026-07-09T08:19:55.370260Z",
+     "shell.execute_reply": "2026-07-09T08:19:55.369655Z"
     }
    },
    "outputs": [],
@@ -1065,10 +1068,10 @@
    "id": "f14d6f85",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.108524Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.108488Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.110815Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.110547Z"
+     "iopub.execute_input": "2026-07-09T08:19:55.372182Z",
+     "iopub.status.busy": "2026-07-09T08:19:55.372090Z",
+     "iopub.status.idle": "2026-07-09T08:19:55.377072Z",
+     "shell.execute_reply": "2026-07-09T08:19:55.376684Z"
     }
    },
    "outputs": [
@@ -1136,10 +1139,10 @@
    "id": "accb2fe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.111636Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.111601Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.113237Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.112907Z"
+     "iopub.execute_input": "2026-07-09T08:19:55.378541Z",
+     "iopub.status.busy": "2026-07-09T08:19:55.378435Z",
+     "iopub.status.idle": "2026-07-09T08:19:55.380980Z",
+     "shell.execute_reply": "2026-07-09T08:19:55.380451Z"
     }
    },
    "outputs": [
@@ -1254,10 +1257,10 @@
    "id": "f03c9fa1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.114005Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.113972Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.124821Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.124563Z"
+     "iopub.execute_input": "2026-07-09T08:19:55.382399Z",
+     "iopub.status.busy": "2026-07-09T08:19:55.382315Z",
+     "iopub.status.idle": "2026-07-09T08:19:55.400674Z",
+     "shell.execute_reply": "2026-07-09T08:19:55.400362Z"
     }
    },
    "outputs": [
@@ -1353,7 +1356,7 @@
     "stage where `BlockKind` fails to advance, the operation count explodes,\n",
     "or an exception is raised is the stage you should look at first. Varying\n",
     "`pretty_print_block(block, depth=N)` before and after `inline` makes it\n",
-    "much easier to spot where a value got disconnected or a phi got dropped."
+    "much easier to spot where a value got disconnected or a merge got dropped."
    ]
   },
   {

--- a/docs/en/tutorial/10_compilation_and_transpilation.py
+++ b/docs/en/tutorial/10_compilation_and_transpilation.py
@@ -376,7 +376,7 @@ assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1
 # This rule **does not forbid dynamic quantum circuits**: `IfOperation` and
 # `WhileOperation` are `OperationKind.CONTROL`, not QUANTUM, so control flow
 # conditioned on a measurement `Bit` (`if bit: ...`, `while bit: ...`)
-# passes the check. Quantum-typed values that survive a phi merge are also
+# passes the check. Quantum-typed values that survive an if-merge are also
 # explicitly exempt. Section 5 walks through which dynamic patterns are
 # allowed and which are rejected, with code examples.
 #
@@ -522,15 +522,18 @@ print(executable.quantum_circuit)
 # |-----------|-------------|--------------------|-------|
 # | `ForOperation` | `operations` (body) | `operands = [start, stop, step]` (all `UInt`) | carries `loop_var` name |
 # | `ForItemsOperation` | `operations` (body) | `operands[0]` is a `DictValue` | always unrolled at transpile time |
-# | `IfOperation` | `true_operations`, `false_operations` | `operands[0]` is a `Bit` | `phi_ops` merge values post-branch |
+# | `IfOperation` | `true_operations`, `false_operations` | `operands[0]` is a `Bit` | `true_yields` / `false_yields` merge values post-branch |
 # | `WhileOperation` | `operations` (body) | `operands[0]` (initial), `operands[1]` (loop-carried) | measurement-backed `Bit` required; optional `max_iterations` hint |
 #
 # All four implement `HasNestedOps`, so passes walk into bodies uniformly via
 # `nested_op_lists()` / `rebuild_nested()` — no isinstance chains.
 #
-# `IfOperation` carries **Phi nodes** (`PhiOp`) to merge values. When both
-# branches update the same logical value, readers past the if refer through
-# the phi to know which branch's version they get.
+# `IfOperation` merges values through its parallel **`true_yields` /
+# `false_yields`** lists: `true_yields[i]` and `false_yields[i]` are the
+# branch values merged into `results[i]`. When both branches update the same
+# logical value, readers past the if refer to the merged result to know which
+# branch's version they get. Passes read the merges through
+# `IfOperation.iter_merges()` rather than touching the yield lists directly.
 #
 # ### 5.3 Per-Pass Behavior
 #
@@ -538,7 +541,7 @@ print(executable.quantum_circuit)
 # |------|-------------|---------------|-----------------|
 # | `inline` | recurses into both branch bodies | recurses into body | recurses into body |
 # | `partial_eval` | constant condition → **replaced by selected branch** (`CompileTimeIfLoweringPass`); measurement condition preserved | bound `BinOp`s folded. **No unrolling** | untouched here |
-# | `analyze` | phi edges enter the dependency graph | `loop_var` enters body deps | measurement-condition treated like a quantum operand |
+# | `analyze` | merge edges enter the dependency graph | `loop_var` enters body deps | measurement-condition treated like a quantum operand |
 # | `validate_symbolic_shapes` | — | unresolved `Vector` shape dim as a bound → rejected | — |
 # | `plan` | `OperationKind.CONTROL` — creates a segment boundary | same | same |
 # | `emit` | emitted as runtime `if` if the backend supports it | `LoopAnalyzer.should_unroll()` decides unroll vs native-loop | emitted as runtime `while` |
@@ -833,7 +836,7 @@ except ModuleNotFoundError:
 # stage where `BlockKind` fails to advance, the operation count explodes,
 # or an exception is raised is the stage you should look at first. Varying
 # `pretty_print_block(block, depth=N)` before and after `inline` makes it
-# much easier to spot where a value got disconnected or a phi got dropped.
+# much easier to spot where a value got disconnected or a merge got dropped.
 
 # %% [markdown]
 # ## 9. Summary

--- a/docs/ja/tutorial/10_compilation_and_transpilation.ipynb
+++ b/docs/ja/tutorial/10_compilation_and_transpilation.ipynb
@@ -29,10 +29,10 @@
    "id": "3bd43646",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.758885Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.758736Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.762897Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.762346Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.569281Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.569187Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.572064Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.571548Z"
     }
    },
    "outputs": [],
@@ -153,10 +153,10 @@
    "id": "ae90556e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.764873Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.764752Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.833001Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.832590Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.573535Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.573438Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.696563Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.696222Z"
     }
    },
    "outputs": [],
@@ -192,10 +192,10 @@
    "id": "27c133a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.834070Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.834006Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.837693Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.837439Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.698212Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.698117Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.702850Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.702423Z"
     },
     "lines_to_next_cell": 2
    },
@@ -237,10 +237,10 @@
    "id": "eaf310bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.838852Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.838800Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.840466Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.840175Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.703964Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.703912Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.705539Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.705275Z"
     }
    },
    "outputs": [],
@@ -285,10 +285,10 @@
    "id": "5bff274f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.841296Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.841256Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.844313Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.844004Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.706433Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.706390Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.710077Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.709714Z"
     }
    },
    "outputs": [
@@ -334,10 +334,10 @@
    "id": "c8efd4cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.845241Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.845196Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.846595Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.846352Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.711080Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.711029Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.712562Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.712297Z"
     }
    },
    "outputs": [
@@ -380,10 +380,10 @@
    "id": "7fbf19e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.847411Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.847374Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.848748Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.848537Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.713335Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.713287Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.714811Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.714529Z"
     }
    },
    "outputs": [
@@ -436,10 +436,10 @@
    "id": "7514789d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.849687Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.849641Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.851926Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.851601Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.715741Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.715670Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.736107Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.735779Z"
     }
    },
    "outputs": [
@@ -488,10 +488,10 @@
    "id": "801cef0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.852791Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.852733Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.854037Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.853797Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.737268Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.737223Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.738839Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.738524Z"
     }
    },
    "outputs": [
@@ -546,10 +546,10 @@
    "id": "1b7714f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.854855Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.854818Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.856500Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.856215Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.739684Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.739626Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.742698Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.742348Z"
     }
    },
    "outputs": [
@@ -589,7 +589,7 @@
     "1. ブロックの入出力が古典であること（量子I/Oはエントリポイントではなく*サブルーチン*ブロックでのみ許可されます）。\n",
     "2. **`OperationKind.QUANTUM`のOperation** が、**古典型オペランド**として測定由来の古典値を受け取らないこと。より具体的には、`rx(q, theta)`の`theta`のようなゲートの古典引数が、測定結果から計算された値であってはいけません（rotation角などの古典計算をJITする必要が出るため）。\n",
     "\n",
-    "この規則は**動的量子回路を禁止するものではありません**。`IfOperation`/`WhileOperation`は`OperationKind.CONTROL`なのでこのチェック対象外で、測定結果`Bit`を条件とする制御フロー（`if bit: ...` / `while bit: ...`）は通ります。また、Phiで合流した量子型の値も明示的に例外扱いです。動的量子回路と禁止パターンの具体的な違いは5章で扱います。\n",
+    "この規則は**動的量子回路を禁止するものではありません**。`IfOperation`/`WhileOperation`は`OperationKind.CONTROL`なのでこのチェック対象外で、測定結果`Bit`を条件とする制御フロー（`if bit: ...` / `while bit: ...`）は通ります。また、ifマージで合流した量子型の値も明示的に例外扱いです。動的量子回路と禁止パターンの具体的な違いは5章で扱います。\n",
     "\n",
     "成功するとブロックは`ANALYZED`へ遷移します。"
    ]
@@ -600,10 +600,10 @@
    "id": "b923fe47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.857328Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.857286Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.858897Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.858625Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.743636Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.743586Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.746257Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.745970Z"
     }
    },
    "outputs": [
@@ -637,10 +637,10 @@
    "id": "82dfef53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.859681Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.859617Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.861346Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.861056Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.747149Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.747104Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.749851Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.749512Z"
     }
    },
    "outputs": [
@@ -684,10 +684,10 @@
    "id": "a690b9a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.862209Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.862169Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.946603Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.946297Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.750826Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.750784Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.951278Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.950885Z"
     }
    },
    "outputs": [
@@ -696,7 +696,13 @@
      "output_type": "stream",
      "text": [
       "parameter_names:   ['theta']\n",
-      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     ┌───┐┌───┐                  ┌─┐                             \n",
       "q_0: ┤ H ├┤ H ├──■───────────────┤M├─────────────────────────────\n",
       "     └───┘└───┘┌─┴─┐┌───────────┐└╥┘┌───┐                  ┌─┐   \n",
@@ -707,7 +713,14 @@
       "q_3: ─────────────────────────────╫─────────────────────────╫──╫─\n",
       "                                  ║                         ║  ║ \n",
       "c: 3/═════════════════════════════╩═════════════════════════╩══╩═\n",
-      "                                  0                         1  2 \n"
+      "                                  0                         1  2 "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -774,12 +787,12 @@
     "|-----------|------------|----------|--------|\n",
     "| `ForOperation` | `operations`（本体） | `operands = [start, stop, step]`（いずれも`UInt`） | `loop_var`名を持つ |\n",
     "| `ForItemsOperation` | `operations`（本体） | `operands[0]`が`DictValue` | 常にコンパイル時アンロール |\n",
-    "| `IfOperation` | `true_operations`, `false_operations` | `operands[0]`が`Bit` | `phi_ops`で分岐後の値マージ |\n",
+    "| `IfOperation` | `true_operations`, `false_operations` | `operands[0]`が`Bit` | `true_yields`/`false_yields`で分岐後の値マージ |\n",
     "| `WhileOperation` | `operations`（本体） | `operands[0]`（初期条件）, `operands[1]`（ループキャリー条件） | 測定結果`Bit`必須、`max_iterations`ヒント可 |\n",
     "\n",
     "4つとも`HasNestedOps`を実装しているので、パスは`nested_op_lists()` / `rebuild_nested()`経由で本体へ再帰的に入れます。`isinstance`のチェーンは書かないのが流儀です。\n",
     "\n",
-    "`IfOperation`には値をマージする**Phiノード** (`PhiOp`) が付きます。両分岐で同じ論理量子ビット・古典変数を異なるバージョンで更新した場合、分岐後に使う側はPhi経由でどちらのバージョンなのかを参照します。\n",
+    "`IfOperation`は並列リスト**`true_yields`/`false_yields`**で値をマージします。`true_yields[i]`と`false_yields[i]`が`results[i]`にマージされる分岐値です。両分岐で同じ論理量子ビット・古典変数を異なるバージョンで更新した場合、分岐後に使う側はマージ結果を通じてどちらのバージョンなのかを参照します。パスがマージを読むときはyieldリストを直接触らず`IfOperation.iter_merges()`を使います。\n",
     "\n",
     "### 5.3 パスごとの挙動\n",
     "\n",
@@ -789,7 +802,7 @@
     "|------|-------------|---------------|-----------------|\n",
     "| `inline` | 両分岐の本体へ再帰 | 本体へ再帰 | 本体へ再帰 |\n",
     "| `partial_eval` | 条件が定数なら**選ばれた分岐で置換**（`CompileTimeIfLoweringPass`）。測定結果条件なら保持 | 境界の`BinOp`は畳み込まれる。**アンロールはしない** | 何もしない（ここでは変形対象外） |\n",
-    "| `analyze` | Phiが依存グラフに反映される | `loop_var`が本体の依存に入る | 測定結果条件を量子オペランドと同様に扱う |\n",
+    "| `analyze` | マージが依存グラフに反映される | `loop_var`が本体の依存に入る | 測定結果条件を量子オペランドと同様に扱う |\n",
     "| `validate_symbolic_shapes` | — | 未解決の`Vector`shape次元が境界にあると拒否 | — |\n",
     "| `plan` | `OperationKind.CONTROL`としてセグメント境界を作る | 同左 | 同左 |\n",
     "| `emit` | 実行時`if`として出力（バックエンドが対応していれば） | `LoopAnalyzer.should_unroll()`で判定し、必要ならアンロール | 実行時`while`として出力 |\n",
@@ -869,10 +882,10 @@
    "id": "3510c719",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.947597Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.947545Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.949694Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.949461Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.952343Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.952261Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.954907Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.954547Z"
     }
    },
    "outputs": [],
@@ -900,10 +913,10 @@
    "id": "a172826f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.950603Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.950569Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.952850Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.952517Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.955807Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.955758Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.959143Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.958846Z"
     }
    },
    "outputs": [
@@ -956,10 +969,10 @@
    "id": "3c8e7e6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.953639Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.953605Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.954991Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.954761Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.960138Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.960089Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.961800Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.961570Z"
     }
    },
    "outputs": [
@@ -1045,10 +1058,10 @@
    "id": "59dcced9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T07:49:12.955834Z",
-     "iopub.status.busy": "2026-05-26T07:49:12.955801Z",
-     "iopub.status.idle": "2026-05-26T07:49:12.960307Z",
-     "shell.execute_reply": "2026-05-26T07:49:12.959944Z"
+     "iopub.execute_input": "2026-07-09T08:20:08.962741Z",
+     "iopub.status.busy": "2026-07-09T08:20:08.962700Z",
+     "iopub.status.idle": "2026-07-09T08:20:08.971873Z",
+     "shell.execute_reply": "2026-07-09T08:20:08.971543Z"
     }
    },
    "outputs": [
@@ -1120,7 +1133,7 @@
     "3. ユーザーが`executor()`を呼べるように`QuantumExecutor[T]`のサブクラスを実装します。\n",
     "4. オプション: emitされた回路で高レベル構造を保つため、QFT/QPEなどの`CompositeGateEmitter`を追加します。\n",
     "\n",
-    "**transpileエラーのデバッグ。** パスを1つずつ実行し、その間に`summarise(block)`で件数の変化を追い、気になるところは`pretty_print_block(block)`で中身を覗きます。`BlockKind`が進まない、Operation数が爆発する、例外が送出される、というステージが最初に見るべき場所です。`pretty_print_block(block, depth=N)`で`CallBlockOperation`の展開深さを変えながら`inline`前後を比較すると、どこで値が切れたか・どのPhiが漏れたかが読み取りやすくなります。"
+    "**transpileエラーのデバッグ。** パスを1つずつ実行し、その間に`summarise(block)`で件数の変化を追い、気になるところは`pretty_print_block(block)`で中身を覗きます。`BlockKind`が進まない、Operation数が爆発する、例外が送出される、というステージが最初に見るべき場所です。`pretty_print_block(block, depth=N)`で`CallBlockOperation`の展開深さを変えながら`inline`前後を比較すると、どこで値が切れたか・どのマージが漏れたかが読み取りやすくなります。"
    ]
   },
   {

--- a/docs/ja/tutorial/10_compilation_and_transpilation.py
+++ b/docs/ja/tutorial/10_compilation_and_transpilation.py
@@ -298,7 +298,7 @@ assert sum(1 for op in block.operations if isinstance(op, ForOperation)) == 1
 # 1. ブロックの入出力が古典であること（量子I/Oはエントリポイントではなく*サブルーチン*ブロックでのみ許可されます）。
 # 2. **`OperationKind.QUANTUM`のOperation** が、**古典型オペランド**として測定由来の古典値を受け取らないこと。より具体的には、`rx(q, theta)`の`theta`のようなゲートの古典引数が、測定結果から計算された値であってはいけません（rotation角などの古典計算をJITする必要が出るため）。
 #
-# この規則は**動的量子回路を禁止するものではありません**。`IfOperation`/`WhileOperation`は`OperationKind.CONTROL`なのでこのチェック対象外で、測定結果`Bit`を条件とする制御フロー（`if bit: ...` / `while bit: ...`）は通ります。また、Phiで合流した量子型の値も明示的に例外扱いです。動的量子回路と禁止パターンの具体的な違いは5章で扱います。
+# この規則は**動的量子回路を禁止するものではありません**。`IfOperation`/`WhileOperation`は`OperationKind.CONTROL`なのでこのチェック対象外で、測定結果`Bit`を条件とする制御フロー（`if bit: ...` / `while bit: ...`）は通ります。また、ifマージで合流した量子型の値も明示的に例外扱いです。動的量子回路と禁止パターンの具体的な違いは5章で扱います。
 #
 # 成功するとブロックは`ANALYZED`へ遷移します。
 
@@ -384,12 +384,12 @@ print(executable.quantum_circuit)
 # |-----------|------------|----------|--------|
 # | `ForOperation` | `operations`（本体） | `operands = [start, stop, step]`（いずれも`UInt`） | `loop_var`名を持つ |
 # | `ForItemsOperation` | `operations`（本体） | `operands[0]`が`DictValue` | 常にコンパイル時アンロール |
-# | `IfOperation` | `true_operations`, `false_operations` | `operands[0]`が`Bit` | `phi_ops`で分岐後の値マージ |
+# | `IfOperation` | `true_operations`, `false_operations` | `operands[0]`が`Bit` | `true_yields`/`false_yields`で分岐後の値マージ |
 # | `WhileOperation` | `operations`（本体） | `operands[0]`（初期条件）, `operands[1]`（ループキャリー条件） | 測定結果`Bit`必須、`max_iterations`ヒント可 |
 #
 # 4つとも`HasNestedOps`を実装しているので、パスは`nested_op_lists()` / `rebuild_nested()`経由で本体へ再帰的に入れます。`isinstance`のチェーンは書かないのが流儀です。
 #
-# `IfOperation`には値をマージする**Phiノード** (`PhiOp`) が付きます。両分岐で同じ論理量子ビット・古典変数を異なるバージョンで更新した場合、分岐後に使う側はPhi経由でどちらのバージョンなのかを参照します。
+# `IfOperation`は並列リスト**`true_yields`/`false_yields`**で値をマージします。`true_yields[i]`と`false_yields[i]`が`results[i]`にマージされる分岐値です。両分岐で同じ論理量子ビット・古典変数を異なるバージョンで更新した場合、分岐後に使う側はマージ結果を通じてどちらのバージョンなのかを参照します。パスがマージを読むときはyieldリストを直接触らず`IfOperation.iter_merges()`を使います。
 #
 # ### 5.3 パスごとの挙動
 #
@@ -399,7 +399,7 @@ print(executable.quantum_circuit)
 # |------|-------------|---------------|-----------------|
 # | `inline` | 両分岐の本体へ再帰 | 本体へ再帰 | 本体へ再帰 |
 # | `partial_eval` | 条件が定数なら**選ばれた分岐で置換**（`CompileTimeIfLoweringPass`）。測定結果条件なら保持 | 境界の`BinOp`は畳み込まれる。**アンロールはしない** | 何もしない（ここでは変形対象外） |
-# | `analyze` | Phiが依存グラフに反映される | `loop_var`が本体の依存に入る | 測定結果条件を量子オペランドと同様に扱う |
+# | `analyze` | マージが依存グラフに反映される | `loop_var`が本体の依存に入る | 測定結果条件を量子オペランドと同様に扱う |
 # | `validate_symbolic_shapes` | — | 未解決の`Vector`shape次元が境界にあると拒否 | — |
 # | `plan` | `OperationKind.CONTROL`としてセグメント境界を作る | 同左 | 同左 |
 # | `emit` | 実行時`if`として出力（バックエンドが対応していれば） | `LoopAnalyzer.should_unroll()`で判定し、必要ならアンロール | 実行時`while`として出力 |
@@ -600,7 +600,7 @@ except ModuleNotFoundError:
 # 3. ユーザーが`executor()`を呼べるように`QuantumExecutor[T]`のサブクラスを実装します。
 # 4. オプション: emitされた回路で高レベル構造を保つため、QFT/QPEなどの`CompositeGateEmitter`を追加します。
 #
-# **transpileエラーのデバッグ。** パスを1つずつ実行し、その間に`summarise(block)`で件数の変化を追い、気になるところは`pretty_print_block(block)`で中身を覗きます。`BlockKind`が進まない、Operation数が爆発する、例外が送出される、というステージが最初に見るべき場所です。`pretty_print_block(block, depth=N)`で`CallBlockOperation`の展開深さを変えながら`inline`前後を比較すると、どこで値が切れたか・どのPhiが漏れたかが読み取りやすくなります。
+# **transpileエラーのデバッグ。** パスを1つずつ実行し、その間に`summarise(block)`で件数の変化を追い、気になるところは`pretty_print_block(block)`で中身を覗きます。`BlockKind`が進まない、Operation数が爆発する、例外が送出される、というステージが最初に見るべき場所です。`pretty_print_block(block, depth=N)`で`CallBlockOperation`の展開深さを変えながら`inline`前後を比較すると、どこで値が切れたか・どのマージが漏れたかが読み取りやすくなります。
 
 # %% [markdown]
 # ## 9. まとめ


### PR DESCRIPTION
## Summary

Docs-only follow-up split out of #574 to keep that PR code-only.

PR #574 replaced `IfOperation.phi_ops` (embedded `PhiOp` merge pseudo-operations) with parallel `true_yields` / `false_yields` value lists read through `IfOperation.iter_merges()`, deleted `PhiOp`, and renamed the branch-merge terminology from "phi" to "merge" across the codebase — including the IR pretty-printer, which now emits `merge(cond ? true : false)` instead of `phi(...)`, and merged-value display names, which are now `x_merge_N` instead of `x_phi_N`.

This PR brings Tutorial 10 (Compilation and Transpilation) in line with that refactor.

## Changes

- Describe `IfOperation` value merging via the parallel `true_yields` / `false_yields` lists, read through `IfOperation.iter_merges()`, instead of the removed `PhiOp` / `phi_ops`.
- Replace the remaining "phi" wording in the prose (`phi merge` → `if-merge`, `phi edges` → `merge edges`, "a phi got dropped" → "a merge got dropped") in both the English and Japanese pages.
- Re-execute the paired `.ipynb` notebooks against current `main` (full settings, no `QAMOMILE_DOCS_TEST` reduced-output mode) so their outputs reflect the shipped code.

## Scope

Only the four Tutorial 10 source files change — English and Japanese `.py` sources plus their paired `.ipynb`. No code files are touched.

## Verification

`uv run pytest -m docs -k "tutorial/10"` passes for both the English and Japanese pages.
