### PR TITLE
Add Qamomile v0.14.0 release notes

### DIFF
--- a/docs/en/myst.yml
+++ b/docs/en/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: Release Notes
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_14_0.md
         - file: release_notes/v0_13_0.md
         - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
@@ -64,10 +65,9 @@ project:
             - file: api/circuit/frontend
             - file: api/circuit/ir
             - file: api/circuit/multi_controlled_x
-            - file: api/circuit/pauli_lcu_block_encoding
-            - file: api/circuit/periodic_shift_lcu_block_encoding
             - file: api/circuit/qft
             - file: api/circuit/qpe
+            - file: api/circuit/qsvt
             - file: api/circuit/serialization
             - file: api/circuit/stdlib
             - file: api/circuit/transpiler

--- a/docs/en/release_notes/index.md
+++ b/docs/en/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # Release Notes
 
+- [v0.14.0](v0_14_0) — composable LCU block encodings and `qmc.qsvt`, lower-width Shor and Ekerå–Håstad factoring circuits, plus `qmc.struct`, `qmc.bit_array`, and structural math
 - [v0.13.0](v0_13_0) — semantic `qmc.select`, exact `qmc.global_phase`, loop-carried scalars, and generic versus explicit Möttönen amplitude encoding; Qiskit moved to the `qiskit` extra
 - [v0.12.7](v0_12_7) — `Dict[K, Float]` coefficients as runtime parameters with `d[key]` subscript, `%` operator on `UInt`, and a batch of new compile-time errors (`QubitRebindError`, `QubitConsumedError`, `TypeError` on `bool` / mismatched args) that reject previously silent miscompiles
 - [v0.12.6](v0_12_6) — circuit inversion with `qmc.inverse` (built-in gates, `@qkernel`s, QFT/IQFT), `qmc.modular_increment` / `qmc.modular_decrement` basis-state arithmetic, job/result types importable from `qamomile.circuit`

--- a/docs/en/release_notes/index.md
+++ b/docs/en/release_notes/index.md
@@ -4,7 +4,7 @@ slug: release-notes
 
 # Release Notes
 
-- [v0.14.0](v0_14_0) — composable LCU block encodings and `qmc.qsvt`, lower-width Shor and Ekerå–Håstad factoring circuits, plus `qmc.struct`, `qmc.bit_array`, and structural math
+- [v0.14.0](v0_14_0) — composable LCU block encodings and `qmc.qsvt`, lower-width Shor order finding and the quantum stage of Ekerå–Håstad factoring, plus `qmc.struct`, `qmc.bit_array`, and `qmc.log2`/`qmc.ceil` for register-width calculations
 - [v0.13.0](v0_13_0) — semantic `qmc.select`, exact `qmc.global_phase`, loop-carried scalars, and generic versus explicit Möttönen amplitude encoding; Qiskit moved to the `qiskit` extra
 - [v0.12.7](v0_12_7) — `Dict[K, Float]` coefficients as runtime parameters with `d[key]` subscript, `%` operator on `UInt`, and a batch of new compile-time errors (`QubitRebindError`, `QubitConsumedError`, `TypeError` on `bool` / mismatched args) that reject previously silent miscompiles
 - [v0.12.6](v0_12_6) — circuit inversion with `qmc.inverse` (built-in gates, `@qkernel`s, QFT/IQFT), `qmc.modular_increment` / `qmc.modular_decrement` basis-state arithmetic, job/result types importable from `qamomile.circuit`

--- a/docs/en/release_notes/v0_13_0.md
+++ b/docs/en/release_notes/v0_13_0.md
@@ -19,26 +19,6 @@ pip install qamomile==0.13.0
 
 ## New Features
 
