### PR TITLE
Document global phase semantics

### DIFF
--- a/docs/en/tutorial/04_controlled_gates.ipynb
+++ b/docs/en/tutorial/04_controlled_gates.ipynb
@@ -675,8 +675,9 @@
     "With both modifiers, the precise call-site meaning is\n",
     "`control((exp(1j * phi) * U) ** power)`. Therefore `power=k` repeats the\n",
     "phase `k` times, while an inverse negates the phase together with inverting\n",
-    "`U`. `global_phase` is a reserved call-site keyword; a target callable with\n",
-    "a same-named ordinary parameter must receive it positionally."
+    "`U`. `global_phase` is a reserved call-site keyword; if the target callable\n",
+    "also has an ordinary parameter named `global_phase`, pass that parameter\n",
+    "positionally."
    ]
   },
   {
@@ -732,7 +733,7 @@
     "Qamomile keeps one target-neutral phase meaning, then verifies the selected\n",
     "quantum SDK/Engine/representation before materialization. Qiskit uses\n",
     "`QuantumCircuit.global_phase`, Quration/PyQret uses its native\n",
-    "`global_phase` intrinsic, and HUGR uses `tket.global_phase`. CUDA-Q has no\n",
+    "`global_phase` intrinsic, and HUGR uses `tket_exts.global_phase()`. CUDA-Q has no\n",
     "circuit-level phase API, so Qamomile emits the exact identity\n",
     "`R1(2 phi) RZ(-2 phi)` on an existing qubit. QURI Parts likewise has no\n",
     "circuit-level phase API. Qamomile reserves a dedicated internal qubit in\n",

--- a/docs/en/tutorial/04_controlled_gates.ipynb
+++ b/docs/en/tutorial/04_controlled_gates.ipynb
@@ -30,10 +30,10 @@
    "id": "fd6f61a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.233170Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.233041Z",
-     "iopub.status.idle": "2026-06-05T10:11:22.236268Z",
-     "shell.execute_reply": "2026-06-05T10:11:22.235727Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.059230Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.059090Z",
+     "iopub.status.idle": "2026-07-14T05:12:51.063799Z",
+     "shell.execute_reply": "2026-07-14T05:12:51.063315Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "id": "2cec0317",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.238211Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.238051Z",
-     "iopub.status.idle": "2026-06-05T10:11:22.331322Z",
-     "shell.execute_reply": "2026-06-05T10:11:22.330889Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.066231Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.066071Z",
+     "iopub.status.idle": "2026-07-14T05:12:51.387884Z",
+     "shell.execute_reply": "2026-07-14T05:12:51.387431Z"
     }
    },
    "outputs": [],
@@ -87,10 +87,10 @@
    "id": "639e2d41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.332544Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.332455Z",
-     "iopub.status.idle": "2026-06-05T10:11:22.334562Z",
-     "shell.execute_reply": "2026-06-05T10:11:22.334346Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.388984Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.388918Z",
+     "iopub.status.idle": "2026-07-14T05:12:51.391163Z",
+     "shell.execute_reply": "2026-07-14T05:12:51.390771Z"
     }
    },
    "outputs": [],
@@ -105,10 +105,10 @@
    "id": "5236530c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.335513Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.335463Z",
-     "iopub.status.idle": "2026-06-05T10:11:22.695272Z",
-     "shell.execute_reply": "2026-06-05T10:11:22.694803Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.391942Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.391891Z",
+     "iopub.status.idle": "2026-07-14T05:12:51.594089Z",
+     "shell.execute_reply": "2026-07-14T05:12:51.593781Z"
     }
    },
    "outputs": [
@@ -143,10 +143,10 @@
    "id": "7dfea4d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.696654Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.696533Z",
-     "iopub.status.idle": "2026-06-05T10:11:22.714891Z",
-     "shell.execute_reply": "2026-06-05T10:11:22.714506Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.595100Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.595031Z",
+     "iopub.status.idle": "2026-07-14T05:12:51.607751Z",
+     "shell.execute_reply": "2026-07-14T05:12:51.607375Z"
     }
    },
    "outputs": [
@@ -194,10 +194,10 @@
    "id": "4f331715",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:22.716040Z",
-     "iopub.status.busy": "2026-06-05T10:11:22.715987Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.077174Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.076800Z"
+     "iopub.execute_input": "2026-07-14T05:12:51.608660Z",
+     "iopub.status.busy": "2026-07-14T05:12:51.608611Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.139473Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.139181Z"
     }
    },
    "outputs": [
@@ -317,10 +317,10 @@
    "id": "c0286f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.078849Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.078744Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.081536Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.081175Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.140779Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.140707Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.143404Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.143015Z"
     }
    },
    "outputs": [],
@@ -342,10 +342,10 @@
    "id": "4aa7cb4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.082534Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.082463Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.105101Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.104697Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.144175Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.144125Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.163805Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.163461Z"
     }
    },
    "outputs": [
@@ -396,10 +396,10 @@
    "id": "ea4443b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.106092Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.106043Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.108339Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.107987Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.164658Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.164615Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.166848Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.166547Z"
     }
    },
    "outputs": [],
@@ -420,10 +420,10 @@
    "id": "82a622ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.109207Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.109163Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.126877Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.126524Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.167784Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.167744Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.182143Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.181784Z"
     }
    },
    "outputs": [
@@ -471,10 +471,10 @@
    "id": "0ef072cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.128102Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.128043Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.130160Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.129912Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.182982Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.182948Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.185075Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.184729Z"
     }
    },
    "outputs": [],
