### PR TITLE
Fix input-dependent public API type narrowing

### DIFF
--- a/.github/workflows/zuban.yml
+++ b/.github/workflows/zuban.yml
@@ -64,12 +64,8 @@ jobs:
         shell: bash
         run: |
           set -eux
-          uv run zuban check qamomile/
+          uv run zuban check qamomile/ tests/typecheck/
           # docs/ is type-clean in this PR (see the docs-side fixes
           # already landed), but the CI gate is intentionally limited
-          # to qamomile/ for now so future docs edits don't accidentally
-          # break the type-check job. Re-enable by switching the line
-          # above to ``uv run zuban check qamomile/ docs/`` once the
-          # docs-side discipline is established; when doing so, drop the
-          # docs_only skip on this job so docs-only pull requests still
-          # get type-checked.
+          # to the library and focused public-typing fixtures so unrelated
+          # test helpers do not enter the production type-check gate.

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -118,10 +118,10 @@ class Oracle:
 
     def __call__(
         self,
-        *qubits: Qubit | Vector[Qubit],
+        *qubits: Qubit | Vector[Qubit] | VectorView[Qubit],
         controls: Sequence[Qubit] = (),
         control_value: int | None = None,
-    ) -> tuple[Qubit, ...] | Vector[Qubit]:
+    ) -> tuple[Qubit, ...] | Vector[Qubit] | VectorView[Qubit]:
         """Apply the oracle to scalar qubits or a vector register.
 
         Args:

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -94,8 +94,8 @@ class Oracle:
         qubits: VectorView[Qubit],
         /,
         *,
-        controls: Sequence[Qubit] = (),
-        control_value: int | None = None,
+        controls: tuple[()] = (),
+        control_value: None = None,
     ) -> VectorView[Qubit]: ...
 
     @overload
@@ -104,8 +104,8 @@ class Oracle:
         qubits: Vector[Qubit],
         /,
         *,
-        controls: Sequence[Qubit] = (),
-        control_value: int | None = None,
+        controls: tuple[()] = (),
+        control_value: None = None,
     ) -> Vector[Qubit]: ...
 
     @overload

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -125,8 +125,8 @@ class Oracle:
         """Apply the oracle to scalar qubits or a vector register.
 
         Args:
-            *qubits (Qubit | Vector[Qubit]): Either a single vector register
-                or ``num_qubits`` scalar qubits.
+            *qubits (Qubit | Vector[Qubit] | VectorView[Qubit]): Either a single
+                vector register or view, or ``num_qubits`` scalar qubits.
             controls (Sequence[Qubit]): Explicit control qubits for scalar
                 calls. Vector and vector-view calls currently require the
                 default empty sequence.

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -136,8 +136,9 @@ class Oracle:
                 ``None``.
 
         Returns:
-            tuple[Qubit, ...] | Vector[Qubit]: Oracle outputs with the same
-                shape as the input form. Vector views remain vector views.
+            tuple[Qubit, ...] | Vector[Qubit] | VectorView[Qubit]: Oracle
+                outputs with the same shape as the input form. Vector views
+                remain vector views.
 
         Raises:
             ValueError: If the provided arity does not match ``num_qubits``

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -127,11 +127,13 @@ class Oracle:
         Args:
             *qubits (Qubit | Vector[Qubit]): Either a single vector register
                 or ``num_qubits`` scalar qubits.
-            controls (Sequence[Qubit]): Explicit control qubits. Defaults to
-                an empty sequence.
-            control_value (int | None): LSB-first activation value for
-                ``controls``. ``None`` uses the ordinary all-ones state.
-                Defaults to ``None``.
+            controls (Sequence[Qubit]): Explicit control qubits for scalar
+                calls. Vector and vector-view calls currently require the
+                default empty sequence.
+            control_value (int | None): LSB-first activation value for scalar
+                ``controls``. ``None`` uses the ordinary all-ones state. Vector
+                and vector-view calls currently require ``None``. Defaults to
+                ``None``.
 
         Returns:
             tuple[Qubit, ...] | Vector[Qubit]: Oracle outputs with the same

--- a/qamomile/circuit/frontend/oracle.py
+++ b/qamomile/circuit/frontend/oracle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, overload
 
 from qamomile.circuit.frontend.callable_signature import CallableSignature
 from qamomile.circuit.frontend.handle.array import Vector, VectorView
