### PR TITLE
Require code examples in branch summaries

### DIFF
--- a/.claude/skills/make-summary/SKILL.md
+++ b/.claude/skills/make-summary/SKILL.md
@@ -21,7 +21,6 @@ Summarize the diff between `origin/main` and the current worktree branch after r
 - If the file already exists, overwrite it without asking.
 - Do not commit the summary file. Leave it untracked.
 - Do not choose `/tmp` or another ephemeral directory as the output location yourself. If the current worktree root itself is under a temporary directory, prefer the worktree root.
-- Write the summary in the language explicitly requested by the user; otherwise use the language of the current conversation. Translate the required headings and limitation-frame labels consistently while preserving their meaning and order.
 - On completion, report only the absolute path and the fact that the file was not committed. If an independent discrepancy check could not run, also mention that briefly.
 
 ## Writing Rules
@@ -48,7 +47,7 @@ Summarize the diff between `origin/main` and the current worktree branch after r
 
 ## Summary Structure
 
-Write exactly the following five semantic top-level (`##`) sections, in this order. Translate the headings into the output language when needed, but do not change their meaning. Do not add or remove a top-level section — no `0. Glossary`, verification results, TODOs, or conversation history as its own `##` heading. Section 3 is the one section that MUST be broken into `###` sub-sections (see its guidance below); the other four are prose and use no sub-headings.
+Write exactly the following five top-level (`##`) sections, in this order. Do not add or remove a top-level section — no `0. Glossary`, verification results, TODOs, or conversation history as its own `##` heading. Section 3 is the one section that MUST be broken into `###` sub-sections (see its guidance below); the other four are prose and use no sub-headings.
 
 ```md
 ## 1. Problem Overview
@@ -76,7 +75,7 @@ In `3. Backend Changes (IR And Internals)`, describe compiler, IR, transpiler, a
 
 In `4. Alternatives Not Adopted And Why This Approach Was Chosen`, describe design-level alternatives, trade-offs, and adoption or rejection reasons. If none apply, write `None`. This section may include alternatives raised in external review or conversation, but only as final design rationale, not as a narrative of the work history.
 
-In `5. Known Limitations`, describe gaps that remain after merge. Cover real cases a user can hit, such as false negatives, false positives, unsupported AST forms, or backend differences, using the `When:` / `Why:` / `Future fix:` frame or faithful translations of those labels. If there are multiple limitations, use separate prose paragraphs rather than bullets. If none apply, write `None` in the output language.
+In `5. Known Limitations`, describe gaps that remain after merge. Cover real cases a user can hit, such as false negatives, false positives, unsupported AST forms, or backend differences, using the `When:` / `Why:` / `Future fix:` frame. If there are multiple limitations, use separate prose paragraphs rather than bullets. If none apply, write `None`.
 
 ## Workflow
 

--- a/.claude/skills/make-summary/SKILL.md
+++ b/.claude/skills/make-summary/SKILL.md
@@ -21,6 +21,7 @@ Summarize the diff between `origin/main` and the current worktree branch after r
 - If the file already exists, overwrite it without asking.
 - Do not commit the summary file. Leave it untracked.
 - Do not choose `/tmp` or another ephemeral directory as the output location yourself. If the current worktree root itself is under a temporary directory, prefer the worktree root.
+- Write the summary in the language explicitly requested by the user; otherwise use the language of the current conversation. Translate the required headings and limitation-frame labels consistently while preserving their meaning and order.
 - On completion, report only the absolute path and the fact that the file was not committed. If an independent discrepancy check could not run, also mention that briefly.
 
 ## Writing Rules
@@ -34,9 +35,20 @@ Summarize the diff between `origin/main` and the current worktree branch after r
 - Reference code concretely as `path/to/file.py:123` or `path/to/file.py:123-145`.
 - Do not create standalone sections for test lists, diff stats, commit history, validation logs, or work chronology. Absorb only the relevant facts into the appropriate section.
 
+## Code Example Rules
+
+- For a code-bearing change, include a fenced code example in each of Sections 1, 2, and 3. Give each example a distinct job instead of repeating the same snippet three times.
+- In Section 1, show the relevant `origin/main` behavior before the branch. For a bugfix, prefer a minimal reproducer that exposes the wrong result or error. For a feature, show the previously unsupported attempt or the nearest code form that demonstrates the missing capability.
+- In Section 2, show user-written code that demonstrates the fixed or newly supported behavior, API, or diagnostic. State the expected result next to the example. Keep compiler and IR implementation details out of this example.
+- In Section 3, show at least one concise compiler-, IR-, transpiler-, or backend-level example of how the branch implements the behavior. Put examples under the purpose-based `###` sub-section they clarify; when several independent mechanisms materially change, illustrate each one that benefits from code.
+- Make every example directly exercise the branch-specific problem, behavior, or mechanism. An example of a neighboring unchanged API does not count merely because it uses the same subsystem. When a bug is unreachable from ordinary user code, make the Section 2 example follow the closest supported frontend path through the changed IR or compiler logic and explain why that path remains safe.
+- Ground every example in `origin/main`, the branch diff, or its tests. Keep snippets minimal, preserve the semantics of the real code, and do not invent APIs, diagnostics, output, or unsupported combinations merely to satisfy the format.
+- Run each example when practical, especially before claiming an exact result or diagnostic. If the before-branch example cannot run on the current branch, verify it against the `origin/main` source and tests. If execution is impractical, trace the relevant code and avoid unverified exact-output claims.
+- If a section has no truthful and useful code example, say why in that section instead of adding a contrived snippet. Documentation-only and configuration-only branches are common reasons, but brevity alone is not.
+
 ## Summary Structure
 