@@ -501,10 +501,10 @@
    "id": "c19a80a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.131169Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.131125Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.145436Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.145125Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.185813Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.185778Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.197728Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.197473Z"
     }
    },
    "outputs": [
@@ -539,10 +539,10 @@
    "id": "4f893a16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.146402Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.146350Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.166493Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.166215Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.198645Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.198606Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.215636Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.215286Z"
     }
    },
    "outputs": [
@@ -600,10 +600,10 @@
    "id": "90e21577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.167569Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.167517Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.169009Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.168680Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.216644Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.216604Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.218103Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.217805Z"
     }
    },
    "outputs": [],
@@ -617,10 +617,10 @@
    "id": "1d401560",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.170040Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.169992Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.184840Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.184471Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.218827Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.218789Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.231925Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.231626Z"
     }
    },
    "outputs": [
@@ -651,6 +651,111 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce69a220",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "(cg-3-4-phase)=\n",
+    "#### Global phase becomes observable under coherent control\n",
+    "\n",
+    "Multiplying an otherwise standalone unitary by `exp(1j * phi)` does not\n",
+    "change ordinary measurement probabilities. It must nevertheless be kept:\n",
+    "once that unitary is controlled, the same factor is a relative phase on the\n",
+    "all-active control subspace. This is particularly important for SELECT\n",
+    "circuits, where even an identity Pauli term may carry a complex coefficient.\n",
+    "\n",
+    "Qamomile provides two equivalent ways to attach this phase:\n",
+    "\n",
+    "- `qmc.global_phase(fn, phi)` constructs `exp(1j * phi) * U` from the\n",
+    "  callable `fn` implementing `U`.\n",
+    "- `qmc.control(fn)(..., global_phase=phi)` attaches the phase at that\n",
+    "  controlled call site.\n",
+    "\n",
+    "With both modifiers, the precise call-site meaning is\n",
+    "`control((exp(1j * phi) * U) ** power)`. Therefore `power=k` repeats the\n",
+    "phase `k` times, while an inverse negates the phase together with inverting\n",
+    "`U`. `global_phase` is a reserved call-site keyword; a target callable with\n",
+    "a same-named ordinary parameter must receive it positionally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "de4a1f6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T05:12:52.232851Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.232816Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.276554Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.276233Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@qmc.qkernel\n",
+    "def _identity_for_phase(q: qmc.Qubit) -> qmc.Qubit:\n",
+    "    return q\n",
+    "\n",
+    "\n",
+    "controlled_phased_identity = qmc.control(_identity_for_phase)\n",
+    "\n",
+    "\n",
+    "@qmc.qkernel\n",
+    "def phase_kickback_demo() -> qmc.Bit:\n",
+    "    control = qmc.h(qmc.qubit(\"control\"))\n",
+    "    target = qmc.qubit(\"target\")\n",
+    "    control, target = controlled_phased_identity(\n",
+    "        control,\n",
+    "        target,\n",
+    "        global_phase=math.pi,\n",
+    "    )\n",
+    "    control = qmc.h(control)\n",
+    "    return qmc.measure(control)\n",
+    "\n",
+    "\n",
+    "phase_counts = dict(\n",
+    "    transpiler.transpile(phase_kickback_demo)\n",
+    "    .sample(transpiler.executor(), shots=256)\n",
+    "    .result()\n",
+    "    .results\n",
+    ")\n",
+    "assert phase_counts == {1: 256}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdec4d5f",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "Qamomile keeps one target-neutral phase meaning, then verifies the selected\n",
+    "quantum SDK/Engine/representation before materialization. Qiskit uses\n",
+    "`QuantumCircuit.global_phase`, Quration/PyQret uses its native\n",
+    "`global_phase` intrinsic, and HUGR uses `tket.global_phase`. CUDA-Q has no\n",
+    "circuit-level phase API, so Qamomile emits the exact identity\n",
+    "`R1(2 phi) RZ(-2 phi)` on an existing qubit. QURI Parts likewise has no\n",
+    "circuit-level phase API. Qamomile reserves a dedicated internal qubit in\n",
+    "`|0>` and applies `RZ(-2 phi)` to it, which produces `exp(i phi)|0>` exactly.\n",
+    "This carrier is separate from multi-control ancillas and is excluded from\n",
+    "measurements and implicit qkernel outputs. QURI Parts can therefore retain a\n",
+    "zero-qubit program phase without changing its logical result ABI. CUDA-Q\n",
+    "still requires an existing program qubit and rejects a nonzero zero-qubit\n",
+    "phase explicitly.\n",
+    "\n",
+    "Native standalone phase does not by itself imply that a quantum\n",
+    "SDK/Engine/representation can transform every reusable call. The current\n",
+    "Quration/PyQret Python API cannot apply generic controlled or inverse call\n",
+    "transforms. HUGR currently handles phase inside a bounded subset of inlined\n",
+    "unitary bodies; exact support depends on the operation and control count and\n",
+    "includes one-control Pauli evolution. Its `power` must resolve to a positive\n",
+    "compile-time integer. Shapes outside a declared capability fail explicitly\n",
+    "rather than losing their phase.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e244ec8a",
    "metadata": {
     "lines_to_next_cell": 2
@@ -669,14 +774,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "2e66193d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.185875Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.185821Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.187954Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.187669Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.277569Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.277528Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.279337Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.279052Z"
     }
    },
    "outputs": [],
@@ -686,14 +791,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "202efcaa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.188911Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.188868Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.204069Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.203784Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.280073Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.280034Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.292952Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.292697Z"
     }
    },
    "outputs": [
@@ -704,7 +809,7 @@
        "<Figure size 690.5x256 with 1 Axes>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -744,14 +849,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "2b925cb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.205157Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.205107Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.206647Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.206375Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.293930Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.293887Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.295438Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.295109Z"
     }
    },
    "outputs": [],
@@ -761,14 +866,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "7069924f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.207434Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.207386Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.230806Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.230537Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.296162Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.296128Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.315766Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.315451Z"
     }
    },
    "outputs": [
@@ -779,7 +884,7 @@
        "<Figure size 702.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -821,14 +926,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "13ddbf83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.231926Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.231876Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.233363Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.233107Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.316692Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.316649Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.318107Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.317847Z"
     }
    },
    "outputs": [],
