### PR TITLE
Add v0.13.0 release notes

### DIFF
--- a/docs/en/myst.yml
+++ b/docs/en/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: Release Notes
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_13_0.md
         - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md

--- a/docs/en/release_notes/index.md
+++ b/docs/en/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # Release Notes
 
+- [v0.13.0](v0_13_0) — semantic `qmc.select`, exact `qmc.global_phase`, loop-carried scalars, and generic versus explicit Möttönen amplitude encoding; Qiskit moved to the `qiskit` extra
 - [v0.12.7](v0_12_7) — `Dict[K, Float]` coefficients as runtime parameters with `d[key]` subscript, `%` operator on `UInt`, and a batch of new compile-time errors (`QubitRebindError`, `QubitConsumedError`, `TypeError` on `bool` / mismatched args) that reject previously silent miscompiles
 - [v0.12.6](v0_12_6) — circuit inversion with `qmc.inverse` (built-in gates, `@qkernel`s, QFT/IQFT), `qmc.modular_increment` / `qmc.modular_decrement` basis-state arithmetic, job/result types importable from `qamomile.circuit`
 - [v0.12.5](v0_12_5) — `PCEConverter` / `PCEEncoder` for Pauli Correlation Encoding, seeded QURI Parts sampling, measured `Vector[Bit]` condition fixes, and `qmc.expval` fixes for `Vector` elements