-Write exactly the following five top-level (`##`) sections, in this order. Do not add or remove a top-level section — no `0. Glossary`, verification results, TODOs, or conversation history as its own `##` heading. Section 3 is the one section that MUST be broken into `###` sub-sections (see its guidance below); the other four are prose and use no sub-headings.
+Write exactly the following five semantic top-level (`##`) sections, in this order. Translate the headings into the output language when needed, but do not change their meaning. Do not add or remove a top-level section — no `0. Glossary`, verification results, TODOs, or conversation history as its own `##` heading. Section 3 is the one section that MUST be broken into `###` sub-sections (see its guidance below); the other four are prose and use no sub-headings.
 
 ```md
 ## 1. Problem Overview
@@ -50,20 +62,21 @@ Write exactly the following five top-level (`##`) sections, in this order. Do no
 ## 5. Known Limitations
 ```
 
-In `1. Problem Overview`, for a bugfix, distinguish what happened on `origin/main`, why it happened, and how the branch changes the behavior. For a feature, explain what becomes possible and why it is needed.
+In `1. Problem Overview`, for a bugfix, distinguish what happened on `origin/main`, why it happened, and how the branch changes the behavior. For a feature, explain what becomes possible and why it is needed. Follow that explanation with the before-branch example required by the Code Example Rules.
 
-In `2. Frontend Changes (User-Written Code Level)`, describe the user-facing behavior: qkernels the user writes, errors the user receives, and API behavior the user touches. Include at least one code example. Do not put backend implementation details here.
+In `2. Frontend Changes (User-Written Code Level)`, describe the user-facing behavior: qkernels the user writes, errors the user receives, and API behavior the user touches. Include the user-facing example and expected result required by the Code Example Rules. Do not put backend implementation details here.
 
 In `3. Backend Changes (IR And Internals)`, describe compiler, IR, transpiler, and backend-side changes. Structure this section as follows, and do NOT write it as one flat mechanism dump:
 
 - Open Section 3 with a short lead paragraph (no sub-heading) stating what the backend changes are collectively trying to achieve — the single objective the sub-sections below serve. A reader should be able to stop after this paragraph and know the point of the whole section.
 - Then divide the rest into `###` sub-sections, one per *purpose*, not one per file or per symbol. Name each sub-section after the goal it serves (e.g. `### 記録機構の増設`, `### 破棄の検出`), not after a function. Order them so an earlier sub-section's output is consumed by a later one, and say so explicitly ("the records built here are what the check in the next sub-section reads").
 - Inside each sub-section, write in this order: (1) what this piece is trying to achieve, (2) why the naive or pre-existing approach cannot achieve it (the forcing reason — e.g. "the frontend cannot raise here because the dead branch's value is gone from the IR by the time the check runs, so a record must be created to carry it forward"), then (3) how the code achieves it, citing each new IR operation, dataclass, pass, or helper with `file:line`. State the role of each cited symbol; explain every term on first use per the Writing Rules.
+- Add the internal code examples required by the Code Example Rules to the relevant sub-sections after explaining their goal and forcing reason. Use prose to connect each snippet to the cited implementation rather than presenting an unexplained source-code dump.
 - Prefer three to six focused sub-sections over one long one. If the whole section fits in a single idea, a single sub-section is fine, but the goal-first framing still applies.
 
 In `4. Alternatives Not Adopted And Why This Approach Was Chosen`, describe design-level alternatives, trade-offs, and adoption or rejection reasons. If none apply, write `None`. This section may include alternatives raised in external review or conversation, but only as final design rationale, not as a narrative of the work history.
 