@@ -838,14 +943,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "b340549a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.234117Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.234074Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.246626Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.246283Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.318818Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.318783Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.329494Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.329154Z"
     }
    },
    "outputs": [
@@ -856,7 +961,7 @@
        "<Figure size 690.5x200 with 1 Axes>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,14 +1031,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "1aee63d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.247658Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.247604Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.268291Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.267906Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.330440Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.330406Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.384348Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.384007Z"
     }
    },
    "outputs": [
@@ -944,7 +1049,7 @@
        "<Figure size 738.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -982,14 +1087,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "3f7bd144",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.269361Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.269309Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.326566Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.326193Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.385352Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.385307Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.404518Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.404143Z"
     }
    },
    "outputs": [
@@ -1000,7 +1105,7 @@
        "<Figure size 702.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1036,14 +1141,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "3a5f6055",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.327772Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.327711Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.351027Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.350756Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.405420Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.405362Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.425610Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.425231Z"
     }
    },
    "outputs": [
@@ -1054,7 +1159,7 @@
        "<Figure size 726.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1098,14 +1203,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "bbf86478",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.352201Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.352127Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.374334Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.373960Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.426558Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.426518Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.445614Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.445211Z"
     }
    },
    "outputs": [
@@ -1116,7 +1221,7 @@
        "<Figure size 726.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1166,14 +1271,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "d8dd4f9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.375358Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.375306Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.400500Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.400174Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.446578Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.446534Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.468049Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.467673Z"
     }
    },
    "outputs": [
@@ -1184,7 +1289,7 @@
        "<Figure size 880.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1230,7 +1335,8 @@
     "asserting the expected exception with a small `expect_error`\n",
     "helper. It ends with a concrete sliced-QFT case that is supported\n",
     "and worth keeping as a regression example for nested controlled\n",
-    "emission.\n",
+    "emission on backends that can convert the nested block to a gate\n",
+    "(Qiskit in this tutorial).\n",
     "\n",
     "| Case | Mode | Exception |\n",
     "| --- | --- | --- |\n",
@@ -1240,19 +1346,19 @@
     "| 6.4 same-pool slot reused as target | symbolic | `UnreturnedBorrowError` |\n",
     "| 6.5 multi-arg control prefix + `control_indices` | symbolic | `ValueError` |\n",
     "| 6.6 single scalar control in symbolic mode | symbolic | `ValueError` |\n",
-    "| 6.7 controlled QFT over a sub-kernel `UInt` slice | concrete | supported |"
+    "| 6.7 controlled QFT over a sub-kernel `UInt` slice | concrete | supported when block-to-gate conversion succeeds |"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "459b0b99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.401506Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.401457Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.403524Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.403113Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.468946Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.468905Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.470660Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.470397Z"
     },
     "lines_to_next_cell": 2
    },
@@ -1295,14 +1401,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "f10ae777",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.404588Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.404534Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.407286Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.407018Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.471481Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.471442Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.474060Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.473754Z"
     }
    },
    "outputs": [
@@ -1348,14 +1454,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "8e972f03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.408142Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.408097Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.410420Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.410133Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.474873Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.474836Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.477258Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.476973Z"
     }
    },
    "outputs": [
@@ -1404,14 +1510,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "b7655d37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.411485Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.411442Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.414526Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.414229Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.478083Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.478048Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.480758Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.480541Z"
     }
    },
    "outputs": [
@@ -1479,14 +1585,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "7fd5cfde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.415426Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.415384Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.417968Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.417687Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.481620Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.481586Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.484259Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.483985Z"
     }
    },
    "outputs": [
@@ -1542,14 +1648,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "4f217959",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.418824Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.418778Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.422093Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.421778Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.485095Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.485062Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.488226Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.488015Z"
     }
    },
    "outputs": [
@@ -1604,14 +1710,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "76c6eeae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.422903Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.422861Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.425436Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.425175Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.489130Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.489094Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.491657Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.491351Z"
     }
    },
    "outputs": [
@@ -1658,23 +1764,25 @@
     "For example, `controlled_qft = qmc.control(apply_qft)` works\n",
     "when `apply_qft(q)` applies QFT to all of `q`.\n",
     "\n",
-    "The same now holds for the narrower pattern below: the wrapped\n",
-    "sub-kernel receives a classical `UInt` argument and uses it to\n",
-    "form a `q[:m]` slice before calling QFT. Qamomile strips the slice\n",
-    "marker inside the nested controlled block after borrow checking,\n",
-    "so the controlled-U emitter can lower the sliced composite block."
+    "The same now holds for the narrower Qiskit-backed pattern below:\n",
+    "the wrapped sub-kernel receives a classical `UInt` argument and uses\n",
+    "it to form a `q[:m]` slice before calling QFT. Qamomile strips the\n",
+    "slice marker inside the nested controlled block after borrow\n",
+    "checking, so a controlled-U emitter whose block-to-gate conversion\n",
+    "succeeds can lower the sliced composite block. Backends without\n",
+    "block-to-gate conversion may still reject this multi-target fallback."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "77a87e4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:23.426310Z",
-     "iopub.status.busy": "2026-06-05T10:11:23.426267Z",
-     "iopub.status.idle": "2026-06-05T10:11:23.433980Z",
-     "shell.execute_reply": "2026-06-05T10:11:23.433711Z"
+     "iopub.execute_input": "2026-07-14T05:12:52.492445Z",
+     "iopub.status.busy": "2026-07-14T05:12:52.492412Z",
+     "iopub.status.idle": "2026-07-14T05:12:52.505480Z",
+     "shell.execute_reply": "2026-07-14T05:12:52.505136Z"
     }
    },
    "outputs": [],

