### PR TITLE
Fix HUGR compiler layer boundaries

### DIFF
--- a/qamomile/circuit/transpiler/__init__.py
+++ b/qamomile/circuit/transpiler/__init__.py
@@ -99,26 +99,42 @@ Design principles
   a distinct native compilation product intentionally.
 """
 
+from qamomile.circuit.frontend.qkernel_like import QKernelLike
 from qamomile.circuit.transpiler.artifact import (
     CompilationDiagnostic,
     CompilationMetadata,
     CompiledProgram,
     DiagnosticSeverity,
 )
+from qamomile.circuit.transpiler.block_parameter_binding import pair_block_operands
 from qamomile.circuit.transpiler.compiler import QamomileCompiler
 from qamomile.circuit.transpiler.config import CompilerConfig, TranspilerConfig
+from qamomile.circuit.transpiler.errors import (
+    CallableDefinitionConflictError,
+    EmitError,
+)
 from qamomile.circuit.transpiler.prepared import PreparedModule, prepare_module
+from qamomile.circuit.transpiler.program_graph import (
+    inline_callables,
+    validate_program_graph_semantics,
+)
 from qamomile.circuit.transpiler.target import CompilationTarget
 
 __all__ = [
+    "CallableDefinitionConflictError",
     "CompilationDiagnostic",
     "CompilationMetadata",
     "CompilationTarget",
     "CompiledProgram",
     "CompilerConfig",
     "DiagnosticSeverity",
+    "EmitError",
     "PreparedModule",
+    "QKernelLike",
     "QamomileCompiler",
     "TranspilerConfig",
+    "inline_callables",
+    "pair_block_operands",
     "prepare_module",
+    "validate_program_graph_semantics",
 ]

--- a/qamomile/circuit/transpiler/errors.py
+++ b/qamomile/circuit/transpiler/errors.py
@@ -114,7 +114,27 @@ class SeparationError(QamomileCompileError):
 
 
 class EmitError(QamomileCompileError):
-    """Error during backend code emission."""
+    """Report a backend failure to emit one semantic operation.
+
+    Args:
+        message (str): Human-readable emission failure.
+        operation (str | None): Related operation description. Defaults to
+            ``None``.
+
+    Example:
+        Correct — identify the unsupported operation at its target boundary::
+
+            raise EmitError(
+                "HUGR cannot emit a symbolic gate power",
+                operation="ControlledUOperation",
+            )
+
+        Incorrect — silently dropping an unsupported operation can change the
+        compiled program's meaning::
+
+            if not target_supports(operation):
+                return
+    """
 
     def __init__(self, message: str, operation: str | None = None):
         """Initialize a backend emission diagnosis.