-### Exact structural math expressions
-
-`qmc.log2` and `qmc.ceil` build target-neutral classical expressions inside a qkernel. They are useful for deriving register widths and other compile-time structure without evaluating traced values in host Python. Concrete inputs fold immediately, while unbound inputs remain exact in resource estimates and are resolved when their arguments are supplied through transpile-time `bindings`. Because these expressions determine circuit structure, their arguments are not runtime backend parameters.
-
-```python
-import qamomile.circuit as qmc
-from qamomile.qiskit import QiskitTranspiler
-
-@qmc.qkernel
-def logarithmic_register(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
-    width = qmc.ceil(qmc.log2(size))
-    return qmc.measure(qmc.qubit_array(width, name="register"))
-
-transpiler = QiskitTranspiler()
-executable = transpiler.transpile(
-    logarithmic_register,
-    bindings={"size": 9},
-)
-```
-
 ### Semantic `qmc.select` and value-activated controls
 
 `qmc.select([U0, U1, ...])` creates a SELECT operation that applies case `Ui` to the shared target qubits when the LSB-first index register represents the integer `i`. The index width can be inferred from the number of cases or specified with a Python `int` or `qmc.UInt`. In addition, `qmc.control(..., control_value=v)` creates a controlled operation that applies the target operation when the flattened control qubits match the concrete LSB-first value `v` ([#597](https://github.com/Jij-Inc/Qamomile/pull/597)).

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -1,6 +1,6 @@
 # Qamomile v0.14.0
 
-Qamomile v0.14.0 adds exact LCU block encodings and `qmc.qsvt`, including Pauli, Ising-Z, and periodic-shift constructors that can be serialized and rebound. FTQC workflows gain more constant-arithmetic primitives, lower-width iterative Shor order finding, and `qmc.ekera_hastad_factoring`. Qkernels can also organize trace-time workspaces with `qmc.struct`, collect measurements with `qmc.bit_array`, and derive structural widths with `qmc.ceil(qmc.log2(...))`. Compiler validation now gives earlier diagnostics for non-unitary transforms, structured control flow, and reachable array bounds.
+Qamomile v0.14.0 adds LCU block encodings for Pauli, Ising-Z, and periodic-shift operators, together with `qmc.qsvt` for quantum singular value transformation (QSVT). It also adds quantum arithmetic circuits such as constant addition and rewrites Shor order finding as an iterative algorithm that uses fewer logical qubits. The new `qmc.ekera_hastad_factoring` API constructs the quantum stage of Ekerå–Håstad factoring.
 
 ```
 pip install qamomile==0.14.0
@@ -9,15 +9,16 @@ pip install qamomile==0.14.0
 ## Breaking Changes
 
 - **The algorithm and standard-library import boundaries have changed.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#626](https://github.com/Jij-Inc/Qamomile/pull/626)).
-- **The qkernel returned by `qmc.shor_order_finding` no longer has a symbolic `n` input.** Its register width is determined by `modulus`, so callers should stop passing `bindings={"n": ...}` or `parameters=["n"]`. Use the factory's `window_size` and `precision` arguments to choose the arithmetic window and measured phase width ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- **The qkernel returned by `qmc.shor_order_finding` no longer has the `n` argument for specifying the quantum-register width.** The width is calculated automatically from `modulus.bit_length()`. Use `precision` to specify the number of phase bits and `window_size` to specify how many qubits modular multiplication processes at once. Execution requires a backend that supports mid-circuit measurement, reset, and feed-forward ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- **`qmc.modmul_const` now uses an FTQC-oriented implementation with measurement and reset.** The width of `reg` must be known when `qmc.modmul_const` is called, and the new `window_size` argument specifies how many input qubits are processed at once during modular multiplication ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 
 ## New Features
 
-### Composable LCU block encodings and QSVT
+### LCU block encodings and QSVT
 
-`qamomile.linalg` now provides `PauliLCU` for general complex power-of-two square matrices and `PeriodicShiftLCU` for one- or multidimensional periodic operators. The circuit API turns these decompositions into exact `LCUBlockEncoding` descriptors with `qmc.pauli_lcu_block_encoding` and `qmc.periodic_shift_lcu_block_encoding`; it also provides direct Ising-Z, identity, and recursive LCU constructors. Each descriptor exposes its normalization, signal and system widths, and a reusable `unitary` qkernel. These descriptors compose through control and inverse operations, survive Protobuf serialization as static bindings, and execute on the supported circuit backends.
+`qamomile.linalg` now provides `PauliLCU` for general complex square matrices whose dimensions are powers of two, and `PeriodicShiftLCU` for one- or multidimensional periodic-shift operators. The corresponding block encoding APIs are `qmc.pauli_lcu_block_encoding` and `qmc.periodic_shift_lcu_block_encoding`. This release also adds APIs for Ising-Z, identity, and block encodings assembled from existing block encodings. Each API returns an instance containing its normalization, signal-register width, system-register width, and a reusable `unitary` qkernel.
 
-`qmc.qsvt` applies a caller-supplied projector-phase sequence to any `LCUBlockEncoding`. Phase values may be fixed through transpile-time `bindings`, or retained as runtime parameters when a compile-time `phase_count` is supplied. Qamomile implements the quantum transformation sequence; synthesizing phases for a desired polynomial and converting from other QSP phase conventions remain the caller's responsibility ([#598](https://github.com/Jij-Inc/Qamomile/pull/598), [#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#611](https://github.com/Jij-Inc/Qamomile/pull/611), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
+`qmc.qsvt` applies a caller-supplied projector-phase sequence to any `LCUBlockEncoding`. Phase values may be fixed through transpile-time `bindings`. To retain the phase sequence as a runtime parameter, fix `phase_count` through `bindings` and specify `parameters=["phases"]`. Phase synthesis for a desired polynomial and conversion from other QSP conventions are not provided, so callers must prepare the phases in advance ([#598](https://github.com/Jij-Inc/Qamomile/pull/598), [#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#611](https://github.com/Jij-Inc/Qamomile/pull/611), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
 
 ```python
 import numpy as np
@@ -49,11 +50,11 @@ executable = transpiler.transpile(
 )
 ```
 
-### FTQC arithmetic and lower-width factoring circuits
+### Arithmetic and lower-width factoring circuits
 
-The standard library adds `qmc.add_const`, controlled constant addition, constant modular addition, and `qmc.lookup_xor`. These reusable operations support the rewritten `qmc.shor_order_finding`, which recycles one phase qubit and uses windowed modular multiplication. For an `n`-bit modulus and fixed `window_size`, the generated body has a peak logical width of `3 * n + window_size + 7`; the default `2 * n` phase precision keeps its gate count at `O(n**3)`.
+The standard library adds constant addition, controlled constant addition, constant modular addition, and a function that uses a quantum register as an address to look up a table value and XOR it into another quantum register. The existing `qmc.shor_order_finding` has also been updated to use windowed modular multiplication.
 
-`qmc.ekera_hastad_factoring` adds the quantum short-discrete-logarithm stage of Ekerå–Håstad factoring for balanced semiprimes. It reuses the same phase qubit and arithmetic workspace for its long and short schedules, then returns both measurement groups in one `Vector[Bit]`. Classical lattice post-processing is outside this qkernel ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+`qmc.ekera_hastad_factoring` constructs the quantum part of Ekerå–Håstad factoring for a product of two primes with similar bit lengths. It returns measured bits for the classical computation that recovers the factors, rather than returning the factors themselves. The circuit reduces the number of logical qubits used at once by reusing qubits after measurement and reset. Classical post-processing that recovers the factors from the measurements is not included ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 
 ```python
 import qamomile.circuit as qmc
@@ -76,11 +77,11 @@ short_dlp_executable = transpiler.transpile(short_dlp)
 
 See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb).
 
-### Trace-time records, fixed Bit arrays, and structural math
+### `qmc.struct`, fixed-length Bit arrays, and structural math
 
-The `qmc.struct` decorator creates an immutable Python record for grouping quantum and classical handles inside trace-time helper code without changing a qkernel's backend ABI. `qmc.bit_array` creates a fixed-length one-dimensional `Vector[Bit]` initialized to zero, so measurement results can be stored by index and returned as one value. Its length must be known while tracing, and stored elements are currently intended for collection and return rather than measurement-driven feed-forward.
+The `qmc.struct` decorator makes helper-based implementations of large algorithms easier to organize. It cannot be used as a qkernel argument or return value. `qmc.bit_array` creates a zero-initialized, fixed-length one-dimensional `Vector[Bit]`, allowing measurement results to be stored by index and returned as one value.
 
-`qmc.log2` and `qmc.ceil` build exact structural expressions for register widths and loop bounds. Concrete inputs fold immediately; unresolved inputs remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before backend emission ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
+The new classical-value operations `qmc.log2` and `qmc.ceil` are evaluated immediately when their inputs are known. When inputs are unresolved, the operations remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before the circuit is generated ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
 
 ```python
 import qamomile.circuit as qmc
@@ -109,11 +110,9 @@ executable = transpiler.transpile(
 
 ## Internal Changes
 
-The block-encoding, QSVT, and low-width factoring APIs above rely on two compiler capabilities that are also visible to advanced users: qkernel effect metadata and explicit structured-region dataflow. Together they keep reusable transformations unitary where required and make compile-time structural validation follow the control-flow paths that can actually execute.
-
 ### First-class qkernel effects
 
-`QKernel.effects` reports a `KernelEffect` flag set containing `MEASUREMENT`, `RESET`, and `FEED_FORWARD`; `KernelEffect.NONE` denotes a unitary body. Effects propagate through nested callable definitions and are reconstructed after serialization. Generic `qmc.control` and `qmc.inverse` transformations, and cases supplied to `qmc.select`, now reject incompatible non-unitary bodies with a direct diagnostic instead of failing later during backend emission ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+`QKernel.effects` reports a `KernelEffect` flag set containing `MEASUREMENT`, `RESET`, and `FEED_FORWARD`; `KernelEffect.NONE` denotes a unitary body. Effects propagate through nested callable definitions and are reconstructed after serialization ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 
 ```python
 import qamomile.circuit as qmc
@@ -131,11 +130,9 @@ transpiler = QiskitTranspiler()
 executable = transpiler.transpile(reset_and_read)
 ```
 
-**Why**: block encodings and QSVT require unitary callable bodies, while iterative factoring intentionally uses measurement, reset, and feed-forward. Recording those semantics on the qkernel lets each API validate the distinction before choosing a transform or execution path.
-
 ### Explicit region dataflow and reachable bounds validation
 
-Structured `if`, `for`, and `while` regions now record their captures, carried values, arguments, and yields explicitly. The same interfaces are preserved through Protobuf serialization and checked before lowering. Array-bound and symbolic-shape validation follows compile-time reachability, so selected branches and nonzero loop iterations are checked while unreachable branches and zero-trip bodies do not produce false failures. Negative indices are rejected even before an array extent is fully resolved ([#616](https://github.com/Jij-Inc/Qamomile/pull/616), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
+Structured `if`, `for`, and `while` regions now record their captures, carried values, arguments, and yields explicitly. These interfaces are preserved through Protobuf serialization and checked before lowering ([#616](https://github.com/Jij-Inc/Qamomile/pull/616), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
 
 ```python
 import qamomile.circuit as qmc
@@ -155,16 +152,14 @@ executable = transpiler.transpile(
 )
 ```
 
-**Why**: QSVT phase prefixes, recursively bound block encodings, and factoring workspaces all carry arrays or structural values across nested regions. Explicit interfaces keep those values tied to the correct version and let validation reason about only the paths that remain after compile-time bindings are applied.
-
 ## Bug Fixes
 
-- **Serialized `control`, `inverse`, and SELECT calls now restore their arguments correctly.** After compile-time bindings are applied, vector controls retain all of their qubits instead of being treated as one scalar control. SELECT cases whose classical arguments precede the quantum register also run with the correct arguments after serialization and deserialization ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606)).
+- **Invalid inverse circuits and argument handling for serialized SELECT calls have been fixed.** Each control of a controlled inverse circuit must be a scalar qubit; passing a qubit array as one control now raises an error. SELECT cases whose classical arguments precede the quantum register can now be serialized and deserialized correctly ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606)).
 - **Switching from a backend-specific implementation to the portable implementation no longer leaves partially generated gates in the circuit.** If a backend-specific implementation cannot complete a callable, Qamomile discards the gates it added before generating the portable version ([#607](https://github.com/Jij-Inc/Qamomile/pull/607)).
 
 ## Documentation
 
-- [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb) now derives concrete costs for the FTQC arithmetic primitives, iterative Shor order finding, and Ekerå–Håstad's quantum stage ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb) now derives concrete costs for quantum arithmetic circuits, iterative Shor order finding, and Ekerå–Håstad's quantum stage ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - [**Multidimensional QFT for Estimating Nanosheet Material Properties**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/multidimensional_qft.ipynb) has a clearer title and corrected paper citation ([#621](https://github.com/Jij-Inc/Qamomile/pull/621)).
 - [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/pce_maxcut.ipynb) has clearer section names, cross-references, and index text for its MaxCut workflow ([#622](https://github.com/Jij-Inc/Qamomile/pull/622)).
 

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -8,7 +8,7 @@ pip install qamomile==0.14.0
 
 ## Breaking Changes
 
-- **The algorithm and standard-library import boundaries have changed.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#626](https://github.com/Jij-Inc/Qamomile/pull/626)).
+- **The algorithm and standard-library import boundaries have changed.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - **The qkernel returned by `qmc.shor_order_finding` no longer has the `n` argument for specifying the quantum-register width.** The width is calculated automatically from `modulus.bit_length()`. Use `precision` to specify the number of phase bits and `window_size` to specify how many qubits modular multiplication processes at once. Execution requires a backend that supports mid-circuit measurement, reset, and feed-forward ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - **`qmc.modmul_const` now uses an FTQC-oriented implementation with measurement and reset.** The width of `reg` must be known when `qmc.modmul_const` is called, and the new `window_size` argument specifies how many input qubits are processed at once during modular multiplication ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 
@@ -62,12 +62,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 order_finding = qmc.shor_order_finding(
     base=2,
-    modulus=3,
+    modulus=15,
     precision=2,
 )
 short_dlp = qmc.ekera_hastad_factoring(
     generator=2,
-    modulus=3,
+    modulus=15,
 )
 
 transpiler = QiskitTranspiler()
@@ -79,7 +79,7 @@ See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/bl
 
 ### `qmc.struct`, fixed-length Bit arrays, and structural math
 
-The `qmc.struct` decorator makes helper-based implementations of large algorithms easier to organize. It cannot be used as a qkernel argument or return value. `qmc.bit_array` creates a zero-initialized, fixed-length one-dimensional `Vector[Bit]`, allowing measurement results to be stored by index and returned as one value.
+The `qmc.struct` decorator makes helper-based implementations of large algorithms easier to organize. It cannot be used as a qkernel argument or return value. `qmc.bit_array` creates a zero-initialized, fixed-length one-dimensional `Vector[Bit]`, allowing measurement results to be stored by index and returned as one value ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#623](https://github.com/Jij-Inc/Qamomile/pull/623)).
 
 The new classical-value operations `qmc.log2` and `qmc.ceil` are evaluated immediately when their inputs are known. When inputs are unresolved, the operations remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before the circuit is generated ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
 
@@ -130,9 +130,9 @@ transpiler = QiskitTranspiler()
 executable = transpiler.transpile(reset_and_read)
 ```
 
-### Explicit region dataflow and reachable bounds validation
+### Explicit region dataflow
 
-Structured `if`, `for`, and `while` regions now record their captures, carried values, arguments, and yields explicitly. These interfaces are preserved through Protobuf serialization and checked before lowering ([#616](https://github.com/Jij-Inc/Qamomile/pull/616), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
+Structured `if`, `for`, and `while` regions now record their captures, carried values, arguments, and yields explicitly. These interfaces are preserved through Protobuf serialization and checked before lowering ([#616](https://github.com/Jij-Inc/Qamomile/pull/616)).
 
 ```python
 import qamomile.circuit as qmc
@@ -154,12 +154,13 @@ executable = transpiler.transpile(
 
 ## Bug Fixes
 
-- **Invalid inverse circuits and argument handling for serialized SELECT calls have been fixed.** Each control of a controlled inverse circuit must be a scalar qubit; passing a qubit array as one control now raises an error. SELECT cases whose classical arguments precede the quantum register can now be serialized and deserialized correctly ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606)).
+- **Control, inverse, and serialized SELECT argument handling have been fixed.** Control and inverse calls now use the correct qubit widths after their values are resolved at transpile time. Deserialized inverse calls now reject an invalid layout in which a qubit array is recorded as one control qubit. SELECT cases whose classical arguments precede the quantum register can now be serialized and deserialized correctly ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606), [#608](https://github.com/Jij-Inc/Qamomile/pull/608)).
 - **Switching from a backend-specific implementation to the portable implementation no longer leaves partially generated gates in the circuit.** If a backend-specific implementation cannot complete a callable, Qamomile discards the gates it added before generating the portable version ([#607](https://github.com/Jij-Inc/Qamomile/pull/607)).
 
 ## Documentation
 
 - [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb) now derives concrete costs for quantum arithmetic circuits, iterative Shor order finding, and Ekerå–Håstad's quantum stage ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- The algorithm index now links correctly to [**Möttönen Amplitude Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/mottonen_amplitude_encoding.ipynb) and describes its Qamomile APIs more clearly ([#620](https://github.com/Jij-Inc/Qamomile/pull/620)).
 - [**Multidimensional QFT for Estimating Nanosheet Material Properties**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/multidimensional_qft.ipynb) has a clearer title and corrected paper citation ([#621](https://github.com/Jij-Inc/Qamomile/pull/621)).
 - [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/pce_maxcut.ipynb) has clearer section names, cross-references, and index text for its MaxCut workflow ([#622](https://github.com/Jij-Inc/Qamomile/pull/622)).
 

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -1,0 +1,173 @@
+# Qamomile v0.14.0
+
+Qamomile v0.14.0 adds exact LCU block encodings and `qmc.qsvt`, including Pauli, Ising-Z, and periodic-shift constructors that can be serialized and rebound. FTQC workflows gain more constant-arithmetic primitives, lower-width iterative Shor order finding, and `qmc.ekera_hastad_factoring`. Qkernels can also organize trace-time workspaces with `qmc.struct`, collect measurements with `qmc.bit_array`, and derive structural widths with `qmc.ceil(qmc.log2(...))`. Compiler validation now gives earlier diagnostics for non-unitary transforms, structured control flow, and reachable array bounds.
+
+```
+pip install qamomile==0.14.0
+```
+
+## Breaking Changes
+
+- **The algorithm and standard-library import boundaries have changed.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#626](https://github.com/Jij-Inc/Qamomile/pull/626)).
+- **The qkernel returned by `qmc.shor_order_finding` no longer has a symbolic `n` input.** Its register width is determined by `modulus`, so callers should stop passing `bindings={"n": ...}` or `parameters=["n"]`. Use the factory's `window_size` and `precision` arguments to choose the arithmetic window and measured phase width ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+
+## New Features
+
+### Composable LCU block encodings and QSVT
+
+`qamomile.linalg` now provides `PauliLCU` for general complex power-of-two square matrices and `PeriodicShiftLCU` for one- or multidimensional periodic operators. The circuit API turns these decompositions into exact `LCUBlockEncoding` descriptors with `qmc.pauli_lcu_block_encoding` and `qmc.periodic_shift_lcu_block_encoding`; it also provides direct Ising-Z, identity, and recursive LCU constructors. Each descriptor exposes its normalization, signal and system widths, and a reusable `unitary` qkernel. These descriptors compose through control and inverse operations, survive Protobuf serialization as static bindings, and execute on the supported circuit backends.
+
+`qmc.qsvt` applies a caller-supplied projector-phase sequence to any `LCUBlockEncoding`. Phase values may be fixed through transpile-time `bindings`, or retained as runtime parameters when a compile-time `phase_count` is supplied. Qamomile implements the quantum transformation sequence; synthesizing phases for a desired polynomial and converting from other QSP phase conventions remain the caller's responsibility ([#598](https://github.com/Jij-Inc/Qamomile/pull/598), [#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#611](https://github.com/Jij-Inc/Qamomile/pull/611), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
+
+```python
+import numpy as np
+
+import qamomile.circuit as qmc
+from qamomile.linalg import PauliLCU
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def transform(
+    encoding: qmc.LCUBlockEncoding,
+    phases: qmc.Vector[qmc.Float],
+) -> tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]:
+    signal = qmc.qubit_array(encoding.num_signal_qubits, "signal")
+    system = qmc.qubit_array(encoding.num_system_qubits, "system")
+    signal, system = qmc.qsvt(signal, system, phases, encoding)
+    return qmc.measure(signal), qmc.measure(system)
+
+matrix = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
+block_encoding = qmc.pauli_lcu_block_encoding(PauliLCU.from_matrix(matrix))
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    transform,
+    bindings={
+        "encoding": block_encoding,
+        "phases": [0.0, 0.0],
+    },
+)
+```
+
+### FTQC arithmetic and lower-width factoring circuits
+
+The standard library adds `qmc.add_const`, controlled constant addition, constant modular addition, and `qmc.lookup_xor`. These reusable operations support the rewritten `qmc.shor_order_finding`, which recycles one phase qubit and uses windowed modular multiplication. For an `n`-bit modulus and fixed `window_size`, the generated body has a peak logical width of `3 * n + window_size + 7`; the default `2 * n` phase precision keeps its gate count at `O(n**3)`.
+
+`qmc.ekera_hastad_factoring` adds the quantum short-discrete-logarithm stage of Ekerå–Håstad factoring for balanced semiprimes. It reuses the same phase qubit and arithmetic workspace for its long and short schedules, then returns both measurement groups in one `Vector[Bit]`. Classical lattice post-processing is outside this qkernel ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+order_finding = qmc.shor_order_finding(
+    base=2,
+    modulus=3,
+    precision=2,
+)
+short_dlp = qmc.ekera_hastad_factoring(
+    generator=2,
+    modulus=3,
+)
+
+transpiler = QiskitTranspiler()
+order_executable = transpiler.transpile(order_finding)
+short_dlp_executable = transpiler.transpile(short_dlp)
+```
+
+See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb).
+
+### Trace-time records, fixed Bit arrays, and structural math
+
+The `qmc.struct` decorator creates an immutable Python record for grouping quantum and classical handles inside trace-time helper code without changing a qkernel's backend ABI. `qmc.bit_array` creates a fixed-length one-dimensional `Vector[Bit]` initialized to zero, so measurement results can be stored by index and returned as one value. Its length must be known while tracing, and stored elements are currently intended for collection and return rather than measurement-driven feed-forward.
+
+`qmc.log2` and `qmc.ceil` build exact structural expressions for register widths and loop bounds. Concrete inputs fold immediately; unresolved inputs remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before backend emission ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.struct
+class Workspace:
+    qubits: qmc.Vector[qmc.Qubit]
+
+@qmc.qkernel
+def collect_bits(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    width = qmc.ceil(qmc.log2(size))
+    workspace = Workspace(qmc.qubit_array(width, "workspace"))
+    measured = qmc.measure(workspace.qubits)
+    output = qmc.bit_array(width, name="output")
+    for index in qmc.range(width):
+        output[index] = measured[index]
+    return output
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    collect_bits,
+    bindings={"size": 9},
+)
+```
+
+## Internal Changes
+
+The block-encoding, QSVT, and low-width factoring APIs above rely on two compiler capabilities that are also visible to advanced users: qkernel effect metadata and explicit structured-region dataflow. Together they keep reusable transformations unitary where required and make compile-time structural validation follow the control-flow paths that can actually execute.
+
+### First-class qkernel effects
+
+`QKernel.effects` reports a `KernelEffect` flag set containing `MEASUREMENT`, `RESET`, and `FEED_FORWARD`; `KernelEffect.NONE` denotes a unitary body. Effects propagate through nested callable definitions and are reconstructed after serialization. Generic `qmc.control` and `qmc.inverse` transformations, and cases supplied to `qmc.select`, now reject incompatible non-unitary bodies with a direct diagnostic instead of failing later during backend emission ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def reset_and_read() -> tuple[qmc.Bit, qmc.Bit]:
+    qubit = qmc.x(qmc.qubit("qubit"))
+    qubit, before = qmc.measure_reset(qubit)
+    after = qmc.measure(qubit)
+    return before, after
+
+effects = reset_and_read.effects
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(reset_and_read)
+```
+
+**Why**: block encodings and QSVT require unitary callable bodies, while iterative factoring intentionally uses measurement, reset, and feed-forward. Recording those semantics on the qkernel lets each API validate the distinction before choosing a transform or execution path.
+
+### Explicit region dataflow and reachable bounds validation
+
+Structured `if`, `for`, and `while` regions now record their captures, carried values, arguments, and yields explicitly. The same interfaces are preserved through Protobuf serialization and checked before lowering. Array-bound and symbolic-shape validation follows compile-time reachability, so selected branches and nonzero loop iterations are checked while unreachable branches and zero-trip bodies do not produce false failures. Negative indices are rejected even before an array extent is fully resolved ([#616](https://github.com/Jij-Inc/Qamomile/pull/616), [#618](https://github.com/Jij-Inc/Qamomile/pull/618)).
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def fill_register(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    qubits = qmc.qubit_array(size, "qubits")
+    for index in qmc.range(size):
+        qubits[index] = qmc.x(qubits[index])
+    return qmc.measure(qubits)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    fill_register,
+    bindings={"size": 3},
+)
+```
+
+**Why**: QSVT phase prefixes, recursively bound block encodings, and factoring workspaces all carry arrays or structural values across nested regions. Explicit interfaces keep those values tied to the correct version and let validation reason about only the paths that remain after compile-time bindings are applied.
+
+## Bug Fixes
+
+- **Serialized `control`, `inverse`, and SELECT calls now restore their arguments correctly.** After compile-time bindings are applied, vector controls retain all of their qubits instead of being treated as one scalar control. SELECT cases whose classical arguments precede the quantum register also run with the correct arguments after serialization and deserialization ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606)).
+- **Switching from a backend-specific implementation to the portable implementation no longer leaves partially generated gates in the circuit.** If a backend-specific implementation cannot complete a callable, Qamomile discards the gates it added before generating the portable version ([#607](https://github.com/Jij-Inc/Qamomile/pull/607)).
+
+## Documentation
+
+- [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb) now derives concrete costs for the FTQC arithmetic primitives, iterative Shor order finding, and Ekerå–Håstad's quantum stage ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- [**Multidimensional QFT for Estimating Nanosheet Material Properties**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/multidimensional_qft.ipynb) has a clearer title and corrected paper citation ([#621](https://github.com/Jij-Inc/Qamomile/pull/621)).
+- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/pce_maxcut.ipynb) has clearer section names, cross-references, and index text for its MaxCut workflow ([#622](https://github.com/Jij-Inc/Qamomile/pull/622)).
+
+## Learn More
+
+- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -8,7 +8,7 @@ pip install qamomile==0.14.0
 
 ## Breaking Changes
 
-- **The algorithm and standard-library import boundaries have changed.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
+- **Several functions have moved to different import paths.** `shor_order_finding` moved from `qamomile.circuit.stdlib` to `qamomile.circuit.algorithm`. `modular_increment` and `modular_decrement` moved in the opposite direction, from `qamomile.circuit.algorithm` and its `arithmetic` subpackage to `qamomile.circuit.stdlib`. The top-level `qmc.shor_order_finding`, `qmc.modular_increment`, and `qmc.modular_decrement` imports remain available ([#608](https://github.com/Jij-Inc/Qamomile/pull/608), [#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - **The qkernel returned by `qmc.shor_order_finding` no longer has the `n` argument for specifying the quantum-register width.** The width is calculated automatically from `modulus.bit_length()`. Use `precision` to specify the number of phase bits and `window_size` to specify how many qubits modular multiplication processes at once. Execution requires a backend that supports mid-circuit measurement, reset, and feed-forward ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - **`qmc.modmul_const` now uses an FTQC-oriented implementation with measurement and reset.** The width of `reg` must be known when `qmc.modmul_const` is called, and the new `window_size` argument specifies how many input qubits are processed at once during modular multiplication ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 
@@ -75,13 +75,15 @@ order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
 
+This example uses `modulus=15` so that constructing and transpiling the quantum kernel remains quick. For this input, part of the Ekerå–Håstad computation is effectively skipped, so the example is not intended to demonstrate the full algorithm.
+
 See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb).
 
-### `qmc.struct`, fixed-length Bit arrays, and structural math
+### `qmc.struct`, fixed-length `Bit` arrays, and register-width calculations
 
 The `qmc.struct` decorator makes helper-based implementations of large algorithms easier to organize. It cannot be used as a qkernel argument or return value. `qmc.bit_array` creates a zero-initialized, fixed-length one-dimensional `Vector[Bit]`, allowing measurement results to be stored by index and returned as one value ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#623](https://github.com/Jij-Inc/Qamomile/pull/623)).
 
-The new classical-value operations `qmc.log2` and `qmc.ceil` are evaluated immediately when their inputs are known. When inputs are unresolved, the operations remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before the circuit is generated ([#613](https://github.com/Jij-Inc/Qamomile/pull/613), [#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
+The new classical-value operations `qmc.log2` and `qmc.ceil` are evaluated immediately when their inputs are known. When inputs are unresolved, the operations remain symbolic in resource estimates and must be supplied through transpile-time `bindings` before the circuit is generated ([#615](https://github.com/Jij-Inc/Qamomile/pull/615)).
 
 ```python
 import qamomile.circuit as qmc
@@ -154,7 +156,7 @@ executable = transpiler.transpile(
 
 ## Bug Fixes
 
-- **Control, inverse, and serialized SELECT argument handling have been fixed.** Control and inverse calls now use the correct qubit widths after their values are resolved at transpile time. Deserialized inverse calls now reject an invalid layout in which a qubit array is recorded as one control qubit. SELECT cases whose classical arguments precede the quantum register can now be serialized and deserialized correctly ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606), [#608](https://github.com/Jij-Inc/Qamomile/pull/608)).
+- **Serialization of control, inverse, and SELECT calls has been fixed.** Quantum kernels containing `qmc.control` or `qmc.inverse` can now be transpiled correctly after serialization and deserialization. Invalid inverse calls that treat a qubit array as one control qubit are rejected, and SELECT cases whose classical arguments precede the quantum register are restored with the correct argument order ([#605](https://github.com/Jij-Inc/Qamomile/pull/605), [#606](https://github.com/Jij-Inc/Qamomile/pull/606), [#608](https://github.com/Jij-Inc/Qamomile/pull/608)).
 - **Switching from a backend-specific implementation to the portable implementation no longer leaves partially generated gates in the circuit.** If a backend-specific implementation cannot complete a callable, Qamomile discards the gates it added before generating the portable version ([#607](https://github.com/Jij-Inc/Qamomile/pull/607)).
 
 ## Documentation
@@ -162,7 +164,7 @@ executable = transpiler.transpile(
 - [**Tutorial 05 — Resource Estimation**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb) now derives concrete costs for quantum arithmetic circuits, iterative Shor order finding, and Ekerå–Håstad's quantum stage ([#613](https://github.com/Jij-Inc/Qamomile/pull/613)).
 - The algorithm index now links correctly to [**Möttönen Amplitude Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/mottonen_amplitude_encoding.ipynb) and describes its Qamomile APIs more clearly ([#620](https://github.com/Jij-Inc/Qamomile/pull/620)).
 - [**Multidimensional QFT for Estimating Nanosheet Material Properties**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/multidimensional_qft.ipynb) has a clearer title and corrected paper citation ([#621](https://github.com/Jij-Inc/Qamomile/pull/621)).
-- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/pce_maxcut.ipynb) has clearer section names, cross-references, and index text for its MaxCut workflow ([#622](https://github.com/Jij-Inc/Qamomile/pull/622)).
+- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/algorithm/pce_maxcut.ipynb) has clearer section names and cross-references for its MaxCut workflow, along with a clearer description in the algorithm index ([#622](https://github.com/Jij-Inc/Qamomile/pull/622)).
 
 ## Learn More
 

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -67,7 +67,8 @@ order_finding = qmc.shor_order_finding(
 )
 short_dlp = qmc.ekera_hastad_factoring(
     generator=2,
-    modulus=15,
+    modulus=21,
+    window_size=1,
 )
 
 transpiler = QiskitTranspiler()
@@ -75,7 +76,7 @@ order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
 
-This example uses `modulus=15` so that constructing and transpiling the quantum kernel remains quick. For this input, part of the Ekerå–Håstad computation is effectively skipped, so the example is not intended to demonstrate the full algorithm.
+This example uses `modulus=15` for Shor order finding and `modulus=21`, the product of 3 and 7, for the quantum stage of Ekerå–Håstad factoring. It also sets `window_size=1` to reduce the number of logical qubits used at once by the Ekerå–Håstad kernel.
 
 See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb).
 

--- a/docs/en/release_notes/v0_14_0.md
+++ b/docs/en/release_notes/v0_14_0.md
@@ -1,6 +1,6 @@
 # Qamomile v0.14.0
 
-Qamomile v0.14.0 adds LCU block encodings for Pauli, Ising-Z, and periodic-shift operators, together with `qmc.qsvt` for quantum singular value transformation (QSVT). It also adds quantum arithmetic circuits such as constant addition and rewrites Shor order finding as an iterative algorithm that uses fewer logical qubits. The new `qmc.ekera_hastad_factoring` API constructs the quantum stage of Ekerå–Håstad factoring.
+Qamomile v0.14.0 adds LCU block encodings for Pauli, Ising-Z, and periodic-shift operators, together with `qmc.qsvt` for quantum singular value transformation (QSVT). It also adds quantum arithmetic circuits such as constant addition and rewrites Shor order finding as an iterative algorithm that uses fewer logical qubits. The new `qmc.ekera_hastad_factoring` API constructs the quantum part of Ekerå–Håstad factoring.
 
 ```
 pip install qamomile==0.14.0
@@ -75,8 +75,6 @@ transpiler = QiskitTranspiler()
 order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
-
-This example uses `modulus=15` for Shor order finding and `modulus=21`, the product of 3 and 7, for the quantum stage of Ekerå–Håstad factoring. It also sets `window_size=1` to reduce the number of logical qubits used at once by the Ekerå–Håstad kernel.
 
 See [Tutorial 05 — Resource Estimation](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/en/tutorial/05_resource_estimation.ipynb).
 

--- a/docs/ja/myst.yml
+++ b/docs/ja/myst.yml
@@ -40,6 +40,7 @@ project:
     - title: リリースノート
       file: release_notes/index.md
       children:
+        - file: release_notes/v0_14_0.md
         - file: release_notes/v0_13_0.md
         - file: release_notes/v0_12_7.md
         - file: release_notes/v0_12_6.md
@@ -64,10 +65,9 @@ project:
             - file: api/circuit/frontend
             - file: api/circuit/ir
             - file: api/circuit/multi_controlled_x
-            - file: api/circuit/pauli_lcu_block_encoding
-            - file: api/circuit/periodic_shift_lcu_block_encoding
             - file: api/circuit/qft
             - file: api/circuit/qpe
+            - file: api/circuit/qsvt
             - file: api/circuit/serialization
             - file: api/circuit/stdlib
             - file: api/circuit/transpiler

--- a/docs/ja/release_notes/index.md
+++ b/docs/ja/release_notes/index.md
@@ -4,6 +4,7 @@ slug: release-notes
 
 # リリースノート
 
+- [v0.14.0](v0_14_0) — 組み合わせ可能なLCU block encodingと`qmc.qsvt`、量子ビット幅を抑えたShorおよびEkerå–Håstad素因数分解回路、`qmc.struct`、`qmc.bit_array`、構造的な数式
 - [v0.13.0](v0_13_0) — semanticな`qmc.select`、厳密な`qmc.global_phase`、ループをまたぐscalar、汎用と明示的なMöttönen amplitude encoding。Qiskitを`qiskit` extraへ移動
 - [v0.12.7](v0_12_7) — `Dict[K, Float]`の係数を`d[key]`添字付きでruntime parameterとして扱う、`UInt`の`%`演算子、これまでsilentなmiscompileだったパターンを拒否する一連の新しいコンパイル時エラー(`QubitRebindError`、`QubitConsumedError`、`bool` / 型不一致引数への`TypeError`)
 - [v0.12.6](v0_12_6) — `qmc.inverse`による回路の逆操作(ビルトインゲート・`@qkernel`・QFT/IQFT)、計算基底レジスタの算術`qmc.modular_increment` / `qmc.modular_decrement`、job型・結果型を`qamomile.circuit`からimport可能に

--- a/docs/ja/release_notes/index.md
+++ b/docs/ja/release_notes/index.md
@@ -4,7 +4,7 @@ slug: release-notes
 
 # リリースノート
 
-- [v0.14.0](v0_14_0) — 組み合わせ可能なLCU block encodingと`qmc.qsvt`、量子ビット幅を抑えたShorおよびEkerå–Håstad素因数分解回路、`qmc.struct`、`qmc.bit_array`、構造的な数式
+- [v0.14.0](v0_14_0) — 組み合わせ可能なLCU block encodingと`qmc.qsvt`、量子ビット幅を抑えたShorの位数探索とEkerå–Håstad法の量子計算部分、`qmc.struct`、`qmc.bit_array`、レジスタ幅の計算に使える`qmc.log2`と`qmc.ceil`
 - [v0.13.0](v0_13_0) — semanticな`qmc.select`、厳密な`qmc.global_phase`、ループをまたぐscalar、汎用と明示的なMöttönen amplitude encoding。Qiskitを`qiskit` extraへ移動
 - [v0.12.7](v0_12_7) — `Dict[K, Float]`の係数を`d[key]`添字付きでruntime parameterとして扱う、`UInt`の`%`演算子、これまでsilentなmiscompileだったパターンを拒否する一連の新しいコンパイル時エラー(`QubitRebindError`、`QubitConsumedError`、`bool` / 型不一致引数への`TypeError`)
 - [v0.12.6](v0_12_6) — `qmc.inverse`による回路の逆操作(ビルトインゲート・`@qkernel`・QFT/IQFT)、計算基底レジスタの算術`qmc.modular_increment` / `qmc.modular_decrement`、job型・結果型を`qamomile.circuit`からimport可能に

--- a/docs/ja/release_notes/v0_13_0.md
+++ b/docs/ja/release_notes/v0_13_0.md
@@ -19,26 +19,6 @@ pip install qamomile==0.13.0
 
 ## 新機能
 
-### 構造を表す厳密な数学式
-
-`qmc.log2`と`qmc.ceil`は、量子カーネル内にtarget非依存の古典式を構築します。trace中の値をhost Pythonで評価せずに、register幅などのcompile-time構造を導出できます。具体値は即座にfoldし、未bindの入力はresource estimateで厳密な式として保持され、transpile時の`bindings`で引数を指定すると解決されます。これらの式は回路構造を決めるため、引数はruntime backend parameterではありません。
-
-```python
-import qamomile.circuit as qmc
-from qamomile.qiskit import QiskitTranspiler
-
-@qmc.qkernel
-def logarithmic_register(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
-    width = qmc.ceil(qmc.log2(size))
-    return qmc.measure(qmc.qubit_array(width, name="register"))
-
-transpiler = QiskitTranspiler()
-executable = transpiler.transpile(
-    logarithmic_register,
-    bindings={"size": 9},
-)
-```
-
 ### Semanticな`qmc.select`と値指定のcontrol
 
 `qmc.select([U0, U1, ...])`は、LSB-firstのindex registerが整数`i`を表すときに、共有するtarget量子ビットへcase `Ui`を適用するSELECT操作を作ります。index幅はcase数から推論できるほか、Pythonの`int`または`qmc.UInt`で指定できます。また、`qmc.control(..., control_value=v)`は、flattenした制御量子ビットが具体的なLSB-firstの値`v`と一致するときに対象の操作を実行する制御演算を作ります([#597](https://github.com/Jij-Inc/Qamomile/pull/597))。

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -1,6 +1,6 @@
 # Qamomile v0.14.0
 
-Qamomile v0.14.0では、Pauli、Ising-Z、周期shift向けのLCU block encodingと、量子特異値変換（QSVT）を行う`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を論理量子ビット数を抑えた反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築する`qmc.ekera_hastad_factoring`を追加しました。
+Qamomile v0.14.0では、Pauli、Ising-Z、周期シフト向けのLCU block encodingと、量子特異値変換（QSVT）を行う`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を論理量子ビット数を抑えた反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築する`qmc.ekera_hastad_factoring`を追加しました。
 
 ```
 pip install qamomile==0.14.0
@@ -8,7 +8,7 @@ pip install qamomile==0.14.0
 
 ## 破壊的変更
 
-- **`algorithm`と標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`サブパッケージから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- **一部の関数のimport先を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`サブパッケージから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 - **`qmc.shor_order_finding`が返す量子カーネルから、量子レジスタ幅を表す`n`引数を廃止しました。** 量子レジスタ幅は`modulus.bit_length()`から自動的に計算されます。位相ビット数は`precision`、modular multiplicationで一度に参照する量子ビット数は`window_size`で指定します。実行にはmid-circuit measurement、reset、feed-forwardに対応したbackendが必要です([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 - **`qmc.modmul_const`を測定とresetを用いるFTQC向けの実装へ変更しました。** `reg`の幅は`qmc.modmul_const`を呼び出す時点で確定している必要があり、modular multiplicationで入力を一度に何量子ビットずつ処理するかは、新しい`window_size`引数で指定します([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 
@@ -16,7 +16,7 @@ pip install qamomile==0.14.0
 
 ### LCU block encodingとQSVT
 
-`qamomile.linalg`に、次元が2のべき乗である一般の複素正方行列向けの`PauliLCU`と、1次元または多次元の周期shift演算子向けの`PeriodicShiftLCU`を追加しました。対応するblock encoding APIとして、`qmc.pauli_lcu_block_encoding`と`qmc.periodic_shift_lcu_block_encoding`を追加しました。このほか、Ising-Z、identity、既存の複数のblock encodingを組み合わせるAPIも追加しました。各APIはnormalization、signal register幅、system register幅、および再利用可能な`unitary`量子カーネルを持つインスタンスを返します。
+`qamomile.linalg`に、次元が2のべき乗である一般の複素正方行列向けの`PauliLCU`と、1次元または多次元の周期シフト演算子向けの`PeriodicShiftLCU`を追加しました。対応するblock encoding APIとして、`qmc.pauli_lcu_block_encoding`と`qmc.periodic_shift_lcu_block_encoding`を追加しました。このほか、Ising-Z、identity、既存の複数のblock encodingを組み合わせるAPIも追加しました。各APIはnormalization、signal register幅、system register幅、および再利用可能な`unitary`量子カーネルを持つインスタンスを返します。
 
 `qmc.qsvt`は、呼び出し側が与えたprojector phase列を任意の`LCUBlockEncoding`に適用します。位相値はトランスパイル時の`bindings`で固定できます。また、`phase_count`を`bindings`で固定し、`parameters=["phases"]`を指定すると、位相列をruntime parameterとして残せます。`qmc.qsvt`は、目的の多項式に対する位相の生成や、他のQSP conventionからの変換には対応していません。必要な位相列はユーザーが事前に用意する必要があります([#598](https://github.com/Jij-Inc/Qamomile/pull/598)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#611](https://github.com/Jij-Inc/Qamomile/pull/611)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
 
@@ -75,13 +75,15 @@ order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
 
+この例では、量子カーネルの構築とトランスパイルを短時間で確認できるように`modulus=15`を使っています。この入力ではEkerå–Håstad法の計算の一部が実質的に省略されるため、アルゴリズム全体の動作確認には適していません。
+
 [チュートリアル05 — リソース推定](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)も参照してください。
 
-### `qmc.struct`、固定長の`Bit`配列、構造的な数式
+### `qmc.struct`、固定長の`Bit`配列、レジスタ幅の計算
 
 `qmc.struct`デコレータを使うと、ヘルパー関数で大規模なアルゴリズムを実装する際のコードを整理できます。ただし、量子カーネルの引数や返り値には使えません。`qmc.bit_array`は、ゼロで初期化した固定長の1次元`Vector[Bit]`を作り、測定結果をインデックスごとに格納して1つの値として返せます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#623](https://github.com/Jij-Inc/Qamomile/pull/623))。
 
-古典値演算として`qmc.log2`と`qmc.ceil`が追加されました。入力値が確定している場合は即座に計算され、未確定の場合はresource estimateでsymbolicなまま保持されます。回路を生成する前に、トランスパイル時の`bindings`で指定する必要があります([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
+古典値演算として`qmc.log2`と`qmc.ceil`が追加されました。入力値が確定している場合は即座に計算され、未確定の場合はresource estimateでsymbolicなまま保持されます。回路を生成する前に、トランスパイル時の`bindings`で指定する必要があります([#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
 
 ```python
 import qamomile.circuit as qmc
@@ -154,15 +156,15 @@ executable = transpiler.transpile(
 
 ## バグ修正
 
-- **control、inverse、serializationしたSELECTの引数処理を修正しました。** トランスパイル時に値が確定した後も、controlとinverseのcallが正しい量子ビット幅を使うようにしました。また、serializationしたinverse callでは、量子ビット配列を1つの制御量子ビットとして記録した不正な形式を検出します。古典引数を量子レジスタより先に受け取るSELECT caseも、正しくserializationして読み戻せるようになりました([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608))。
+- **control、inverse、SELECTのserializationを修正しました。** `qmc.control`や`qmc.inverse`を含む量子カーネルをserializationして読み戻した後も、正しくトランスパイルできるようになりました。また、量子ビット配列を1つの制御量子ビットとして扱う不正なinverse callを検出し、古典引数を量子レジスタより先に受け取るSELECT caseも正しく読み戻せるようになりました([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608))。
 - **変換先固有の処理から共通実装へ切り替えた際に、途中まで生成されたgateが残る問題を修正しました。** 変換先固有の実装で処理できない場合は、追加済みのgateを取り除いてから共通実装で回路を生成します([#607](https://github.com/Jij-Inc/Qamomile/pull/607))。
 
 ## ドキュメント
 
 - [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)を更新し、量子算術回路、反復型Shor位数探索、Ekerå–Håstad法の量子段階の具体的なコストを導出しました([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
-- [**Möttönen振幅エンコーディング**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb)のindexページのリンクを修正し、説明を更新しました([#620](https://github.com/Jij-Inc/Qamomile/pull/620))。
+- アルゴリズム一覧ページから[**Möttönen振幅エンコーディング**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb)へのリンクを修正し、Qamomile APIの説明を更新しました([#620](https://github.com/Jij-Inc/Qamomile/pull/620))。
 - [**多次元量子フーリエ変換によるナノシート物質特性推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/multidimensional_qft.ipynb)のタイトルを明確にし、論文の引用を修正しました([#621](https://github.com/Jij-Inc/Qamomile/pull/621))。
-- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのセクション名、相互参照、indexページの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
+- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのセクション名、相互参照、一覧ページの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
 
 ## さらに詳しく
 

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -1,6 +1,6 @@
 # Qamomile v0.14.0
 
-Qamomile v0.14.0では、Pauli、Ising-Z、周期シフト向けのLCU block encodingと、量子特異値変換（QSVT）を行う`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を論理量子ビット数を抑えた反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築する`qmc.ekera_hastad_factoring`を追加しました。
+Qamomile v0.14.0では、Pauli、Ising-Z、周期シフト向けのLCU block encodingと、量子特異値変換（QSVT）を行う`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を論理量子ビット数を抑えた反復型へ刷新しました。さらに、Ekerå–Håstad法の量子部分を構築する`qmc.ekera_hastad_factoring`を追加しました。
 
 ```
 pip install qamomile==0.14.0
@@ -75,8 +75,6 @@ transpiler = QiskitTranspiler()
 order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
-
-この例では、Shorの位数探索に`modulus=15`を使い、Ekerå–Håstad法の量子計算部分には3と7の積である`modulus=21`を使っています。また、Ekerå–Håstad法の量子カーネルが同時に使用する論理量子ビット数を抑えるため、`window_size=1`を指定しています。
 
 [チュートリアル05 — リソース推定](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)も参照してください。
 

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -67,7 +67,8 @@ order_finding = qmc.shor_order_finding(
 )
 short_dlp = qmc.ekera_hastad_factoring(
     generator=2,
-    modulus=15,
+    modulus=21,
+    window_size=1,
 )
 
 transpiler = QiskitTranspiler()
@@ -75,7 +76,7 @@ order_executable = transpiler.transpile(order_finding)
 short_dlp_executable = transpiler.transpile(short_dlp)
 ```
 
-この例では、量子カーネルの構築とトランスパイルを短時間で確認できるように`modulus=15`を使っています。この入力ではEkerå–Håstad法の計算の一部が実質的に省略されるため、アルゴリズム全体の動作確認には適していません。
+この例では、Shorの位数探索に`modulus=15`を使い、Ekerå–Håstad法の量子計算部分には3と7の積である`modulus=21`を使っています。また、Ekerå–Håstad法の量子カーネルが同時に使用する論理量子ビット数を抑えるため、`window_size=1`を指定しています。
 
 [チュートリアル05 — リソース推定](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)も参照してください。
 

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -8,7 +8,7 @@ pip install qamomile==0.14.0
 
 ## 破壊的変更
 
-- **`algorithm`と標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`サブパッケージから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#626](https://github.com/Jij-Inc/Qamomile/pull/626))。
+- **`algorithm`と標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`サブパッケージから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 - **`qmc.shor_order_finding`が返す量子カーネルから、量子レジスタ幅を表す`n`引数を廃止しました。** 量子レジスタ幅は`modulus.bit_length()`から自動的に計算されます。位相ビット数は`precision`、modular multiplicationで一度に参照する量子ビット数は`window_size`で指定します。実行にはmid-circuit measurement、reset、feed-forwardに対応したbackendが必要です([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 - **`qmc.modmul_const`を測定とresetを用いるFTQC向けの実装へ変更しました。** `reg`の幅は`qmc.modmul_const`を呼び出す時点で確定している必要があり、modular multiplicationで入力を一度に何量子ビットずつ処理するかは、新しい`window_size`引数で指定します([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 
@@ -62,12 +62,12 @@ from qamomile.qiskit import QiskitTranspiler
 
 order_finding = qmc.shor_order_finding(
     base=2,
-    modulus=3,
+    modulus=15,
     precision=2,
 )
 short_dlp = qmc.ekera_hastad_factoring(
     generator=2,
-    modulus=3,
+    modulus=15,
 )
 
 transpiler = QiskitTranspiler()
@@ -79,7 +79,7 @@ short_dlp_executable = transpiler.transpile(short_dlp)
 
 ### `qmc.struct`、固定長の`Bit`配列、構造的な数式
 
-`qmc.struct`デコレータを使うと、ヘルパー関数で大規模なアルゴリズムを実装する際のコードを整理できます。ただし、量子カーネルの引数や返り値には使えません。`qmc.bit_array`は、ゼロで初期化した固定長の1次元`Vector[Bit]`を作り、測定結果をインデックスごとに格納して1つの値として返せます。
+`qmc.struct`デコレータを使うと、ヘルパー関数で大規模なアルゴリズムを実装する際のコードを整理できます。ただし、量子カーネルの引数や返り値には使えません。`qmc.bit_array`は、ゼロで初期化した固定長の1次元`Vector[Bit]`を作り、測定結果をインデックスごとに格納して1つの値として返せます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#623](https://github.com/Jij-Inc/Qamomile/pull/623))。
 
 古典値演算として`qmc.log2`と`qmc.ceil`が追加されました。入力値が確定している場合は即座に計算され、未確定の場合はresource estimateでsymbolicなまま保持されます。回路を生成する前に、トランスパイル時の`bindings`で指定する必要があります([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
 
@@ -130,9 +130,9 @@ transpiler = QiskitTranspiler()
 executable = transpiler.transpile(reset_and_read)
 ```
 
-### region dataflowの明示化と到達可能な境界の検証
+### region dataflowの明示化
 
-`if`、`for`、`while`のstructured regionは、capture、carried value、引数、yieldを明示的に記録するようになりました。このinterfaceはProtobuf serialization後も保持され、lowering前に検証されます([#616](https://github.com/Jij-Inc/Qamomile/pull/616)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
+`if`、`for`、`while`のstructured regionは、capture、carried value、引数、yieldを明示的に記録するようになりました。このinterfaceはProtobuf serialization後も保持され、lowering前に検証されます([#616](https://github.com/Jij-Inc/Qamomile/pull/616))。
 
 ```python
 import qamomile.circuit as qmc
@@ -154,15 +154,16 @@ executable = transpiler.transpile(
 
 ## バグ修正
 
-- **不正なinverse回路と、serializationしたSELECTの引数処理を修正しました。** 制御付きinverse回路では、各制御に1つの量子ビットを指定する必要があります。量子ビット配列を1つの制御として渡した不正な回路が、エラーにならない不具合を修正しました。また、古典引数を量子レジスタより先に受け取るSELECT caseも、正しくserializationして読み戻せるようになりました([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606))。
+- **control、inverse、serializationしたSELECTの引数処理を修正しました。** トランスパイル時に値が確定した後も、controlとinverseのcallが正しい量子ビット幅を使うようにしました。また、serializationしたinverse callでは、量子ビット配列を1つの制御量子ビットとして記録した不正な形式を検出します。古典引数を量子レジスタより先に受け取るSELECT caseも、正しくserializationして読み戻せるようになりました([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608))。
 - **変換先固有の処理から共通実装へ切り替えた際に、途中まで生成されたgateが残る問題を修正しました。** 変換先固有の実装で処理できない場合は、追加済みのgateを取り除いてから共通実装で回路を生成します([#607](https://github.com/Jij-Inc/Qamomile/pull/607))。
 
 ## ドキュメント
 
 - [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)を更新し、量子算術回路、反復型Shor位数探索、Ekerå–Håstad法の量子段階の具体的なコストを導出しました([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- [**Möttönen振幅エンコーディング**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/mottonen_amplitude_encoding.ipynb)のindexページのリンクを修正し、説明を更新しました([#620](https://github.com/Jij-Inc/Qamomile/pull/620))。
 - [**多次元量子フーリエ変換によるナノシート物質特性推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/multidimensional_qft.ipynb)のタイトルを明確にし、論文の引用を修正しました([#621](https://github.com/Jij-Inc/Qamomile/pull/621))。
 - [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのセクション名、相互参照、indexページの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
 
 ## さらに詳しく
 
-- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)
+- [GitHubリポジトリ](https://github.com/Jij-Inc/Qamomile)

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -1,0 +1,167 @@
+# Qamomile v0.14.0
+
+Qamomile v0.14.0では、Pauli、Ising-Z、周期shift向けのLCU block encodingを追加、また、量子特異値変換（QSVT）`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を少ない論理量子ビットで動作する反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築するqmc.ekera_hastad_factoringを追加しました。
+
+```
+pip install qamomile==0.14.0
+```
+
+## 破壊的変更
+
+- **algorithmと標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`subpackageから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#626](https://github.com/Jij-Inc/Qamomile/pull/626))。
+- **`qmc.shor_order_finding`が返す量子カーネルは、入力として量子ビット数`n`を廃止しました。** 量子ビット数は`modulus`から自動的に計算されるようになりました。また、位相を観測するための量子ビット数として`precision`引数を、moduler multiplication実行の際に一度に扱う量子ビット列の長さとして`window_size`引数を追加しました。([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+
+## 新機能
+
+### LCU block encodingとQSVT
+
+`qamomile.linalg`に、次元が2のべき乗である一般の複素正方行列向けの`PauliLCU`と、1次元または多次元の周期operator向けの`PeriodicShiftLCU`を追加しました。ブロックエンコーディングを行うAPIとしては、`qmc.pauli_lcu_block_encoding`と`qmc.periodic_shift_lcu_block_encoding`が追加されました。この他にIsing-Z、identity、既に持っている複数のブロックエンコーディングを利用したブロックエンコーディングを行うAPIも追加されました。各APIはnormalization、signal register幅、system register幅、再利用可能な`unitary`量子カーネルを持つインスタンスを返しします。
+
+`qmc.qsvt`は、呼び出し側が与えたprojector phase列を任意の`LCUBlockEncoding`へ適用します。位相値はトランスパイル時の`bindings`で固定できるほか、parametersとして`phase_count`を指定すればruntime parameterとして残せます。目的の多項式に対する位相の生成はこのバージョンではまだ対応していないため、ユーザーが用意する必要があります([#598](https://github.com/Jij-Inc/Qamomile/pull/598)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#611](https://github.com/Jij-Inc/Qamomile/pull/611)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
+
+```python
+import numpy as np
+
+import qamomile.circuit as qmc
+from qamomile.linalg import PauliLCU
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def transform(
+    encoding: qmc.LCUBlockEncoding,
+    phases: qmc.Vector[qmc.Float],
+) -> tuple[qmc.Vector[qmc.Bit], qmc.Vector[qmc.Bit]]:
+    signal = qmc.qubit_array(encoding.num_signal_qubits, "signal")
+    system = qmc.qubit_array(encoding.num_system_qubits, "system")
+    signal, system = qmc.qsvt(signal, system, phases, encoding)
+    return qmc.measure(signal), qmc.measure(system)
+
+matrix = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
+block_encoding = qmc.pauli_lcu_block_encoding(PauliLCU.from_matrix(matrix))
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    transform,
+    bindings={
+        "encoding": block_encoding,
+        "phases": [0.0, 0.0],
+    },
+)
+```
+
+### 算術回路と量子ビット幅を抑えた素因数分解回路
+
+`qmc.stdlib`に定数加算、制御付き定数加算、定数modular addition、量子レジスタをaddressとして表を参照し、対応する値を別の量子レジスタへXORする関数を追加しました。また、既存の`qmc.shor_order_finding`は更新され、modular multiplicationとして、windowed modular multiplicationを利用するようになりました。
+
+`qmc.ekera_hastad_factoring`は、同程度のビット長を持つ2つの素数の積に対して、Ekerå–Håstad法の量子計算部分を構築します。返り値は素因数ではなく、素因数を復元する古典計算に渡す測定bit列です。回路は測定・resetした量子ビットを再利用することで、同時に必要な論理量子ビット数を抑えています。測定結果から素因数を求める古典的な後処理は含まれません([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+order_finding = qmc.shor_order_finding(
+    base=2,
+    modulus=3,
+    precision=2,
+)
+short_dlp = qmc.ekera_hastad_factoring(
+    generator=2,
+    modulus=3,
+)
+
+transpiler = QiskitTranspiler()
+order_executable = transpiler.transpile(order_finding)
+short_dlp_executable = transpiler.transpile(short_dlp)
+```
+
+[チュートリアル05 — リソース推定](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)も参照してください。
+
+### Struct、固定長Bit配列、構造的な数式の追加
+
+新たに追加された`qmc.struct` decoratorは、大規模なアルゴリズムをヘルパー関数を用いて実装する時に見通しを良くするために使用することが可能です。ただし、量子カーネルの引数や返り値としては設定できないことに注意してください。また、`qmc.bit_array`は、ゼロで初期化した固定長1次元`Vector[Bit]`を作り、測定結果をindexごとに格納して1つの値として返せます。
+
+古典値演算として追加された`qmc.log2`と`qmc.ceil`は、レジスタ幅やループ境界を表す厳密な構造的数式を構築します。具体的な入力は即座にfoldされ、未解決の入力はresource estimateでsymbolicなまま保持されます。emission前にトランスパイル時の`bindings`で指定する必要があります([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.struct
+class Workspace:
+    qubits: qmc.Vector[qmc.Qubit]
+
+@qmc.qkernel
+def collect_bits(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    width = qmc.ceil(qmc.log2(size))
+    workspace = Workspace(qmc.qubit_array(width, "workspace"))
+    measured = qmc.measure(workspace.qubits)
+    output = qmc.bit_array(width, name="output")
+    for index in qmc.range(width):
+        output[index] = measured[index]
+    return output
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    collect_bits,
+    bindings={"size": 9},
+)
+```
+
+## 内部的な変更
+
+### 量子カーネルのeffect情報
+
+`QKernel.effects`は`MEASUREMENT`、`RESET`、`FEED_FORWARD`からなる`KernelEffect` flag setを返し、`KernelEffect.NONE`はunitaryな本体を表します。effectは入れ子のcallable definitionを通して伝播し、serialization後にも再構築されます([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def reset_and_read() -> tuple[qmc.Bit, qmc.Bit]:
+    qubit = qmc.x(qmc.qubit("qubit"))
+    qubit, before = qmc.measure_reset(qubit)
+    after = qmc.measure(qubit)
+    return before, after
+
+effects = reset_and_read.effects
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(reset_and_read)
+```
+
+### 明示的なregion dataflowと到達可能な境界の検証
+
+structuredな`if`、`for`、`while` regionは、capture、carried value、引数、yieldを明示的に記録するようになりました。同じinterfaceがProtobuf serialization後にも保持され、lowering前に検証されます([#616](https://github.com/Jij-Inc/Qamomile/pull/616)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
+
+```python
+import qamomile.circuit as qmc
+from qamomile.qiskit import QiskitTranspiler
+
+@qmc.qkernel
+def fill_register(size: qmc.UInt) -> qmc.Vector[qmc.Bit]:
+    qubits = qmc.qubit_array(size, "qubits")
+    for index in qmc.range(size):
+        qubits[index] = qmc.x(qubits[index])
+    return qmc.measure(qubits)
+
+transpiler = QiskitTranspiler()
+executable = transpiler.transpile(
+    fill_register,
+    bindings={"size": 3},
+)
+```
+
+## バグ修正
+
+- **serializationしたcontrol、inverse、SELECTで、引数が正しく復元されない問題を修正しました。** 制御量子ビットを配列で渡した場合も、そのすべての要素を正しく認識します。また、古典引数を量子レジスタより先に受け取るSELECT caseも、serializationして読み戻した後に正しい引数で実行されます([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606))。
+- **backend固有の処理から共通実装へ切り替えた際に、途中まで生成されたgateが残る問題を修正しました。** backend固有の実装で処理できない場合は、追加済みのgateを取り除いてから共通実装で回路を生成します([#607](https://github.com/Jij-Inc/Qamomile/pull/607))。
+
+## ドキュメント
+
+- [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)は、更新され、算術primitive、反復型Shor order finding、Ekerå–Håstadの量子段階について具体的なコストを導出します([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- [**多次元量子フーリエ変換によるナノシート物質特性推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/multidimensional_qft.ipynb)のタイトルを明確にし、論文のcitationを修正しました([#621](https://github.com/Jij-Inc/Qamomile/pull/621))。
+- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのsection名、相互参照、indexの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
+
+## さらに詳しく
+
+- [GitHub Repository](https://github.com/Jij-Inc/Qamomile)

--- a/docs/ja/release_notes/v0_14_0.md
+++ b/docs/ja/release_notes/v0_14_0.md
@@ -1,6 +1,6 @@
 # Qamomile v0.14.0
 
-Qamomile v0.14.0では、Pauli、Ising-Z、周期shift向けのLCU block encodingを追加、また、量子特異値変換（QSVT）`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を少ない論理量子ビットで動作する反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築するqmc.ekera_hastad_factoringを追加しました。
+Qamomile v0.14.0では、Pauli、Ising-Z、周期shift向けのLCU block encodingと、量子特異値変換（QSVT）を行う`qmc.qsvt`を追加しました。また、定数加算などの量子算術回路を追加し、Shorの位数探索を論理量子ビット数を抑えた反復型へ刷新しました。さらに、Ekerå–Håstad法の量子段階を構築する`qmc.ekera_hastad_factoring`を追加しました。
 
 ```
 pip install qamomile==0.14.0
@@ -8,16 +8,17 @@ pip install qamomile==0.14.0
 
 ## 破壊的変更
 
-- **algorithmと標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`subpackageから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#626](https://github.com/Jij-Inc/Qamomile/pull/626))。
-- **`qmc.shor_order_finding`が返す量子カーネルは、入力として量子ビット数`n`を廃止しました。** 量子ビット数は`modulus`から自動的に計算されるようになりました。また、位相を観測するための量子ビット数として`precision`引数を、moduler multiplication実行の際に一度に扱う量子ビット列の長さとして`window_size`引数を追加しました。([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- **`algorithm`と標準ライブラリのimport境界を変更しました。** `shor_order_finding`を`qamomile.circuit.stdlib`から`qamomile.circuit.algorithm`へ移動しました。`modular_increment`と`modular_decrement`は逆に、`qamomile.circuit.algorithm`とその`arithmetic`サブパッケージから`qamomile.circuit.stdlib`へ移動しました。top-levelの`qmc.shor_order_finding`、`qmc.modular_increment`、`qmc.modular_decrement`は引き続き利用できます([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#626](https://github.com/Jij-Inc/Qamomile/pull/626))。
+- **`qmc.shor_order_finding`が返す量子カーネルから、量子レジスタ幅を表す`n`引数を廃止しました。** 量子レジスタ幅は`modulus.bit_length()`から自動的に計算されます。位相ビット数は`precision`、modular multiplicationで一度に参照する量子ビット数は`window_size`で指定します。実行にはmid-circuit measurement、reset、feed-forwardに対応したbackendが必要です([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- **`qmc.modmul_const`を測定とresetを用いるFTQC向けの実装へ変更しました。** `reg`の幅は`qmc.modmul_const`を呼び出す時点で確定している必要があり、modular multiplicationで入力を一度に何量子ビットずつ処理するかは、新しい`window_size`引数で指定します([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 
 ## 新機能
 
 ### LCU block encodingとQSVT
 
-`qamomile.linalg`に、次元が2のべき乗である一般の複素正方行列向けの`PauliLCU`と、1次元または多次元の周期operator向けの`PeriodicShiftLCU`を追加しました。ブロックエンコーディングを行うAPIとしては、`qmc.pauli_lcu_block_encoding`と`qmc.periodic_shift_lcu_block_encoding`が追加されました。この他にIsing-Z、identity、既に持っている複数のブロックエンコーディングを利用したブロックエンコーディングを行うAPIも追加されました。各APIはnormalization、signal register幅、system register幅、再利用可能な`unitary`量子カーネルを持つインスタンスを返しします。
+`qamomile.linalg`に、次元が2のべき乗である一般の複素正方行列向けの`PauliLCU`と、1次元または多次元の周期shift演算子向けの`PeriodicShiftLCU`を追加しました。対応するblock encoding APIとして、`qmc.pauli_lcu_block_encoding`と`qmc.periodic_shift_lcu_block_encoding`を追加しました。このほか、Ising-Z、identity、既存の複数のblock encodingを組み合わせるAPIも追加しました。各APIはnormalization、signal register幅、system register幅、および再利用可能な`unitary`量子カーネルを持つインスタンスを返します。
 
-`qmc.qsvt`は、呼び出し側が与えたprojector phase列を任意の`LCUBlockEncoding`へ適用します。位相値はトランスパイル時の`bindings`で固定できるほか、parametersとして`phase_count`を指定すればruntime parameterとして残せます。目的の多項式に対する位相の生成はこのバージョンではまだ対応していないため、ユーザーが用意する必要があります([#598](https://github.com/Jij-Inc/Qamomile/pull/598)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#611](https://github.com/Jij-Inc/Qamomile/pull/611)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
+`qmc.qsvt`は、呼び出し側が与えたprojector phase列を任意の`LCUBlockEncoding`に適用します。位相値はトランスパイル時の`bindings`で固定できます。また、`phase_count`を`bindings`で固定し、`parameters=["phases"]`を指定すると、位相列をruntime parameterとして残せます。`qmc.qsvt`は、目的の多項式に対する位相の生成や、他のQSP conventionからの変換には対応していません。必要な位相列はユーザーが事前に用意する必要があります([#598](https://github.com/Jij-Inc/Qamomile/pull/598)、[#608](https://github.com/Jij-Inc/Qamomile/pull/608)、[#611](https://github.com/Jij-Inc/Qamomile/pull/611)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
 
 ```python
 import numpy as np
@@ -51,9 +52,9 @@ executable = transpiler.transpile(
 
 ### 算術回路と量子ビット幅を抑えた素因数分解回路
 
-`qmc.stdlib`に定数加算、制御付き定数加算、定数modular addition、量子レジスタをaddressとして表を参照し、対応する値を別の量子レジスタへXORする関数を追加しました。また、既存の`qmc.shor_order_finding`は更新され、modular multiplicationとして、windowed modular multiplicationを利用するようになりました。
+`qmc.stdlib`に定数加算、制御付き定数加算、定数modular addition、量子レジスタをaddressとして表を参照し、対応する値を別の量子レジスタにXORする関数を追加しました。また、既存の`qmc.shor_order_finding`を更新し、modular multiplicationをwindowed方式に変更しました。
 
-`qmc.ekera_hastad_factoring`は、同程度のビット長を持つ2つの素数の積に対して、Ekerå–Håstad法の量子計算部分を構築します。返り値は素因数ではなく、素因数を復元する古典計算に渡す測定bit列です。回路は測定・resetした量子ビットを再利用することで、同時に必要な論理量子ビット数を抑えています。測定結果から素因数を求める古典的な後処理は含まれません([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+`qmc.ekera_hastad_factoring`は、同程度のビット長を持つ2つの素数の積に対して、Ekerå–Håstad法の量子計算部分を構築します。返り値は素因数ではなく、素因数を復元する古典計算へ渡す測定結果のビット列です。回路は測定後にresetした量子ビットを再利用することで、同時に使用する論理量子ビット数を抑えています。測定結果から素因数を求める古典的な後処理は含まれません([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 
 ```python
 import qamomile.circuit as qmc
@@ -76,11 +77,11 @@ short_dlp_executable = transpiler.transpile(short_dlp)
 
 [チュートリアル05 — リソース推定](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)も参照してください。
 
-### Struct、固定長Bit配列、構造的な数式の追加
+### `qmc.struct`、固定長の`Bit`配列、構造的な数式
 
-新たに追加された`qmc.struct` decoratorは、大規模なアルゴリズムをヘルパー関数を用いて実装する時に見通しを良くするために使用することが可能です。ただし、量子カーネルの引数や返り値としては設定できないことに注意してください。また、`qmc.bit_array`は、ゼロで初期化した固定長1次元`Vector[Bit]`を作り、測定結果をindexごとに格納して1つの値として返せます。
+`qmc.struct`デコレータを使うと、ヘルパー関数で大規模なアルゴリズムを実装する際のコードを整理できます。ただし、量子カーネルの引数や返り値には使えません。`qmc.bit_array`は、ゼロで初期化した固定長の1次元`Vector[Bit]`を作り、測定結果をインデックスごとに格納して1つの値として返せます。
 
-古典値演算として追加された`qmc.log2`と`qmc.ceil`は、レジスタ幅やループ境界を表す厳密な構造的数式を構築します。具体的な入力は即座にfoldされ、未解決の入力はresource estimateでsymbolicなまま保持されます。emission前にトランスパイル時の`bindings`で指定する必要があります([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
+古典値演算として`qmc.log2`と`qmc.ceil`が追加されました。入力値が確定している場合は即座に計算され、未確定の場合はresource estimateでsymbolicなまま保持されます。回路を生成する前に、トランスパイル時の`bindings`で指定する必要があります([#613](https://github.com/Jij-Inc/Qamomile/pull/613)、[#615](https://github.com/Jij-Inc/Qamomile/pull/615))。
 
 ```python
 import qamomile.circuit as qmc
@@ -111,7 +112,7 @@ executable = transpiler.transpile(
 
 ### 量子カーネルのeffect情報
 
-`QKernel.effects`は`MEASUREMENT`、`RESET`、`FEED_FORWARD`からなる`KernelEffect` flag setを返し、`KernelEffect.NONE`はunitaryな本体を表します。effectは入れ子のcallable definitionを通して伝播し、serialization後にも再構築されます([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+`QKernel.effects`は`MEASUREMENT`、`RESET`、`FEED_FORWARD`からなる`KernelEffect`のフラグ集合を返し、`KernelEffect.NONE`はunitaryな本体を表します。effectは入れ子のcallable definitionを通じて伝播し、serialization後も再構築されます([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
 
 ```python
 import qamomile.circuit as qmc
@@ -129,9 +130,9 @@ transpiler = QiskitTranspiler()
 executable = transpiler.transpile(reset_and_read)
 ```
 
-### 明示的なregion dataflowと到達可能な境界の検証
+### region dataflowの明示化と到達可能な境界の検証
 
-structuredな`if`、`for`、`while` regionは、capture、carried value、引数、yieldを明示的に記録するようになりました。同じinterfaceがProtobuf serialization後にも保持され、lowering前に検証されます([#616](https://github.com/Jij-Inc/Qamomile/pull/616)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
+`if`、`for`、`while`のstructured regionは、capture、carried value、引数、yieldを明示的に記録するようになりました。このinterfaceはProtobuf serialization後も保持され、lowering前に検証されます([#616](https://github.com/Jij-Inc/Qamomile/pull/616)、[#618](https://github.com/Jij-Inc/Qamomile/pull/618))。
 
 ```python
 import qamomile.circuit as qmc
@@ -153,14 +154,14 @@ executable = transpiler.transpile(
 
 ## バグ修正
 
-- **serializationしたcontrol、inverse、SELECTで、引数が正しく復元されない問題を修正しました。** 制御量子ビットを配列で渡した場合も、そのすべての要素を正しく認識します。また、古典引数を量子レジスタより先に受け取るSELECT caseも、serializationして読み戻した後に正しい引数で実行されます([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606))。
-- **backend固有の処理から共通実装へ切り替えた際に、途中まで生成されたgateが残る問題を修正しました。** backend固有の実装で処理できない場合は、追加済みのgateを取り除いてから共通実装で回路を生成します([#607](https://github.com/Jij-Inc/Qamomile/pull/607))。
+- **不正なinverse回路と、serializationしたSELECTの引数処理を修正しました。** 制御付きinverse回路では、各制御に1つの量子ビットを指定する必要があります。量子ビット配列を1つの制御として渡した不正な回路が、エラーにならない不具合を修正しました。また、古典引数を量子レジスタより先に受け取るSELECT caseも、正しくserializationして読み戻せるようになりました([#605](https://github.com/Jij-Inc/Qamomile/pull/605)、[#606](https://github.com/Jij-Inc/Qamomile/pull/606))。
+- **変換先固有の処理から共通実装へ切り替えた際に、途中まで生成されたgateが残る問題を修正しました。** 変換先固有の実装で処理できない場合は、追加済みのgateを取り除いてから共通実装で回路を生成します([#607](https://github.com/Jij-Inc/Qamomile/pull/607))。
 
 ## ドキュメント
 
-- [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)は、更新され、算術primitive、反復型Shor order finding、Ekerå–Håstadの量子段階について具体的なコストを導出します([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
-- [**多次元量子フーリエ変換によるナノシート物質特性推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/multidimensional_qft.ipynb)のタイトルを明確にし、論文のcitationを修正しました([#621](https://github.com/Jij-Inc/Qamomile/pull/621))。
-- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのsection名、相互参照、indexの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
+- [**チュートリアル05 — リソース推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/tutorial/05_resource_estimation.ipynb)を更新し、量子算術回路、反復型Shor位数探索、Ekerå–Håstad法の量子段階の具体的なコストを導出しました([#613](https://github.com/Jij-Inc/Qamomile/pull/613))。
+- [**多次元量子フーリエ変換によるナノシート物質特性推定**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/multidimensional_qft.ipynb)のタイトルを明確にし、論文の引用を修正しました([#621](https://github.com/Jij-Inc/Qamomile/pull/621))。
+- [**Pauli Correlation Encoding**](https://github.com/Jij-Inc/Qamomile/blob/v0.14.0/docs/ja/algorithm/pce_maxcut.ipynb)では、MaxCutワークフローのセクション名、相互参照、indexページの説明を分かりやすくしました([#622](https://github.com/Jij-Inc/Qamomile/pull/622))。
 
 ## さらに詳しく
 


### PR DESCRIPTION
## Summary

- Add English and Japanese release notes for Qamomile v0.14.0, covering LCU block encodings and QSVT, lower-width Shor order finding, the quantum stage of Ekerå–Håstad factoring, structural helpers, compiler internals, bug fixes, and documentation updates.
- Describe the import and API changes that affect existing users, including the revised `qmc.shor_order_finding` and `qmc.modmul_const` interfaces.
- Restore the v0.13.0 notes to the published tag by removing `qmc.log2` and `qmc.ceil`, which were introduced after v0.13.0, and update the bilingual release-note indexes and documentation navigation.
- Keep the Japanese and English examples aligned and clarify that the compact Ekerå–Håstad example is intended for quick construction and transpilation checks rather than demonstrating the full algorithm.

## Validation

- Executed every Python block in the v0.14.0 notes verbatim: all five blocks and six executable programs successfully built, transpiled, and sampled.
- Ran the related QSVT, block-encoding, arithmetic, Shor, struct, bit-array, structural-math, effect, control-flow, inverse, and SELECT tests: 910 passed and 148 skipped.
- Built both documentation sites with `./docs/build.sh build-en` and `./docs/build.sh build-ja`.
- Ran `uv run ruff check qamomile/ tests/` and `uv run ruff format --check qamomile/ tests/` successfully.
- Confirmed `git diff --check`, English/Japanese code-block parity, and exact v0.13.0 release-note parity with the v0.13.0 tag.

## Notes

`uv run zuban check qamomile/` continues to report the existing 56 errors in `qamomile/hugr/lowerer.py`. This branch does not change `qamomile/` or `tests/`, and the result matches `origin/main`.