-In `5. Known Limitations`, describe gaps that remain after merge. Cover real cases a user can hit, such as false negatives, false positives, unsupported AST forms, or backend differences, using the `When:` / `Why:` / `Future fix:` frame. If there are multiple limitations, use separate prose paragraphs rather than bullets. If none apply, write `None`.
+In `5. Known Limitations`, describe gaps that remain after merge. Cover real cases a user can hit, such as false negatives, false positives, unsupported AST forms, or backend differences, using the `When:` / `Why:` / `Future fix:` frame or faithful translations of those labels. If there are multiple limitations, use separate prose paragraphs rather than bullets. If none apply, write `None` in the output language.
 
 ## Workflow
 
@@ -80,7 +93,7 @@ git diff origin/main...HEAD --stat
 
 ### Step 2. Read The Diff
 
-Actually read the changed files. Understand heavily changed files, new files, new classes or functions, and deleted symbols. Read added tests too, but do not make a test list in the summary; absorb expected behavior into the relevant sections. For a bugfix, gather enough detail to explain the bug on `origin/main` and the branch behavior with concrete examples when possible.
+Actually read the changed files. Understand heavily changed files, new files, new classes or functions, and deleted symbols. Read added tests too, but do not make a test list in the summary; absorb expected behavior into the relevant sections. Gather three complementary examples when the change is code-bearing: the `origin/main` problem or missing capability for Section 1, the user-facing branch behavior for Section 2, and the internal implementation mechanism for Section 3.
 
 ### Step 3. Write The Draft
 
@@ -92,7 +105,7 @@ By default, ask a memory-isolated subagent to adversarially check the summary ag
 
 Include the absolute path of the summary, the absolute paths of the primary implementation files, the key symbols or line ranges referenced by the summary, a request to point out any statement that does not match the real code in a bulleted list and answer `no discrepancies` if there are none, and constraints forbidding code edits, file creation or deletion, and command execution.
 
-The checker verifies factual accuracy, but factual accuracy is not enough — a summary can be entirely correct and still fail its purpose by being unreadable to the target reader. So after the factual check passes, do a readability pass yourself against the Writing Rules: read Section 3 as if you were the junior engineer it is written for, and flag any term used before it is explained, any wall-of-text paragraph that concatenates unrelated mechanisms, and any sub-section that states a mechanism without first stating the goal it serves and why the naive approach fails. Fix what you find. A factual `no discrepancies` does not exempt the summary from this pass.
+The checker verifies factual accuracy, including that every code example matches the stated branch or `origin/main` behavior and directly exercises the change it claims to illustrate, but factual accuracy is not enough — a summary can be entirely correct and still fail its purpose by being unreadable to the target reader. So after the factual check passes, do a readability pass yourself against the Writing Rules: read Section 3 as if you were the junior engineer it is written for, and flag any term used before it is explained, any wall-of-text paragraph that concatenates unrelated mechanisms, any unexplained or redundant code example, and any sub-section that states a mechanism without first stating the goal it serves and why the naive approach fails. Fix what you find. A factual `no discrepancies` does not exempt the summary from this pass.
 
 If the checker reports discrepancies, re-confirm each point against the real code, fix the summary, and verify that line-number edits did not shift other references. Then ask for another check. Repeat until there are no points left. If a point requires reconsidering a design decision, do not merely edit the summary; ask the user. Do not relay every iteration of the discrepancy-check loop to the user.
 
@@ -110,4 +123,5 @@ After Step 4 returns `no discrepancies`, or after self-checking because no indep
 - Do not insert manual soft line breaks within a paragraph.
 - Do not write conversation history or a story of the work.
 - Do not discuss alternatives outside section 4.
+- Do not fabricate examples or copy long implementation blocks when a focused excerpt conveys the behavior.
 - Do not relay every discrepancy-check iteration to the user.


### PR DESCRIPTION
## Summary

Require code-bearing branch summaries to include three complementary examples: the relevant `origin/main` behavior in Section 1, user-facing branch behavior in Section 2, and the internal implementation mechanism in Section 3. Each example must directly exercise the change, remain grounded in source or tests, and be executed when practical before exact output is claimed.

## Why

The previous guidance required a frontend example but did not consistently show the original failure or missing capability, and backend explanations could remain prose-only. The stronger rules make summaries easier to evaluate without reading the full diff while preventing adjacent or invented examples from satisfying the requirement.

## Validation

- Forward-tested the updated skill against the inverse-block vector-control fix.
- Generated examples for the original malformed IR, a frontend control-and-inverse round trip, and the constructor, serialization, and emission mechanisms.
- The generated summary completed an independent discrepancy check with no remaining findings.
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/` reports the same 56 optional HUGR dependency errors as `origin/main`; no errors are introduced by this branch.