--- a/qamomile/circuit/transpiler/program_graph.py
+++ b/qamomile/circuit/transpiler/program_graph.py
@@ -1,0 +1,77 @@
+"""Public compiler support for direct program-graph targets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from qamomile.circuit.ir.block import Block
+from qamomile.circuit.ir.operation.callable import CallPolicy
+from qamomile.circuit.transpiler.passes.analyze import (
+    reject_control_flow_quantum_discard,
+)
+from qamomile.circuit.transpiler.passes.inline import InlinePass
+from qamomile.circuit.transpiler.passes.validate_while import (
+    ValidateWhileContractPass,
+)
+from qamomile.circuit.transpiler.prepared import PreparedModule
+
+__all__ = ["inline_callables", "validate_program_graph_semantics"]
+
+
+def inline_callables(block: Block) -> Block:
+    """Expand inline-policy callables once with the compiler's default policy.
+
+    Boxed calls, transformed calls, and recursive calls that remain after one
+    pass are preserved. Direct program-graph targets use this narrow helper at
+    target legalization boundaries without depending on the configurable
+    compiler pass implementation.
+
+    Args:
+        block (Block): Hierarchical or traced semantic block to rewrite.
+
+    Returns:
+        Block: Block after one default callable-inlining pass.
+
+    Raises:
+        QubitConsumedError: If an invocation binds the same quantum resource
+            to multiple formal operands.
+    """
+    return InlinePass().run(block)
+
+
+def validate_program_graph_semantics(program: PreparedModule) -> None:
+    """Validate shared semantics for a direct program-graph target.
+
+    Circuit-family planning runs these checks during partial evaluation,
+    analysis, and segmentation. A direct program-graph target preserves the
+    prepared structure, so this helper runs only the non-destructive semantic
+    checks. Inline-policy callables are expanded in the validation view so
+    their formal values retain call-site provenance; the prepared program
+    itself remains hierarchical.
+
+    Args:
+        program (PreparedModule): Prepared entrypoint and callable bodies.
+
+    Raises:
+        ValidationError: If a while condition is not measurement-backed.
+        AffineTypeError: If structured control flow discards a quantum value.
+        QubitConsumedError: If callable inlining binds one quantum resource to
+            multiple formal operands.
+    """
+    blocks: list[tuple[Block, Mapping[str, Any]]] = [
+        (inline_callables(program.entrypoint), program.bindings)
+    ]
+    blocks.extend(
+        (inline_callables(definition.body), {})
+        for definition in program.definitions.values()
+        if definition.body is not None
+        and definition.default_policy is not CallPolicy.INLINE
+    )
+    visited: set[int] = set()
+    for block, bindings in blocks:
+        if id(block) in visited:
+            continue
+        visited.add(id(block))
+        ValidateWhileContractPass().run(block)
+        reject_control_flow_quantum_discard(block.operations, dict(bindings))

--- a/qamomile/hugr/lowerer.py
+++ b/qamomile/hugr/lowerer.py
@@ -20,7 +20,6 @@ from qamomile.circuit.ir.operation.arithmetic_operations import (
 )
 from qamomile.circuit.ir.operation.callable import (
     CallableRef,
-    CallPolicy,
     CallTransform,
     InvokeOperation,
 )
@@ -68,23 +67,16 @@ from qamomile.circuit.ir.value import (
     resolve_root_array_index,
     resolve_root_qubit_address,
 )
-from qamomile.circuit.transpiler.artifact import (
+from qamomile.circuit.transpiler import (
+    CallableDefinitionConflictError,
     CompilationMetadata,
     CompiledProgram,
-)
-from qamomile.circuit.transpiler.block_parameter_binding import pair_block_operands
-from qamomile.circuit.transpiler.errors import (
-    CallableDefinitionConflictError,
     EmitError,
+    PreparedModule,
+    inline_callables,
+    pair_block_operands,
+    validate_program_graph_semantics,
 )
-from qamomile.circuit.transpiler.passes.analyze import (
-    reject_control_flow_quantum_discard,
-)
-from qamomile.circuit.transpiler.passes.inline import InlinePass
-from qamomile.circuit.transpiler.passes.validate_while import (
-    ValidateWhileContractPass,
-)
-from qamomile.circuit.transpiler.prepared import PreparedModule
 
 _QuantumOrigin: TypeAlias = tuple[str, int | None]
 _QuantumFootprint: TypeAlias = frozenset[_QuantumOrigin]
@@ -148,7 +140,7 @@ class HugrTarget:
             CallableDefinitionConflictError: If one source callable produced
                 multiple specialized bodies that cannot share one HUGR symbol.
         """
-        _validate_direct_semantics(program)
+        validate_program_graph_semantics(program)
         for ref, variants in program.definition_variants.items():
             if len(variants) > 1:
                 symbol = f"{ref.namespace}.{ref.name}@{ref.version}"
@@ -206,42 +198,6 @@ class HugrTarget:
                 "HUGR support requires the optional 'hugr' and 'tket-exts' packages."
             ) from error
         validate(artifact.to_bytes())