--- a/docs/en/tutorial/04_controlled_gates.py
+++ b/docs/en/tutorial/04_controlled_gates.py
@@ -330,8 +330,9 @@ power_demo_concrete.draw()
 # With both modifiers, the precise call-site meaning is
 # `control((exp(1j * phi) * U) ** power)`. Therefore `power=k` repeats the
 # phase `k` times, while an inverse negates the phase together with inverting
-# `U`. `global_phase` is a reserved call-site keyword; a target callable with
-# a same-named ordinary parameter must receive it positionally.
+# `U`. `global_phase` is a reserved call-site keyword; if the target callable
+# also has an ordinary parameter named `global_phase`, pass that parameter
+# positionally.
 
 
 # %%
@@ -369,7 +370,7 @@ assert phase_counts == {1: 256}
 # Qamomile keeps one target-neutral phase meaning, then verifies the selected
 # quantum SDK/Engine/representation before materialization. Qiskit uses
 # `QuantumCircuit.global_phase`, Quration/PyQret uses its native
-# `global_phase` intrinsic, and HUGR uses `tket.global_phase`. CUDA-Q has no
+# `global_phase` intrinsic, and HUGR uses `tket_exts.global_phase()`. CUDA-Q has no
 # circuit-level phase API, so Qamomile emits the exact identity
 # `R1(2 phi) RZ(-2 phi)` on an existing qubit. QURI Parts likewise has no
 # circuit-level phase API. Qamomile reserves a dedicated internal qubit in

--- a/docs/en/tutorial/04_controlled_gates.py
+++ b/docs/en/tutorial/04_controlled_gates.py
@@ -311,6 +311,86 @@ def power_demo_concrete() -> qmc.Bit:
 power_demo_concrete.draw()
 
 # %% [markdown]
+# (cg-3-4-phase)=
+# #### Global phase becomes observable under coherent control
+#
+# Multiplying an otherwise standalone unitary by `exp(1j * phi)` does not
+# change ordinary measurement probabilities. It must nevertheless be kept:
+# once that unitary is controlled, the same factor is a relative phase on the
+# all-active control subspace. This is particularly important for SELECT
+# circuits, where even an identity Pauli term may carry a complex coefficient.
+#
+# Qamomile provides two equivalent ways to attach this phase:
+#
+# - `qmc.global_phase(fn, phi)` constructs `exp(1j * phi) * U` from the
+#   callable `fn` implementing `U`.
+# - `qmc.control(fn)(..., global_phase=phi)` attaches the phase at that
+#   controlled call site.
+#
+# With both modifiers, the precise call-site meaning is
+# `control((exp(1j * phi) * U) ** power)`. Therefore `power=k` repeats the
+# phase `k` times, while an inverse negates the phase together with inverting
+# `U`. `global_phase` is a reserved call-site keyword; a target callable with
+# a same-named ordinary parameter must receive it positionally.
+
+
+# %%
+@qmc.qkernel
+def _identity_for_phase(q: qmc.Qubit) -> qmc.Qubit:
+    return q
+
+
+controlled_phased_identity = qmc.control(_identity_for_phase)
+
+
+@qmc.qkernel
+def phase_kickback_demo() -> qmc.Bit:
+    control = qmc.h(qmc.qubit("control"))
+    target = qmc.qubit("target")
+    control, target = controlled_phased_identity(
+        control,
+        target,
+        global_phase=math.pi,
+    )
+    control = qmc.h(control)
+    return qmc.measure(control)
+
+
+phase_counts = dict(
+    transpiler.transpile(phase_kickback_demo)
+    .sample(transpiler.executor(), shots=256)
+    .result()
+    .results
+)
+assert phase_counts == {1: 256}
+
+# %% [markdown]
+# :::{note}
+# Qamomile keeps one target-neutral phase meaning, then verifies the selected
+# quantum SDK/Engine/representation before materialization. Qiskit uses
+# `QuantumCircuit.global_phase`, Quration/PyQret uses its native
+# `global_phase` intrinsic, and HUGR uses `tket.global_phase`. CUDA-Q has no
+# circuit-level phase API, so Qamomile emits the exact identity
+# `R1(2 phi) RZ(-2 phi)` on an existing qubit. QURI Parts likewise has no
+# circuit-level phase API. Qamomile reserves a dedicated internal qubit in
+# `|0>` and applies `RZ(-2 phi)` to it, which produces `exp(i phi)|0>` exactly.
+# This carrier is separate from multi-control ancillas and is excluded from
+# measurements and implicit qkernel outputs. QURI Parts can therefore retain a
+# zero-qubit program phase without changing its logical result ABI. CUDA-Q
+# still requires an existing program qubit and rejects a nonzero zero-qubit
+# phase explicitly.
+#
+# Native standalone phase does not by itself imply that a quantum
+# SDK/Engine/representation can transform every reusable call. The current
+# Quration/PyQret Python API cannot apply generic controlled or inverse call
+# transforms. HUGR currently handles phase inside a bounded subset of inlined
+# unitary bodies; exact support depends on the operation and control count and
+# includes one-control Pauli evolution. Its `power` must resolve to a positive
+# compile-time integer. Shapes outside a declared capability fail explicitly
+# rather than losing their phase.
+# :::
+
+# %% [markdown]
 # (cg-3-5)=
 # ### 3.5 Multiple separate positional control args (CCX style)
 #

--- a/docs/ja/tutorial/04_controlled_gates.ipynb
+++ b/docs/ja/tutorial/04_controlled_gates.ipynb
@@ -22,10 +22,10 @@
    "id": "5d03fc82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.461208Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.461115Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.465281Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.464675Z"
