### PR TITLE
Use allocated qubit names in affine diagnostics

### DIFF
--- a/qamomile/circuit/frontend/handle/handle.py
+++ b/qamomile/circuit/frontend/handle/handle.py
@@ -314,7 +314,7 @@ class Handle(abc.ABC):
             QubitConsumedError: If this quantum handle was already consumed.
         """
         if self._consumed and self._should_enforce_linear():
-            display_name = self.name or f"qubit_{self.id[:8]}"
+            display_name = self.name or self.value.name or f"qubit_{self.id[:8]}"
             first_use, reuse, consumed_at = _describe_consume_sites(
                 self, operation_name
             )

--- a/tests/circuit/test_affine_types.py
+++ b/tests/circuit/test_affine_types.py
@@ -488,6 +488,23 @@ class TestErrorMessageQuality:
         error = exc_info.value
         assert error.handle_name is not None
 
+    def test_error_message_uses_allocated_qubit_name(self):
+        """Allocated qubit diagnostics should use the user-provided name."""
+
+        @qkernel
+        def bad_circuit() -> qm.Bit:
+            qubit = qm.qubit("qubit")
+            qm.x(qubit)
+            qm.h(qubit)
+            return qm.measure(qubit)
+
+        with pytest.raises(QubitConsumedError) as exc_info:
+            bad_circuit.build()
+
+        error = exc_info.value
+        assert error.handle_name == "qubit"
+        assert "Qubit 'qubit'" in str(error)
+
     def test_error_message_contains_operation_names(self):
         """Error messages should name both operations involved."""
 


### PR DESCRIPTION
## Summary

Fix consumed-qubit diagnostics to prefer the user-provided IR value name before falling back to an internal handle UUID.

Add a regression test covering a locally allocated qubit whose stale handle is reused after a gate.

## Root cause

The qubit constructor stores its display name in `Value.name`, while `Handle.name` remains unset. `Handle.validate_consumable()` checked only `Handle.name` before generating a UUID-based fallback, so diagnostics exposed a random label such as `qubit_90060270` instead of the requested name.

## User impact

Affine-type errors now identify `qmc.qubit("qubit")` as `Qubit 'qubit'`, making the diagnostic stable and directly traceable to user code.

## Validation

- `uv run pytest tests/circuit/test_affine_types.py -q` (388 passed)
- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`