-
-
-def _validate_direct_semantics(program: PreparedModule) -> None:
-    """Validate target-neutral invariants skipped by direct HUGR lowering.
-
-    Circuit-family planning runs these checks as part of partial evaluation,
-    analysis, and segmentation. HUGR intentionally preserves the prepared
-    program graph, so it invokes only the non-destructive semantic checks
-    here instead of importing the circuit segmentation pipeline. INLINE
-    callables are expanded only in this validation view so formal values are
-    checked with their call-site provenance; emitted HUGR remains hierarchical.
-
-    Args:
-        program (PreparedModule): Prepared entrypoint and callable bodies.
-
-    Raises:
-        ValidationError: If a while condition is not measurement-backed.
-        AffineTypeError: If control flow discards a quantum value.
-    """
-    inline = InlinePass()
-    blocks: list[tuple[Block, Mapping[str, Any]]] = [
-        (inline.run(program.entrypoint), program.bindings)
-    ]
-    blocks.extend(
-        (inline.run(definition.body), {})
-        for definition in program.definitions.values()
-        if definition.body is not None
-        and definition.default_policy is not CallPolicy.INLINE
-    )
-    visited: set[int] = set()
-    for block, bindings in blocks:
-        if id(block) in visited:
-            continue
-        visited.add(id(block))
-        ValidateWhileContractPass().run(block)
-        reject_control_flow_quantum_discard(block.operations, dict(bindings))
 
 
 def _require_hugr() -> tuple[Any, Any, Any, Any, Any]:
@@ -3019,7 +2975,7 @@ def _lower_transformed_call(
         display_name = operation.target.name
     if body is None:
         raise EmitError(f"Transformed HUGR callable {display_name!r} is opaque")
-    body = InlinePass().run(body)
+    body = inline_callables(body)
     power = _resolve_transformed_power(operation, environment)
     # Array carriers are mutable lists. Keep body-local element updates from
     # changing parent aliases before result publication consumes the old wires.

--- a/qamomile/hugr/transpiler.py
+++ b/qamomile/hugr/transpiler.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from qamomile.circuit.frontend.qkernel_like import QKernelLike
-from qamomile.circuit.transpiler.artifact import CompiledProgram
-from qamomile.circuit.transpiler.compiler import QamomileCompiler
-from qamomile.circuit.transpiler.config import CompilerConfig
+from qamomile.circuit.transpiler import (
+    CompiledProgram,
+    CompilerConfig,
+    QamomileCompiler,
+    QKernelLike,
+)
 from qamomile.hugr.lowerer import HugrTarget
 
 

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -1,0 +1,262 @@
+"""Source-level regression tests for Qamomile package boundaries."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import qamomile.circuit.transpiler as transpiler_api
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+QAMOMILE_ROOT = REPOSITORY_ROOT / "qamomile"
+BACKEND_PACKAGES = (
+    "cudaq",
+    "hugr",
+    "qbraid",
+    "qiskit",
+    "quration",
+    "quri_parts",
+)
+FRONTEND_MODULE = "qamomile.circuit.frontend"
+TRANSPILER_MODULE = "qamomile.circuit.transpiler"
+
+
+@dataclass(frozen=True)
+class _ImportReference:
+    """Describe one source-level import dependency.
+
+    Args:
+        path (Path): Source file containing the import.
+        lineno (int): One-based source line number.
+        module (str): Absolute imported module name.
+        imported_names (tuple[str, ...] | None): Names selected by a
+            ``from`` import, or ``None`` for a plain ``import`` statement.
+    """
+
+    path: Path
+    lineno: int
+    module: str
+    imported_names: tuple[str, ...] | None
+
+
+def _module_name_for_path(path: Path) -> str:
+    """Return the dotted module name represented by a source path.
+
+    Args:
+        path (Path): Python source path below the repository root.
+
+    Returns:
+        str: Absolute dotted module name, with ``.__init__`` removed.
+    """
+    parts = list(path.relative_to(REPOSITORY_ROOT).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _resolve_import_from(path: Path, node: ast.ImportFrom) -> str:
+    """Resolve an ``ImportFrom`` node to an absolute module name.
+
+    Args:
+        path (Path): Source file containing the import.
+        node (ast.ImportFrom): Import node to resolve.
+
+    Returns:
+        str: Absolute module named by the import.
+
+    Raises:
+        ImportError: If a relative import escapes its top-level package.
+    """
+    if node.level == 0:
+        return node.module or ""
+
+    source_module = _module_name_for_path(path)
+    package = (
+        source_module if path.stem == "__init__" else source_module.rpartition(".")[0]
+    )
+    relative_name = "." * node.level + (node.module or "")
+    return importlib.util.resolve_name(relative_name, package)
+
+
+def _iter_source_files(root: Path) -> Iterator[Path]:
+    """Yield Python implementation and stub files below a package root.
+
+    Args:
+        root (Path): Package directory to scan recursively.
+
+    Yields:
+        Path: A ``.py`` or ``.pyi`` source path in stable order.
+    """
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix in {".py", ".pyi"}:
+            yield path
+
+
+def _iter_import_references(root: Path) -> Iterator[_ImportReference]:
+    """Yield every static import found below a package root.
+
+    Function-local imports and imports guarded by ``TYPE_CHECKING`` still
+    express an architectural dependency, so the complete AST is traversed.
+
+    Args:
+        root (Path): Package directory to scan recursively.
+
+    Yields:
+        _ImportReference: An absolute source-level import reference.
+    """
+    for path in _iter_source_files(root):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    yield _ImportReference(path, node.lineno, alias.name, None)
+            elif isinstance(node, ast.ImportFrom):
+                yield _ImportReference(
+                    path,
+                    node.lineno,
+                    _resolve_import_from(path, node),
+                    tuple(alias.name for alias in node.names),
+                )
+
+
+def _is_module_or_child(module: str, prefix: str) -> bool:
+    """Return whether a module is a package prefix or one of its children.
+
+    Args:
+        module (str): Absolute module or imported-name candidate.
+        prefix (str): Package prefix whose boundary must be respected.
+
+    Returns:
+        bool: Whether ``module`` equals ``prefix`` or starts below it.
+    """
+    return module == prefix or module.startswith(f"{prefix}.")
+
+
+def _reference_targets(reference: _ImportReference) -> Iterator[str]:
+    """Yield modules that one import statement can reference.
+
+    Checking selected names catches forms such as
+    ``from qamomile.circuit import frontend`` in addition to imports whose
+    base module already names ``qamomile.circuit.frontend``.
+
+    Args:
+        reference (_ImportReference): Parsed import dependency.
+
+    Yields:
+        str: Base module followed by each explicitly selected child name.
+    """
+    yield reference.module
+    if reference.imported_names is None:
+        return
+    for name in reference.imported_names:
+        if name != "*":
+            yield f"{reference.module}.{name}"
+
+
+def _display_import(reference: _ImportReference) -> str:
+    """Render a compact import spelling for a failure message.
+
+    Args:
+        reference (_ImportReference): Parsed import dependency.
+
+    Returns:
+        str: Human-readable import statement without aliases.
+    """
+    if reference.imported_names is None:
+        return f"import {reference.module}"
+    names = ", ".join(reference.imported_names)
+    return f"from {reference.module} import {names}"
+
+
+def _format_violation(reference: _ImportReference, reason: str) -> str:
+    """Format one architecture violation with its source location.
+
+    Args:
+        reference (_ImportReference): Parsed import dependency.
+        reason (str): Concise explanation of the violated rule.
+
+    Returns:
+        str: Repository-relative ``path:line`` diagnostic.
+    """
+    relative_path = reference.path.relative_to(REPOSITORY_ROOT).as_posix()
+    return f"{relative_path}:{reference.lineno}: {reason}: {_display_import(reference)}"
+
+
+def test_backends_do_not_import_circuit_frontend() -> None:
+    """Backend packages depend on public circuit APIs, never frontend internals."""
+    violations: list[str] = []
+    for backend in BACKEND_PACKAGES:
+        for reference in _iter_import_references(QAMOMILE_ROOT / backend):
+            if any(
+                _is_module_or_child(target, FRONTEND_MODULE)
+                for target in _reference_targets(reference)
+            ):
+                violations.append(
+                    _format_violation(
+                        reference,
+                        "backend imports qamomile.circuit.frontend",
+                    )
+                )
+
+    assert not violations, (
+        "Backend packages must not depend on circuit.frontend internals. "
+        "Expose the required contract through a public circuit API instead:\n"
+        + "\n".join(sorted(violations))
+    )
+
+
+def test_hugr_uses_only_public_transpiler_facade_imports() -> None:
+    """HUGR imports named transpiler symbols only from its public facade."""
+    public_names = frozenset(transpiler_api.__all__)
+    violations: list[str] = []
+
+    for reference in _iter_import_references(QAMOMILE_ROOT / "hugr"):
+        if not any(
+            _is_module_or_child(target, TRANSPILER_MODULE)
+            for target in _reference_targets(reference)
+        ):
+            continue
+
+        if reference.module != TRANSPILER_MODULE:
+            violations.append(
+                _format_violation(
+                    reference,
+                    "HUGR bypasses the public transpiler facade",
+                )
+            )
+            continue
+        if reference.imported_names is None:
+            violations.append(
+                _format_violation(
+                    reference,
+                    "HUGR must use a named from-import from the transpiler facade",
+                )
+            )
+            continue
+        if "*" in reference.imported_names:
+            violations.append(
+                _format_violation(
+                    reference,
+                    "HUGR must not wildcard-import the transpiler facade",
+                )
+            )
+            continue
+
+        non_public = sorted(set(reference.imported_names) - public_names)
+        if non_public:
+            violations.append(
+                _format_violation(
+                    reference,
+                    "HUGR imports names missing from transpiler.__all__ "
+                    f"({', '.join(non_public)})",
+                )
+            )
+
+    assert not violations, (
+        "HUGR must consume transpiler contracts through named imports from "
+        "qamomile.circuit.transpiler, and every imported name must be listed "
+        "in that facade's __all__:\n" + "\n".join(sorted(violations))
+    )


### PR DESCRIPTION
## Overview

This PR fixes the compiler layer boundaries used by the HUGR backend.

HUGR now consumes compiler contracts exclusively through the public `qamomile.circuit.transpiler` facade. Compiler-owned program-graph validation and callable inlining are exposed through narrow public helpers, with architecture tests preventing the same dependency violations from returning.

The change is intended to preserve existing HUGR compilation behavior.

## Background

The HUGR backend directly imported the `QKernelLike` protocol from the circuit frontend. It also depended on transpiler implementation modules and internal passes for artifact types, operand binding, callable inlining, while-loop validation, and quantum-resource analysis.

Backend packages are expected to depend only on circuit IR and public transpiler APIs. These direct imports bypassed that boundary and caused a P1 dependency-direction finding during local review.

## Changed Areas

- `qamomile.circuit.transpiler`
  - re-exported the compiler contracts required by direct program-graph targets
  - added public helpers for default callable inlining and prepared program-graph validation
  - kept the existing protocol, error classes, and operand-pairing helper as identity-preserving exports
  - expanded the public `EmitError` documentation

- `qamomile.hugr`
  - replaced the direct frontend import with the public transpiler facade
  - removed imports of internal transpiler modules and passes
  - delegated semantic validation and transformed-call inlining to the new compiler-owned helpers

- architecture tests
  - reject imports from `qamomile.circuit.frontend` in backend packages
  - require HUGR to import named transpiler contracts from the public facade
  - verify that every transpiler contract imported by HUGR is included in the facade's `__all__`

## Validation

- `uv run ruff check qamomile/ tests/`
- `uv run ruff format --check qamomile/ tests/`
- `uv run zuban check qamomile/`
- HUGR suite: 118 passed
- full unit suite: 11,203 passed, 545 skipped, 2,723 deselected, 1 xfailed
- local review: no P0, P1, P2, or P3 findings
