### PR TITLE
docs: fix Möttönen tutorial cards in algorithm indexes

### DIFF
--- a/docs/en/algorithm/index.md
+++ b/docs/en/algorithm/index.md
@@ -22,8 +22,8 @@ End-to-end CNN + quantum variational circuit on Fashion-MNIST with the parameter
 
 :::{card}
 :header: **Möttönen Amplitude Encoding**
-:link: mottonen_amplitude_encoding
-Prepare an arbitrary real or complex amplitude vector via Gray-code Ry/Rz multiplexers, with three input modes (concrete, bound `Vector[Float]`, runtime-parametric angles).
+:link: mottonen_amplitude_encoding.ipynb
+Learn how to use Möttönen amplitude encoding in Qamomile to prepare arbitrary quantum states. This tutorial introduces state preparation based on `amplitude_encoding` and `mottonen_amplitude_encoding`.
 :::
 
 :::{card}

--- a/docs/ja/algorithm/index.md
+++ b/docs/ja/algorithm/index.md
@@ -22,8 +22,8 @@ CNN＋量子変分回路をFashion-MNISTでend-to-end学習し、パラメータ
 
 :::{card}
 :header: **Möttönen振幅エンコーディング**
-:link: mottonen_amplitude_encoding
-Gray符号Ry/Rz多重制御回転で任意の実数・複素振幅ベクトルを準備します。3つの入力モード(具体値、バインドされた`Vector[Float]`、ランタイムパラメトリックな角度)を扱います。
+:link: mottonen_amplitude_encoding.ipynb
+任意の量子状態を準備するMöttönenの振幅エンコーディングをQamomileで使う方法です。`amplitude_encoding`および`mottonen_amplitude_encoding`に基づく状態準備の方法を紹介します。
 :::
 
 :::{card}


### PR DESCRIPTION
## Summary

- Update the English and Japanese algorithm index descriptions for the Möttönen amplitude encoding tutorial.
- Link directly to `mottonen_amplitude_encoding.ipynb` to prevent MyST from resolving the card link to the identically named API reference.

## Verification

- `./docs/build.sh build-en`
- `./docs/build.sh build-ja`
- Confirmed that both rendered card headers link to `/algorithm/mottonen-amplitude-encoding`.
- `git diff --check`