### PR TITLE
Fix Aer empty multiplexer execution

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -124,6 +124,16 @@ Element-granularity consumption (`if sel: _ = qmc.measure(qs[0])` followed by re
 
 **Future fix**: materialize the native inverse as a directly controllable Qiskit gate, or decompose the annotated inverse before controlling the reusable circuit.
 
+## Qiskit Aer execution may apply an extra lowering pass for empty-parameter multiplexers
+
+**When it bites**: a Qiskit circuit sent through `QiskitExecutor` targets Qiskit Aer and, after Qiskit transpilation, contains a `multiplexer` instruction with an empty `params` list. This shape can be produced by Qiskit's native state-preparation inverse path, including Qamomile's native Qiskit realization of concrete amplitude encoding followed by an inverse inside retained control flow. A params-bearing `multiplexer` is a valid Aer instruction and is left unchanged.
+
+**Why this trade-off was chosen**: Aer treats the operation name `multiplexer` as a native instruction and reads its unitary matrices from `operation.params`. Qiskit can also produce a generic gate named `multiplexer` whose matrices live only in the gate definition, leaving `params` empty. Passing that empty-parameter form to Aer can crash native assembly. To keep Qamomile's public Qiskit circuit as high-level as possible while avoiding an Aer crash at execution time, `QiskitExecutor` recursively inspects the Aer-transpiled circuit, including nested control-flow blocks, and decomposes only empty-parameter multiplexers immediately before `backend.run`.
+
+**Workaround**: if exact Qiskit-native state-preparation structure is not needed, `QiskitTranspiler(use_native_composite=False)` avoids the native `StatePreparation` path and emits Qamomile's explicit fallback decomposition instead. Users who build Qiskit circuits manually can also transpile against a backend target that does not include `multiplexer`, such as a suitable fake backend target, before executing on Aer.
+
+**Future fix**: remove the executor-side lowering once Qiskit and Aer agree on a memory-safe representation for inverse-derived multiplexers, either by keeping the generic empty-parameter form away from Aer-native basis instructions or by having Aer reject/decompose it through the gate definition instead of entering native assembly.
+
 ## `qmc.inverse` requires trace-time-resolvable control flow
 
 **When it bites**: `qmc.inverse(layer)(...)` is traced for a `layer` qkernel whose quantum body contains control flow the eager inverse builder cannot resolve while constructing the fallback `implementation_block`:

--- a/qamomile/qiskit/transpiler.py
+++ b/qamomile/qiskit/transpiler.py
@@ -69,12 +69,17 @@ class QiskitExecutor(QuantumExecutor["QuantumCircuit"]):
         """Execute circuit and return bitstring counts.
 
         Args:
-            circuit: The quantum circuit to execute
-            shots: Number of measurement shots
+            circuit (QuantumCircuit): Qiskit circuit to execute.
+            shots (int): Number of measurement shots.
 
         Returns:
-            Dictionary mapping bitstrings to counts (e.g., {"00": 512, "11": 512).
-            A circuit without quantum or classical bits returns ``{"": shots}``.
+            dict[str, int]: Dictionary mapping bitstrings to counts. A circuit
+            without quantum or classical bits returns ``{"": shots}``.
+
+        Raises:
+            RuntimeError: If no Qiskit backend is available for execution, or
+                if Aer would still receive an empty-parameter multiplexer after
+                the workaround decomposition.
         """
         if circuit.num_qubits == 0 and circuit.num_clbits == 0:
             return {"": shots}
@@ -86,17 +91,9 @@ class QiskitExecutor(QuantumExecutor["QuantumCircuit"]):
 
         circuit_with_meas = self._ensure_measurements(circuit)
         transpiled = transpile(circuit_with_meas, self.backend)
-        # Aer may retain Qiskit's internal multiplexer instruction and crash
-        # in native assembly when it is composed with its inverse. Keep the
-        # public circuit abstract, but lower that private runtime detail before
-        # submitting it to the backend.
-        if type(self.backend).__module__.startswith("qiskit_aer.") and any(
-            instruction.operation.name == "multiplexer"
-            for instruction in transpiled.data
-        ):
-            transpiled = transpile(
-                transpiled.decompose(gates_to_decompose=["multiplexer"], reps=4),
-                self.backend,
+        if type(self.backend).__module__.startswith("qiskit_aer."):
+            transpiled = _decompose_empty_parameter_multiplexers(
+                transpiled, self.backend
             )
         job = self.backend.run(transpiled, shots=shots)
         return job.result().get_counts()
@@ -295,3 +292,63 @@ class QiskitTranspiler(Transpiler["QuantumCircuit"]):
             QiskitExecutor: Executor configured with the backend.
         """
         return QiskitExecutor(backend)
+
+
+def _contains_empty_parameter_multiplexer(circuit: "QuantumCircuit") -> bool:
+    """Return whether a circuit contains Aer's unsafe multiplexer form.
+
+    Args:
+        circuit (QuantumCircuit): Qiskit circuit to inspect, including any
+            nested control-flow blocks reachable through ``ControlFlowOp``.
+
+    Returns:
+        bool: True when the circuit contains a ``multiplexer`` instruction
+            whose parameter list is empty, otherwise False.
+    """
+    from qiskit.circuit import ControlFlowOp
+
+    for instruction in circuit.data:
+        operation = instruction.operation
+        if operation.name == "multiplexer" and not operation.params:
+            return True
+        if isinstance(operation, ControlFlowOp) and any(
+            _contains_empty_parameter_multiplexer(block) for block in operation.blocks
+        ):
+            return True
+    return False
+
+
+def _decompose_empty_parameter_multiplexers(
+    circuit: "QuantumCircuit", backend: Any
+) -> "QuantumCircuit":
+    """Decompose Aer's unsafe empty-parameter multiplexers before execution.
+
+    Args:
+        circuit (QuantumCircuit): Transpiled Qiskit circuit to sanitize.
+        backend (Any): Qiskit backend used for the follow-up transpilation.
+
+    Returns:
+        QuantumCircuit: The original circuit when no unsafe multiplexer is
+            present, otherwise a re-transpiled circuit with matching
+            multiplexers decomposed through nested control-flow blocks.
+
+    Raises:
+        RuntimeError: If an empty-parameter multiplexer remains after the
+            decomposition pass and re-transpilation.
+    """
+    if not _contains_empty_parameter_multiplexer(circuit):
+        return circuit
+
+    from qiskit import transpile
+    from qiskit.circuit import ControlFlowOp
+
+    decomposed = transpile(
+        circuit.decompose(gates_to_decompose=["multiplexer", ControlFlowOp], reps=4),
+        backend,
+    )
+    if _contains_empty_parameter_multiplexer(decomposed):
+        raise RuntimeError(
+            "Aer execution would receive an empty-parameter multiplexer that "
+            "can crash native assembly."
+        )
+    return decomposed

--- a/tests/transpiler/backends/test_qiskit.py
+++ b/tests/transpiler/backends/test_qiskit.py
@@ -59,6 +59,69 @@ class TestQiskitTranspiler(TranspilerTestSuite):
 
         assert executor.backend.options.max_parallel_threads != 1
 
+    def test_executor_decomposes_nested_empty_multiplexer_without_unrolling(
+        self,
+    ) -> None:
+        """Aer workaround decomposes poisoned multiplexers inside for_loop blocks."""
+        import math
+
+        from qiskit import QuantumCircuit, transpile
+        from qiskit.circuit.library import StatePreparation
+        from qiskit_aer import AerSimulator
+
+        from qamomile.qiskit import QiskitExecutor
+        from qamomile.qiskit.transpiler import (
+            _contains_empty_parameter_multiplexer,
+            _decompose_empty_parameter_multiplexers,
+        )
+
+        backend = AerSimulator()
+        amplitudes = [0.5, math.sqrt(0.75)]
+        body = QuantumCircuit(1, 1)
+        body.append(StatePreparation(amplitudes).inverse(), [0])
+        circuit = QuantumCircuit(1, 1)
+        circuit.for_loop(range(2), None, body, [0], [0])
+        circuit.measure(0, 0)
+
+        transpiled = transpile(circuit, backend)
+        fixed = _decompose_empty_parameter_multiplexers(transpiled, backend)
+
+        assert any(inst.operation.name == "for_loop" for inst in fixed.data)
+        assert not _contains_empty_parameter_multiplexer(fixed)
+
+        counts = QiskitExecutor(backend).execute(circuit, shots=8)
+        assert sum(counts.values()) == 8
+
+    def test_executor_leaves_parameterized_multiplexer_untouched(self) -> None:
+        """Aer workaround does not treat valid params-bearing multiplexers as unsafe."""
+        from qiskit import QuantumCircuit, transpile
+        from qiskit.circuit.library import UCGate
+        from qiskit_aer import AerSimulator
+
+        from qamomile.qiskit.transpiler import (
+            _contains_empty_parameter_multiplexer,
+            _decompose_empty_parameter_multiplexers,
+        )
+
+        backend = AerSimulator()
+        circuit = QuantumCircuit(2, 2)
+        circuit.append(UCGate([np.eye(2), np.array([[0, 1], [1, 0]])]), [0, 1])
+        circuit.measure([0, 1], [0, 1])
+
+        transpiled = transpile(circuit, backend)
+        fixed = _decompose_empty_parameter_multiplexers(transpiled, backend)
+
+        multiplexers = [
+            instruction.operation
+            for instruction in fixed.data
+            if instruction.operation.name == "multiplexer"
+        ]
+        assert len(multiplexers) == 1
+        assert len(multiplexers[0].params) == 2
+        assert fixed is transpiled
+        assert not _contains_empty_parameter_multiplexer(fixed)
+        assert backend.run(fixed, shots=8).result().get_counts() == {"00": 8}
+
     def test_bare_loop_variable_angle_is_internal_to_public_abi(self) -> None:
         """A native loop induction angle does not become a public parameter."""
         from qamomile.qiskit import QiskitTranspiler


### PR DESCRIPTION
## Summary
- recursively detect Aer-unsafe empty-parameter multiplexers inside Qiskit control-flow blocks before execution
- decompose only empty-parameter multiplexers, leaving valid params-bearing multiplexers untouched
- document the Aer-specific executor-side lowering in LIMITATIONS.md

## Testing
- uv run pytest tests/transpiler/backends/test_qiskit.py -q
- uv run ruff check qamomile/ tests/
- uv run ruff format --check qamomile/ tests/
- env git diff --check
- uv run zuban check qamomile/ (fails in existing qamomile/hugr/lowerer.py imports/stubs unrelated to this change)