+     "iopub.execute_input": "2026-07-14T05:12:54.775770Z",
+     "iopub.status.busy": "2026-07-14T05:12:54.775603Z",
+     "iopub.status.idle": "2026-07-14T05:12:54.780084Z",
+     "shell.execute_reply": "2026-07-14T05:12:54.779396Z"
     }
    },
    "outputs": [],
@@ -40,10 +40,10 @@
    "id": "be99127e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.466663Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.466583Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.530077Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.529638Z"
+     "iopub.execute_input": "2026-07-14T05:12:54.782023Z",
+     "iopub.status.busy": "2026-07-14T05:12:54.781905Z",
+     "iopub.status.idle": "2026-07-14T05:12:54.995353Z",
+     "shell.execute_reply": "2026-07-14T05:12:54.994941Z"
     }
    },
    "outputs": [],
@@ -76,10 +76,10 @@
    "id": "b5e83adc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.531371Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.531280Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.533645Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.533385Z"
+     "iopub.execute_input": "2026-07-14T05:12:54.996512Z",
+     "iopub.status.busy": "2026-07-14T05:12:54.996439Z",
+     "iopub.status.idle": "2026-07-14T05:12:54.998804Z",
+     "shell.execute_reply": "2026-07-14T05:12:54.998411Z"
     }
    },
    "outputs": [],
@@ -94,10 +94,10 @@
    "id": "61fc6a86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.534628Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.534581Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.720531Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.720174Z"
+     "iopub.execute_input": "2026-07-14T05:12:54.999633Z",
+     "iopub.status.busy": "2026-07-14T05:12:54.999588Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.157200Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.156846Z"
     }
    },
    "outputs": [
@@ -132,10 +132,10 @@
    "id": "8735a534",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.721701Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.721606Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.736728Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.736182Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.158257Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.158193Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.172617Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.172336Z"
     }
    },
    "outputs": [
@@ -179,10 +179,10 @@
    "id": "f9d83545",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.737809Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.737749Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.942949Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.942664Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.173556Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.173510Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.506947Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.506591Z"
     }
    },
    "outputs": [
@@ -276,10 +276,10 @@
    "id": "9cfee820",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.944456Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.944348Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.947280Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.946899Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.508086Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.508013Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.510604Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.510304Z"
     }
    },
    "outputs": [],
@@ -301,10 +301,10 @@
    "id": "82ba4264",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.948236Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.948181Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.969887Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.969267Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.511458Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.511413Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.529480Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.529196Z"
     }
    },
    "outputs": [
@@ -353,10 +353,10 @@
    "id": "8b6aef0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.970855Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.970794Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.973107Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.972809Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.530436Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.530399Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.532412Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.532129Z"
     }
    },
    "outputs": [],
@@ -377,10 +377,10 @@
    "id": "9ae2a998",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.974013Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.973965Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.990724Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.990458Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.533115Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.533081Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.547472Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.547110Z"
     }
    },
    "outputs": [
@@ -427,10 +427,10 @@
    "id": "53684416",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.991873Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.991814Z",
-     "iopub.status.idle": "2026-06-05T10:11:26.993981Z",
-     "shell.execute_reply": "2026-06-05T10:11:26.993612Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.548344Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.548303Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.550484Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.550184Z"
     }
    },
    "outputs": [],
@@ -456,10 +456,10 @@
    "id": "e80b1305",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:26.994946Z",
-     "iopub.status.busy": "2026-06-05T10:11:26.994898Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.009981Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.009591Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.551281Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.551246Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.563294Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.563031Z"
     }
    },
    "outputs": [
@@ -494,10 +494,10 @@
    "id": "ca3400e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.011064Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.011001Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.031849Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.031503Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.564239Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.564203Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.581333Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.581046Z"
     }
    },
    "outputs": [
@@ -550,10 +550,10 @@
    "id": "03953777",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.033014Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.032956Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.034507Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.034226Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.582271Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.582232Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.583733Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.583447Z"
     }
    },
    "outputs": [],
