### PR TITLE
Unify for-loop bound resolution across emit and runtime

### DIFF
--- a/qamomile/circuit/transpiler/classical_executor.py
+++ b/qamomile/circuit/transpiler/classical_executor.py
@@ -640,24 +640,29 @@ class ClassicalExecutor:
         scoped_locals: dict[str, Any],
     ) -> None:
         """Execute a classical for loop."""
-        start = (
-            int(self._get_value(op.operands[0], context, results, scoped_locals))
-            if len(op.operands) > 0
-            else 0
-        )
-        stop = (
-            int(self._get_value(op.operands[1], context, results, scoped_locals))
-            if len(op.operands) > 1
-            else 0
-        )
-        step = (
-            int(self._get_value(op.operands[2], context, results, scoped_locals))
-            if len(op.operands) > 2
-            else 1
-        )
+        from qamomile.circuit.transpiler.passes.eval_utils import resolve_for_bounds
 
-        if step == 0:
-            raise ExecutionError("ForOperation step must not be zero")
+        def _resolve_bound(operand: Any) -> int:
+            """Resolve one loop-bound operand to a concrete int at runtime.
+
+            Args:
+                operand (Any): A ``start`` / ``stop`` / ``step`` bound operand.
+
+            Returns:
+                int: The operand's concrete runtime value.
+            """
+            return int(self._get_value(operand, context, results, scoped_locals))
+
+        try:
+            start, stop, step = resolve_for_bounds(op, _resolve_bound)
+        except ValueError as error:
+            raise ExecutionError(str(error)) from error
+
+        if start is None or stop is None or step is None:
+            raise ExecutionError(
+                "ForOperation bounds could not be resolved to concrete "
+                "integers at runtime."
+            )
 
         self._materialize_loop_store_defaults(
             op.operations, context, results, scoped_locals

--- a/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
+++ b/qamomile/circuit/transpiler/passes/emit_support/control_flow_emission.py
@@ -103,25 +103,43 @@ def resolve_loop_bounds(
 ) -> tuple[int | None, int | None, int | None]:
     """Resolve for-loop bounds (start, stop, step) from operands.
 
-    Missing operands use defaults: start=0, stop=1, step=1.
-    Returns None for bounds that cannot be resolved to concrete ints.
+    Delegates to :func:`resolve_for_bounds`, the single source of truth for
+    for-loop boundary semantics shared with runtime execution. Missing
+    operands use the shared defaults (start=0, stop=0, step=1). Returns None
+    for bounds that cannot be resolved to concrete ints (symbolic operands),
+    so the caller can fall back to its unrolled path.
+
+    Args:
+        resolver (Any): Value resolver used to fold each bound operand to a
+            concrete ``int`` under ``bindings``.
+        op (ForOperation): Loop whose bounds are resolved.
+        bindings (dict[str, Any]): Active emit-time bindings.
+
+    Returns:
+        tuple[int | None, int | None, int | None]: The resolved
+            ``(start, stop, step)``, each ``None`` when its operand is symbolic.
+
+    Raises:
+        EmitError: If ``step`` concretely resolves to ``0``.
     """
-    start = (
-        resolver.resolve_int_value(op.operands[0], bindings)
-        if len(op.operands) > 0
-        else 0
-    )
-    stop = (
-        resolver.resolve_int_value(op.operands[1], bindings)
-        if len(op.operands) > 1
-        else 1
-    )
-    step = (
-        resolver.resolve_int_value(op.operands[2], bindings)
-        if len(op.operands) > 2
-        else 1
-    )
-    return start, stop, step
+    from qamomile.circuit.transpiler.passes.eval_utils import resolve_for_bounds
+
+    def _resolve_bound(operand: Any) -> int | None:
+        """Resolve one loop-bound operand to a concrete int at emit time.
+
+        Args:
+            operand (Any): A ``start`` / ``stop`` / ``step`` bound operand.
+
+        Returns:
+            int | None: The operand's concrete value, or ``None`` when it is
+                symbolic under the active bindings.
+        """
+        return resolver.resolve_int_value(operand, bindings)
+
+    try:
+        return resolve_for_bounds(op, _resolve_bound)
+    except ValueError as error:
+        raise EmitError(str(error), operation="ForOperation") from error
 
 
 def runtime_condition_source_key(

--- a/qamomile/circuit/transpiler/passes/eval_utils.py
+++ b/qamomile/circuit/transpiler/passes/eval_utils.py
@@ -67,11 +67,11 @@ def resolve_for_bounds(
     This is the shared definition of for-loop boundary semantics for the two
     execution-facing paths — emit-time lowering (``resolve_loop_bounds``) and
     runtime execution (``classical_executor._execute_for``). Both used to
-    resolve the
-    operands independently and disagreed on the default for a missing ``stop``
-    (emit used ``1``, runtime used ``0``), so an under-specified loop unrolled
-    to one iteration at emit time yet ran zero iterations at runtime. Routing
-    both callers through this helper removes that divergence.
+    resolve the operands independently and disagreed on the default for a
+    missing ``stop`` (emit used ``1``, runtime used ``0``), so an
+    under-specified loop unrolled to one iteration at emit time yet ran zero
+    iterations at runtime. Routing both callers through this helper removes
+    that divergence.
 
     Missing operands fall back to :data:`_FOR_BOUND_DEFAULTS`
     (``start=0``, ``stop=0``, ``step=1``), so an under-specified loop is empty

--- a/qamomile/circuit/transpiler/passes/eval_utils.py
+++ b/qamomile/circuit/transpiler/passes/eval_utils.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import enum
 import math
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from qamomile.circuit.ir.operation.arithmetic_operations import (
     BinOp,
@@ -45,6 +45,64 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
     UnaryMathOp,
     UnaryMathOpKind,
 )
+
+if TYPE_CHECKING:
+    from qamomile.circuit.ir.operation.control_flow import ForOperation
+
+
+# Shared ``ForOperation`` bound defaults for an operand that is absent from
+# the IR, as ``(start, stop, step)``. A missing ``stop`` resolves to ``0`` so
+# an under-specified loop is empty rather than single-trip; this is the safer
+# default and — crucially — the value both the emit and runtime paths now
+# agree on (see ``resolve_for_bounds``).
+_FOR_BOUND_DEFAULTS: tuple[int, int, int] = (0, 0, 1)
+
+
+def resolve_for_bounds(
+    op: "ForOperation",
+    resolve: Callable[[Any], int | None],
+) -> tuple[int | None, int | None, int | None]:
+    """Resolve a ``ForOperation``'s ``(start, stop, step)`` from its operands.
+
+    This is the shared definition of for-loop boundary semantics for the two
+    execution-facing paths — emit-time lowering (``resolve_loop_bounds``) and
+    runtime execution (``classical_executor._execute_for``). Both used to
+    resolve the
+    operands independently and disagreed on the default for a missing ``stop``
+    (emit used ``1``, runtime used ``0``), so an under-specified loop unrolled
+    to one iteration at emit time yet ran zero iterations at runtime. Routing
+    both callers through this helper removes that divergence.
+
+    Missing operands fall back to :data:`_FOR_BOUND_DEFAULTS`
+    (``start=0``, ``stop=0``, ``step=1``), so an under-specified loop is empty
+    rather than single-trip. A ``step`` that concretely resolves to ``0`` is
+    rejected; a ``step`` that stays unresolved (``None``, i.e. symbolic at
+    emit time) is passed through so the caller can fall back to its unrolled
+    path.
+
+    Args:
+        op (ForOperation): Loop whose bounds are resolved. Only
+            ``op.operands`` is read.
+        resolve (Callable[[Any], int | None]): Resolver mapping one bound
+            operand to a concrete ``int``, or ``None`` when it cannot be
+            resolved at the caller's stage (symbolic emit-time operands).
+
+    Returns:
+        tuple[int | None, int | None, int | None]: The resolved
+            ``(start, stop, step)``. Any element is ``None`` when its operand
+            could not be resolved by ``resolve``.
+
+    Raises:
+        ValueError: If ``step`` concretely resolves to ``0``.
+    """
+    operands = op.operands
+    start_default, stop_default, step_default = _FOR_BOUND_DEFAULTS
+    start = resolve(operands[0]) if len(operands) > 0 else start_default
+    stop = resolve(operands[1]) if len(operands) > 1 else stop_default
+    step = resolve(operands[2]) if len(operands) > 2 else step_default
+    if step == 0:
+        raise ValueError("ForOperation step must not be zero.")
+    return start, stop, step
 
 
 class FoldPolicy(enum.Enum):

--- a/tests/transpiler/test_runtime_execution.py
+++ b/tests/transpiler/test_runtime_execution.py
@@ -24,7 +24,7 @@ from qamomile.circuit.transpiler.compiled_segments import (
     CompiledExpvalSegment,
     CompiledQuantumSegment,
 )
-from qamomile.circuit.transpiler.errors import ExecutionError
+from qamomile.circuit.transpiler.errors import EmitError, ExecutionError
 from qamomile.circuit.transpiler.executable import ExecutableProgram
 from qamomile.circuit.transpiler.execution_context import ExecutionContext
 from qamomile.circuit.transpiler.job import SampleJob
@@ -51,6 +51,40 @@ def _uint_const(value: int, name: str = "const") -> Value:
 
 def _float_const(value: float, name: str = "const") -> Value:
     return Value(type=FloatType(), name=name).with_const(value)
+
+
+class _MapResolver:
+    """Minimal emit-time resolver mapping bound operands to concrete ints.
+
+    Stands in for the real ``ValueResolver`` so ``resolve_loop_bounds`` can be
+    exercised without building a full emit pass. Operands are matched by object
+    identity; unknown operands resolve to ``None`` (symbolic).
+    """
+
+    def __init__(self, mapping: dict[int, int]) -> None:
+        """Record the identity-keyed operand-to-int resolution table.
+
+        Args:
+            mapping (dict[int, int]): ``id(operand) -> concrete int`` for each
+                operand this resolver should resolve; others stay symbolic.
+        """
+        self._mapping = mapping
+
+    def resolve_int_value(
+        self, value: object, bindings: dict[str, object]
+    ) -> int | None:
+        """Resolve one operand to its recorded int, or ``None`` if unknown.
+
+        Args:
+            value (object): The bound operand to resolve.
+            bindings (dict[str, object]): Ignored; present for signature parity
+                with the real resolver.
+
+        Returns:
+            int | None: The recorded concrete value, or ``None`` when the
+                operand is not in the table (treated as symbolic).
+        """
+        return self._mapping.get(id(value))
 
 
 class _FakeExecutor(QuantumExecutor[str]):
@@ -247,6 +281,78 @@ class TestClassicalExecutorControlFlow:
         )
 
         assert results[out.uuid] == 11
+
+    def test_for_bounds_defaults_agree_between_emit_and_runtime(self) -> None:
+        """A missing ``stop`` yields an empty loop on both emit and runtime.
+
+        ``resolve_loop_bounds`` (emit) once defaulted a missing ``stop`` to
+        ``1`` while the runtime executor defaulted it to ``0``, so an
+        under-specified loop unrolled to one iteration yet ran zero times.
+        Both paths now delegate to the shared ``resolve_for_bounds`` helper
+        and agree on the empty-loop default.
+        """
+        from qamomile.circuit.transpiler.passes.emit_support.control_flow_emission import (  # noqa: E501
+            resolve_loop_bounds,
+        )
+        from qamomile.circuit.transpiler.passes.eval_utils import resolve_for_bounds
+
+        start = _uint_const(4)
+        loop_out = Value(type=UIntType(), name="loop_out")
+        # Only ``start`` is present; ``stop`` and ``step`` are absent so the
+        # shared defaults decide the semantics.
+        start_only = ForOperation(
+            loop_var="i",
+            loop_var_value=Value(type=UIntType(), name="i"),
+            operands=[start],
+            operations=[
+                BinOp(
+                    kind=BinOpKind.ADD,
+                    operands=[Value(type=UIntType(), name="i"), _uint_const(1)],
+                    results=[loop_out],
+                )
+            ],
+        )
+
+        # Shared helper locks the empty-loop default (stop=0, step=1).
+        assert resolve_for_bounds(start_only, lambda _operand: 4) == (4, 0, 1)
+
+        # Emit side delegates to the same helper.
+        emit_bounds = resolve_loop_bounds(_MapResolver({id(start): 4}), start_only, {})
+        assert emit_bounds == (4, 0, 1)
+
+        # Runtime side agrees: the body never runs, so its result is unset.
+        results = ClassicalExecutor().execute(
+            ClassicalSegment(operations=[start_only]),
+            ExecutionContext(),
+        )
+        assert loop_out.uuid not in results
+
+    def test_for_bounds_zero_step_rejected_on_both_paths(self) -> None:
+        """A concrete zero ``step`` is rejected identically on emit and runtime."""
+        from qamomile.circuit.transpiler.passes.emit_support.control_flow_emission import (  # noqa: E501
+            resolve_loop_bounds,
+        )
+
+        start, stop, step = _uint_const(0), _uint_const(5), _uint_const(0)
+        zero_step = ForOperation(
+            loop_var="i",
+            loop_var_value=Value(type=UIntType(), name="i"),
+            operands=[start, stop, step],
+            operations=[],
+        )
+
+        with pytest.raises(EmitError, match="step must not be zero"):
+            resolve_loop_bounds(
+                _MapResolver({id(start): 0, id(stop): 5, id(step): 0}),
+                zero_step,
+                {},
+            )
+
+        with pytest.raises(ExecutionError, match="step must not be zero"):
+            ClassicalExecutor().execute(
+                ClassicalSegment(operations=[zero_step]),
+                ExecutionContext(),
+            )
 
 
 class TestExecutableProgramRuntime:


### PR DESCRIPTION
## Summary

- BACKLOG-8897. `ForOperation` start/stop/step resolution was duplicated between the emit-time lowering (`resolve_loop_bounds`) and the runtime executor (`_execute_for`), and the two disagreed on the default for a **missing `stop` operand**: emit used `1` (one iteration) while runtime used `0` (empty loop). The `step == 0` guard was likewise only present on the runtime side. The same IR could therefore unroll to a different iteration count at emit time than it ran at runtime (backlog CE-1).
- Introduce a shared `resolve_for_bounds(op, resolve)` helper in `eval_utils` as the single definition of for-loop boundary semantics for both execution-facing paths. Missing operands fall back to `(start=0, stop=0, step=1)` — an under-specified loop is empty rather than single-trip (the safer default) — and a concrete zero step is rejected in one place, translated to `ExecutionError` at runtime and `EmitError` at emit. Symbolic (unresolved) operands pass through as `None` so emit still falls back to its unrolled path.
- The counts-aggregation half of the backlog item (backlog EM-1) is already implemented on `main` (`_aggregate_typed_results` / `_typed_result_key` in `job.py`) and covered end-to-end by `test_sample_projects_implicit_outputs_and_aggregates_hidden_bits`; this PR adds no duplicate implementation, only locks the for-bounds behavior with new tests.
- No user-facing change: the frontend always normalizes `qmc.range(...)` to three operands, so ordinary qkernel loops (written with the qkernel decorator) compile and run identically. Only the runtime zero-step exception message gains a trailing period; exception types are unchanged.
- Out of scope: a third resolver (`_evaluate_loop_range` in `visualization/analyzer.py`) intentionally keeps a missing/symbolic `stop` as `None` (unknown iteration count for resource estimation) and is deliberately left unchanged; and the backlog's EM-4 / EM-9 / CE-6 / `select_phi_input` items, which are separate refactors outside this ticket's Goal and Test Plan.

## Test plan

- `uv run pytest tests/transpiler/test_runtime_execution.py` — includes two new regression tests: `test_for_bounds_defaults_agree_between_emit_and_runtime` and `test_for_bounds_zero_step_rejected_on_both_paths`.
- `uv run pytest tests/` — full unit suite green (9634 passed, 414 skipped, 1 xfailed).
- `uv run ruff check qamomile/ tests/` and `uv run ruff format --check qamomile/ tests/` — clean.
- `uv run zuban check qamomile/` — no new errors in changed files (the pre-existing errors are confined to `qamomile/hugr/lowerer.py`, unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_013ehehNB7EFnxbNtvgWTbHp)_