--- a/docs/en/release_notes/v0_13_0.md
+++ b/docs/en/release_notes/v0_13_0.md
@@ -1,0 +1,244 @@
+# Qamomile v0.13.0
+
+Qamomile v0.13.0 adds SELECT and global-phase operations. In addition, `qmc.control` now accepts an integer `control_value`. Qiskit and circuit visualization are now optional, so users who want to continue using Qiskit should run `pip install "qamomile[qiskit]"`.
+
+```
+pip install qamomile==0.13.0
+```
+
+## Breaking Changes
+
+- **Qiskit is now an optional dependency.** A base `pip install qamomile==0.13.0` installs the Engine-independent compiler core. To install Qiskit and the circuit-visualization dependencies used by the examples in these release notes, run `pip install "qamomile[qiskit,visualization]==0.13.0"` ([#599](https://github.com/Jij-Inc/Qamomile/pull/599)).
+- **The class-based composite-gate API has been removed.** `CompositeGate`, `QFT`, `IQFT`, and similar APIs are no longer public. Define named reusable bodies with `@qmc.composite_gate`. The decorator returns an ordinary `QKernel`, so it uses the same `build()`, `draw()`, `estimate_resources()`, `qmc.control`, and `qmc.inverse` paths as other qkernels.
+- The state-preparation module moved from `qamomile.circuit.algorithm.state_preparation` to `qamomile.circuit.stdlib.state_preparation`. The top-level `qmc.amplitude_encoding`, `qmc.amplitude_encoding_from_angles`, and `qmc.computational_basis_state` imports remain available ([#571](https://github.com/Jij-Inc/Qamomile/pull/571), [#586](https://github.com/Jij-Inc/Qamomile/pull/586)).
+- **`qmc.amplitude_encoding` is now a state-preparation API that does not specify a synthesis method.** It uses native state preparation when the Engine provides it and otherwise uses Möttönen state preparation. Use `qmc.mottonen_amplitude_encoding` when you want to request Möttönen state preparation explicitly ([#602](https://github.com/Jij-Inc/Qamomile/pull/602)).
+- **The resource-estimation data model has changed.** `GateCount`, `count_gates`, `qubits_counter`, and the `qamomile.circuit.estimator.algorithmic` modules were removed. Use `qkernel.estimate_resources()` or `qmc.estimate_resources()` and the new `ResourceEstimate` fields for width, gates, depth, calls, assumptions, and estimate quality. The compatibility aliases `estimate.qubits`, `estimate.gates.t_gates`, `estimate.gates.clifford_gates`, and `estimate.gates.rotation_gates` remain, but direct construction and the `to_dict()` schema have changed ([#571](https://github.com/Jij-Inc/Qamomile/pull/571)).
+- **Block-level JSON and MessagePack serialization has been removed.** `dump_json`, `load_json`, `dump_msgpack`, `load_msgpack`, `to_dict`, and `from_dict` are no longer exposed from `qamomile.circuit.ir.serialize`, and v0.12.7 payloads are not migrated. Use `qamomile.circuit.serialization.serialize()` and `deserialize()` to persist an unbound qkernel as deterministic Protobuf bytes ([#595](https://github.com/Jij-Inc/Qamomile/pull/595)).
+- **Engine emitter and artifact classes are no longer part of the supported public API.** `QuriPartsEmitPass`, `CudaqEmitPass`, `CudaqKernelEmitter`, `CudaqKernelArtifact`, and `BoundCudaqKernelArtifact` were removed from their package exports. Continue to use `QiskitTranspiler`, `QuriPartsTranspiler`, or `CudaqTranspiler` and their executors ([#586](https://github.com/Jij-Inc/Qamomile/pull/586)).
+- **`SliceBorrowViolationError` has been removed.** Post-fold slice failures now report the semantic cause with `QubitBorrowConflictError` or `QubitConsumedError`; unsupported ownership propagation across control flow raises `ValidationError` ([#591](https://github.com/Jij-Inc/Qamomile/pull/591)).
+
+## New Features
+
+### Semantic `qmc.select` and value-activated controls
+
+`qmc.select([U0, U1, ...])` creates a SELECT operation that applies case `Ui` to the shared target qubits when the LSB-first index register represents the integer `i`. The index width can be inferred from the number of cases or specified with a Python `int` or `qmc.UInt`. In addition, `qmc.control(..., control_value=v)` creates a controlled operation that applies the target operation when the flattened control qubits match the concrete LSB-first value `v` ([#597](https://github.com/Jij-Inc/Qamomile/pull/597)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def select_example() -> tuple[qmc.Bit, qmc.Bit]:
+    index = qmc.qubit(name="index")
+    target = qmc.qubit(name="target")
+    index = qmc.x(index)   # select case 1
+    target = qmc.x(target)
+    index, target = qmc.select([qmc.x, qmc.z])(index, target)
+    return qmc.measure(index), qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(select_example)
+```
+
+### Exact global phase for reusable operations
+
+`qmc.global_phase(target, phase)` applies `target` followed by `exp(i * phase)` and preserves the phase explicitly through nested qkernel calls, control, inverse, powers, structured control flow, and Protobuf round trips. A standalone global phase is not observable, but under controlled or SELECT operations it becomes a relative phase and appears in interference results ([#593](https://github.com/Jij-Inc/Qamomile/pull/593), [#596](https://github.com/Jij-Inc/Qamomile/pull/596)).
+
+```python
+import math
+
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def identity(qubit: qmc.Qubit) -> qmc.Qubit:
+    return qubit
+
+@qmc.qkernel
+def phased_identity(qubit: qmc.Qubit) -> qmc.Qubit:
+    return qmc.global_phase(identity, math.pi)(qubit)
+
+@qmc.qkernel
+def phase_kickback() -> tuple[qmc.Bit, qmc.Bit]:
+    control = qmc.h(qmc.qubit(name="control"))
+    target = qmc.h(qmc.qubit(name="target"))
+    control, target = qmc.control(phased_identity)(control, target)
+    control = qmc.h(control)
+    target = qmc.h(target)
+    return qmc.measure(control), qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(phase_kickback)
+```
+
+### Loop-carried scalars and classical comparisons
+
+Reassigning a same-type `UInt` or `Float` inside `qmc.range` and `qmc.items` now carries the updated value into the next iteration instead of raising `ValidationError`. This supports accumulators and values computed for later gate parameters or compile-time branches. Runtime-trip-count `while` carries, measurement-backed `Bit` carries, mixed-type reassignments, and measurement-derived carries inside loops that also contain quantum work remain unsupported. In addition, `Bit`, `UInt`, and `Float` handles now implement the supported Python comparison operators without collapsing to host-language booleans during tracing. This includes numeric ordering, equality and inequality, mixed `UInt`/`Float` comparisons, and `Bit` equality with `Bit`, `bool`, zero-or-one integers, or `UInt` ([#580](https://github.com/Jij-Inc/Qamomile/pull/580), [#587](https://github.com/Jij-Inc/Qamomile/pull/587)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def accumulated_branch(n: qmc.UInt) -> qmc.Bit:
+    qubit = qmc.qubit(name="qubit")
+    total = 0
+    for i in qmc.range(n):
+        total = total + i
+    if total >= 3:
+        qubit = qmc.x(qubit)
+    return qmc.measure(qubit)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(accumulated_branch, bindings={"n": 3})
+```
+
+### Retaining projection and reset operations
+
+`qmc.project_x`, `qmc.project_y`, and `qmc.project_z` return both the projected qubit and its classical `Bit`, so a qkernel can continue using the post-measurement state. `qmc.reset` returns a fresh handle for the same qubit in `|0>`, and `qmc.measure_reset` combines Z-basis projection and reset. These operations keep Qamomile's affine ownership checks intact because the input handle is consumed and the returned qubit handle carries the state forward ([#599](https://github.com/Jij-Inc/Qamomile/pull/599)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def measure_and_reset() -> tuple[qmc.Bit, qmc.Bit]:
+    qubit = qmc.x(qmc.qubit(name="qubit"))
+    qubit, before = qmc.measure_reset(qubit)
+    after = qmc.measure(qubit)
+    return before, after
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(measure_and_reset)
+```
+
+### Generic and explicit Möttönen amplitude encoding
+
+`qmc.amplitude_encoding` now describes the state to prepare without prescribing how the Engine synthesizes it. `qmc.mottonen_amplitude_encoding` explicitly uses the Möttönen algorithm ([#602](https://github.com/Jij-Inc/Qamomile/pull/602)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def prepare_bell() -> qmc.Vector[qmc.Bit]:
+    qubits = qmc.qubit_array(2, name="qubits")
+    qubits = qmc.mottonen_amplitude_encoding(
+        qubits, [1.0, 0.0, 0.0, 1.0]
+    )
+    return qmc.measure(qubits)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(prepare_bell)
+```
+
+See [Möttönen Amplitude Encoding](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/algorithm/mottonen_amplitude_encoding.ipynb).
+
+### Unified callables, opaque oracles, and an expanded standard library
+
+Named composite gates are now ordinary qkernels with one call model for direct calls, control, inverse, serialization, visualization, and body-derived resource estimation. `qmc.opaque(name, ...)` and `qmc.Oracle` add bodyless callables for top-down design; they can carry a fixed or context-dependent resource cost until a target implementation or substitution is supplied. `ResourceEstimate` now reports logical width, gate categories, depth, callable/query counts, assumptions, an explanation trace, and estimate quality, including symbolic expressions for unbound inputs. The public standard library now includes `qmc.mcx`, reversible ripple-carry and modular arithmetic, Grover search helpers, and Shor order finding. State-preparation helpers also use this callable model, so the same executable bodies drive transpilation and resource estimates ([#571](https://github.com/Jij-Inc/Qamomile/pull/571), [#586](https://github.com/Jij-Inc/Qamomile/pull/586)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def stdlib_mcx() -> tuple[qmc.Vector[qmc.Bit], qmc.Bit]:
+    controls = qmc.x(qmc.qubit_array(3, name="controls"))
+    target = qmc.qubit(name="target")
+    controls, target = qmc.mcx(controls, target)
+    return qmc.measure(controls), qmc.measure(target)
+
+estimate = stdlib_mcx.estimate_resources()
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(stdlib_mcx)
+```
+
+### Protobuf qkernel serialization
+
+`qamomile.circuit.serialization.serialize()` writes a static, unbound qkernel as deterministic Protobuf bytes, including its public signature, hierarchical body, callable definitions, defaults, annotations, global-phase operations, and value relationships. `deserialize()` reconstructs a qkernel-like object that can receive fresh compile-time bindings and runtime parameters through the normal transpiler interface. Bound or lowered artifacts, runtime values, and Engine objects remain outside the format ([#595](https://github.com/Jij-Inc/Qamomile/pull/595), [#596](https://github.com/Jij-Inc/Qamomile/pull/596)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.circuit.serialization import deserialize, serialize
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def serializable_flip() -> qmc.Bit:
+    qubit = qmc.x(qmc.qubit(name="qubit"))
+    return qmc.measure(qubit)
+
+payload = serialize(serializable_flip)
+restored = deserialize(payload)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(restored)
+```
+
+## Internal Changes
+
+The features above are built on a target-neutral preparation stage, a unified callable graph, and an Engine-neutral circuit representation. These boundaries let circuit SDKs and program-graph targets share Qamomile semantics without forcing every target through the same execution model.
+
+### Explicit compiler targets and Engine-neutral circuit lowering
+
+`QamomileCompiler.prepare()` now produces a `PreparedModule` that preserves reachable callable definitions, structured control flow, the call graph, and the classical ABI. Circuit Engines lower this into a verified `CircuitProgram` before native materialization, while the new `HugrTranspiler` compiles prepared semantics directly to a HUGR package. The new `QurationTranspiler` materializes through PyQret and exposes Quration resource compilation; HUGR dependencies are available through the `hugr` extra, while PyQret must currently be installed separately ([#586](https://github.com/Jij-Inc/Qamomile/pull/586)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.circuit.transpiler import QamomileCompiler
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def compiler_example() -> qmc.Bit:
+    qubit = qmc.h(qmc.qubit(name="qubit"))
+    return qmc.measure(qubit)
+
+prepared = QamomileCompiler().prepare(compiler_example)
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(compiler_example)
+```
+
+**Why**: preserving semantic call and control-flow structure until a target chooses its lowering keeps the core IR Engine-independent, allows HUGR to retain program-graph structure, and gives circuit Engines one verified boundary before constructing SDK-native objects.
+
+### Yield-based branch merges
+
+`IfOperation` now records each merged result with parallel true-branch and false-branch yield values. The former `PhiOp` pseudo-operation has been removed, while `iter_merges()` and `add_merge()` provide one validated accessor path for compiler passes, serialization, dependency analysis, and classical execution ([#570](https://github.com/Jij-Inc/Qamomile/pull/570), [#574](https://github.com/Jij-Inc/Qamomile/pull/574)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def measurement_branch_merge() -> tuple[qmc.Bit, qmc.Bit]:
+    condition = qmc.measure(qmc.h(qmc.qubit(name="condition")))
+    target = qmc.qubit(name="target")
+    if condition:
+        target = qmc.x(target)
+    return condition, qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(measurement_branch_merge)
+```
+
+**Why**: unlike the user-facing features above, this is an independent internal restructuring. Representing branch results as explicit yields aligns the IR with structured control flow, prevents affine quantum values from being double-counted as operands, and keeps merge semantics consistent across compiler consumers.
+
+## Bug Fixes
+
+- **Measurement-derived classical outputs are no longer dropped.** A comparison, arithmetic expression, or logical expression derived from measurements and returned from a qkernel now runs in host-side post-processing when appropriate instead of resolving to `None`. This path also works on Engines without dynamic-circuit support ([#546](https://github.com/Jij-Inc/Qamomile/pull/546)).
+- **Compile-time branches inside controlled qkernels are folded before emission.** Binding-driven `if` statements nested in `qmc.control` now select the correct branch on Qiskit, QURI Parts, and CUDA-Q instead of reaching Engine emission as unsupported classical control flow ([#579](https://github.com/Jij-Inc/Qamomile/pull/579)).
+- **Qiskit Aer no longer crashes on empty-parameter multiplexers produced by native state preparation.** `QiskitExecutor` recursively checks the transpiled circuit, including nested control-flow blocks, and decomposes only the empty-parameter `multiplexer` form before Aer execution. Valid parameter-bearing multiplexers are left unchanged ([#601](https://github.com/Jij-Inc/Qamomile/pull/601)).
+- **QURI Parts multi-controlled gates now scale linearly in the control count.** The fallback uses a clean-ancilla Toffoli cascade instead of constructing an exponentially large dense unitary. Runtime-parameterized multi-controlled rotations and control widths beyond the former dense-matrix cap now transpile; the added ancillas are uncomputed before execution completes ([#555](https://github.com/Jij-Inc/Qamomile/pull/555)).
+- **Compiler and Engine contracts fail earlier and more consistently.** Invalid scalar, array, and dictionary bindings now receive shape and type validation; runtime parameters retain deterministic ordering; canonical identity includes NumPy shape; and controlled, inverse, measurement, and Pauli-evolution paths have aligned checks across Qiskit, QURI Parts, CUDA-Q, HUGR, qBraid, and Quration ([#599](https://github.com/Jij-Inc/Qamomile/pull/599)).
+
+## Documentation
+
+- [**Tutorial 04 — Controlled Gates**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/tutorial/04_controlled_gates.ipynb) now covers value-activated controls, SELECT multiplexers, and global-phase semantics ([#593](https://github.com/Jij-Inc/Qamomile/pull/593), [#597](https://github.com/Jij-Inc/Qamomile/pull/597)).
+- [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/tutorial/05_resource_estimation.ipynb) reflects body-derived symbolic estimates and the redesigned resource model ([#588](https://github.com/Jij-Inc/Qamomile/pull/588)).
+- [**Tutorial 06 — Execution Models**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/tutorial/06_execution_models.ipynb) clarifies qkernel return order, `Vector` measurement index order, and the least-significant-bit convention for tuple outcomes ([#581](https://github.com/Jij-Inc/Qamomile/pull/581)).
+- [**Tutorial 10 — Compilation and Transpilation**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/tutorial/10_compilation_and_transpilation.ipynb) documents callable invocation, the reconstructed transpiler pipeline, if-merge yields, and semantic slice-borrow errors ([#578](https://github.com/Jij-Inc/Qamomile/pull/578), [#588](https://github.com/Jij-Inc/Qamomile/pull/588), [#592](https://github.com/Jij-Inc/Qamomile/pull/592)).
+- [**Möttönen Amplitude Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/algorithm/mottonen_amplitude_encoding.ipynb) now distinguishes method-independent state preparation from the explicit Möttönen APIs and demonstrates transpile-time amplitude binding, runtime angle rebinding, fidelity checks, and resource formulas ([#602](https://github.com/Jij-Inc/Qamomile/pull/602)).
+- The [**Qiskit**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/integration/qiskit_support.ipynb), [**QURI Parts**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/integration/quri_parts_support.ipynb), and [**CUDA-Q**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/en/integration/cudaq_support.ipynb) integration pages were updated for the current transpiler and installation surfaces ([#588](https://github.com/Jij-Inc/Qamomile/pull/588), [#599](https://github.com/Jij-Inc/Qamomile/pull/599)).
+
+## Learn More
+
+- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)

--- a/docs/ja/myst.yml
+++ b/docs/ja/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: リリースノート
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_13_0.md
         - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
         - file: release_notes/v0_12_5.md

--- a/docs/ja/release_notes/index.md
+++ b/docs/ja/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # リリースノート
 
+- [v0.13.0](v0_13_0) — semanticな`qmc.select`、厳密な`qmc.global_phase`、ループをまたぐscalar、汎用と明示的なMöttönen amplitude encoding。Qiskitを`qiskit` extraへ移動
 - [v0.12.7](v0_12_7) — `Dict[K, Float]`の係数を`d[key]`添字付きでruntime parameterとして扱う、`UInt`の`%`演算子、これまでsilentなmiscompileだったパターンを拒否する一連の新しいコンパイル時エラー(`QubitRebindError`、`QubitConsumedError`、`bool` / 型不一致引数への`TypeError`)
 - [v0.12.6](v0_12_6) — `qmc.inverse`による回路の逆操作(ビルトインゲート・`@qkernel`・QFT/IQFT)、計算基底レジスタの算術`qmc.modular_increment` / `qmc.modular_decrement`、job型・結果型を`qamomile.circuit`からimport可能に
 - [v0.12.5](v0_12_5) — Pauli Correlation Encoding用の`PCEConverter` / `PCEEncoder`、QURI Partsサンプリングへのseed指定、測定済み`Vector[Bit]`を使う条件分岐の修正、`Vector`要素の`qmc.expval`修正

--- a/docs/ja/release_notes/v0_13_0.md
+++ b/docs/ja/release_notes/v0_13_0.md
@@ -1,0 +1,244 @@
+# Qamomile v0.13.0
+
+Qamomile v0.13.0では、SELECT操作とglobal phase操作を追加しました。さらに、`qmc.control`では、整数の`control_value`を指定できるようになりました。Qiskitと回路描画機能はoptionalになったため、引き続きQiskitを利用する場合は`pip install "qamomile[qiskit]"`を実行してください。
+
+```
+pip install qamomile==0.13.0
+```
+
+## 破壊的変更
+
+- **Qiskitがoptional dependencyになりました。** `pip install qamomile==0.13.0`では変換先非依存のcompiler coreをインストールします。本リリースノートの例で使うQiskitや回路描画を追加するには、`pip install "qamomile[qiskit,visualization]==0.13.0"`を実行してください([#599](https://github.com/Jij-Inc/Qamomile/pull/599))。
+- **class-basedなcomposite gate APIを削除しました。** `CompositeGate`や`QFT`、`IQFT`などはpublic APIではなくなりました。名前付きの再利用可能な本体は`@qmc.composite_gate`で定義します。このdecoratorが返すのは通常の`QKernel`なので、他の量子カーネルと同じ`build()`、`draw()`、`estimate_resources()`、`qmc.control`、`qmc.inverse`を使います。
+- 状態準備のモジュールを`qamomile.circuit.algorithm.state_preparation`から`qamomile.circuit.stdlib.state_preparation`へ移動しました。top-levelの`qmc.amplitude_encoding`、`qmc.amplitude_encoding_from_angles`、`qmc.computational_basis_state`は引き続き利用できます([#571](https://github.com/Jij-Inc/Qamomile/pull/571)、[#586](https://github.com/Jij-Inc/Qamomile/pull/586))。
+- **`qmc.amplitude_encoding`は、方式を指定しない状態準備APIになりました。** エンジンがnativeな状態準備を提供する場合はそれを利用し、提供しない場合はMöttönenの状態準備を使います。Möttönenの状態準備を明示的に扱いたい場合は、`qmc.mottonen_amplitude_encoding`を使ってください([#602](https://github.com/Jij-Inc/Qamomile/pull/602))。
+- **resource estimateのデータモデルを変更しました。** `GateCount`、`count_gates`、`qubits_counter`、`qamomile.circuit.estimator.algorithmic`の各moduleを削除しました。`qkernel.estimate_resources()`または`qmc.estimate_resources()`と、width、gate、depth、call、assumption、estimate qualityを持つ新しい`ResourceEstimate`フィールドを使ってください。互換aliasの`estimate.qubits`、`estimate.gates.t_gates`、`estimate.gates.clifford_gates`、`estimate.gates.rotation_gates`は残っていますが、直接構築する場合の引数と`to_dict()`のschemaは変わりました([#571](https://github.com/Jij-Inc/Qamomile/pull/571))。
+- **Block単位のJSONとMessagePack serializationを削除しました。** `qamomile.circuit.ir.serialize`から`dump_json`、`load_json`、`dump_msgpack`、`load_msgpack`、`to_dict`、`from_dict`を公開しなくなり、v0.12.7のpayloadを移行する互換処理もありません。未bindの量子カーネルを決定的なProtobuf byte列として保存するには、`qamomile.circuit.serialization.serialize()`と`deserialize()`を使ってください([#595](https://github.com/Jij-Inc/Qamomile/pull/595))。
+- **エンジンのemitter classとartifact classはsupported public APIではなくなりました。** `QuriPartsEmitPass`、`CudaqEmitPass`、`CudaqKernelEmitter`、`CudaqKernelArtifact`、`BoundCudaqKernelArtifact`を各packageのexportから削除しました。引き続き`QiskitTranspiler`、`QuriPartsTranspiler`、`CudaqTranspiler`と対応するExecutorは使用可能です([#586](https://github.com/Jij-Inc/Qamomile/pull/586))。
+- **`SliceBorrowViolationError`を削除しました。** fold後のslice borrow失敗は、semanticな原因に応じて`QubitBorrowConflictError`または`QubitConsumedError`を送出します。control flowをまたぐ未対応のownership伝播は`ValidationError`になります([#591](https://github.com/Jij-Inc/Qamomile/pull/591))。
+
+## 新機能
+
+### Semanticな`qmc.select`と値指定のcontrol
+
+`qmc.select([U0, U1, ...])`は、LSB-firstのindex registerが整数`i`を表すときに、共有するtarget量子ビットへcase `Ui`を適用するSELECT操作を作ります。index幅はcase数から推論できるほか、Pythonの`int`または`qmc.UInt`で指定できます。また、`qmc.control(..., control_value=v)`は、flattenした制御量子ビットが具体的なLSB-firstの値`v`と一致するときに対象の操作を実行する制御演算を作ります([#597](https://github.com/Jij-Inc/Qamomile/pull/597))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def select_example() -> tuple[qmc.Bit, qmc.Bit]:
+    index = qmc.qubit(name="index")
+    target = qmc.qubit(name="target")
+    index = qmc.x(index)   # case 1を選択
+    target = qmc.x(target)
+    index, target = qmc.select([qmc.x, qmc.z])(index, target)
+    return qmc.measure(index), qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(select_example)
+```
+
+### 再利用可能な操作でglobal phaseを厳密に保持
+
+`qmc.global_phase(target, phase)`は`target`を適用した後に`exp(i * phase)`を掛け、入れ子の量子カーネル呼び出し、control、inverse、power、structured control flow、Protobufのround tripを通して位相を明示的に保持します。単独のglobal phaseは観測できませんが、制御演算やSELECT演算の下では相対位相となり、干渉結果に現れます([#593](https://github.com/Jij-Inc/Qamomile/pull/593)、[#596](https://github.com/Jij-Inc/Qamomile/pull/596))。
+
+```python
+import math
+
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def identity(qubit: qmc.Qubit) -> qmc.Qubit:
+    return qubit
+
+@qmc.qkernel
+def phased_identity(qubit: qmc.Qubit) -> qmc.Qubit:
+    return qmc.global_phase(identity, math.pi)(qubit)
+
+@qmc.qkernel
+def phase_kickback() -> tuple[qmc.Bit, qmc.Bit]:
+    control = qmc.h(qmc.qubit(name="control"))
+    target = qmc.h(qmc.qubit(name="target"))
+    control, target = qmc.control(phased_identity)(control, target)
+    control = qmc.h(control)
+    target = qmc.h(target)
+    return qmc.measure(control), qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(phase_kickback)
+```
+
+### ループをまたぐスカラー値と古典比較
+
+`qmc.range`と`qmc.items`の中で同じ型の`UInt`または`Float`を再代入すると、`ValidationError`を送出せず、更新した値を次の反復へ渡せるようになりました。accumulatorや、後続のgate parameterまたはコンパイル時分岐に使う値を計算できます。実行時に反復回数が決まる`while`での持ち越し、測定結果に基づく`Bit`の持ち越し、型の異なる再代入、測定結果に依存する値を量子操作も含むループ内で持ち越す処理はサポートしていません。また、`Bit`、`UInt`、`Float`ハンドルは、トレース時にPythonのbooleanへ変換されず、対応するPython比較演算子を使えるようになりました。数値の大小比較、等値・非等値、`UInt`と`Float`の混在比較、`Bit`と`Bit`・`bool`・0または1の整数・`UInt`との等値比較をサポートします([#580](https://github.com/Jij-Inc/Qamomile/pull/580)、[#587](https://github.com/Jij-Inc/Qamomile/pull/587))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def accumulated_branch(n: qmc.UInt) -> qmc.Bit:
+    qubit = qmc.qubit(name="qubit")
+    total = 0
+    for i in qmc.range(n):
+        total = total + i
+    if total >= 3:
+        qubit = qmc.x(qubit)
+    return qmc.measure(qubit)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(accumulated_branch, bindings={"n": 3})
+```
+
+### 量子ビットを保持する射影とreset操作
+
+`qmc.project_x`、`qmc.project_y`、`qmc.project_z`では、射影後の量子ビットと古典`Bit`の両方を返します。このため、測定後の状態をそのまま使い続けられます。`qmc.reset`は同じ量子ビットを`|0>`にした新しいhandleを返し、`qmc.measure_reset`はZ基底の射影とresetをまとめて実行します。入力handleをconsumeし、返された量子ビットhandleへ状態を引き継ぐため、Qamomileのaffine ownership checkを維持します([#599](https://github.com/Jij-Inc/Qamomile/pull/599))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def measure_and_reset() -> tuple[qmc.Bit, qmc.Bit]:
+    qubit = qmc.x(qmc.qubit(name="qubit"))
+    qubit, before = qmc.measure_reset(qubit)
+    after = qmc.measure(qubit)
+    return before, after
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(measure_and_reset)
+```
+
+### 汎用APIとMöttönen方式を指定するamplitude encoding
+
+`qmc.amplitude_encoding`は、エンジンでの合成方法を規定せず、準備する状態を表すようになりました。`qmc.mottonen_amplitude_encoding`は明示的にMöttönenのアルゴリズムを利用します([#602](https://github.com/Jij-Inc/Qamomile/pull/602))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def prepare_bell() -> qmc.Vector[qmc.Bit]:
+    qubits = qmc.qubit_array(2, name="qubits")
+    qubits = qmc.mottonen_amplitude_encoding(
+        qubits, [1.0, 0.0, 0.0, 1.0]
+    )
+    return qmc.measure(qubits)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(prepare_bell)
+```
+
+[Möttönen Amplitude Encoding](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb)を参照してください。
+
+### 統一したcallable、opaque Oracle、拡張した標準ライブラリ
+
+名前付きcomposite gateは通常の量子カーネルになり、直接呼び出し、control、inverse、serialization、visualization、本体からのresource estimateに1つのcall modelを使います。`qmc.opaque(name, ...)`と`qmc.Oracle`は、本体を持たないcallableとしてtop-down設計に利用できます。target実装またはsubstitutionを指定するまで、固定またはcontext依存のresource costを保持できます。`ResourceEstimate`は論理width、gate category、depth、call・query数、assumption、説明用trace、estimate qualityを返し、未bindの入力はsymbolicな式として扱います。また、publicな標準ライブラリには、`qmc.mcx`、reversibleなripple-carry・modular算術、Grover search helper、Shor order findingを追加しました。状態準備helperも同じcallable modelを使うため、トランスパイルとresource estimateが同じ実行可能な本体を参照します([#571](https://github.com/Jij-Inc/Qamomile/pull/571)、[#586](https://github.com/Jij-Inc/Qamomile/pull/586))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def stdlib_mcx() -> tuple[qmc.Vector[qmc.Bit], qmc.Bit]:
+    controls = qmc.x(qmc.qubit_array(3, name="controls"))
+    target = qmc.qubit(name="target")
+    controls, target = qmc.mcx(controls, target)
+    return qmc.measure(controls), qmc.measure(target)
+
+estimate = stdlib_mcx.estimate_resources()
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(stdlib_mcx)
+```
+
+### Protobufによる量子カーネルのserialization
+
+`qamomile.circuit.serialization.serialize()`は、staticで未bindの量子カーネルを決定的なProtobuf byte列として書き出します。public signature、階層的な本体、callable definition、default値、annotation、global phase操作、値の関係を保持します。`deserialize()`は、通常のtranspiler interfaceから新しいcompile-time bindingとruntime parameterを受け取れる量子カーネル相当のobjectを復元します。bind済みまたはlowering済みのartifact、runtime value、エンジンのobjectはformatに含まれません([#595](https://github.com/Jij-Inc/Qamomile/pull/595)、[#596](https://github.com/Jij-Inc/Qamomile/pull/596))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.circuit.serialization import deserialize, serialize
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def serializable_flip() -> qmc.Bit:
+    qubit = qmc.x(qmc.qubit(name="qubit"))
+    return qmc.measure(qubit)
+
+payload = serialize(serializable_flip)
+restored = deserialize(payload)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(restored)
+```
+
+## 内部的な変更
+
+上記の機能は、target非依存の準備stage、統一したcallable graph、エンジン非依存の回路表現の上に構築されています。これらの境界により、すべてのtargetを同じ実行modelへ押し込めずに、回路SDKとprogram graph targetでQamomileのsemanticsを共有できます。
+
+### 明示的なcompiler targetとエンジン非依存の回路lowering
+
+`QamomileCompiler.prepare()`は、到達可能なcallable definition、structured control flow、call graph、古典ABIを保持する`PreparedModule`を生成します。回路エンジンはnative materializationの前に、これを検証済み`CircuitProgram`へloweringします。新しい`HugrTranspiler`は準備済みsemanticsをHUGR packageへ直接トランスパイルします。新しい`QurationTranspiler`はPyQretを通してmaterializeし、Qurationのresource compilationを公開します。HUGRのdependencyは`hugr` extraからインストールできますが、現時点でPyQretは別途インストールが必要です([#586](https://github.com/Jij-Inc/Qamomile/pull/586))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.circuit.transpiler import QamomileCompiler
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def compiler_example() -> qmc.Bit:
+    qubit = qmc.h(qmc.qubit(name="qubit"))
+    return qmc.measure(qubit)
+
+prepared = QamomileCompiler().prepare(compiler_example)
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(compiler_example)
+```
+
+**Why**: targetがloweringを選ぶまでsemanticなcallとcontrol flowの構造を保持することで、core IRをエンジン非依存に保ち、HUGRではprogram graph構造を維持し、回路エンジンではSDK native objectを構築する前に1つの検証済み境界を共有できます。
+
+### Yieldによるbranch merge
+
+`IfOperation`は、mergeする各resultをtrue branchとfalse branchの並列なyield valueとして記録するようになりました。従来の`PhiOp` pseudo-operationは削除し、`iter_merges()`と`add_merge()`により、compiler pass、serialization、dependency analysis、classical executionで共通する検証済みのaccessor経路を提供します([#570](https://github.com/Jij-Inc/Qamomile/pull/570)、[#574](https://github.com/Jij-Inc/Qamomile/pull/574))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def measurement_branch_merge() -> tuple[qmc.Bit, qmc.Bit]:
+    condition = qmc.measure(qmc.h(qmc.qubit(name="condition")))
+    target = qmc.qubit(name="target")
+    if condition:
+        target = qmc.x(target)
+    return condition, qmc.measure(target)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(measurement_branch_merge)
+```
+
+**Why**: 上記のuser-facing featureとは独立した内部構造の変更です。branch resultを明示的なyieldで表すことで、IRをstructured control flowに合わせ、affineなquantum valueがoperandとして二重に数えられるのを防ぎ、compilerの各consumerでmerge semanticsを一貫させます。
+
+## バグ修正
+
+- **測定結果から計算した古典出力を失わなくなりました。** 測定結果から導いた比較、算術式、論理式を量子カーネルから返す場合、適切なときはhost側の後処理で実行し、`None`に解決されなくなりました。この処理はdynamic circuitをサポートしないエンジンでも動作します([#546](https://github.com/Jij-Inc/Qamomile/pull/546))。
+- **制御化した量子カーネル内のcompile-time分岐をemit前に解決します。** `qmc.control`内でbindingによって決まる`if`は、未対応の古典control flowとしてエンジンのemit段階へ到達せず、Qiskit、QURI Parts、CUDA-Qで正しいbranchを選択します([#579](https://github.com/Jij-Inc/Qamomile/pull/579))。
+- **nativeな状態準備が生成するempty-parameter multiplexerでQiskit Aerがcrashしなくなりました。** `QiskitExecutor`は、入れ子のcontrol-flow blockを含むtranspile済み回路を再帰的に調べ、Aer実行前にparameterが空の`multiplexer`だけを分解します。有効なparameter付きmultiplexerは変更しません([#601](https://github.com/Jij-Inc/Qamomile/pull/601))。
+- **QURI Partsの多重制御gateはcontrol数に対して線形にscaleします。** fallbackは指数的に大きくなるdense unitaryを構築せず、clean ancillaを使うToffoli cascadeを使います。runtime parameterを持つ多重制御rotationと、以前のdense matrix上限を超えるcontrol幅もトランスパイルでき、追加したancillaは実行終了前にuncomputeします([#555](https://github.com/Jij-Inc/Qamomile/pull/555))。
+- **compilerとエンジンのcontractを早い段階で一貫して検証します。** 不正なscalar、array、dictionary bindingをshapeと型で検証し、runtime parameterの順序を決定的に保ち、canonical identityにNumPy arrayのshapeを含めます。control、inverse、measurement、Pauli evolutionのcheckもQiskit、QURI Parts、CUDA-Q、HUGR、qBraid、Qurationで整合させました([#599](https://github.com/Jij-Inc/Qamomile/pull/599))。
+
+## ドキュメント
+
+- [**チュートリアル04 — 制御ゲート**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/tutorial/04_controlled_gates.ipynb)に、値指定のcontrol、SELECT multiplexer、global phaseのsemanticsを追加しました([#593](https://github.com/Jij-Inc/Qamomile/pull/593)、[#597](https://github.com/Jij-Inc/Qamomile/pull/597))。
+- [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/tutorial/05_resource_estimation.ipynb)を、本体から導出するsymbolic estimateと新しいresource modelに合わせて更新しました([#588](https://github.com/Jij-Inc/Qamomile/pull/588))。
+- [**チュートリアル06 — 実行モデル**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/tutorial/06_execution_models.ipynb)で、量子カーネルのreturn order、`Vector`の測定index順序、tuple outcomeのleast-significant-bit conventionを明確にしました([#581](https://github.com/Jij-Inc/Qamomile/pull/581))。
+- [**チュートリアル10 — コンパイルとトランスパイル**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/tutorial/10_compilation_and_transpilation.ipynb)に、callable invocation、再構築したtranspiler pipeline、if-merge yield、semanticなslice borrow errorを反映しました([#578](https://github.com/Jij-Inc/Qamomile/pull/578)、[#588](https://github.com/Jij-Inc/Qamomile/pull/588)、[#592](https://github.com/Jij-Inc/Qamomile/pull/592))。
+- [**Möttönen Amplitude Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb)で、合成方法に依存しない状態準備と明示的なMöttönen APIを区別し、transpile時のamplitude binding、runtimeでのangle再binding、fidelity check、resource formulaを説明します([#602](https://github.com/Jij-Inc/Qamomile/pull/602))。
+- [**Qiskit**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/integration/qiskit_support.ipynb)、[**QURI Parts**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/integration/quri_parts_support.ipynb)、[**CUDA-Q**](https://github.com/Jij-Inc/Qamomile/blob/v0.13.0/docs/ja/integration/cudaq_support.ipynb)のintegration pageを、現在のtranspilerとinstallation APIに合わせて更新しました([#588](https://github.com/Jij-Inc/Qamomile/pull/588)、[#599](https://github.com/Jij-Inc/Qamomile/pull/599))。
+
+## さらに詳しく
+
+- [GitHubリポジトリ](https://github.com/Jij-Inc/Qamomile)


### PR DESCRIPTION
## Summary

- Add English and Japanese release notes for Qamomile v0.13.0.
- Document breaking changes, SELECT and global-phase operations, value-activated controls, compiler internals, bug fixes, and documentation updates.
- Register v0.13.0 in the English and Japanese release-note indexes and MyST navigation.
- Use Engine terminology consistently in English and エンジン in Japanese.

## Validation

- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- Executed all 9 release-note code examples with Qiskit and sampled 16 shots from each.
- Ran 12 targeted tests for state preparation, SELECT index widths, integer control values, and global-phase preservation.
- Verified English/Japanese code parity, PR-link parity, tagged documentation links, punctuation, and terminology.