### PR TITLE
Thread module-global-shadowed locals through if branches

### DIFF
--- a/qamomile/circuit/frontend/ast_transform.py
+++ b/qamomile/circuit/frontend/ast_transform.py
@@ -54,6 +54,49 @@ class VariableCollector(ast.NodeVisitor):
         self._store_names: set[str] = set()
         self._store_order: list[str] = []
 
+    def _prescan_call_targets(self, node: ast.AST) -> None:
+        """Record call-target names so exclusion is visit-order independent.
+
+        ``visit_Call`` excludes the name of a called function (``foo`` in
+        ``foo(q)``) from the collected variables. Doing so incrementally makes
+        the result depend on visit order: a name seen as a plain variable
+        *before* the call that names it would leak into ``vars``, while the same
+        name seen after the call would be excluded. Collecting every call target
+        up front removes that dependency. Nested function definitions (sync and
+        async) are not descended into, mirroring the main pass
+        (``visit_FunctionDef`` / ``visit_AsyncFunctionDef``), so their call
+        targets do not affect the enclosing scope's dataflow.
+
+        Args:
+            node (ast.AST): Subtree to scan for called-function names.
+        """
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            self._exclude.add(node.func.id)
+        for child in ast.iter_child_nodes(node):
+            self._prescan_call_targets(child)
+
+    def collect(self, *nodes: ast.AST) -> "VariableCollector":
+        """Collect variable dataflow over ``nodes`` in two order-independent passes.
+
+        The first pass records every call target across all nodes; the second
+        pass gathers variable dataflow while honouring those exclusions. Running
+        both passes over the full node set makes the result independent of the
+        order in which statements (and the calls within them) appear.
+
+        Args:
+            *nodes (ast.AST): Statements or expressions to collect over.
+
+        Returns:
+            VariableCollector: This collector, to allow fluent property access.
+        """
+        for node in nodes:
+            self._prescan_call_targets(node)
+        for node in nodes:
+            self.visit(node)
+        return self
+
     def visit_Call(self, node: ast.Call):
         """Exclude the function name of a call."""
         if isinstance(node.func, ast.Name):
@@ -154,7 +197,26 @@ class VariableCollector(ast.NodeVisitor):
             self.visit(target)
 
     def visit_FunctionDef(self, node: ast.FunctionDef):
-        """Skip traversal of inner function definitions."""
+        """Skip traversal of inner function definitions.
+
+        A nested definition introduces its own scope; its names are not part of
+        the enclosing block's dataflow, so it is not descended into (which also
+        keeps this pass consistent with ``_prescan_call_targets``).
+
+        Args:
+            node (ast.FunctionDef): Inner function definition to skip.
+        """
+        pass
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        """Skip traversal of inner async function definitions.
+
+        Mirrors ``visit_FunctionDef`` so both function-definition kinds are
+        treated identically by the main pass and the call-target pre-scan.
+
+        Args:
+            node (ast.AsyncFunctionDef): Inner async function definition to skip.
+        """
         pass
 
     def visit_Name(self, node: ast.Name):
@@ -283,7 +345,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
         per_stmt_collectors: list[VariableCollector] = []
         for stmt in body:
             c = VariableCollector(global_names=self._global_names)
-            c.visit(stmt)
+            c.collect(stmt)
             per_stmt_collectors.append(c)
 
         # Build suffix-union of read vars in reverse (O(n))
@@ -352,10 +414,9 @@ class ControlFlowTransformer(ast.NodeTransformer):
     def _collect_variables(self, nodes: list[ast.AST] | ast.AST) -> list[str]:
         collector = VariableCollector(global_names=self._global_names)
         if isinstance(nodes, list):
-            for node in nodes:
-                collector.visit(node)
+            collector.collect(*nodes)
         else:
-            collector.visit(nodes)
+            collector.collect(nodes)
         # Targets variables that have a registered type or that appear in the nodes.
         # Global variables (modules, builtins, etc.) are excluded.
         return sorted(list(collector.vars))