@@ -567,10 +567,10 @@
    "id": "2410c353",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.035393Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.035347Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.052058Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.051691Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.584495Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.584462Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.597828Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.597431Z"
     }
    },
    "outputs": [
@@ -601,6 +601,109 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ebf7f005",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "(cg-3-4-phase)=\n",
+    "#### global phaseはcoherent controlの下で観測可能になる\n",
+    "\n",
+    "standaloneなユニタリに`exp(1j * phi)`を掛けても、通常の測定確率は\n",
+    "変わりません。しかし、この位相を捨ててはいけません。同じユニタリを\n",
+    "制御化すると、この係数は全制御量子ビットがactiveな部分空間に対する\n",
+    "relative phaseになります。identity Pauli項にも複素係数を持たせられる\n",
+    "SELECT回路では、特に重要な性質です。\n",
+    "\n",
+    "Qamomileでは、次の等価な2通りで位相を付加できます。\n",
+    "\n",
+    "- `qmc.global_phase(fn, phi)`は、`U`を実装するcallable `fn`から\n",
+    "  `exp(1j * phi) * U`を作ります。\n",
+    "- `qmc.control(fn)(..., global_phase=phi)`は、その制御呼び出しに\n",
+    "  位相を付加します。\n",
+    "\n",
+    "どちらの場合も、呼び出しの厳密な意味は\n",
+    "`control((exp(1j * phi) * U) ** power)`です。そのため`power=k`では\n",
+    "位相も`k`回反復され、inverseでは`U`の反転と一緒に位相の符号も反転します。\n",
+    "`global_phase`は呼び出し側の予約keywordです。制御対象のcallableが同名の\n",
+    "通常パラメータを持つ場合は、そのパラメータをpositionalに渡してください。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "b4e101de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-14T05:12:55.598694Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.598650Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.643461Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.643107Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@qmc.qkernel\n",
+    "def _identity_for_phase(q: qmc.Qubit) -> qmc.Qubit:\n",
+    "    return q\n",
+    "\n",
+    "\n",
+    "controlled_phased_identity = qmc.control(_identity_for_phase)\n",
+    "\n",
+    "\n",
+    "@qmc.qkernel\n",
+    "def phase_kickback_demo() -> qmc.Bit:\n",
+    "    control = qmc.h(qmc.qubit(\"control\"))\n",
+    "    target = qmc.qubit(\"target\")\n",
+    "    control, target = controlled_phased_identity(\n",
+    "        control,\n",
+    "        target,\n",
+    "        global_phase=math.pi,\n",
+    "    )\n",
+    "    control = qmc.h(control)\n",
+    "    return qmc.measure(control)\n",
+    "\n",
+    "\n",
+    "phase_counts = dict(\n",
+    "    transpiler.transpile(phase_kickback_demo)\n",
+    "    .sample(transpiler.executor(), shots=256)\n",
+    "    .result()\n",
+    "    .results\n",
+    ")\n",
+    "assert phase_counts == {1: 256}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24bad8cc",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "Qamomileは量子SDK/Engine/representationに依存しない1つの位相の意味を保ち、\n",
+    "materialize前に選択先のcapabilityを検証します。Qiskitは\n",
+    "`QuantumCircuit.global_phase`、Quration/PyQretはnativeの`global_phase`\n",
+    "intrinsic、HUGRは`tket.global_phase`を使います。CUDA-Qには回路全体の\n",
+    "phase APIがないため、既存量子ビット上に厳密な恒等演算\n",
+    "`R1(2 phi) RZ(-2 phi)`を出力します。QURI Partsにも回路全体のphase APIが\n",
+    "ないため、`|0>`に固定した専用の内部量子ビットへ`RZ(-2 phi)`を適用し、\n",
+    "`exp(i phi)|0>`を厳密に実現します。このcarrierはmulti-control用ancillaから\n",
+    "分離され、measure結果や明示的な戻り値を持たない量子カーネルの暗黙出力には\n",
+    "含まれません。そのためQURI Partsは、論理的な結果ABIを変えずに0量子ビット\n",
+    "プログラムの位相も保持できます。CUDA-Qは既存のプログラム量子ビットを必要と\n",
+    "するため、非ゼロ位相を持つ0量子ビットプログラムを明示的にrejectします。\n",
+    "\n",
+    "nativeなstandalone phaseを持つことと、あらゆる再利用可能呼び出しを変換できる\n",
+    "ことは別です。現在のQuration/PyQret Python APIはgenericなcontrolled/inverse\n",
+    "call変換を提供していません。HUGRはinline後のunitary bodyの限定された部分集合で\n",
+    "phaseを扱い、正確な対応範囲はoperationと制御数に依存します。1制御のPauli\n",
+    "evolutionにも対応しますが、`power`はcompile時に正の整数へ解決できる必要が\n",
+    "あります。宣言されたcapability外の構造は、phaseを失うことなく明示的に\n",
+    "失敗します。\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "54c7f935",
    "metadata": {
     "lines_to_next_cell": 2
@@ -614,14 +717,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "9f9da68d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.053278Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.053210Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.055255Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.055002Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.644365Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.644321Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.646194Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.645874Z"
     }
    },
    "outputs": [],
@@ -631,14 +734,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "9a48cb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.056235Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.056191Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.070959Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.070679Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.646935Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.646896Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.659868Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.659550Z"
     }
    },
    "outputs": [
@@ -649,7 +752,7 @@
        "<Figure size 690.5x256 with 1 Axes>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -684,14 +787,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "7494e53f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.072134Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.072086Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.073648Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.073318Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.660685Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.660649Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.662107Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.661809Z"
     }
    },
    "outputs": [],
@@ -701,14 +804,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "2f199abd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.074535Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.074484Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.098328Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.098028Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.662862Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.662825Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.682574Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.682267Z"
     }
    },
    "outputs": [
@@ -719,7 +822,7 @@
        "<Figure size 702.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,14 +856,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "bc23756b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.099470Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.099423Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.100863Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.100585Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.683479Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.683441Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.685016Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.684648Z"
     }
    },
    "outputs": [],
@@ -770,14 +873,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "04c52db7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.101663Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.101620Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.114692Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.114331Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.685730Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.685694Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.696550Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.696214Z"
     }
    },
    "outputs": [
@@ -788,7 +891,7 @@
        "<Figure size 690.5x200 with 1 Axes>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -839,14 +942,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "4b91b1f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.115746Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.115692Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.136557Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.135949Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.697370Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.697333Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.713936Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.713638Z"
     }
    },
    "outputs": [
@@ -857,7 +960,7 @@
        "<Figure size 738.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -891,14 +994,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "407a6992",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.137598Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.137529Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.159503Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.159226Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.714847Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.714808Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.767081Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.766692Z"
     }
    },
    "outputs": [
@@ -909,7 +1012,7 @@
        "<Figure size 702.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -942,14 +1045,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "9fdee7af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.160746Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.160687Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.217457Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.217189Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.767978Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.767931Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.787258Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.786981Z"
     }
    },
    "outputs": [
@@ -960,7 +1063,7 @@
        "<Figure size 726.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -996,14 +1099,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "2dbebd6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.218533Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.218479Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.241027Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.240671Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.788256Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.788216Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.807446Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.807064Z"
     }
    },
    "outputs": [
@@ -1014,7 +1117,7 @@
        "<Figure size 726.5x416 with 1 Axes>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1052,14 +1155,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "e542fc2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.242126Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.242076Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.266958Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.266540Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.808377Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.808334Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.831236Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.830942Z"
     }
    },
    "outputs": [
@@ -1070,7 +1173,7 @@
        "<Figure size 880.5x336 with 1 Axes>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1111,7 +1214,7 @@
     "(cg-6)=\n",
     "## 6. rejectされるパターンとedge case\n",
     "\n",
-    "本章ではrejectされる呼び出し形を1つずつ見ていきます。最後に、nested controlled emissionのregression例として残しておきたい、現在はsupportedなsliced-QFTのconcrete caseも確認します。\n",
+    "本章ではrejectされる呼び出し形を1つずつ見ていきます。最後に、nested blockをgateへ変換できるbackend(Qiskitなど)でsupportedな、sliced-QFTのconcrete caseもregression例として確認します。\n",
     "\n",
     "| ケース | モード | 例外 |\n",
     "| --- | --- | --- |\n",
@@ -1121,19 +1224,19 @@
     "| 6.4 同じpool量子ビットをtargetに再利用 | symbolic | `UnreturnedBorrowError` |\n",
     "| 6.5 multi-arg制御prefix + `control_indices` | symbolic | `ValueError` |\n",
     "| 6.6 symbolic modeで単一scalar制御 | symbolic | `ValueError` |\n",
-    "| 6.7 sub-kernel内の`UInt` sliceに対するcontrolled QFT | concrete | supported |"
+    "| 6.7 sub-kernel内の`UInt` sliceに対するcontrolled QFT | concrete | block-to-gate変換が成功する場合はsupported |"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "62d62f65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.267893Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.267840Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.269731Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.269467Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.832220Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.832179Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.834061Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.833737Z"
     },
     "lines_to_next_cell": 2
    },