@@ -88,6 +88,34 @@ class Oracle:
         self.signature = signature
         self.cost = cost
 
+    @overload
+    def __call__(
+        self,
+        qubits: VectorView[Qubit],
+        /,
+        *,
+        controls: Sequence[Qubit] = (),
+        control_value: int | None = None,
+    ) -> VectorView[Qubit]: ...
+
+    @overload
+    def __call__(
+        self,
+        qubits: Vector[Qubit],
+        /,
+        *,
+        controls: Sequence[Qubit] = (),
+        control_value: int | None = None,
+    ) -> Vector[Qubit]: ...
+
+    @overload
+    def __call__(
+        self,
+        *qubits: Qubit,
+        controls: Sequence[Qubit] = (),
+        control_value: int | None = None,
+    ) -> tuple[Qubit, ...]: ...
+
     def __call__(
         self,
         *qubits: Qubit | Vector[Qubit],
@@ -107,7 +135,7 @@ class Oracle:
 
         Returns:
             tuple[Qubit, ...] | Vector[Qubit]: Oracle outputs with the same
-            shape as the input form.
+                shape as the input form. Vector views remain vector views.
 
         Raises:
             ValueError: If the provided arity does not match ``num_qubits``

--- a/qamomile/circuit/stdlib/arithmetic/modular_multiplication.py
+++ b/qamomile/circuit/stdlib/arithmetic/modular_multiplication.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from typing import overload
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.handle import Qubit, UInt, Vector
@@ -11,6 +12,30 @@ from qamomile.circuit.frontend.handle.utils import get_size
 from .bitwise import _xor_bit
 from .carry_venting import _dirty_const_add_extended
 from .ripple_carry import _apply_ripple_carry_add
+
+
+@overload
+def modmul_const(
+    reg: Vector[Qubit],
+    *,
+    multiplier: int | UInt,
+    modulus: int | UInt,
+    window_size: int = 2,
+    inverse_multiplier: int | UInt | None = None,
+    control: None = None,
+) -> Vector[Qubit]: ...
+
+
+@overload
+def modmul_const(
+    reg: Vector[Qubit],
+    *,
+    multiplier: int | UInt,
+    modulus: int | UInt,
+    window_size: int = 2,
+    inverse_multiplier: int | UInt | None = None,
+    control: Qubit,
+) -> tuple[Qubit, Vector[Qubit]]: ...
 
 
 def modmul_const(

--- a/qamomile/circuit/stdlib/grover.py
+++ b/qamomile/circuit/stdlib/grover.py
@@ -76,6 +76,7 @@ def grover_iteration_count(
             expressions.
 
     Raises:
+        TypeError: If ``num_qubits`` or ``num_marked`` is a boolean.
         ValueError: If concrete ``num_qubits`` or ``num_marked`` is not
             positive.
 
@@ -88,6 +89,8 @@ def grover_iteration_count(
     # agrees with the symbolic overload while preserving positivity validation.
     n_in: Any = num_qubits
     m_in: Any = num_marked
+    if isinstance(n_in, (bool, np.bool_)) or isinstance(m_in, (bool, np.bool_)):
+        raise TypeError("num_qubits and num_marked must not be booleans.")
     n_nonpositive_integer = (
         isinstance(n_in, (int, np.integer, sp.Integer)) and int(n_in) <= 0
     )

--- a/qamomile/circuit/stdlib/grover.py
+++ b/qamomile/circuit/stdlib/grover.py
@@ -37,13 +37,6 @@ from qamomile.circuit.frontend.qkernel_like import QKernelLike
 
 @overload
 def grover_iteration_count(
-    num_qubits: int | np.integer[Any],
-    num_marked: int | np.integer[Any] = 1,
-) -> int: ...
-
-
-@overload
-def grover_iteration_count(
     num_qubits: sp.Expr,
     num_marked: int | np.integer[Any] | sp.Expr = 1,
 ) -> sp.Expr: ...
@@ -54,6 +47,13 @@ def grover_iteration_count(
     num_qubits: int | np.integer[Any],
     num_marked: sp.Expr,
 ) -> sp.Expr: ...
+
+
+@overload
+def grover_iteration_count(
+    num_qubits: int | np.integer[Any],
+    num_marked: int | np.integer[Any] = 1,
+) -> int: ...
 
 
 def grover_iteration_count(
@@ -88,9 +88,13 @@ def grover_iteration_count(
     # agrees with the symbolic overload while preserving positivity validation.
     n_in: Any = num_qubits
     m_in: Any = num_marked
-    n_sympy_nonpositive = isinstance(n_in, sp.Integer) and int(n_in) <= 0
-    m_sympy_nonpositive = isinstance(m_in, sp.Integer) and int(m_in) <= 0
-    if n_sympy_nonpositive or m_sympy_nonpositive:
+    n_nonpositive_integer = (
+        isinstance(n_in, (int, np.integer, sp.Integer)) and int(n_in) <= 0
+    )
+    m_nonpositive_integer = (
+        isinstance(m_in, (int, np.integer, sp.Integer)) and int(m_in) <= 0
+    )
+    if n_nonpositive_integer or m_nonpositive_integer:
         raise ValueError("num_qubits and num_marked must be positive.")
     n_val = int(n_in) if isinstance(n_in, (int, np.integer)) else n_in
     m_val = int(m_in) if isinstance(m_in, (int, np.integer)) else m_in

--- a/qamomile/circuit/stdlib/grover.py
+++ b/qamomile/circuit/stdlib/grover.py
@@ -23,33 +23,57 @@ straight from one estimate call::
 
 from __future__ import annotations
 
-import numbers
-from typing import Any, Callable, cast
+from typing import Any, Callable, cast, overload
 
+import numpy as np
 import sympy as sp
 
 import qamomile.circuit as qmc
 from qamomile.circuit.frontend.handle import Qubit, Vector
 from qamomile.circuit.frontend.operation.control_flow import for_loop
+from qamomile.circuit.frontend.oracle import Oracle
 from qamomile.circuit.frontend.qkernel_like import QKernelLike
 
 
+@overload
 def grover_iteration_count(
-    num_qubits: int | sp.Expr,
-    num_marked: int | sp.Expr = 1,
+    num_qubits: int | np.integer[Any],
+    num_marked: int | np.integer[Any] = 1,
+) -> int: ...
+
+
+@overload
+def grover_iteration_count(
+    num_qubits: sp.Expr,
+    num_marked: int | np.integer[Any] | sp.Expr = 1,
+) -> sp.Expr: ...
+
+
+@overload
+def grover_iteration_count(
+    num_qubits: int | np.integer[Any],
+    num_marked: sp.Expr,
+) -> sp.Expr: ...
+
+
+def grover_iteration_count(
+    num_qubits: int | np.integer[Any] | sp.Expr,
+    num_marked: int | np.integer[Any] | sp.Expr = 1,
 ) -> int | sp.Expr:
     """Return the optimal Grover iteration count ``floor((pi/4) sqrt(N/m))``.
 
     Args:
-        num_qubits (int | sp.Expr): Number of search qubits ``n`` (search space
-            ``N = 2**n``). May be symbolic.
-        num_marked (int | sp.Expr): Number of marked solutions ``m``. Defaults
-            to ``1``.
+        num_qubits (int | np.integer[Any] | sp.Expr): Number of search qubits
+            ``n`` (search space ``N = 2**n``). May be a Python or NumPy integer,
+            or a symbolic expression.
+        num_marked (int | np.integer[Any] | sp.Expr): Number of marked
+            solutions ``m``. Defaults to ``1``.
 
     Returns:
         int | sp.Expr: Concrete iteration count when both arguments are concrete
-        integers (Python or NumPy), otherwise the symbolic expression
-        ``floor((pi/4) sqrt(2**n / m))``.
+            Python or NumPy integers, otherwise the symbolic expression
+            ``floor((pi/4) sqrt(2**n / m))``. SymPy integers remain SymPy
+            expressions.
 
     Raises:
         ValueError: If concrete ``num_qubits`` or ``num_marked`` is not
@@ -60,13 +84,16 @@ def grover_iteration_count(
         3
     """
     # Normalize NumPy integer scalars (np.int64, ...) to Python ints so they
-    # take the concrete, positivity-validated path rather than falling through
-    # to the symbolic branch. Route through ``Any`` so the numeric-tower check
-    # is not narrowed away by the declared ``int | sp.Expr`` annotation.
+    # take the concrete path. Keep SymPy integers symbolic so the runtime result
+    # agrees with the symbolic overload while preserving positivity validation.
     n_in: Any = num_qubits
     m_in: Any = num_marked
-    n_val = int(n_in) if isinstance(n_in, numbers.Integral) else n_in
-    m_val = int(m_in) if isinstance(m_in, numbers.Integral) else m_in
+    n_sympy_nonpositive = isinstance(n_in, sp.Integer) and int(n_in) <= 0
+    m_sympy_nonpositive = isinstance(m_in, sp.Integer) and int(m_in) <= 0
+    if n_sympy_nonpositive or m_sympy_nonpositive:
+        raise ValueError("num_qubits and num_marked must be positive.")
+    n_val = int(n_in) if isinstance(n_in, (int, np.integer)) else n_in
+    m_val = int(m_in) if isinstance(m_in, (int, np.integer)) else m_in
     if isinstance(n_val, int) and isinstance(m_val, int):
         if n_val <= 0 or m_val <= 0:
             raise ValueError("num_qubits and num_marked must be positive.")
@@ -114,7 +141,7 @@ def _diffusion(reg: Vector[Qubit]) -> Vector[Qubit]:
 
 def grover_search(
     reg: Vector[Qubit],
-    oracle: QKernelLike,
+    oracle: Oracle | QKernelLike,
     iterations: int | qmc.UInt,
 ) -> Vector[Qubit]:
     """Run the Grover amplitude-amplification loop on ``reg``.
@@ -128,9 +155,9 @@ def grover_search(
 
     Args:
         reg (Vector[Qubit]): Search register in the all-zero state on entry.
-        oracle (QKernelLike): Phase oracle marking the solution(s). Supply a
-            costed opaque box (e.g. ``qmc.opaque(..., cost=...)``)
-            so the estimator can cost each query.
+        oracle (Oracle | QKernelLike): Phase oracle marking the solution(s).
+            Supply a costed opaque box (e.g. ``qmc.opaque(..., cost=...)``) so
+            the estimator can cost each query.
         iterations (int | qmc.UInt): Number of Grover iterations. Use
             :func:`grover_iteration_count` to obtain the optimal value; leave it
             as an unbound ``UInt`` parameter for symbolic estimation.
@@ -162,12 +189,12 @@ def grover_search(
     return reg
 
 
-def _grover_step(reg: Vector[Qubit], oracle: QKernelLike) -> Vector[Qubit]:
+def _grover_step(reg: Vector[Qubit], oracle: Oracle | QKernelLike) -> Vector[Qubit]:
     """Apply one Grover iteration: an oracle query then the diffusion operator.
 
     Args:
         reg (Vector[Qubit]): Search register.
-        oracle (QKernelLike): Phase oracle marking the solution(s).
+        oracle (Oracle | QKernelLike): Phase oracle marking the solution(s).
 
     Returns:
         Vector[Qubit]: Register after one amplitude-amplification step.

--- a/tests/circuit/test_grover.py
+++ b/tests/circuit/test_grover.py
@@ -125,6 +125,20 @@ def test_grover_iteration_count_accepts_numpy_integers() -> None:
         grover_iteration_count(np.int64(0), 1)
 
 
+def test_grover_iteration_count_preserves_sympy_integers() -> None:
+    """SymPy integer inputs retain a symbolic result and positivity checks."""
+    count_from_qubits = grover_iteration_count(sp.Integer(4), 1)
+    count_from_marked = grover_iteration_count(4, sp.Integer(1))
+
+    assert isinstance(count_from_qubits, sp.Integer)
+    assert isinstance(count_from_marked, sp.Integer)
+    assert count_from_qubits == count_from_marked == 3
+    with pytest.raises(ValueError, match="must be positive"):
+        grover_iteration_count(sp.Integer(0), 1)
+    with pytest.raises(ValueError, match="must be positive"):
+        grover_iteration_count(4, sp.Integer(0))
+
+
 def test_grover_iteration_count_uses_arbitrary_precision() -> None:
     """Large search spaces return exact Python integers without overflow."""
     count = grover_iteration_count(1024, 1)

--- a/tests/circuit/test_grover.py
+++ b/tests/circuit/test_grover.py
@@ -125,6 +125,18 @@ def test_grover_iteration_count_accepts_numpy_integers() -> None:
         grover_iteration_count(np.int64(0), 1)
 
 
+def test_grover_iteration_count_rejects_booleans() -> None:
+    """Boolean scalars are not accepted as integer search parameters."""
+    for num_qubits, num_marked in (
+        (True, 1),
+        (4, False),
+        (np.bool_(True), 1),
+        (4, np.bool_(False)),
+    ):
+        with pytest.raises(TypeError, match="must not be booleans"):
+            grover_iteration_count(num_qubits, num_marked)
+
+
 def test_grover_iteration_count_preserves_sympy_integers() -> None:
     """SymPy integer inputs retain a symbolic result and positivity checks."""
     count_from_qubits = grover_iteration_count(sp.Integer(4), 1)

--- a/tests/circuit/test_grover.py
+++ b/tests/circuit/test_grover.py
@@ -137,6 +137,14 @@ def test_grover_iteration_count_preserves_sympy_integers() -> None:
         grover_iteration_count(sp.Integer(0), 1)
     with pytest.raises(ValueError, match="must be positive"):
         grover_iteration_count(4, sp.Integer(0))
+    for num_qubits, num_marked in (
+        (sp.Integer(4), -1),
+        (-1, sp.Integer(1)),
+        (sp.Integer(4), np.int64(0)),
+        (np.int64(0), sp.Integer(1)),
+    ):
+        with pytest.raises(ValueError, match="must be positive"):
+            grover_iteration_count(num_qubits, num_marked)
 
 
 def test_grover_iteration_count_uses_arbitrary_precision() -> None:

--- a/tests/circuit/test_oracle_contract.py
+++ b/tests/circuit/test_oracle_contract.py
@@ -9,6 +9,20 @@ _CONTROLLED_ORACLE = qmc.Oracle(
     num_qubits=2,
     num_control_qubits=1,
 )
+_VECTOR_ORACLE = qmc.Oracle(
+    "vector_contract",
+    signature=qmc.CallableSignature(
+        inputs=[qmc.Vector[qmc.Qubit]],
+        outputs=[qmc.Vector[qmc.Qubit]],
+    ),
+)
+
+
+@qmc.qkernel
+def _valid_vector_call() -> qmc.Vector[qmc.Qubit]:
+    """Return a vector passed through a vector-signature oracle."""
+    qubits = qmc.qubit_array(2, "qubits")
+    return _VECTOR_ORACLE(qubits)
 
 
 @qmc.qkernel
@@ -22,3 +36,11 @@ def test_vector_oracle_cannot_bypass_declared_controls() -> None:
     """Vector syntax rejects an oracle that requires explicit controls."""
     with pytest.raises(ValueError, match="requires 1 explicit control"):
         _invalid_vector_call.build()
+
+
+def test_vector_oracle_preserves_vector_result_shape() -> None:
+    """Vector oracle calls retain one vector output at runtime."""
+    block = _valid_vector_call.build()
+
+    assert len(block.output_values) == 1
+    assert block.output_values[0].type.label() == "QubitType"

--- a/tests/circuit/test_oracle_contract.py
+++ b/tests/circuit/test_oracle_contract.py
@@ -3,6 +3,7 @@
 import pytest
 
 import qamomile.circuit as qmc
+from qamomile.circuit.ir.value import ArrayValue, array_static_length
 
 _CONTROLLED_ORACLE = qmc.Oracle(
     "controlled_vector_contract",
@@ -43,4 +44,7 @@ def test_vector_oracle_preserves_vector_result_shape() -> None:
     block = _valid_vector_call.build()
 
     assert len(block.output_values) == 1
-    assert block.output_values[0].type.label() == "QubitType"
+    output = block.output_values[0]
+    assert isinstance(output, ArrayValue)
+    assert array_static_length(output) == 2
+    assert output.type.label() == "QubitType"

--- a/tests/circuit/test_oracle_contract.py
+++ b/tests/circuit/test_oracle_contract.py
@@ -3,6 +3,7 @@
 import pytest
 
 import qamomile.circuit as qmc
+from qamomile.circuit.ir.types import QubitType
 from qamomile.circuit.ir.value import ArrayValue, array_static_length
 
 _CONTROLLED_ORACLE = qmc.Oracle(
@@ -47,4 +48,4 @@ def test_vector_oracle_preserves_vector_result_shape() -> None:
     output = block.output_values[0]
     assert isinstance(output, ArrayValue)
     assert array_static_length(output) == 2
-    assert output.type.label() == "QubitType"
+    assert output.type == QubitType()

--- a/tests/typecheck/public_api.py
+++ b/tests/typecheck/public_api.py
@@ -46,6 +46,7 @@ def _check_grover_types(
     oracle: qmc.Oracle,
     register: qmc.Vector[qmc.Qubit],
     numpy_integer: np.integer[Any],
+    sympy_integer: sp.Integer,
     symbolic: sp.Expr,
 ) -> None:
     """Verify concrete, symbolic, and opaque-oracle Grover contracts."""
@@ -53,6 +54,8 @@ def _check_grover_types(
     assert_type(qmc.grover_iteration_count(numpy_integer), int)
     assert_type(qmc.grover_iteration_count(symbolic), sp.Expr)
     assert_type(qmc.grover_iteration_count(3, symbolic), sp.Expr)
+    assert_type(qmc.grover_iteration_count(sympy_integer), sp.Expr)
+    assert_type(qmc.grover_iteration_count(3, sympy_integer), sp.Expr)
     assert_type(
         qmc.grover_search(
             register,

--- a/tests/typecheck/public_api.py
+++ b/tests/typecheck/public_api.py
@@ -1,0 +1,63 @@
+"""Static type contracts for public APIs with input-dependent results."""
+
+from __future__ import annotations
+
+from typing import Any, assert_type
+
+import numpy as np
+import sympy as sp
+
+import qamomile.circuit as qmc
+
+
+def _check_oracle_result_shapes(
+    oracle: qmc.Oracle,
+    qubit: qmc.Qubit,
+    vector: qmc.Vector[qmc.Qubit],
+    view: qmc.VectorView[qmc.Qubit],
+) -> None:
+    """Verify that oracle calls preserve their input form statically."""
+    assert_type(oracle(qubit), tuple[qmc.Qubit, ...])
+    assert_type(oracle(vector), qmc.Vector[qmc.Qubit])
+    assert_type(oracle(view), qmc.VectorView[qmc.Qubit])
+
+
+def _check_modmul_result_shapes(
+    control: qmc.Qubit,
+    register: qmc.Vector[qmc.Qubit],
+) -> None:
+    """Verify that modular multiplication narrows on its control argument."""
+    assert_type(
+        qmc.modmul_const(register, multiplier=2, modulus=15),
+        qmc.Vector[qmc.Qubit],
+    )
+    assert_type(
+        qmc.modmul_const(
+            register,
+            multiplier=2,
+            modulus=15,
+            control=control,
+        ),
+        tuple[qmc.Qubit, qmc.Vector[qmc.Qubit]],
+    )
+
+
+def _check_grover_types(
+    oracle: qmc.Oracle,
+    register: qmc.Vector[qmc.Qubit],
+    numpy_integer: np.integer[Any],
+    symbolic: sp.Expr,
+) -> None:
+    """Verify concrete, symbolic, and opaque-oracle Grover contracts."""
+    assert_type(qmc.grover_iteration_count(3), int)
+    assert_type(qmc.grover_iteration_count(numpy_integer), int)
+    assert_type(qmc.grover_iteration_count(symbolic), sp.Expr)
+    assert_type(qmc.grover_iteration_count(3, symbolic), sp.Expr)
+    assert_type(
+        qmc.grover_search(
+            register,
+            oracle,
+            qmc.grover_iteration_count(3),
+        ),
+        qmc.Vector[qmc.Qubit],
+    )


### PR DESCRIPTION
## Summary

- Narrow `Oracle.__call__` results for scalar, vector, and vector-view call forms.
- Narrow `modmul_const` results based on whether a control qubit is supplied.
- Align Grover helper annotations with concrete, symbolic, NumPy-integer, and opaque-oracle behavior.
- Add focused public typing contracts to the Zuban CI gate.

## Root cause

These public APIs exposed implementation-level union annotations even when call arguments uniquely determined their result types. Type checkers therefore propagated impossible union members into valid qkernel code and rejected chaining, unpacking, and documented examples. Grover also accepted opaque Oracle objects at runtime while annotating only the qkernel protocol.

## Compatibility

Circuit construction and emitted IR are unchanged. SymPy integer inputs to `grover_iteration_count` now retain a SymPy expression result so runtime behavior agrees with the symbolic overload; existing positivity validation is preserved.

## Checks

- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/ tests/typecheck/`
- Pyright over all changed public API files and typing fixtures
- `uv run pytest -q` (9636 passed, 413 skipped, 2705 deselected, 1 xfailed)
- Focused regression suite after the final review fix (45 passed)