### PR TITLE
Add block-encoding and QSVT resource estimation coverage

### DIFF
--- a/qamomile/circuit/estimator/resource_estimator.py
+++ b/qamomile/circuit/estimator/resource_estimator.py
@@ -1108,6 +1108,8 @@ class ResourceEstimator:
         Raises:
             ValueError: If an input name is neither a free symbol nor a declared
                 kernel argument.
+            ValidationError: If concrete array inputs make a reachable array
+                access fall outside its resolved extent.
         """
         build_inputs, estimation_inputs = _partition_estimation_inputs(kernel, inputs)
         block_or_ops = self._coerce_input(

--- a/qamomile/circuit/estimator/resource_estimator.py
+++ b/qamomile/circuit/estimator/resource_estimator.py
@@ -13,7 +13,7 @@ import sympy as sp
 
 from qamomile.circuit.estimator._loop_executor import symbolic_iterations
 from qamomile.circuit.estimator._resolver import ExprResolver, UnresolvedValueError
-from qamomile.circuit.ir.block import Block
+from qamomile.circuit.ir.block import Block, BlockKind
 from qamomile.circuit.ir.operation.callable import (
     CallTransform,
     InvokeOperation,
@@ -56,6 +56,16 @@ from qamomile.circuit.transpiler.passes.analyze import (
     build_dependency_graph,
     find_measurement_derived_values,
     find_measurement_results,
+)
+from qamomile.circuit.transpiler.passes.array_bounds_validation import (
+    ArrayBoundsValidationPass,
+)
+from qamomile.circuit.transpiler.passes.compile_time_if_lowering import (
+    CompileTimeIfLoweringPass,
+)
+from qamomile.circuit.transpiler.passes.constant_fold import ConstantFoldingPass
+from qamomile.circuit.transpiler.passes.parameter_shape_resolution import (
+    ParameterShapeResolutionPass,
 )
 
 if TYPE_CHECKING:
@@ -1105,6 +1115,10 @@ class ResourceEstimator:
             build_inputs,
             estimation_inputs,
         )
+        _validate_estimation_input_bounds(
+            block_or_ops,
+            {**build_inputs, **estimation_inputs},
+        )
         config = dataclasses.replace(
             self.config,
             strategies={**self.config.strategies, **dict(strategies or {})},
@@ -1118,11 +1132,16 @@ class ResourceEstimator:
         if build_inputs:
             estimate = _substitute_bindings(estimate, build_inputs)
         if estimation_inputs:
+            expanded_inputs, derived_input_sources = _expand_array_shape_inputs(
+                block_or_ops,
+                estimation_inputs,
+            )
             estimate = _apply_inputs(
                 estimate,
-                _expand_array_shape_inputs(block_or_ops, estimation_inputs),
+                expanded_inputs,
                 contract_names=_contract_names(block_or_ops),
                 branch_condition_names=interpreter.branch_condition_names,
+                derived_input_sources=derived_input_sources,
             )
         if config.simplify:
             estimate = estimate.simplify()
@@ -1230,8 +1249,24 @@ class ResourceInterpreter:
                 for value in block_or_ops.input_values
                 if isinstance(value, Value) and value.type.is_quantum()
             }
+            input_value_uuids = {
+                value.uuid
+                for value in block_or_ops.input_values
+                if isinstance(value, Value) and value.type.is_quantum()
+            }
+            # Top-level tracing represents caller-owned quantum ports with
+            # QInit markers sharing the port UUID. They establish the input
+            # handles but are not body allocations.
+            operations = [
+                operation
+                for operation in block_or_ops.operations
+                if not (
+                    isinstance(operation, QInitOperation)
+                    and operation.results[0].uuid in input_value_uuids
+                )
+            ]
             body = self.eval_operations(
-                block_or_ops.operations,
+                operations,
                 resolver,
                 initial_allocations=input_allocations,
             )
@@ -5298,10 +5333,62 @@ def _contract_names(
     return frozenset(slot.name for slot in block_or_ops.param_slots)
 
 
+def _validate_estimation_input_bounds(
+    block_or_ops: "Block | Sequence[Operation]",
+    inputs: Mapping[str, Any],
+) -> None:
+    """Validate concrete array accesses on a specialized diagnostic copy.
+
+    Resource interpretation deliberately keeps scalar sizes symbolic until
+    after traversal. That avoids constructing problem-sized circuits, but it
+    also means a later substitution cannot recover frontend array-bound
+    contracts. This focused pass sequence resolves only shapes, constants,
+    and compile-time branches before applying the compiler's reachable bounds
+    validator; the original symbolic block remains unchanged for estimation.
+
+    Args:
+        block_or_ops (Block | Sequence[Operation]): IR input selected for
+            resource interpretation.
+        inputs (Mapping[str, Any]): Build-time and estimation-time values used
+            to specialize reachable array accesses.
+
+    Returns:
+        None: The function only validates the diagnostic block copy.
+
+    Raises:
+        ValidationError: If a reachable concrete array access is outside its
+            resolved extent.
+    """
+    if not isinstance(block_or_ops, Block) or not inputs:
+        return
+    if block_or_ops.kind not in (
+        BlockKind.TRACED,
+        BlockKind.HIERARCHICAL,
+        BlockKind.AFFINE,
+    ):
+        return
+
+    diagnostic = block_or_ops
+    if diagnostic.kind is not BlockKind.HIERARCHICAL:
+        diagnostic = dataclasses.replace(diagnostic, kind=BlockKind.HIERARCHICAL)
+    concrete_inputs = dict(inputs)
+    diagnostic = ParameterShapeResolutionPass(concrete_inputs).run(diagnostic)
+    diagnostic = ConstantFoldingPass(
+        concrete_inputs,
+        strip_slice_ops=False,
+    ).run(diagnostic)
+    diagnostic = CompileTimeIfLoweringPass(concrete_inputs).run(diagnostic)
+    diagnostic = ConstantFoldingPass(
+        concrete_inputs,
+        strip_slice_ops=False,
+    ).run(diagnostic)
+    ArrayBoundsValidationPass().run(diagnostic)
+
+
 def _expand_array_shape_inputs(
     block_or_ops: "Block | Sequence[Operation]",
     inputs: Mapping[str, Any],
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], dict[str, str]]:
     """Expand supplied array shapes into their IR dimension symbols.
 
     Args:
@@ -5309,12 +5396,14 @@ def _expand_array_shape_inputs(
         inputs (Mapping[str, Any]): User-provided estimation inputs.
 
     Returns:
-        dict[str, Any]: Inputs plus one concrete value for each matching array
-        dimension symbol.
+        tuple[dict[str, Any], dict[str, str]]: Inputs plus one concrete value
+            for each matching array dimension symbol, followed by a mapping
+            from each derived dimension name to its declared source input.
     """
     expanded = dict(inputs)
+    derived_input_sources: dict[str, str] = {}
     if not isinstance(block_or_ops, Block):
-        return expanded
+        return expanded, derived_input_sources
     for name, ir_value in zip(block_or_ops.label_args, block_or_ops.input_values):
         if name not in inputs or not isinstance(ir_value, ArrayValue):
             continue
@@ -5322,7 +5411,8 @@ def _expand_array_shape_inputs(
         for dimension, size in zip(ir_value.shape, shape):
             if dimension.name:
                 expanded[dimension.name] = size
-    return expanded
+                derived_input_sources[dimension.name] = name
+    return expanded, derived_input_sources
 
 
 def _concrete_input_shape(value: Any) -> tuple[int, ...]:
@@ -5384,6 +5474,7 @@ def _apply_inputs(
     *,
     contract_names: frozenset[str] | None = None,
     branch_condition_names: set[str] | None = None,
+    derived_input_sources: Mapping[str, str] | None = None,
 ) -> ResourceEstimate:
     """Specialize a symbolic estimate with qkernel input values.
 
@@ -5409,6 +5500,9 @@ def _apply_inputs(
         branch_condition_names (set[str] | None): Names that participated in a
             compile-time branch predicate during interpretation. Defaults to
             ``None``.
+        derived_input_sources (Mapping[str, str] | None): Internal array-shape
+            symbol names mapped to their declared source inputs. Defaults to
+            ``None``.
 
     Returns:
         ResourceEstimate: Estimate with the inputs applied.
@@ -5431,8 +5525,13 @@ def _apply_inputs(
         symbols_by_name.setdefault(_symbol_display_name(symbol), []).append(symbol)
     known = contract_names or frozenset()
     referenced = branch_condition_names or set()
+    derived_sources = derived_input_sources or {}
     unknown = [
-        name for name in inputs if name not in symbols_by_name and name not in known
+        name
+        for name in inputs
+        if name not in symbols_by_name
+        and name not in known
+        and name not in derived_sources
     ]
     if unknown:
         available = ", ".join(sorted(set(symbols_by_name) | set(known))) or "(none)"
@@ -5443,12 +5542,24 @@ def _apply_inputs(
         )
     subs: dict[sp.Symbol, sp.Expr] = {}
     ignored: list[str] = []
+    shape_specialized_sources = {
+        source
+        for derived_name, source in derived_sources.items()
+        if derived_name in symbols_by_name
+    }
     for name, value in inputs.items():
         if name not in symbols_by_name:
             # Not a free symbol: either it participated in a branch predicate
             # (silent — specialization or undecidable-note covers it) or it
-            # genuinely affects nothing (recorded as an ignored no-op).
-            if name not in referenced:
+            # supplied an array shape through a derived dimension symbol, or it
+            # genuinely affects nothing (recorded as an ignored no-op). Derived
+            # dimension names are internal aliases and never surface as ignored
+            # user inputs.
+            if (
+                name not in referenced
+                and name not in derived_sources
+                and name not in shape_specialized_sources
+            ):
                 ignored.append(name)
             continue
         sympified = sp.sympify(value)

--- a/tests/circuit/estimator/test_block_encoding_qsvt_resource_estimation.py
+++ b/tests/circuit/estimator/test_block_encoding_qsvt_resource_estimation.py
@@ -1,0 +1,282 @@
+"""Resource regressions for catalogued block encodings and QSVT."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+import qamomile.circuit as qmc
+from qamomile.circuit.transpiler.errors import ValidationError
+from tests.circuit.qkernel_catalog import QKERNEL_BY_ID, entries_with_tag
+
+_ENCODING_EXPECTATIONS = {
+    "identity": (1, 2, 0, 0),
+    "pauli": (1, 1, 5, 5),
+    "ising_z": (2, 2, 13, 12),
+    "periodic_shift": (2, 2, 15, 14),
+    "recursive_lcu": (3, 2, 16, 15),
+}
+
+
+def _shift_matrix(system_width: int, offset: int) -> np.ndarray:
+    """Return a periodic displacement in computational-basis order.
+
+    Args:
+        system_width (int): System-register width in qubits.
+        offset (int): Signed modular basis displacement.
+
+    Returns:
+        np.ndarray: Dense periodic-shift matrix.
+    """
+    dimension = 1 << system_width
+    matrix = np.zeros((dimension, dimension), dtype=np.complex128)
+    for basis in range(dimension):
+        matrix[(basis + offset) % dimension, basis] = 1.0
+    return matrix
+
+
+_ISING_Z_MATRIX = np.diag(
+    [
+        0.5
+        + (1.0 if basis & 1 == 0 else -1.0)
+        - 0.25j * (1.0 if basis & 2 == 0 else -1.0)
+        for basis in range(4)
+    ]
+)
+_ENCODED_MATRICES = {
+    "identity": np.eye(4, dtype=np.complex128),
+    "pauli": np.asarray([[0.0, 1.0], [0.0, 0.0]], dtype=np.complex128),
+    "ising_z": _ISING_Z_MATRIX,
+    "periodic_shift": (
+        _shift_matrix(2, -1)
+        - 2.0 * np.eye(4, dtype=np.complex128)
+        + _shift_matrix(2, 1)
+    ),
+    "recursive_lcu": (0.75 * np.eye(4, dtype=np.complex128) - 0.5j * _ISING_Z_MATRIX),
+}
+
+
+@qmc.qkernel
+def _measured_qsvt_consumer(
+    encoding: qmc.LCUBlockEncoding,
+    phases: qmc.Vector[qmc.Float],
+    phase_count: qmc.UInt,
+) -> tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]:
+    """Apply QSVT and measure its public registers for backend emission.
+
+    Args:
+        encoding (qmc.LCUBlockEncoding): Static block encoding to transform.
+        phases (qmc.Vector[qmc.Float]): Projector-rotation phase vector.
+        phase_count (qmc.UInt): Number of phase entries to consume.
+
+    Returns:
+        tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]: Measured signal and
+            system registers.
+    """
+    signal = qmc.qubit_array(encoding.num_signal_qubits, "signal")
+    system = qmc.qubit_array(encoding.num_system_qubits, "system")
+    signal, system = qmc.qsvt(
+        signal,
+        system,
+        phases,
+        encoding,
+        phase_count=phase_count,
+    )
+    return qmc.measure(signal), qmc.measure(system)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    entries_with_tag("block_encoding"),
+    ids=lambda entry: entry.id,
+)
+def test_catalogued_block_encoding_logical_resources(entry: Any) -> None:
+    """Every public encoding family has a stable logical resource canary."""
+    name = entry.id.removeprefix("block_encoding_")
+    signal_width, system_width, gates, depth = _ENCODING_EXPECTATIONS[name]
+
+    estimate = entry.qkernel.estimate_resources(inputs=entry.minimum_inputs())
+
+    assert estimate.qubits == signal_width + system_width
+    assert estimate.width.allocated_qubits == signal_width + system_width
+    assert estimate.width.peak_qubits == signal_width + system_width
+    assert estimate.gates.total == gates
+    assert estimate.depth.depth == depth
+    assert estimate.assumptions == ()
+    assert estimate.parameters == {}
+
+
+@pytest.mark.parametrize("degree", [0, 1, 2, 4, 8])
+@pytest.mark.parametrize(
+    "entry",
+    entries_with_tag("qsvt"),
+    ids=lambda entry: entry.id,
+)
+def test_qsvt_resources_follow_query_and_projector_formula(
+    entry: Any,
+    degree: int,
+) -> None:
+    """Degree d uses d encodings and d + 1 projector rotations.
+
+    Args:
+        entry (Any): Catalogued QSVT consumer and fixed block encoding.
+        degree (int): Singular-value polynomial degree, equal to the number of
+            block-encoding or inverse-block-encoding queries.
+    """
+    name = entry.id.removeprefix("qsvt_")
+    encoding_entry = QKERNEL_BY_ID[f"block_encoding_{name}"]
+    encoding = entry.fixed_inputs["encoding"]
+    phase_count = degree + 1
+
+    encoding_estimate = encoding_entry.qkernel.estimate_resources(
+        inputs=encoding_entry.minimum_inputs()
+    )
+    projector_estimate = entry.qkernel.estimate_resources(
+        inputs={**entry.fixed_inputs, "phase_count": 1}
+    )
+    estimate = entry.qkernel.estimate_resources(
+        inputs={**entry.fixed_inputs, "phase_count": phase_count}
+    )
+
+    assert estimate.qubits == (
+        encoding.num_signal_qubits + encoding.num_system_qubits + 1
+    )
+    assert estimate.gates.total == (
+        degree * encoding_estimate.gates.total
+        + phase_count * (2 * encoding.num_signal_qubits + 3)
+    )
+    for field in dataclasses.fields(estimate.gates):
+        actual = getattr(estimate.gates, field.name)
+        expected = degree * getattr(
+            encoding_estimate.gates, field.name
+        ) + phase_count * getattr(projector_estimate.gates, field.name)
+        assert actual == expected, field.name
+    for field in dataclasses.fields(estimate.depth):
+        actual = getattr(estimate.depth, field.name)
+        expected = degree * getattr(
+            encoding_estimate.depth, field.name
+        ) + phase_count * getattr(projector_estimate.depth, field.name)
+        assert actual == expected, field.name
+    assert estimate.assumptions == ()
+    assert estimate.parameters == {}
+
+
+@pytest.mark.parametrize(
+    ("inputs", "message"),
+    [
+        pytest.param({"phase_count": 0}, "Index -1", id="zero-count"),
+        pytest.param(
+            {"phase_count": 1, "phases": []},
+            "Index 0",
+            id="empty-phases",
+        ),
+        pytest.param(
+            {"phase_count": 3, "phases": [0.1, 0.2]},
+            "Index 2",
+            id="short-phases",
+        ),
+    ],
+)
+def test_qsvt_resource_estimation_rejects_invalid_phase_extent(
+    inputs: dict[str, Any],
+    message: str,
+) -> None:
+    """Resource specialization enforces the compiler's phase bounds.
+
+    Args:
+        inputs (dict[str, Any]): Invalid phase-count or vector specialization.
+        message (str): Concrete invalid index expected in the diagnostic.
+    """
+    entry = QKERNEL_BY_ID["qsvt_identity"]
+
+    with pytest.raises(ValidationError, match=message):
+        entry.qkernel.estimate_resources(inputs={**entry.fixed_inputs, **inputs})
+
+
+@pytest.mark.parametrize(
+    "entry",
+    entries_with_tag("qsvt"),
+    ids=lambda entry: entry.id,
+)
+def test_qsvt_estimated_width_matches_qiskit_emission(
+    qiskit_transpiler: Any,
+    entry: Any,
+) -> None:
+    """The logical width agrees with one emitted degree-two QSVT circuit.
+
+    Args:
+        qiskit_transpiler (Any): Qiskit transpiler fixture.
+        entry (Any): Catalogued QSVT consumer and fixed block encoding.
+    """
+    degree = 2
+    phases = [0.0, -math.pi / 2.0, math.pi / 2.0]
+    estimate = entry.qkernel.estimate_resources(
+        inputs={**entry.fixed_inputs, "phase_count": degree + 1}
+    )
+    executable = qiskit_transpiler.transpile(
+        _measured_qsvt_consumer,
+        bindings={**entry.fixed_inputs, "phase_count": degree + 1},
+        parameters=["phases"],
+    )
+
+    assert executable.quantum_circuit.num_qubits == estimate.qubits
+    assert executable.compiled_quantum[0].parameter_metadata.arrays[
+        "phases"
+    ].expected_shape == (len(phases),)
+
+
+@pytest.mark.parametrize("name", _ENCODED_MATRICES)
+def test_degree_two_qsvt_matches_even_singular_value_transform(
+    qiskit_transpiler: Any,
+    name: str,
+) -> None:
+    """The T2 phase canary transforms every catalogued encoding family.
+
+    For ``B = A / alpha``, the even singular-value transform of
+    ``T2(x) = 2 x**2 - 1`` is ``2 B dagger B - I``. The non-Hermitian Pauli
+    case is therefore a canary against accidentally computing ``B**2``.
+
+    Args:
+        qiskit_transpiler (Any): Qiskit transpiler fixture.
+        name (str): Catalog suffix selecting an encoding and target matrix.
+    """
+    encoding = QKERNEL_BY_ID[f"qsvt_{name}"].fixed_inputs["encoding"]
+    phases = [0.0, -math.pi / 2.0, math.pi / 2.0]
+    executable = qiskit_transpiler.transpile(
+        _measured_qsvt_consumer,
+        bindings={
+            "encoding": encoding,
+            "phases": phases,
+            "phase_count": len(phases),
+        },
+    )
+
+    from qiskit.quantum_info import Operator
+
+    circuit = executable.quantum_circuit.remove_final_measurements(inplace=False)
+    unitary = np.asarray(Operator(circuit).data)
+    signal_width = encoding.num_signal_qubits
+    system_width = encoding.num_system_qubits
+    system_dimension = 1 << system_width
+    projected_indices = np.arange(system_dimension) << signal_width
+    projected_block = unitary[np.ix_(projected_indices, projected_indices)]
+
+    normalized = _ENCODED_MATRICES[name] / encoding.normalization
+    expected = 2.0 * normalized.conj().T @ normalized - np.eye(
+        system_dimension, dtype=np.complex128
+    )
+    np.testing.assert_allclose(projected_block, expected, rtol=0.0, atol=1e-8)
+
+    auxiliary_one = np.arange(1 << (signal_width + system_width)) + (
+        1 << (signal_width + system_width)
+    )
+    np.testing.assert_allclose(
+        unitary[np.ix_(auxiliary_one, projected_indices)],
+        0.0,
+        rtol=0.0,
+        atol=1e-8,
+    )

--- a/tests/circuit/estimator/test_inputs_ux.py
+++ b/tests/circuit/estimator/test_inputs_ux.py
@@ -8,6 +8,7 @@ import sympy as sp
 
 import qamomile.circuit as qmc
 import qamomile.observable as qm_o
+from qamomile.circuit.transpiler.errors import ValidationError
 
 
 @qmc.composite_gate(name="phase_u")
@@ -345,6 +346,21 @@ def test_quantum_port_is_not_an_estimation_input() -> None:
         quantum_input.estimate_resources(inputs={"q": 0})
 
 
+def test_quantum_ports_are_not_counted_as_body_allocations() -> None:
+    """Direct quantum-I/O estimation counts each caller-owned port once."""
+    encoding = qmc.identity_block_encoding(num_system_qubits=2)
+
+    estimate = encoding.unitary.estimate_resources()
+    signal_width = estimate.parameters["signal_dim0"]
+    system_width = estimate.parameters["system_dim0"]
+    input_width = signal_width + system_width
+
+    assert sp.simplify(estimate.width.input_qubits - input_width) == 0
+    assert estimate.width.allocated_qubits == 0
+    assert sp.simplify(estimate.width.peak_qubits - input_width) == 0
+    assert sp.simplify(estimate.qubits - input_width) == 0
+
+
 def test_interleaved_composite_signature_binds_resource_parameter() -> None:
     """Resource estimation reweaves grouped operands to formal order."""
 
@@ -412,4 +428,36 @@ def test_numeric_vector_input_specializes_shape(angles: object) -> None:
 
     assert estimate.qubits == 3
     assert estimate.gates.total == 3
+    assert estimate.assumptions == ()
     assert estimate.parameters == {}
+
+
+def test_numeric_vector_input_with_unused_shape_is_accepted() -> None:
+    """An unused derived array dimension does not become an unknown input."""
+
+    @qmc.qkernel
+    def fixed_width_probe(angles: qmc.Vector[qmc.Float]) -> qmc.Qubit:
+        """Apply one rotation whose angle does not change its resource cost."""
+        qubit = qmc.qubit("qubit")
+        return qmc.rx(qubit, angles[0])
+
+    estimate = fixed_width_probe.estimate_resources(inputs={"angles": [0.1]})
+
+    assert estimate.gates.total == 1
+    assert [assumption.message for assumption in estimate.assumptions] == [
+        "input(s) 'angles' do not affect any resource metric; ignored"
+    ]
+    assert estimate.parameters == {}
+
+
+def test_numeric_vector_input_rejects_reachable_out_of_bounds_access() -> None:
+    """Concrete shape validation remains consistent with compilation."""
+
+    @qmc.qkernel
+    def first_rotation(angles: qmc.Vector[qmc.Float]) -> qmc.Qubit:
+        """Apply the first supplied rotation angle."""
+        qubit = qmc.qubit("qubit")
+        return qmc.rx(qubit, angles[0])
+
+    with pytest.raises(ValidationError, match="Index 0 is out of range"):
+        first_rotation.estimate_resources(inputs={"angles": []})

--- a/tests/circuit/qkernel_catalog.py
+++ b/tests/circuit/qkernel_catalog.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import itertools
 import math
 from dataclasses import dataclass, field
+from typing import Any
 
+import numpy as np
 import sympy as sp
 
 import qamomile.circuit as qmc
@@ -15,18 +17,33 @@ from qamomile.circuit.ir.operation.callable import (
     CompositeGateType,
     InvokeOperation,
 )
+from qamomile.linalg import PauliLCU, PeriodicShiftLCU
 
 
 @dataclass(frozen=True)
 class QKernelEntry:
-    """A catalog entry for a qkernel circuit."""
+    """A catalog entry for a qkernel circuit.
+
+    ``min_params`` contains numeric sweep parameters, while ``fixed_inputs``
+    carries structural values such as static block-encoding descriptors that
+    remain unchanged across the sweep.
+    """
 
     id: str
     qkernel: QKernel
     description: str
     param_names: tuple[str, ...] = ()
     min_params: dict[str, int] = field(default_factory=dict)
+    fixed_inputs: dict[str, Any] = field(default_factory=dict)
     tags: tuple[str, ...] = ()
+
+    def minimum_inputs(self) -> dict[str, Any]:
+        """Return fixed inputs combined with the minimum sweep parameters.
+
+        Returns:
+            dict[str, Any]: Complete minimum input mapping for this entry.
+        """
+        return {**self.fixed_inputs, **self.min_params}
 
 
 # ============================================================
@@ -1207,6 +1224,140 @@ def cdkm_adder(
 
 
 # ============================================================
+# Block encoding / QSVT resource consumers
+# ============================================================
+
+
+@qmc.qkernel
+def block_encoding_consumer(
+    encoding: qmc.LCUBlockEncoding,
+) -> tuple[qmc.Vector[qmc.Qubit], qmc.Vector[qmc.Qubit]]:
+    r"""Allocate and apply one exact block encoding.
+
+    Let ``a`` and ``n`` be the signal and system widths. In the notation of
+    Gilyén et al. (arXiv:1806.01838, Definition 43), the descriptor implements
+
+    ``B = (<0|**a tensor I) U (|0>**a tensor I) = A / alpha``,
+
+    where ``alpha = encoding.normalization``. Qamomile's current LCU
+    descriptors are exact, so the paper's block-encoding error ``epsilon`` is
+    zero. This consumer allocates both registers before invoking ``U``;
+    consequently its logical width is ``a + n``.
+
+    Args:
+        encoding (qmc.LCUBlockEncoding): Static exact block-encoding
+            descriptor whose all-zero signal block is consumed.
+
+    Returns:
+        tuple[qmc.Vector[qmc.Qubit], qmc.Vector[qmc.Qubit]]: Signal and system
+            registers after one application of the block-encoding unitary.
+    """
+    signal = qmc.qubit_array(encoding.num_signal_qubits, "signal")
+    system = qmc.qubit_array(encoding.num_system_qubits, "system")
+    return encoding.unitary(signal, system)
+
+
+@qmc.qkernel
+def qsvt_consumer(
+    encoding: qmc.LCUBlockEncoding,
+    phases: qmc.Vector[qmc.Float],
+    phase_count: qmc.UInt,
+) -> tuple[qmc.Vector[qmc.Qubit], qmc.Vector[qmc.Qubit]]:
+    r"""Allocate and apply one QSVT sequence in projector-phase convention.
+
+    Write ``Pi = |0><0|**a tensor I`` and
+    ``R(phi) = exp(i phi (2 Pi - I))``. For ``phase_count = d + 1``, Qamomile
+    chronologically applies ``R(phi_0), U, R(phi_1), U dagger, ...,
+    R(phi_d)``. Thus the circuit makes exactly ``d`` block-encoding or inverse
+    queries and ``d + 1`` projector rotations.
+
+    If ``B = W Sigma V dagger`` is the normalized encoded block, Gilyén et al.
+    (arXiv:1806.01838, Definitions 15-17) show that projection back onto the
+    signal-zero subspace gives ``W P(Sigma) V dagger`` for odd ``P`` and
+    ``V P(Sigma) V dagger`` for even ``P``. In particular, the Qamomile phases
+    ``(0, -pi/2, pi/2)`` realize ``T_2(x) = 2 x**2 - 1``, so the expected even
+    transform is ``2 B dagger B - I``. For the non-Hermitian catalog canary
+    ``B = |0><1|``, this is ``-Z`` rather than the incorrect matrix polynomial
+    ``B**2 = 0``.
+
+    One Qamomile projector rotation contains ``2a`` X gates, two MCX gates,
+    and one RZ gate, hence logical cost ``2a + 3``. If one encoding query costs
+    ``C_U``, the complete logical estimate is therefore
+    ``d C_U + (d + 1)(2a + 3)`` gates and ``n + a + 1`` qubits; the final one
+    is the reusable projector auxiliary. Martyn et al. (arXiv:2105.02859,
+    Section II and Appendix A) explain why phases synthesized in the different
+    ``Wx`` convention require conversion before being used here.
+
+    Args:
+        encoding (qmc.LCUBlockEncoding): Static exact block encoding of
+            ``A / alpha``.
+        phases (qmc.Vector[qmc.Float]): Projector-rotation phases in sequence
+            order.
+        phase_count (qmc.UInt): Positive number ``d + 1`` of phases to apply.
+
+    Returns:
+        tuple[qmc.Vector[qmc.Qubit], qmc.Vector[qmc.Qubit]]: Signal and system
+            registers after the singular-value transformation.
+    """
+    signal = qmc.qubit_array(encoding.num_signal_qubits, "signal")
+    system = qmc.qubit_array(encoding.num_system_qubits, "system")
+    return qmc.qsvt(
+        signal,
+        system,
+        phases,
+        encoding,
+        phase_count=phase_count,
+    )
+
+
+# The catalog values are mathematical canaries, not application benchmarks:
+# they span signal widths a=1, 2, 3 and include complex/non-Hermitian blocks.
+# Qamomile keeps one pass-through signal qubit for the identity descriptor so
+# it remains composable, although Definition 44's abstract trivial encoding
+# could use a=0.
+_BLOCK_ENCODING_IDENTITY = qmc.identity_block_encoding(num_system_qubits=2)
+# PauliLCU.from_matrix encodes B = |0><1| with alpha=1. Its zero singular
+# value makes the even T_2 result -Z and detects an accidental B**2 transform.
+_BLOCK_ENCODING_PAULI = qmc.pauli_lcu_block_encoding(
+    PauliLCU.from_matrix(
+        np.asarray([[0.0, 1.0], [0.0, 0.0]], dtype=np.complex128),
+        atol=1e-12,
+    )
+)
+# The diagonal Ising operator is A = 0.5 I + Z_0 - 0.25 i Z_1, with
+# alpha = 0.5 + 1 + 0.25 = 1.75 and a two-qubit selector for three terms.
+_BLOCK_ENCODING_ISING_Z = qmc.ising_z_block_encoding(
+    {(): 0.5, (0,): 1.0, (1,): -0.25j},
+    num_system_qubits=2,
+)
+# This is the periodic second-difference operator A = S^-1 - 2I + S. The LCU
+# normalization is alpha = |1| + |-2| + |1| = 4.
+_BLOCK_ENCODING_PERIODIC_SHIFT = qmc.periodic_shift_lcu_block_encoding(
+    PeriodicShiftLCU.from_coefficients(
+        {-1: 1.0, 0: -2.0, 1: 1.0},
+        register_sizes=(2,),
+    )
+)
+# Lemma 52 of arXiv:1806.01838 gives the recursive normalization
+# alpha = sum_j |c_j| alpha_j = 0.75 + 0.5 * 1.75 = 1.625. The outer selector
+# adds one signal qubit to the two-qubit Ising child, giving a=3.
+_BLOCK_ENCODING_RECURSIVE_LCU = qmc.lcu_block_encoding(
+    (
+        qmc.LCUBlockEncodingTerm(0.75, _BLOCK_ENCODING_IDENTITY),
+        qmc.LCUBlockEncodingTerm(-0.5j, _BLOCK_ENCODING_ISING_Z),
+    )
+)
+
+_BLOCK_ENCODING_CATALOG_CASES = (
+    ("identity", _BLOCK_ENCODING_IDENTITY),
+    ("pauli", _BLOCK_ENCODING_PAULI),
+    ("ising_z", _BLOCK_ENCODING_ISING_Z),
+    ("periodic_shift", _BLOCK_ENCODING_PERIODIC_SHIFT),
+    ("recursive_lcu", _BLOCK_ENCODING_RECURSIVE_LCU),
+)
+
+
+# ============================================================
 # Catalog
 # ============================================================
 
@@ -1555,6 +1706,29 @@ QKERNEL_CATALOG: list[QKernelEntry] = [
         },
         tags=("oracle",),
     ),
+    # --- Block encoding / QSVT ---
+    *[
+        QKernelEntry(
+            id=f"block_encoding_{name}",
+            qkernel=block_encoding_consumer,
+            description=f"Resource consumer for the {name} block encoding",
+            fixed_inputs={"encoding": encoding},
+            tags=("block_encoding", "resource_estimation"),
+        )
+        for name, encoding in _BLOCK_ENCODING_CATALOG_CASES
+    ],
+    *[
+        QKernelEntry(
+            id=f"qsvt_{name}",
+            qkernel=qsvt_consumer,
+            description=f"QSVT resource consumer for the {name} block encoding",
+            param_names=("phase_count",),
+            min_params={"phase_count": 1},
+            fixed_inputs={"encoding": encoding},
+            tags=("qsvt", "resource_estimation"),
+        )
+        for name, encoding in _BLOCK_ENCODING_CATALOG_CASES
+    ],
     # --- Arithmetic ---
     QKernelEntry(
         id="maj",

--- a/tests/circuit/test_qkernel_catalog_integrity.py
+++ b/tests/circuit/test_qkernel_catalog_integrity.py
@@ -1,12 +1,12 @@
 """Integrity tests for the shared qkernel catalog test asset.
 
-The catalog's ``min_params`` metadata is what downstream consumers
-(visualization regression, resource estimation with concrete bindings)
-feed into ``QKernel.build``. This module guards that contract directly:
-symbolic-only consumers such as the resource-estimation tests never
-exercise concrete bindings, which previously let invalid ``min_params``
-(wrong argument names, affine-coverage violations that only trigger on
-concrete shapes) ship unnoticed.
+The catalog's minimum and fixed input metadata is what downstream consumers
+(visualization regression, resource estimation with concrete bindings) feed
+into ``QKernel.build``. This module guards that contract directly:
+symbolic-only consumers such as the resource-estimation tests never exercise
+concrete bindings, which previously let invalid metadata (wrong argument
+names, affine-coverage violations that only trigger on concrete shapes) ship
+unnoticed.
 """
 
 import pytest
@@ -17,9 +17,9 @@ from tests.circuit.qkernel_catalog import QKERNEL_CATALOG
 @pytest.mark.parametrize(
     "entry", QKERNEL_CATALOG, ids=[entry.id for entry in QKERNEL_CATALOG]
 )
-def test_entry_builds_with_min_params(entry):
-    """Every catalog entry must build successfully with its declared min_params."""
-    block = entry.qkernel.build(**entry.min_params)
+def test_entry_builds_with_minimum_inputs(entry):
+    """Every catalog entry builds with its declared minimum input set."""
+    block = entry.qkernel.build(**entry.minimum_inputs())
     assert block is not None
 
 
@@ -27,7 +27,9 @@ def test_entry_builds_with_min_params(entry):
     "entry", QKERNEL_CATALOG, ids=[entry.id for entry in QKERNEL_CATALOG]
 )
 def test_metadata_names_are_kernel_arguments(entry):
-    """param_names and min_params keys must name real kernel arguments."""
+    """All catalog input metadata must name real kernel arguments."""
     kernel_args = set(entry.qkernel.signature.parameters.keys())
     assert set(entry.param_names) <= kernel_args
     assert set(entry.min_params.keys()) <= kernel_args
+    assert set(entry.fixed_inputs.keys()) <= kernel_args
+    assert set(entry.min_params).isdisjoint(entry.fixed_inputs)


### PR DESCRIPTION
## Summary

This adds qkernel-catalog coverage for the five existing block-encoding families—identity, Pauli LCU, Ising-Z LCU, periodic-shift LCU, and recursive LCU—and exercises them both directly and through QSVT resource estimation.

The QSVT regressions derive and verify the logical formula `C_QSVT(d) = d C_U + (d + 1)(2a + 3)` with width `n + a + 1`, where `d` is the singular-value polynomial degree, `C_U` is one block-encoding query cost, `a` is the signal-register width, and `n` is the system-register width. They also validate the degree-two Chebyshev transform `2 B†B - I` on emitted Qiskit unitaries, including a non-Hermitian canary that distinguishes singular-value transformation from the incorrect matrix polynomial `B²`.

The mathematical comments cite Gilyén et al., arXiv:1806.01838, for block encoding and singular-value transformation, and Martyn et al., arXiv:2105.02859, for projector-phase and `Wx` phase conventions.

## Estimator fixes

Resource estimation now treats root quantum input markers as caller-owned ports instead of fresh body allocations, maps derived vector-dimension symbols back to their public input names, and runs concrete array-bounds validation on a specialized diagnostic copy before interpreting the original symbolic block. These fixes remove doubled widths and spurious input warnings while preserving scalable symbolic estimation and compiler-consistent errors for empty or short QSVT phase vectors.

## Validation

- `uv run pytest`: 9,698 passed, 414 skipped, 2,592 deselected, 1 xfailed
- Focused block-encoding, QSVT, input-UX, and catalog integrity tests: 210 passed
- `uv run ruff check qamomile/ tests/`: passed
- `uv run ruff format --check qamomile/ tests/`: passed
- `uv run zuban check qamomile/` with the CI `hugr` extra installed: passed