@@ -1172,14 +1275,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "717dbad7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.270866Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.270815Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.273762Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.273424Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.834822Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.834788Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.837507Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.837252Z"
     }
    },
    "outputs": [
@@ -1222,14 +1325,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "91afb857",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.274658Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.274614Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.276940Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.276704Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.838327Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.838293Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.840777Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.840470Z"
     }
    },
    "outputs": [
@@ -1276,14 +1379,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "c5955d9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.278102Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.278061Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.281337Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.281025Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.841623Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.841590Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.844554Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.844270Z"
     }
    },
    "outputs": [
@@ -1336,14 +1439,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "04cd340d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.282326Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.282275Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.285018Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.284695Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.845394Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.845355Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.848103Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.847734Z"
     }
    },
    "outputs": [
@@ -1396,14 +1499,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "c02d61a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.285875Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.285826Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.289440Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.289128Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.848852Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.848819Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.851972Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.851693Z"
     }
    },
    "outputs": [
@@ -1455,14 +1558,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "5b4d73e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.290282Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.290235Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.292697Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.292401Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.852772Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.852738Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.855170Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.854905Z"
     }
    },
    "outputs": [
@@ -1506,19 +1609,19 @@
     "\n",
     "制御対象のsub-kernelが、呼び出し側でサイズの分かっている`Vector[Qubit]`引数全体に`qmc.qft` / `qmc.iqft`を適用する形は使えます。例えば`apply_qft(q)`が`q`全体にQFTを適用するなら、`controlled_qft = qmc.control(apply_qft)`という形は動作します。\n",
     "\n",
-    "下のようにsub-kernelが古典`UInt`引数を受け取り、その値で`q[:m]`を作ってからQFTを呼ぶ、より狭い形も現在は動作します。Qamomileはborrow checkの後、nested controlled block内のslice markerを取り除くため、controlled-U emitterがsliced composite blockをlowerできます。"
+    "下のようにsub-kernelが古典`UInt`引数を受け取り、その値で`q[:m]`を作ってからQFTを呼ぶ、より狭い形もQiskit-backedな経路では動作します。Qamomileはborrow checkの後、nested controlled block内のslice markerを取り除くため、block-to-gate変換が成功するcontrolled-U emitterはsliced composite blockをlowerできます。一方で、block-to-gate変換を持たないbackendでは、このmulti-target fallbackをまだrejectすることがあります。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "6710cd20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T10:11:27.293637Z",
-     "iopub.status.busy": "2026-06-05T10:11:27.293594Z",
-     "iopub.status.idle": "2026-06-05T10:11:27.300771Z",
-     "shell.execute_reply": "2026-06-05T10:11:27.300382Z"
+     "iopub.execute_input": "2026-07-14T05:12:55.855980Z",
+     "iopub.status.busy": "2026-07-14T05:12:55.855942Z",
+     "iopub.status.idle": "2026-07-14T05:12:55.867745Z",
+     "shell.execute_reply": "2026-07-14T05:12:55.867418Z"
     }
    },
    "outputs": [],

--- a/docs/ja/tutorial/04_controlled_gates.ipynb
+++ b/docs/ja/tutorial/04_controlled_gates.ipynb
@@ -682,7 +682,7 @@
     "Qamomileは量子SDK/Engine/representationに依存しない1つの位相の意味を保ち、\n",
     "materialize前に選択先のcapabilityを検証します。Qiskitは\n",
     "`QuantumCircuit.global_phase`、Quration/PyQretはnativeの`global_phase`\n",
-    "intrinsic、HUGRは`tket.global_phase`を使います。CUDA-Qには回路全体の\n",
+    "intrinsic、HUGRは`tket_exts.global_phase()`を使います。CUDA-Qには回路全体の\n",
     "phase APIがないため、既存量子ビット上に厳密な恒等演算\n",
     "`R1(2 phi) RZ(-2 phi)`を出力します。QURI Partsにも回路全体のphase APIが\n",
     "ないため、`|0>`に固定した専用の内部量子ビットへ`RZ(-2 phi)`を適用し、\n",

--- a/docs/ja/tutorial/04_controlled_gates.py
+++ b/docs/ja/tutorial/04_controlled_gates.py
@@ -261,6 +261,84 @@ def power_demo_concrete() -> qmc.Bit:
 power_demo_concrete.draw()
 
 # %% [markdown]