@@ -765,7 +826,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
             set[str]: Loaded local or closure variable names.
         """
         collector = VariableCollector(global_names=self._global_names)
-        collector.visit(node)
+        collector.collect(node)
         return set(collector.load_vars)
 
     def _stmt_live_in(self, stmt: ast.stmt, live_out: set[str]) -> set[str]:
@@ -816,7 +877,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
             return post_loop_live | iter_loads | body_entry_live_in
 
         collector = VariableCollector(global_names=self._global_names)
-        collector.visit(stmt)
+        collector.collect(stmt)
         return set(collector.load_vars) | (set(live_out) - set(collector.store_vars))
 
     def _block_live_in(self, body: list[ast.stmt], live_out: set[str]) -> set[str]:
@@ -900,8 +961,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
                 reassigns no pre-existing variable.
         """
         collector = VariableCollector(global_names=self._global_names)
-        for stmt in body:
-            collector.visit(stmt)
+        collector.collect(*body)
         outer_defined = set(self._outer_defined_vars)
         pre_existing = outer_defined | self._lexical_defined_vars
         candidates = (collector.store_vars - bound_names) & pre_existing
@@ -947,8 +1007,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
             SyntaxError: If a body-local name is live after the loop.
         """
         collector = VariableCollector(global_names=self._global_names)
-        for stmt in body:
-            collector.visit(stmt)
+        collector.collect(*body)
         escaping = (
             (collector.store_vars - bound_names) - set(self._outer_defined_vars)
         ) & set(self._after_stmt_load_vars)
@@ -1224,7 +1283,7 @@ class ControlFlowTransformer(ast.NodeTransformer):
         # Also propagate loop back-edge liveness. VariableCollector.incoming_vars
         # is lexical and misses mixed-path Load-before-Store cases at loop entry.
         cond_collector = VariableCollector(global_names=self._global_names)
-        cond_collector.visit(node.test)
+        cond_collector.collect(node.test)
         cond_loads = set(cond_collector.load_vars)
         signature = self._region_signatures.get(
             RegionLocation("while", node.lineno, node.col_offset)
@@ -1903,16 +1962,14 @@ class ControlFlowTransformer(ast.NodeTransformer):
         )
         # Collect variables from the pre-transform AST (post generic_visit would include generated names)
         collector_test = VariableCollector(global_names=self._global_names)
-        collector_test.visit(node.test)
+        collector_test.collect(node.test)
 
         collector_body = VariableCollector(global_names=self._global_names)
-        for stmt in node.body:
-            collector_body.visit(stmt)
+        collector_body.collect(*node.body)
 
         collector_orelse = VariableCollector(global_names=self._global_names)
         if node.orelse:
-            for stmt in node.orelse:
-                collector_orelse.visit(stmt)
+            collector_orelse.collect(*node.orelse)
 
         # --- Input/output variable separation ---
         # input_vars: variables that exist before the if (passed to inner funcs)
@@ -2308,6 +2365,16 @@ def transform_control_flow(
 
     # Collect global names (modules, builtins, etc.)
     global_names = set(func.__globals__.keys())
+
+    # A name assigned anywhere in the function body is a function-local by
+    # Python's scoping rules, even when a module global of the same name
+    # exists (common in notebooks, where a prior cell leaves a same-named
+    # global behind). Such a shadowed local must still be threaded as
+    # dataflow through control-flow branches, so it must not be treated as a
+    # global. ``co_varnames`` covers parameters and locally bound names;
+    # ``co_cellvars`` covers locals captured by nested functions.
+    local_names = set(func.__code__.co_varnames) | set(func.__code__.co_cellvars)
+    global_names -= local_names
 
     # Exclude closure variables too (so VariableCollector does not add them to target_vars).
     # Closure values are injected into name_space later, so inner functions can still access them.

--- a/tests/circuit/test_ast_transform.py
+++ b/tests/circuit/test_ast_transform.py
@@ -460,6 +460,56 @@ class TestVariableCollectorAttributeAccess:
         assert "q" in collector.load_vars
 
 
+class TestVariableCollectorVisitOrderIndependence:
+    """Call-target exclusion must not depend on statement/visit order (FE-17)."""
+
+    @staticmethod
+    def _collect(source: str) -> VariableCollector:
+        """Collect variable dataflow from ``source`` with an empty global set."""
+        body = ast.parse(textwrap.dedent(source)).body
+        return VariableCollector(global_names=set()).collect(*body)
+
+    def test_call_target_excluded_regardless_of_statement_order(self):
+        """A name used as a call target is excluded whether it appears first or last.
+
+        Before the two-pass collection, a name seen as a plain variable
+        *before* the call that names it leaked into ``vars``, while the same
+        name seen after the call was excluded — so the two orderings below
+        disagreed on whether ``f`` was a variable.
+        """
+        store_then_call = self._collect(
+            """
+            f = g
+            f(a)
+            """
+        )
+        call_then_store = self._collect(
+            """
+            f(a)
+            f = g
+            """
+        )
+
+        # ``f`` is a call target, so it is excluded from the variable set in
+        # both orderings, and the two collections agree exactly.
+        assert "f" not in store_then_call.vars
+        assert "f" not in call_then_store.vars
+        assert store_then_call.vars == call_then_store.vars == {"g", "a"}
+
+    def test_call_target_in_later_statement_excludes_earlier_use(self):
+        """A call in a later statement still excludes the same name used earlier."""
+        collector = self._collect(
+            """
+            x = helper
+            y = helper + 1
+            helper(x)
+            """
+        )
+
+        assert "helper" not in collector.vars
+        assert collector.vars == {"x", "y"}
+
+
 class TestEmptyClosureCell:
     """Empty closure cells should now fail closed at decoration time."""
 

--- a/tests/circuit/test_control_flow_if.py
+++ b/tests/circuit/test_control_flow_if.py
@@ -35,6 +35,17 @@ from qamomile.circuit.ir.types import ObservableType, QFixedType
 from qamomile.circuit.ir.types.primitives import BitType, FloatType, QubitType
 from qamomile.circuit.ir.value import Value
 
+# A module-level global deliberately sharing the name of a kernel-local used in
+# ``TestIfModuleGlobalShadowing``. Its presence in the kernel's ``__globals__``
+# used to make the transform treat the same-named local as a global and silently
+# drop assignments to it inside ``if`` branches.
+_shadowed_count = 123
+
+# A second module-level global shadowed by a kernel-local that is *captured by a
+# nested function*, making it a cell variable (``co_cellvars``) rather than a
+# plain local (``co_varnames``) in ``TestIfModuleGlobalShadowing``.
+_cell_shadowed_count = 999
+
 
 def _collect_emit_if_bindings(source: str) -> list[tuple[list[str], list[str]]]:
     """Return transformed emit_if assignment targets and input variable names."""
@@ -1972,3 +1983,108 @@ class TestBoolBindingWithDynamicIf:
             "Expected m0/m1 to vary across shots; the dynamic IfOperations "
             "may not be executing."
         )
+
+
+class TestIfModuleGlobalShadowing:
+    """A function-local shadowing a module global must thread through ``if``."""
+
+    def test_module_global_shadowing_local_threads_through_if(self):
+        """A local assigned in an ``if`` branch survives when a global shadows it.
+
+        ``_shadowed_count`` exists at module scope, so before the fix the
+        transform excluded the same-named kernel-local from the branch dataflow
+        and discarded ``_shadowed_count = 1.0``, leaving the returned value at
+        the pre-branch ``0.0``.
+        """
+
+        @qkernel
+        def circuit(flag: qm.UInt) -> Float:
+            _shadowed_count = 0.0
+            if flag == 1:
+                _shadowed_count = 1.0
+            return _shadowed_count
+
+        block = circuit.build(flag=1)
+        if_ops = [op for op in block.operations if isinstance(op, IfOperation)]
+        assert len(if_ops) == 1
+
+        # The shadowed local is threaded: it is a block output and the branch
+        # produces a merge result for it.
+        assert block.output_names == ["_shadowed_count"]
+        assert len(block.output_values) == 1
+        assert len(if_ops[0].results) >= 1
+
+        # The true branch yields 1.0 and the pre-branch 0.0 flows through the
+        # false side, i.e. the assignment is no longer discarded.
+        true_consts = [
+            v.metadata.scalar.const_value
+            for v in if_ops[0].true_yields
+            if v.metadata and v.metadata.scalar
+        ]
+        false_consts = [
+            v.metadata.scalar.const_value
+            for v in if_ops[0].false_yields
+            if v.metadata and v.metadata.scalar
+        ]
+        assert 1.0 in true_consts
+        assert 0.0 in false_consts
+
+    def test_cell_variable_shadowing_global_threads_through_if(self):
+        """A cell-variable local (captured by a nested def) also threads through.
+
+        ``_cell_shadowed_count`` is assigned in the kernel and captured by a
+        nested function, so it is a cell variable (``co_cellvars``) rather than
+        a plain local (``co_varnames``). The fix subtracts both sets from the
+        globals, so this shadowed local is threaded through the ``if`` too.
+        """
+
+        @qkernel
+        def circuit(flag: qm.UInt) -> Float:
+            _cell_shadowed_count = 0.0
+
+            def _capture() -> Float:
+                # Referencing the local here makes it a cell variable.
+                return _cell_shadowed_count
+
+            if flag == 1:
+                _cell_shadowed_count = 1.0
+            return _cell_shadowed_count
+
+        block = circuit.build(flag=1)
+        if_ops = [op for op in block.operations if isinstance(op, IfOperation)]
+        assert len(if_ops) == 1
+        assert block.output_names == ["_cell_shadowed_count"]
+        assert len(block.output_values) == 1
+        assert len(if_ops[0].results) >= 1
+
+    def test_shadowed_local_resolves_to_branch_value_after_lowering(self):
+        """End-to-end: the compile-time ``if`` resolves to the branch value.
+
+        With ``flag`` bound at compile time the ``if`` folds to a single value;
+        the fix ensures that value is the branch assignment (``1.0``) rather than
+        the pre-branch default (``0.0``).
+        """
+        qiskit = pytest.importorskip("qamomile.qiskit")
+
+        @qkernel
+        def circuit(flag: qm.UInt) -> Float:
+            _shadowed_count = 0.0
+            if flag == 1:
+                _shadowed_count = 1.0
+            return _shadowed_count
+
+        transpiler = qiskit.QiskitTranspiler()
+        for flag_value, expected in ((1, 1.0), (0, 0.0)):
+            bindings = {"flag": flag_value}
+            block = transpiler.to_block(circuit, bindings=bindings)
+            block = transpiler.inline(transpiler.substitute(block))
+            block = transpiler.affine_validate(block)
+            block = transpiler.constant_fold(block, bindings=bindings)
+            block = transpiler.lower_compile_time_ifs(block, bindings=bindings)
+            block = transpiler.constant_fold(block, bindings=bindings)
+            outputs = [
+                v.metadata.scalar.const_value
+                for v in block.output_values
+                if v.metadata and v.metadata.scalar
+            ]
+            assert outputs == [expected]


### PR DESCRIPTION
## Summary

A kernel-local variable that shares a name with a module global was treated as a global by the control-flow transform. `VariableCollector` excludes global names from a branch's input/output set, so a same-named local was dropped from `if`-branch dataflow and assignments to it inside the branch were silently discarded (BACKLOG-8898). This is easy to hit in notebooks, where a variable left behind by a previous cell becomes a module global.

Changes:

- **Primary fix.** `transform_control_flow` now subtracts function-local bound names (`co_varnames | co_cellvars`) from `global_names`. A name assigned anywhere in the function body is a Python local for the whole scope regardless of a same-named global, so it must be threaded as dataflow. Read-only globals and `global`-declared names never appear in `co_varnames`/`co_cellvars`, so genuine globals stay classified as globals and are unaffected.
- **Secondary fix.** `VariableCollector`'s call-target exclusion was visit-order dependent: a name seen as a variable before the call that names it leaked into the collected set, while the same name seen after the call was excluded. A new two-pass `collect(*nodes)` method pre-scans call targets across all nodes before collecting variable dataflow, making the result order-independent. All collector call sites now route through it. Nested function definitions (sync and async) are skipped consistently by both passes.

The IR abstraction level and layer boundaries are unchanged; this is a frontend-only transform fix.

## Test plan

- `uv run pytest tests/circuit/test_control_flow_if.py tests/circuit/test_ast_transform.py` — new `TestIfModuleGlobalShadowing` (plain-local and cell-variable shadowing paths, plus the compile-time-folded value resolving to the branch assignment) and `TestVariableCollectorVisitOrderIndependence` (call-target exclusion is order independent) pass alongside the existing suites.
- `uv run pytest tests/` — full unit suite green (9636 passed).
- `uv run ruff check qamomile/ tests/` and `uv run ruff format --check qamomile/ tests/` — clean.
- `uv run zuban check qamomile/` — no new type errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHbNShC7tKEB8uDojG2F5j