+# (cg-3-4-phase)=
+# #### global phaseはcoherent controlの下で観測可能になる
+#
+# standaloneなユニタリに`exp(1j * phi)`を掛けても、通常の測定確率は
+# 変わりません。しかし、この位相を捨ててはいけません。同じユニタリを
+# 制御化すると、この係数は全制御量子ビットがactiveな部分空間に対する
+# relative phaseになります。identity Pauli項にも複素係数を持たせられる
+# SELECT回路では、特に重要な性質です。
+#
+# Qamomileでは、次の等価な2通りで位相を付加できます。
+#
+# - `qmc.global_phase(fn, phi)`は、`U`を実装するcallable `fn`から
+#   `exp(1j * phi) * U`を作ります。
+# - `qmc.control(fn)(..., global_phase=phi)`は、その制御呼び出しに
+#   位相を付加します。
+#
+# どちらの場合も、呼び出しの厳密な意味は
+# `control((exp(1j * phi) * U) ** power)`です。そのため`power=k`では
+# 位相も`k`回反復され、inverseでは`U`の反転と一緒に位相の符号も反転します。
+# `global_phase`は呼び出し側の予約keywordです。制御対象のcallableが同名の
+# 通常パラメータを持つ場合は、そのパラメータをpositionalに渡してください。
+
+
+# %%
+@qmc.qkernel
+def _identity_for_phase(q: qmc.Qubit) -> qmc.Qubit:
+    return q
+
+
+controlled_phased_identity = qmc.control(_identity_for_phase)
+
+
+@qmc.qkernel
+def phase_kickback_demo() -> qmc.Bit:
+    control = qmc.h(qmc.qubit("control"))
+    target = qmc.qubit("target")
+    control, target = controlled_phased_identity(
+        control,
+        target,
+        global_phase=math.pi,
+    )
+    control = qmc.h(control)
+    return qmc.measure(control)
+
+
+phase_counts = dict(
+    transpiler.transpile(phase_kickback_demo)
+    .sample(transpiler.executor(), shots=256)
+    .result()
+    .results
+)
+assert phase_counts == {1: 256}
+
+# %% [markdown]
+# :::{note}
+# Qamomileは量子SDK/Engine/representationに依存しない1つの位相の意味を保ち、
+# materialize前に選択先のcapabilityを検証します。Qiskitは
+# `QuantumCircuit.global_phase`、Quration/PyQretはnativeの`global_phase`
+# intrinsic、HUGRは`tket.global_phase`を使います。CUDA-Qには回路全体の
+# phase APIがないため、既存量子ビット上に厳密な恒等演算
+# `R1(2 phi) RZ(-2 phi)`を出力します。QURI Partsにも回路全体のphase APIが
+# ないため、`|0>`に固定した専用の内部量子ビットへ`RZ(-2 phi)`を適用し、
+# `exp(i phi)|0>`を厳密に実現します。このcarrierはmulti-control用ancillaから
+# 分離され、measure結果や明示的な戻り値を持たない量子カーネルの暗黙出力には
+# 含まれません。そのためQURI Partsは、論理的な結果ABIを変えずに0量子ビット
+# プログラムの位相も保持できます。CUDA-Qは既存のプログラム量子ビットを必要と
+# するため、非ゼロ位相を持つ0量子ビットプログラムを明示的にrejectします。
+#
+# nativeなstandalone phaseを持つことと、あらゆる再利用可能呼び出しを変換できる
+# ことは別です。現在のQuration/PyQret Python APIはgenericなcontrolled/inverse
+# call変換を提供していません。HUGRはinline後のunitary bodyの限定された部分集合で
+# phaseを扱い、正確な対応範囲はoperationと制御数に依存します。1制御のPauli
+# evolutionにも対応しますが、`power`はcompile時に正の整数へ解決できる必要が
+# あります。宣言されたcapability外の構造は、phaseを失うことなく明示的に
+# 失敗します。
+# :::
+
+# %% [markdown]
 # (cg-3-5)=
 # ### 3.5 制御引数を別々のpositionalで渡す(CCXスタイル)
 #

--- a/docs/ja/tutorial/04_controlled_gates.py
+++ b/docs/ja/tutorial/04_controlled_gates.py
@@ -319,7 +319,7 @@ assert phase_counts == {1: 256}
 # Qamomileは量子SDK/Engine/representationに依存しない1つの位相の意味を保ち、
 # materialize前に選択先のcapabilityを検証します。Qiskitは
 # `QuantumCircuit.global_phase`、Quration/PyQretはnativeの`global_phase`
-# intrinsic、HUGRは`tket.global_phase`を使います。CUDA-Qには回路全体の
+# intrinsic、HUGRは`tket_exts.global_phase()`を使います。CUDA-Qには回路全体の
 # phase APIがないため、既存量子ビット上に厳密な恒等演算
 # `R1(2 phi) RZ(-2 phi)`を出力します。QURI Partsにも回路全体のphase APIが
 # ないため、`|0>`に固定した専用の内部量子ビットへ`RZ(-2 phi)`を適用し、


### PR DESCRIPTION
## Summary

- Add English and Japanese guidance for preserving global phase under coherent control.
- Demonstrate phase kickback with an executable assertion using the new controlled-call phase API.
- Explain how each supported quantum SDK, Engine, or representation realizes global phase and where explicit capability limits remain.

This is a stacked documentation PR for #593. Its base is the implementation branch so the review diff contains only the four paired tutorial files; after #593 merges, the base can be changed to `main`.

## Validation

- `./docs/build.sh page-build docs/en/tutorial/04_controlled_gates.py docs/ja/tutorial/04_controlled_gates.py`
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- Jupytext source/notebook diff checks for both language pairs
- Local review completed with no findings
